### PR TITLE
`JoinToTimeSpineNode` bug fix

### DIFF
--- a/.changes/unreleased/Fixes-20241121-073923.yaml
+++ b/.changes/unreleased/Fixes-20241121-073923.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Always treat metric_time and the agg_time_dimension the same in the JoinToTimeSpineNode.
+time: 2024-11-21T07:39:23.698194-08:00
+custom:
+  Author: courtneyholcomb
+  Issue: "1541"

--- a/metricflow-semantics/metricflow_semantics/instances.py
+++ b/metricflow-semantics/metricflow_semantics/instances.py
@@ -145,10 +145,10 @@ class TimeDimensionInstance(LinkableInstance[TimeDimensionSpec], SemanticModelEl
             spec=transformed_spec,
         )
 
-    def with_new_defined_from(self, defined_from: Tuple[SemanticModelElementReference, ...]) -> TimeDimensionInstance:
+    def with_new_defined_from(self, defined_from: Sequence[SemanticModelElementReference]) -> TimeDimensionInstance:
         """Returns a new instance with the defined_from field replaced."""
         return TimeDimensionInstance(
-            associated_columns=self.associated_columns, defined_from=defined_from, spec=self.spec
+            associated_columns=self.associated_columns, defined_from=tuple(defined_from), spec=self.spec
         )
 
 

--- a/metricflow-semantics/metricflow_semantics/instances.py
+++ b/metricflow-semantics/metricflow_semantics/instances.py
@@ -145,6 +145,12 @@ class TimeDimensionInstance(LinkableInstance[TimeDimensionSpec], SemanticModelEl
             spec=transformed_spec,
         )
 
+    def with_new_defined_from(self, defined_from: Tuple[SemanticModelElementReference, ...]) -> TimeDimensionInstance:
+        """Returns a new instance with the defined_from field replaced."""
+        return TimeDimensionInstance(
+            associated_columns=self.associated_columns, defined_from=defined_from, spec=self.spec
+        )
+
 
 @dataclass(frozen=True)
 class EntityInstance(LinkableInstance[EntitySpec], SemanticModelElementInstance):  # noqa: D101

--- a/metricflow-semantics/metricflow_semantics/specs/time_dimension_spec.py
+++ b/metricflow-semantics/metricflow_semantics/specs/time_dimension_spec.py
@@ -244,3 +244,16 @@ class TimeDimensionSpec(DimensionSpec):  # noqa: D101
             date_part=self.date_part,
             aggregation_state=self.aggregation_state,
         )
+
+    @staticmethod
+    def with_base_grains(time_dimension_specs: Sequence[TimeDimensionSpec]) -> List[TimeDimensionSpec]:
+        """Return the list of time dimension specs, replacing any custom grains with base grains.
+
+        Dedupes new specs, but preserves the initial order.
+        """
+        base_grain_specs: List[TimeDimensionSpec] = []
+        for spec in time_dimension_specs:
+            base_grain_spec = spec.with_base_grain()
+            if base_grain_spec not in base_grain_specs:
+                base_grain_specs.append(base_grain_spec)
+        return base_grain_specs

--- a/metricflow-semantics/metricflow_semantics/specs/time_dimension_spec.py
+++ b/metricflow-semantics/metricflow_semantics/specs/time_dimension_spec.py
@@ -246,7 +246,7 @@ class TimeDimensionSpec(DimensionSpec):  # noqa: D101
         )
 
     @staticmethod
-    def with_base_grains(time_dimension_specs: Sequence[TimeDimensionSpec]) -> List[TimeDimensionSpec]:
+    def with_base_grains(time_dimension_specs: Sequence[TimeDimensionSpec]) -> Sequence[TimeDimensionSpec]:
         """Return the list of time dimension specs, replacing any custom grains with base grains.
 
         Dedupes new specs, but preserves the initial order.

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_window_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_window_metric_with_non_default_grains__plan0.sql
@@ -8,34 +8,34 @@ sql_engine: BigQuery
 ---
 -- Re-aggregate Metric via Group By
 SELECT
-  subq_11.metric_time__week
-  , subq_11.booking__ds__month
+  subq_11.booking__ds__month
+  , subq_11.metric_time__week
   , subq_11.every_two_days_bookers_fill_nulls_with_0
 FROM (
   -- Window Function for Metric Re-aggregation
   SELECT
-    subq_10.metric_time__week
-    , subq_10.booking__ds__month
+    subq_10.booking__ds__month
+    , subq_10.metric_time__week
     , FIRST_VALUE(subq_10.every_two_days_bookers_fill_nulls_with_0) OVER (
       PARTITION BY
-        subq_10.metric_time__week
-        , subq_10.booking__ds__month
+        subq_10.booking__ds__month
+        , subq_10.metric_time__week
       ORDER BY subq_10.metric_time__day
       ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
     ) AS every_two_days_bookers_fill_nulls_with_0
   FROM (
     -- Compute Metrics via Expressions
     SELECT
-      subq_9.metric_time__day
+      subq_9.booking__ds__month
+      , subq_9.metric_time__day
       , subq_9.metric_time__week
-      , subq_9.booking__ds__month
       , COALESCE(subq_9.bookers, 0) AS every_two_days_bookers_fill_nulls_with_0
     FROM (
       -- Join to Time Spine Dataset
       SELECT
-        subq_7.metric_time__day AS metric_time__day
+        DATETIME_TRUNC(subq_7.metric_time__day, month) AS booking__ds__month
+        , subq_7.metric_time__day AS metric_time__day
         , DATETIME_TRUNC(subq_7.metric_time__day, isoweek) AS metric_time__week
-        , subq_6.booking__ds__month AS booking__ds__month
         , subq_6.bookers AS bookers
       FROM (
         -- Time Spine
@@ -380,6 +380,6 @@ FROM (
   ) subq_10
 ) subq_11
 GROUP BY
-  metric_time__week
-  , booking__ds__month
+  booking__ds__month
+  , metric_time__week
   , every_two_days_bookers_fill_nulls_with_0

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_window_metric_with_non_default_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_window_metric_with_non_default_grains__plan0_optimized.sql
@@ -8,28 +8,28 @@ sql_engine: BigQuery
 ---
 -- Re-aggregate Metric via Group By
 SELECT
-  metric_time__week
-  , booking__ds__month
+  booking__ds__month
+  , metric_time__week
   , every_two_days_bookers_fill_nulls_with_0
 FROM (
   -- Compute Metrics via Expressions
   -- Window Function for Metric Re-aggregation
   SELECT
-    metric_time__week
-    , booking__ds__month
+    booking__ds__month
+    , metric_time__week
     , FIRST_VALUE(COALESCE(bookers, 0)) OVER (
       PARTITION BY
-        metric_time__week
-        , booking__ds__month
+        booking__ds__month
+        , metric_time__week
       ORDER BY metric_time__day
       ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
     ) AS every_two_days_bookers_fill_nulls_with_0
   FROM (
     -- Join to Time Spine Dataset
     SELECT
-      subq_20.ds AS metric_time__day
+      DATETIME_TRUNC(subq_20.ds, month) AS booking__ds__month
+      , subq_20.ds AS metric_time__day
       , DATETIME_TRUNC(subq_20.ds, isoweek) AS metric_time__week
-      , subq_18.booking__ds__month AS booking__ds__month
       , subq_18.bookers AS bookers
     FROM ***************************.mf_time_spine subq_20
     LEFT OUTER JOIN (
@@ -60,6 +60,6 @@ FROM (
   ) subq_21
 ) subq_23
 GROUP BY
-  metric_time__week
-  , booking__ds__month
+  booking__ds__month
+  , metric_time__week
   , every_two_days_bookers_fill_nulls_with_0

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_window_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_window_metric_with_non_default_grains__plan0.sql
@@ -8,34 +8,34 @@ sql_engine: Databricks
 ---
 -- Re-aggregate Metric via Group By
 SELECT
-  subq_11.metric_time__week
-  , subq_11.booking__ds__month
+  subq_11.booking__ds__month
+  , subq_11.metric_time__week
   , subq_11.every_two_days_bookers_fill_nulls_with_0
 FROM (
   -- Window Function for Metric Re-aggregation
   SELECT
-    subq_10.metric_time__week
-    , subq_10.booking__ds__month
+    subq_10.booking__ds__month
+    , subq_10.metric_time__week
     , FIRST_VALUE(subq_10.every_two_days_bookers_fill_nulls_with_0) OVER (
       PARTITION BY
-        subq_10.metric_time__week
-        , subq_10.booking__ds__month
+        subq_10.booking__ds__month
+        , subq_10.metric_time__week
       ORDER BY subq_10.metric_time__day
       ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
     ) AS every_two_days_bookers_fill_nulls_with_0
   FROM (
     -- Compute Metrics via Expressions
     SELECT
-      subq_9.metric_time__day
+      subq_9.booking__ds__month
+      , subq_9.metric_time__day
       , subq_9.metric_time__week
-      , subq_9.booking__ds__month
       , COALESCE(subq_9.bookers, 0) AS every_two_days_bookers_fill_nulls_with_0
     FROM (
       -- Join to Time Spine Dataset
       SELECT
-        subq_7.metric_time__day AS metric_time__day
+        DATE_TRUNC('month', subq_7.metric_time__day) AS booking__ds__month
+        , subq_7.metric_time__day AS metric_time__day
         , DATE_TRUNC('week', subq_7.metric_time__day) AS metric_time__week
-        , subq_6.booking__ds__month AS booking__ds__month
         , subq_6.bookers AS bookers
       FROM (
         -- Time Spine
@@ -380,6 +380,6 @@ FROM (
   ) subq_10
 ) subq_11
 GROUP BY
-  subq_11.metric_time__week
-  , subq_11.booking__ds__month
+  subq_11.booking__ds__month
+  , subq_11.metric_time__week
   , subq_11.every_two_days_bookers_fill_nulls_with_0

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_window_metric_with_non_default_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_window_metric_with_non_default_grains__plan0_optimized.sql
@@ -8,28 +8,28 @@ sql_engine: Databricks
 ---
 -- Re-aggregate Metric via Group By
 SELECT
-  metric_time__week
-  , booking__ds__month
+  booking__ds__month
+  , metric_time__week
   , every_two_days_bookers_fill_nulls_with_0
 FROM (
   -- Compute Metrics via Expressions
   -- Window Function for Metric Re-aggregation
   SELECT
-    metric_time__week
-    , booking__ds__month
+    booking__ds__month
+    , metric_time__week
     , FIRST_VALUE(COALESCE(bookers, 0)) OVER (
       PARTITION BY
-        metric_time__week
-        , booking__ds__month
+        booking__ds__month
+        , metric_time__week
       ORDER BY metric_time__day
       ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
     ) AS every_two_days_bookers_fill_nulls_with_0
   FROM (
     -- Join to Time Spine Dataset
     SELECT
-      subq_20.ds AS metric_time__day
+      DATE_TRUNC('month', subq_20.ds) AS booking__ds__month
+      , subq_20.ds AS metric_time__day
       , DATE_TRUNC('week', subq_20.ds) AS metric_time__week
-      , subq_18.booking__ds__month AS booking__ds__month
       , subq_18.bookers AS bookers
     FROM ***************************.mf_time_spine subq_20
     LEFT OUTER JOIN (
@@ -60,6 +60,6 @@ FROM (
   ) subq_21
 ) subq_23
 GROUP BY
-  metric_time__week
-  , booking__ds__month
+  booking__ds__month
+  , metric_time__week
   , every_two_days_bookers_fill_nulls_with_0

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_window_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_window_metric_with_non_default_grains__plan0.sql
@@ -8,34 +8,34 @@ sql_engine: DuckDB
 ---
 -- Re-aggregate Metric via Group By
 SELECT
-  subq_11.metric_time__week
-  , subq_11.booking__ds__month
+  subq_11.booking__ds__month
+  , subq_11.metric_time__week
   , subq_11.every_two_days_bookers_fill_nulls_with_0
 FROM (
   -- Window Function for Metric Re-aggregation
   SELECT
-    subq_10.metric_time__week
-    , subq_10.booking__ds__month
+    subq_10.booking__ds__month
+    , subq_10.metric_time__week
     , FIRST_VALUE(subq_10.every_two_days_bookers_fill_nulls_with_0) OVER (
       PARTITION BY
-        subq_10.metric_time__week
-        , subq_10.booking__ds__month
+        subq_10.booking__ds__month
+        , subq_10.metric_time__week
       ORDER BY subq_10.metric_time__day
       ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
     ) AS every_two_days_bookers_fill_nulls_with_0
   FROM (
     -- Compute Metrics via Expressions
     SELECT
-      subq_9.metric_time__day
+      subq_9.booking__ds__month
+      , subq_9.metric_time__day
       , subq_9.metric_time__week
-      , subq_9.booking__ds__month
       , COALESCE(subq_9.bookers, 0) AS every_two_days_bookers_fill_nulls_with_0
     FROM (
       -- Join to Time Spine Dataset
       SELECT
-        subq_7.metric_time__day AS metric_time__day
+        DATE_TRUNC('month', subq_7.metric_time__day) AS booking__ds__month
+        , subq_7.metric_time__day AS metric_time__day
         , DATE_TRUNC('week', subq_7.metric_time__day) AS metric_time__week
-        , subq_6.booking__ds__month AS booking__ds__month
         , subq_6.bookers AS bookers
       FROM (
         -- Time Spine
@@ -380,6 +380,6 @@ FROM (
   ) subq_10
 ) subq_11
 GROUP BY
-  subq_11.metric_time__week
-  , subq_11.booking__ds__month
+  subq_11.booking__ds__month
+  , subq_11.metric_time__week
   , subq_11.every_two_days_bookers_fill_nulls_with_0

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_window_metric_with_non_default_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_window_metric_with_non_default_grains__plan0_optimized.sql
@@ -8,28 +8,28 @@ sql_engine: DuckDB
 ---
 -- Re-aggregate Metric via Group By
 SELECT
-  metric_time__week
-  , booking__ds__month
+  booking__ds__month
+  , metric_time__week
   , every_two_days_bookers_fill_nulls_with_0
 FROM (
   -- Compute Metrics via Expressions
   -- Window Function for Metric Re-aggregation
   SELECT
-    metric_time__week
-    , booking__ds__month
+    booking__ds__month
+    , metric_time__week
     , FIRST_VALUE(COALESCE(bookers, 0)) OVER (
       PARTITION BY
-        metric_time__week
-        , booking__ds__month
+        booking__ds__month
+        , metric_time__week
       ORDER BY metric_time__day
       ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
     ) AS every_two_days_bookers_fill_nulls_with_0
   FROM (
     -- Join to Time Spine Dataset
     SELECT
-      subq_20.ds AS metric_time__day
+      DATE_TRUNC('month', subq_20.ds) AS booking__ds__month
+      , subq_20.ds AS metric_time__day
       , DATE_TRUNC('week', subq_20.ds) AS metric_time__week
-      , subq_18.booking__ds__month AS booking__ds__month
       , subq_18.bookers AS bookers
     FROM ***************************.mf_time_spine subq_20
     LEFT OUTER JOIN (
@@ -60,6 +60,6 @@ FROM (
   ) subq_21
 ) subq_23
 GROUP BY
-  metric_time__week
-  , booking__ds__month
+  booking__ds__month
+  , metric_time__week
   , every_two_days_bookers_fill_nulls_with_0

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_window_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_window_metric_with_non_default_grains__plan0.sql
@@ -8,34 +8,34 @@ sql_engine: Postgres
 ---
 -- Re-aggregate Metric via Group By
 SELECT
-  subq_11.metric_time__week
-  , subq_11.booking__ds__month
+  subq_11.booking__ds__month
+  , subq_11.metric_time__week
   , subq_11.every_two_days_bookers_fill_nulls_with_0
 FROM (
   -- Window Function for Metric Re-aggregation
   SELECT
-    subq_10.metric_time__week
-    , subq_10.booking__ds__month
+    subq_10.booking__ds__month
+    , subq_10.metric_time__week
     , FIRST_VALUE(subq_10.every_two_days_bookers_fill_nulls_with_0) OVER (
       PARTITION BY
-        subq_10.metric_time__week
-        , subq_10.booking__ds__month
+        subq_10.booking__ds__month
+        , subq_10.metric_time__week
       ORDER BY subq_10.metric_time__day
       ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
     ) AS every_two_days_bookers_fill_nulls_with_0
   FROM (
     -- Compute Metrics via Expressions
     SELECT
-      subq_9.metric_time__day
+      subq_9.booking__ds__month
+      , subq_9.metric_time__day
       , subq_9.metric_time__week
-      , subq_9.booking__ds__month
       , COALESCE(subq_9.bookers, 0) AS every_two_days_bookers_fill_nulls_with_0
     FROM (
       -- Join to Time Spine Dataset
       SELECT
-        subq_7.metric_time__day AS metric_time__day
+        DATE_TRUNC('month', subq_7.metric_time__day) AS booking__ds__month
+        , subq_7.metric_time__day AS metric_time__day
         , DATE_TRUNC('week', subq_7.metric_time__day) AS metric_time__week
-        , subq_6.booking__ds__month AS booking__ds__month
         , subq_6.bookers AS bookers
       FROM (
         -- Time Spine
@@ -380,6 +380,6 @@ FROM (
   ) subq_10
 ) subq_11
 GROUP BY
-  subq_11.metric_time__week
-  , subq_11.booking__ds__month
+  subq_11.booking__ds__month
+  , subq_11.metric_time__week
   , subq_11.every_two_days_bookers_fill_nulls_with_0

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_window_metric_with_non_default_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_window_metric_with_non_default_grains__plan0_optimized.sql
@@ -8,28 +8,28 @@ sql_engine: Postgres
 ---
 -- Re-aggregate Metric via Group By
 SELECT
-  metric_time__week
-  , booking__ds__month
+  booking__ds__month
+  , metric_time__week
   , every_two_days_bookers_fill_nulls_with_0
 FROM (
   -- Compute Metrics via Expressions
   -- Window Function for Metric Re-aggregation
   SELECT
-    metric_time__week
-    , booking__ds__month
+    booking__ds__month
+    , metric_time__week
     , FIRST_VALUE(COALESCE(bookers, 0)) OVER (
       PARTITION BY
-        metric_time__week
-        , booking__ds__month
+        booking__ds__month
+        , metric_time__week
       ORDER BY metric_time__day
       ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
     ) AS every_two_days_bookers_fill_nulls_with_0
   FROM (
     -- Join to Time Spine Dataset
     SELECT
-      subq_20.ds AS metric_time__day
+      DATE_TRUNC('month', subq_20.ds) AS booking__ds__month
+      , subq_20.ds AS metric_time__day
       , DATE_TRUNC('week', subq_20.ds) AS metric_time__week
-      , subq_18.booking__ds__month AS booking__ds__month
       , subq_18.bookers AS bookers
     FROM ***************************.mf_time_spine subq_20
     LEFT OUTER JOIN (
@@ -60,6 +60,6 @@ FROM (
   ) subq_21
 ) subq_23
 GROUP BY
-  metric_time__week
-  , booking__ds__month
+  booking__ds__month
+  , metric_time__week
   , every_two_days_bookers_fill_nulls_with_0

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_window_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_window_metric_with_non_default_grains__plan0.sql
@@ -8,34 +8,34 @@ sql_engine: Redshift
 ---
 -- Re-aggregate Metric via Group By
 SELECT
-  subq_11.metric_time__week
-  , subq_11.booking__ds__month
+  subq_11.booking__ds__month
+  , subq_11.metric_time__week
   , subq_11.every_two_days_bookers_fill_nulls_with_0
 FROM (
   -- Window Function for Metric Re-aggregation
   SELECT
-    subq_10.metric_time__week
-    , subq_10.booking__ds__month
+    subq_10.booking__ds__month
+    , subq_10.metric_time__week
     , FIRST_VALUE(subq_10.every_two_days_bookers_fill_nulls_with_0) OVER (
       PARTITION BY
-        subq_10.metric_time__week
-        , subq_10.booking__ds__month
+        subq_10.booking__ds__month
+        , subq_10.metric_time__week
       ORDER BY subq_10.metric_time__day
       ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
     ) AS every_two_days_bookers_fill_nulls_with_0
   FROM (
     -- Compute Metrics via Expressions
     SELECT
-      subq_9.metric_time__day
+      subq_9.booking__ds__month
+      , subq_9.metric_time__day
       , subq_9.metric_time__week
-      , subq_9.booking__ds__month
       , COALESCE(subq_9.bookers, 0) AS every_two_days_bookers_fill_nulls_with_0
     FROM (
       -- Join to Time Spine Dataset
       SELECT
-        subq_7.metric_time__day AS metric_time__day
+        DATE_TRUNC('month', subq_7.metric_time__day) AS booking__ds__month
+        , subq_7.metric_time__day AS metric_time__day
         , DATE_TRUNC('week', subq_7.metric_time__day) AS metric_time__week
-        , subq_6.booking__ds__month AS booking__ds__month
         , subq_6.bookers AS bookers
       FROM (
         -- Time Spine
@@ -380,6 +380,6 @@ FROM (
   ) subq_10
 ) subq_11
 GROUP BY
-  subq_11.metric_time__week
-  , subq_11.booking__ds__month
+  subq_11.booking__ds__month
+  , subq_11.metric_time__week
   , subq_11.every_two_days_bookers_fill_nulls_with_0

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_window_metric_with_non_default_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_window_metric_with_non_default_grains__plan0_optimized.sql
@@ -8,28 +8,28 @@ sql_engine: Redshift
 ---
 -- Re-aggregate Metric via Group By
 SELECT
-  metric_time__week
-  , booking__ds__month
+  booking__ds__month
+  , metric_time__week
   , every_two_days_bookers_fill_nulls_with_0
 FROM (
   -- Compute Metrics via Expressions
   -- Window Function for Metric Re-aggregation
   SELECT
-    metric_time__week
-    , booking__ds__month
+    booking__ds__month
+    , metric_time__week
     , FIRST_VALUE(COALESCE(bookers, 0)) OVER (
       PARTITION BY
-        metric_time__week
-        , booking__ds__month
+        booking__ds__month
+        , metric_time__week
       ORDER BY metric_time__day
       ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
     ) AS every_two_days_bookers_fill_nulls_with_0
   FROM (
     -- Join to Time Spine Dataset
     SELECT
-      subq_20.ds AS metric_time__day
+      DATE_TRUNC('month', subq_20.ds) AS booking__ds__month
+      , subq_20.ds AS metric_time__day
       , DATE_TRUNC('week', subq_20.ds) AS metric_time__week
-      , subq_18.booking__ds__month AS booking__ds__month
       , subq_18.bookers AS bookers
     FROM ***************************.mf_time_spine subq_20
     LEFT OUTER JOIN (
@@ -60,6 +60,6 @@ FROM (
   ) subq_21
 ) subq_23
 GROUP BY
-  metric_time__week
-  , booking__ds__month
+  booking__ds__month
+  , metric_time__week
   , every_two_days_bookers_fill_nulls_with_0

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_window_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_window_metric_with_non_default_grains__plan0.sql
@@ -8,34 +8,34 @@ sql_engine: Snowflake
 ---
 -- Re-aggregate Metric via Group By
 SELECT
-  subq_11.metric_time__week
-  , subq_11.booking__ds__month
+  subq_11.booking__ds__month
+  , subq_11.metric_time__week
   , subq_11.every_two_days_bookers_fill_nulls_with_0
 FROM (
   -- Window Function for Metric Re-aggregation
   SELECT
-    subq_10.metric_time__week
-    , subq_10.booking__ds__month
+    subq_10.booking__ds__month
+    , subq_10.metric_time__week
     , FIRST_VALUE(subq_10.every_two_days_bookers_fill_nulls_with_0) OVER (
       PARTITION BY
-        subq_10.metric_time__week
-        , subq_10.booking__ds__month
+        subq_10.booking__ds__month
+        , subq_10.metric_time__week
       ORDER BY subq_10.metric_time__day
       ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
     ) AS every_two_days_bookers_fill_nulls_with_0
   FROM (
     -- Compute Metrics via Expressions
     SELECT
-      subq_9.metric_time__day
+      subq_9.booking__ds__month
+      , subq_9.metric_time__day
       , subq_9.metric_time__week
-      , subq_9.booking__ds__month
       , COALESCE(subq_9.bookers, 0) AS every_two_days_bookers_fill_nulls_with_0
     FROM (
       -- Join to Time Spine Dataset
       SELECT
-        subq_7.metric_time__day AS metric_time__day
+        DATE_TRUNC('month', subq_7.metric_time__day) AS booking__ds__month
+        , subq_7.metric_time__day AS metric_time__day
         , DATE_TRUNC('week', subq_7.metric_time__day) AS metric_time__week
-        , subq_6.booking__ds__month AS booking__ds__month
         , subq_6.bookers AS bookers
       FROM (
         -- Time Spine
@@ -380,6 +380,6 @@ FROM (
   ) subq_10
 ) subq_11
 GROUP BY
-  subq_11.metric_time__week
-  , subq_11.booking__ds__month
+  subq_11.booking__ds__month
+  , subq_11.metric_time__week
   , subq_11.every_two_days_bookers_fill_nulls_with_0

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_window_metric_with_non_default_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_window_metric_with_non_default_grains__plan0_optimized.sql
@@ -8,28 +8,28 @@ sql_engine: Snowflake
 ---
 -- Re-aggregate Metric via Group By
 SELECT
-  metric_time__week
-  , booking__ds__month
+  booking__ds__month
+  , metric_time__week
   , every_two_days_bookers_fill_nulls_with_0
 FROM (
   -- Compute Metrics via Expressions
   -- Window Function for Metric Re-aggregation
   SELECT
-    metric_time__week
-    , booking__ds__month
+    booking__ds__month
+    , metric_time__week
     , FIRST_VALUE(COALESCE(bookers, 0)) OVER (
       PARTITION BY
-        metric_time__week
-        , booking__ds__month
+        booking__ds__month
+        , metric_time__week
       ORDER BY metric_time__day
       ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
     ) AS every_two_days_bookers_fill_nulls_with_0
   FROM (
     -- Join to Time Spine Dataset
     SELECT
-      subq_20.ds AS metric_time__day
+      DATE_TRUNC('month', subq_20.ds) AS booking__ds__month
+      , subq_20.ds AS metric_time__day
       , DATE_TRUNC('week', subq_20.ds) AS metric_time__week
-      , subq_18.booking__ds__month AS booking__ds__month
       , subq_18.bookers AS bookers
     FROM ***************************.mf_time_spine subq_20
     LEFT OUTER JOIN (
@@ -60,6 +60,6 @@ FROM (
   ) subq_21
 ) subq_23
 GROUP BY
-  metric_time__week
-  , booking__ds__month
+  booking__ds__month
+  , metric_time__week
   , every_two_days_bookers_fill_nulls_with_0

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_window_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_window_metric_with_non_default_grains__plan0.sql
@@ -8,34 +8,34 @@ sql_engine: Trino
 ---
 -- Re-aggregate Metric via Group By
 SELECT
-  subq_11.metric_time__week
-  , subq_11.booking__ds__month
+  subq_11.booking__ds__month
+  , subq_11.metric_time__week
   , subq_11.every_two_days_bookers_fill_nulls_with_0
 FROM (
   -- Window Function for Metric Re-aggregation
   SELECT
-    subq_10.metric_time__week
-    , subq_10.booking__ds__month
+    subq_10.booking__ds__month
+    , subq_10.metric_time__week
     , FIRST_VALUE(subq_10.every_two_days_bookers_fill_nulls_with_0) OVER (
       PARTITION BY
-        subq_10.metric_time__week
-        , subq_10.booking__ds__month
+        subq_10.booking__ds__month
+        , subq_10.metric_time__week
       ORDER BY subq_10.metric_time__day
       ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
     ) AS every_two_days_bookers_fill_nulls_with_0
   FROM (
     -- Compute Metrics via Expressions
     SELECT
-      subq_9.metric_time__day
+      subq_9.booking__ds__month
+      , subq_9.metric_time__day
       , subq_9.metric_time__week
-      , subq_9.booking__ds__month
       , COALESCE(subq_9.bookers, 0) AS every_two_days_bookers_fill_nulls_with_0
     FROM (
       -- Join to Time Spine Dataset
       SELECT
-        subq_7.metric_time__day AS metric_time__day
+        DATE_TRUNC('month', subq_7.metric_time__day) AS booking__ds__month
+        , subq_7.metric_time__day AS metric_time__day
         , DATE_TRUNC('week', subq_7.metric_time__day) AS metric_time__week
-        , subq_6.booking__ds__month AS booking__ds__month
         , subq_6.bookers AS bookers
       FROM (
         -- Time Spine
@@ -380,6 +380,6 @@ FROM (
   ) subq_10
 ) subq_11
 GROUP BY
-  subq_11.metric_time__week
-  , subq_11.booking__ds__month
+  subq_11.booking__ds__month
+  , subq_11.metric_time__week
   , subq_11.every_two_days_bookers_fill_nulls_with_0

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_window_metric_with_non_default_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_window_metric_with_non_default_grains__plan0_optimized.sql
@@ -8,28 +8,28 @@ sql_engine: Trino
 ---
 -- Re-aggregate Metric via Group By
 SELECT
-  metric_time__week
-  , booking__ds__month
+  booking__ds__month
+  , metric_time__week
   , every_two_days_bookers_fill_nulls_with_0
 FROM (
   -- Compute Metrics via Expressions
   -- Window Function for Metric Re-aggregation
   SELECT
-    metric_time__week
-    , booking__ds__month
+    booking__ds__month
+    , metric_time__week
     , FIRST_VALUE(COALESCE(bookers, 0)) OVER (
       PARTITION BY
-        metric_time__week
-        , booking__ds__month
+        booking__ds__month
+        , metric_time__week
       ORDER BY metric_time__day
       ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
     ) AS every_two_days_bookers_fill_nulls_with_0
   FROM (
     -- Join to Time Spine Dataset
     SELECT
-      subq_20.ds AS metric_time__day
+      DATE_TRUNC('month', subq_20.ds) AS booking__ds__month
+      , subq_20.ds AS metric_time__day
       , DATE_TRUNC('week', subq_20.ds) AS metric_time__week
-      , subq_18.booking__ds__month AS booking__ds__month
       , subq_18.bookers AS bookers
     FROM ***************************.mf_time_spine subq_20
     LEFT OUTER JOIN (
@@ -60,6 +60,6 @@ FROM (
   ) subq_21
 ) subq_23
 GROUP BY
-  metric_time__week
-  , booking__ds__month
+  booking__ds__month
+  , metric_time__week
   , every_two_days_bookers_fill_nulls_with_0

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/BigQuery/test_offset_metric_with_custom_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/BigQuery/test_offset_metric_with_custom_granularity__plan0.sql
@@ -26,16 +26,6 @@ FROM (
         -- Join to Custom Granularity Dataset
         SELECT
           subq_2.booking__ds__day AS booking__ds__day
-          , DATETIME_TRUNC(subq_2.booking__ds__day, isoweek) AS booking__ds__week
-          , DATETIME_TRUNC(subq_2.booking__ds__day, month) AS booking__ds__month
-          , DATETIME_TRUNC(subq_2.booking__ds__day, quarter) AS booking__ds__quarter
-          , DATETIME_TRUNC(subq_2.booking__ds__day, year) AS booking__ds__year
-          , EXTRACT(year FROM subq_2.booking__ds__day) AS booking__ds__extract_year
-          , EXTRACT(quarter FROM subq_2.booking__ds__day) AS booking__ds__extract_quarter
-          , EXTRACT(month FROM subq_2.booking__ds__day) AS booking__ds__extract_month
-          , EXTRACT(day FROM subq_2.booking__ds__day) AS booking__ds__extract_day
-          , IF(EXTRACT(dayofweek FROM subq_2.booking__ds__day) = 1, 7, EXTRACT(dayofweek FROM subq_2.booking__ds__day) - 1) AS booking__ds__extract_dow
-          , EXTRACT(dayofyear FROM subq_2.booking__ds__day) AS booking__ds__extract_doy
           , subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
@@ -69,6 +59,16 @@ FROM (
           , subq_1.paid_at__extract_day AS paid_at__extract_day
           , subq_1.paid_at__extract_dow AS paid_at__extract_dow
           , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+          , subq_1.booking__ds__week AS booking__ds__week
+          , subq_1.booking__ds__month AS booking__ds__month
+          , subq_1.booking__ds__quarter AS booking__ds__quarter
+          , subq_1.booking__ds__year AS booking__ds__year
+          , subq_1.booking__ds__extract_year AS booking__ds__extract_year
+          , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
+          , subq_1.booking__ds__extract_month AS booking__ds__extract_month
+          , subq_1.booking__ds__extract_day AS booking__ds__extract_day
+          , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
+          , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
           , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
           , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
           , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/BigQuery/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/BigQuery/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
@@ -26,16 +26,6 @@ FROM (
         SELECT
           subq_5.metric_time__martian_day
           , subq_5.metric_time__day
-          , subq_5.metric_time__week
-          , subq_5.metric_time__month
-          , subq_5.metric_time__quarter
-          , subq_5.metric_time__year
-          , subq_5.metric_time__extract_year
-          , subq_5.metric_time__extract_quarter
-          , subq_5.metric_time__extract_month
-          , subq_5.metric_time__extract_day
-          , subq_5.metric_time__extract_dow
-          , subq_5.metric_time__extract_doy
           , subq_5.ds__day
           , subq_5.ds__week
           , subq_5.ds__month
@@ -102,6 +92,16 @@ FROM (
           , subq_5.booking__paid_at__extract_day
           , subq_5.booking__paid_at__extract_dow
           , subq_5.booking__paid_at__extract_doy
+          , subq_5.metric_time__week
+          , subq_5.metric_time__month
+          , subq_5.metric_time__quarter
+          , subq_5.metric_time__year
+          , subq_5.metric_time__extract_year
+          , subq_5.metric_time__extract_quarter
+          , subq_5.metric_time__extract_month
+          , subq_5.metric_time__extract_day
+          , subq_5.metric_time__extract_dow
+          , subq_5.metric_time__extract_doy
           , subq_5.listing
           , subq_5.guest
           , subq_5.host
@@ -128,16 +128,6 @@ FROM (
           -- Join to Custom Granularity Dataset
           SELECT
             subq_2.metric_time__day AS metric_time__day
-            , DATETIME_TRUNC(subq_2.metric_time__day, isoweek) AS metric_time__week
-            , DATETIME_TRUNC(subq_2.metric_time__day, month) AS metric_time__month
-            , DATETIME_TRUNC(subq_2.metric_time__day, quarter) AS metric_time__quarter
-            , DATETIME_TRUNC(subq_2.metric_time__day, year) AS metric_time__year
-            , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-            , IF(EXTRACT(dayofweek FROM subq_2.metric_time__day) = 1, 7, EXTRACT(dayofweek FROM subq_2.metric_time__day) - 1) AS metric_time__extract_dow
-            , EXTRACT(dayofyear FROM subq_2.metric_time__day) AS metric_time__extract_doy
             , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
@@ -204,6 +194,16 @@ FROM (
             , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_1.metric_time__week AS metric_time__week
+            , subq_1.metric_time__month AS metric_time__month
+            , subq_1.metric_time__quarter AS metric_time__quarter
+            , subq_1.metric_time__year AS metric_time__year
+            , subq_1.metric_time__extract_year AS metric_time__extract_year
+            , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_1.metric_time__extract_month AS metric_time__extract_month
+            , subq_1.metric_time__extract_day AS metric_time__extract_day
+            , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_1.metric_time__extract_doy AS metric_time__extract_doy
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Databricks/test_offset_metric_with_custom_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Databricks/test_offset_metric_with_custom_granularity__plan0.sql
@@ -26,16 +26,6 @@ FROM (
         -- Join to Custom Granularity Dataset
         SELECT
           subq_2.booking__ds__day AS booking__ds__day
-          , DATE_TRUNC('week', subq_2.booking__ds__day) AS booking__ds__week
-          , DATE_TRUNC('month', subq_2.booking__ds__day) AS booking__ds__month
-          , DATE_TRUNC('quarter', subq_2.booking__ds__day) AS booking__ds__quarter
-          , DATE_TRUNC('year', subq_2.booking__ds__day) AS booking__ds__year
-          , EXTRACT(year FROM subq_2.booking__ds__day) AS booking__ds__extract_year
-          , EXTRACT(quarter FROM subq_2.booking__ds__day) AS booking__ds__extract_quarter
-          , EXTRACT(month FROM subq_2.booking__ds__day) AS booking__ds__extract_month
-          , EXTRACT(day FROM subq_2.booking__ds__day) AS booking__ds__extract_day
-          , EXTRACT(DAYOFWEEK_ISO FROM subq_2.booking__ds__day) AS booking__ds__extract_dow
-          , EXTRACT(doy FROM subq_2.booking__ds__day) AS booking__ds__extract_doy
           , subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
@@ -69,6 +59,16 @@ FROM (
           , subq_1.paid_at__extract_day AS paid_at__extract_day
           , subq_1.paid_at__extract_dow AS paid_at__extract_dow
           , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+          , subq_1.booking__ds__week AS booking__ds__week
+          , subq_1.booking__ds__month AS booking__ds__month
+          , subq_1.booking__ds__quarter AS booking__ds__quarter
+          , subq_1.booking__ds__year AS booking__ds__year
+          , subq_1.booking__ds__extract_year AS booking__ds__extract_year
+          , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
+          , subq_1.booking__ds__extract_month AS booking__ds__extract_month
+          , subq_1.booking__ds__extract_day AS booking__ds__extract_day
+          , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
+          , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
           , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
           , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
           , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Databricks/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Databricks/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
@@ -26,16 +26,6 @@ FROM (
         SELECT
           subq_5.metric_time__martian_day
           , subq_5.metric_time__day
-          , subq_5.metric_time__week
-          , subq_5.metric_time__month
-          , subq_5.metric_time__quarter
-          , subq_5.metric_time__year
-          , subq_5.metric_time__extract_year
-          , subq_5.metric_time__extract_quarter
-          , subq_5.metric_time__extract_month
-          , subq_5.metric_time__extract_day
-          , subq_5.metric_time__extract_dow
-          , subq_5.metric_time__extract_doy
           , subq_5.ds__day
           , subq_5.ds__week
           , subq_5.ds__month
@@ -102,6 +92,16 @@ FROM (
           , subq_5.booking__paid_at__extract_day
           , subq_5.booking__paid_at__extract_dow
           , subq_5.booking__paid_at__extract_doy
+          , subq_5.metric_time__week
+          , subq_5.metric_time__month
+          , subq_5.metric_time__quarter
+          , subq_5.metric_time__year
+          , subq_5.metric_time__extract_year
+          , subq_5.metric_time__extract_quarter
+          , subq_5.metric_time__extract_month
+          , subq_5.metric_time__extract_day
+          , subq_5.metric_time__extract_dow
+          , subq_5.metric_time__extract_doy
           , subq_5.listing
           , subq_5.guest
           , subq_5.host
@@ -128,16 +128,6 @@ FROM (
           -- Join to Custom Granularity Dataset
           SELECT
             subq_2.metric_time__day AS metric_time__day
-            , DATE_TRUNC('week', subq_2.metric_time__day) AS metric_time__week
-            , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('quarter', subq_2.metric_time__day) AS metric_time__quarter
-            , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-            , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-            , EXTRACT(DAYOFWEEK_ISO FROM subq_2.metric_time__day) AS metric_time__extract_dow
-            , EXTRACT(doy FROM subq_2.metric_time__day) AS metric_time__extract_doy
             , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
@@ -204,6 +194,16 @@ FROM (
             , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_1.metric_time__week AS metric_time__week
+            , subq_1.metric_time__month AS metric_time__month
+            , subq_1.metric_time__quarter AS metric_time__quarter
+            , subq_1.metric_time__year AS metric_time__year
+            , subq_1.metric_time__extract_year AS metric_time__extract_year
+            , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_1.metric_time__extract_month AS metric_time__extract_month
+            , subq_1.metric_time__extract_day AS metric_time__extract_day
+            , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_1.metric_time__extract_doy AS metric_time__extract_doy
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/DuckDB/test_offset_metric_with_custom_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/DuckDB/test_offset_metric_with_custom_granularity__plan0.sql
@@ -26,16 +26,6 @@ FROM (
         -- Join to Custom Granularity Dataset
         SELECT
           subq_2.booking__ds__day AS booking__ds__day
-          , DATE_TRUNC('week', subq_2.booking__ds__day) AS booking__ds__week
-          , DATE_TRUNC('month', subq_2.booking__ds__day) AS booking__ds__month
-          , DATE_TRUNC('quarter', subq_2.booking__ds__day) AS booking__ds__quarter
-          , DATE_TRUNC('year', subq_2.booking__ds__day) AS booking__ds__year
-          , EXTRACT(year FROM subq_2.booking__ds__day) AS booking__ds__extract_year
-          , EXTRACT(quarter FROM subq_2.booking__ds__day) AS booking__ds__extract_quarter
-          , EXTRACT(month FROM subq_2.booking__ds__day) AS booking__ds__extract_month
-          , EXTRACT(day FROM subq_2.booking__ds__day) AS booking__ds__extract_day
-          , EXTRACT(isodow FROM subq_2.booking__ds__day) AS booking__ds__extract_dow
-          , EXTRACT(doy FROM subq_2.booking__ds__day) AS booking__ds__extract_doy
           , subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
@@ -69,6 +59,16 @@ FROM (
           , subq_1.paid_at__extract_day AS paid_at__extract_day
           , subq_1.paid_at__extract_dow AS paid_at__extract_dow
           , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+          , subq_1.booking__ds__week AS booking__ds__week
+          , subq_1.booking__ds__month AS booking__ds__month
+          , subq_1.booking__ds__quarter AS booking__ds__quarter
+          , subq_1.booking__ds__year AS booking__ds__year
+          , subq_1.booking__ds__extract_year AS booking__ds__extract_year
+          , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
+          , subq_1.booking__ds__extract_month AS booking__ds__extract_month
+          , subq_1.booking__ds__extract_day AS booking__ds__extract_day
+          , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
+          , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
           , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
           , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
           , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/DuckDB/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/DuckDB/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
@@ -26,16 +26,6 @@ FROM (
         SELECT
           subq_5.metric_time__martian_day
           , subq_5.metric_time__day
-          , subq_5.metric_time__week
-          , subq_5.metric_time__month
-          , subq_5.metric_time__quarter
-          , subq_5.metric_time__year
-          , subq_5.metric_time__extract_year
-          , subq_5.metric_time__extract_quarter
-          , subq_5.metric_time__extract_month
-          , subq_5.metric_time__extract_day
-          , subq_5.metric_time__extract_dow
-          , subq_5.metric_time__extract_doy
           , subq_5.ds__day
           , subq_5.ds__week
           , subq_5.ds__month
@@ -102,6 +92,16 @@ FROM (
           , subq_5.booking__paid_at__extract_day
           , subq_5.booking__paid_at__extract_dow
           , subq_5.booking__paid_at__extract_doy
+          , subq_5.metric_time__week
+          , subq_5.metric_time__month
+          , subq_5.metric_time__quarter
+          , subq_5.metric_time__year
+          , subq_5.metric_time__extract_year
+          , subq_5.metric_time__extract_quarter
+          , subq_5.metric_time__extract_month
+          , subq_5.metric_time__extract_day
+          , subq_5.metric_time__extract_dow
+          , subq_5.metric_time__extract_doy
           , subq_5.listing
           , subq_5.guest
           , subq_5.host
@@ -128,16 +128,6 @@ FROM (
           -- Join to Custom Granularity Dataset
           SELECT
             subq_2.metric_time__day AS metric_time__day
-            , DATE_TRUNC('week', subq_2.metric_time__day) AS metric_time__week
-            , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('quarter', subq_2.metric_time__day) AS metric_time__quarter
-            , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-            , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-            , EXTRACT(isodow FROM subq_2.metric_time__day) AS metric_time__extract_dow
-            , EXTRACT(doy FROM subq_2.metric_time__day) AS metric_time__extract_doy
             , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
@@ -204,6 +194,16 @@ FROM (
             , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_1.metric_time__week AS metric_time__week
+            , subq_1.metric_time__month AS metric_time__month
+            , subq_1.metric_time__quarter AS metric_time__quarter
+            , subq_1.metric_time__year AS metric_time__year
+            , subq_1.metric_time__extract_year AS metric_time__extract_year
+            , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_1.metric_time__extract_month AS metric_time__extract_month
+            , subq_1.metric_time__extract_day AS metric_time__extract_day
+            , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_1.metric_time__extract_doy AS metric_time__extract_doy
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Postgres/test_offset_metric_with_custom_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Postgres/test_offset_metric_with_custom_granularity__plan0.sql
@@ -26,16 +26,6 @@ FROM (
         -- Join to Custom Granularity Dataset
         SELECT
           subq_2.booking__ds__day AS booking__ds__day
-          , DATE_TRUNC('week', subq_2.booking__ds__day) AS booking__ds__week
-          , DATE_TRUNC('month', subq_2.booking__ds__day) AS booking__ds__month
-          , DATE_TRUNC('quarter', subq_2.booking__ds__day) AS booking__ds__quarter
-          , DATE_TRUNC('year', subq_2.booking__ds__day) AS booking__ds__year
-          , EXTRACT(year FROM subq_2.booking__ds__day) AS booking__ds__extract_year
-          , EXTRACT(quarter FROM subq_2.booking__ds__day) AS booking__ds__extract_quarter
-          , EXTRACT(month FROM subq_2.booking__ds__day) AS booking__ds__extract_month
-          , EXTRACT(day FROM subq_2.booking__ds__day) AS booking__ds__extract_day
-          , EXTRACT(isodow FROM subq_2.booking__ds__day) AS booking__ds__extract_dow
-          , EXTRACT(doy FROM subq_2.booking__ds__day) AS booking__ds__extract_doy
           , subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
@@ -69,6 +59,16 @@ FROM (
           , subq_1.paid_at__extract_day AS paid_at__extract_day
           , subq_1.paid_at__extract_dow AS paid_at__extract_dow
           , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+          , subq_1.booking__ds__week AS booking__ds__week
+          , subq_1.booking__ds__month AS booking__ds__month
+          , subq_1.booking__ds__quarter AS booking__ds__quarter
+          , subq_1.booking__ds__year AS booking__ds__year
+          , subq_1.booking__ds__extract_year AS booking__ds__extract_year
+          , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
+          , subq_1.booking__ds__extract_month AS booking__ds__extract_month
+          , subq_1.booking__ds__extract_day AS booking__ds__extract_day
+          , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
+          , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
           , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
           , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
           , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Postgres/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Postgres/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
@@ -26,16 +26,6 @@ FROM (
         SELECT
           subq_5.metric_time__martian_day
           , subq_5.metric_time__day
-          , subq_5.metric_time__week
-          , subq_5.metric_time__month
-          , subq_5.metric_time__quarter
-          , subq_5.metric_time__year
-          , subq_5.metric_time__extract_year
-          , subq_5.metric_time__extract_quarter
-          , subq_5.metric_time__extract_month
-          , subq_5.metric_time__extract_day
-          , subq_5.metric_time__extract_dow
-          , subq_5.metric_time__extract_doy
           , subq_5.ds__day
           , subq_5.ds__week
           , subq_5.ds__month
@@ -102,6 +92,16 @@ FROM (
           , subq_5.booking__paid_at__extract_day
           , subq_5.booking__paid_at__extract_dow
           , subq_5.booking__paid_at__extract_doy
+          , subq_5.metric_time__week
+          , subq_5.metric_time__month
+          , subq_5.metric_time__quarter
+          , subq_5.metric_time__year
+          , subq_5.metric_time__extract_year
+          , subq_5.metric_time__extract_quarter
+          , subq_5.metric_time__extract_month
+          , subq_5.metric_time__extract_day
+          , subq_5.metric_time__extract_dow
+          , subq_5.metric_time__extract_doy
           , subq_5.listing
           , subq_5.guest
           , subq_5.host
@@ -128,16 +128,6 @@ FROM (
           -- Join to Custom Granularity Dataset
           SELECT
             subq_2.metric_time__day AS metric_time__day
-            , DATE_TRUNC('week', subq_2.metric_time__day) AS metric_time__week
-            , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('quarter', subq_2.metric_time__day) AS metric_time__quarter
-            , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-            , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-            , EXTRACT(isodow FROM subq_2.metric_time__day) AS metric_time__extract_dow
-            , EXTRACT(doy FROM subq_2.metric_time__day) AS metric_time__extract_doy
             , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
@@ -204,6 +194,16 @@ FROM (
             , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_1.metric_time__week AS metric_time__week
+            , subq_1.metric_time__month AS metric_time__month
+            , subq_1.metric_time__quarter AS metric_time__quarter
+            , subq_1.metric_time__year AS metric_time__year
+            , subq_1.metric_time__extract_year AS metric_time__extract_year
+            , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_1.metric_time__extract_month AS metric_time__extract_month
+            , subq_1.metric_time__extract_day AS metric_time__extract_day
+            , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_1.metric_time__extract_doy AS metric_time__extract_doy
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Redshift/test_offset_metric_with_custom_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Redshift/test_offset_metric_with_custom_granularity__plan0.sql
@@ -26,16 +26,6 @@ FROM (
         -- Join to Custom Granularity Dataset
         SELECT
           subq_2.booking__ds__day AS booking__ds__day
-          , DATE_TRUNC('week', subq_2.booking__ds__day) AS booking__ds__week
-          , DATE_TRUNC('month', subq_2.booking__ds__day) AS booking__ds__month
-          , DATE_TRUNC('quarter', subq_2.booking__ds__day) AS booking__ds__quarter
-          , DATE_TRUNC('year', subq_2.booking__ds__day) AS booking__ds__year
-          , EXTRACT(year FROM subq_2.booking__ds__day) AS booking__ds__extract_year
-          , EXTRACT(quarter FROM subq_2.booking__ds__day) AS booking__ds__extract_quarter
-          , EXTRACT(month FROM subq_2.booking__ds__day) AS booking__ds__extract_month
-          , EXTRACT(day FROM subq_2.booking__ds__day) AS booking__ds__extract_day
-          , CASE WHEN EXTRACT(dow FROM subq_2.booking__ds__day) = 0 THEN EXTRACT(dow FROM subq_2.booking__ds__day) + 7 ELSE EXTRACT(dow FROM subq_2.booking__ds__day) END AS booking__ds__extract_dow
-          , EXTRACT(doy FROM subq_2.booking__ds__day) AS booking__ds__extract_doy
           , subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
@@ -69,6 +59,16 @@ FROM (
           , subq_1.paid_at__extract_day AS paid_at__extract_day
           , subq_1.paid_at__extract_dow AS paid_at__extract_dow
           , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+          , subq_1.booking__ds__week AS booking__ds__week
+          , subq_1.booking__ds__month AS booking__ds__month
+          , subq_1.booking__ds__quarter AS booking__ds__quarter
+          , subq_1.booking__ds__year AS booking__ds__year
+          , subq_1.booking__ds__extract_year AS booking__ds__extract_year
+          , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
+          , subq_1.booking__ds__extract_month AS booking__ds__extract_month
+          , subq_1.booking__ds__extract_day AS booking__ds__extract_day
+          , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
+          , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
           , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
           , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
           , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Redshift/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Redshift/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
@@ -26,16 +26,6 @@ FROM (
         SELECT
           subq_5.metric_time__martian_day
           , subq_5.metric_time__day
-          , subq_5.metric_time__week
-          , subq_5.metric_time__month
-          , subq_5.metric_time__quarter
-          , subq_5.metric_time__year
-          , subq_5.metric_time__extract_year
-          , subq_5.metric_time__extract_quarter
-          , subq_5.metric_time__extract_month
-          , subq_5.metric_time__extract_day
-          , subq_5.metric_time__extract_dow
-          , subq_5.metric_time__extract_doy
           , subq_5.ds__day
           , subq_5.ds__week
           , subq_5.ds__month
@@ -102,6 +92,16 @@ FROM (
           , subq_5.booking__paid_at__extract_day
           , subq_5.booking__paid_at__extract_dow
           , subq_5.booking__paid_at__extract_doy
+          , subq_5.metric_time__week
+          , subq_5.metric_time__month
+          , subq_5.metric_time__quarter
+          , subq_5.metric_time__year
+          , subq_5.metric_time__extract_year
+          , subq_5.metric_time__extract_quarter
+          , subq_5.metric_time__extract_month
+          , subq_5.metric_time__extract_day
+          , subq_5.metric_time__extract_dow
+          , subq_5.metric_time__extract_doy
           , subq_5.listing
           , subq_5.guest
           , subq_5.host
@@ -128,16 +128,6 @@ FROM (
           -- Join to Custom Granularity Dataset
           SELECT
             subq_2.metric_time__day AS metric_time__day
-            , DATE_TRUNC('week', subq_2.metric_time__day) AS metric_time__week
-            , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('quarter', subq_2.metric_time__day) AS metric_time__quarter
-            , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-            , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-            , CASE WHEN EXTRACT(dow FROM subq_2.metric_time__day) = 0 THEN EXTRACT(dow FROM subq_2.metric_time__day) + 7 ELSE EXTRACT(dow FROM subq_2.metric_time__day) END AS metric_time__extract_dow
-            , EXTRACT(doy FROM subq_2.metric_time__day) AS metric_time__extract_doy
             , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
@@ -204,6 +194,16 @@ FROM (
             , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_1.metric_time__week AS metric_time__week
+            , subq_1.metric_time__month AS metric_time__month
+            , subq_1.metric_time__quarter AS metric_time__quarter
+            , subq_1.metric_time__year AS metric_time__year
+            , subq_1.metric_time__extract_year AS metric_time__extract_year
+            , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_1.metric_time__extract_month AS metric_time__extract_month
+            , subq_1.metric_time__extract_day AS metric_time__extract_day
+            , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_1.metric_time__extract_doy AS metric_time__extract_doy
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Snowflake/test_offset_metric_with_custom_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Snowflake/test_offset_metric_with_custom_granularity__plan0.sql
@@ -26,16 +26,6 @@ FROM (
         -- Join to Custom Granularity Dataset
         SELECT
           subq_2.booking__ds__day AS booking__ds__day
-          , DATE_TRUNC('week', subq_2.booking__ds__day) AS booking__ds__week
-          , DATE_TRUNC('month', subq_2.booking__ds__day) AS booking__ds__month
-          , DATE_TRUNC('quarter', subq_2.booking__ds__day) AS booking__ds__quarter
-          , DATE_TRUNC('year', subq_2.booking__ds__day) AS booking__ds__year
-          , EXTRACT(year FROM subq_2.booking__ds__day) AS booking__ds__extract_year
-          , EXTRACT(quarter FROM subq_2.booking__ds__day) AS booking__ds__extract_quarter
-          , EXTRACT(month FROM subq_2.booking__ds__day) AS booking__ds__extract_month
-          , EXTRACT(day FROM subq_2.booking__ds__day) AS booking__ds__extract_day
-          , EXTRACT(dayofweekiso FROM subq_2.booking__ds__day) AS booking__ds__extract_dow
-          , EXTRACT(doy FROM subq_2.booking__ds__day) AS booking__ds__extract_doy
           , subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
@@ -69,6 +59,16 @@ FROM (
           , subq_1.paid_at__extract_day AS paid_at__extract_day
           , subq_1.paid_at__extract_dow AS paid_at__extract_dow
           , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+          , subq_1.booking__ds__week AS booking__ds__week
+          , subq_1.booking__ds__month AS booking__ds__month
+          , subq_1.booking__ds__quarter AS booking__ds__quarter
+          , subq_1.booking__ds__year AS booking__ds__year
+          , subq_1.booking__ds__extract_year AS booking__ds__extract_year
+          , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
+          , subq_1.booking__ds__extract_month AS booking__ds__extract_month
+          , subq_1.booking__ds__extract_day AS booking__ds__extract_day
+          , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
+          , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
           , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
           , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
           , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Snowflake/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Snowflake/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
@@ -26,16 +26,6 @@ FROM (
         SELECT
           subq_5.metric_time__martian_day
           , subq_5.metric_time__day
-          , subq_5.metric_time__week
-          , subq_5.metric_time__month
-          , subq_5.metric_time__quarter
-          , subq_5.metric_time__year
-          , subq_5.metric_time__extract_year
-          , subq_5.metric_time__extract_quarter
-          , subq_5.metric_time__extract_month
-          , subq_5.metric_time__extract_day
-          , subq_5.metric_time__extract_dow
-          , subq_5.metric_time__extract_doy
           , subq_5.ds__day
           , subq_5.ds__week
           , subq_5.ds__month
@@ -102,6 +92,16 @@ FROM (
           , subq_5.booking__paid_at__extract_day
           , subq_5.booking__paid_at__extract_dow
           , subq_5.booking__paid_at__extract_doy
+          , subq_5.metric_time__week
+          , subq_5.metric_time__month
+          , subq_5.metric_time__quarter
+          , subq_5.metric_time__year
+          , subq_5.metric_time__extract_year
+          , subq_5.metric_time__extract_quarter
+          , subq_5.metric_time__extract_month
+          , subq_5.metric_time__extract_day
+          , subq_5.metric_time__extract_dow
+          , subq_5.metric_time__extract_doy
           , subq_5.listing
           , subq_5.guest
           , subq_5.host
@@ -128,16 +128,6 @@ FROM (
           -- Join to Custom Granularity Dataset
           SELECT
             subq_2.metric_time__day AS metric_time__day
-            , DATE_TRUNC('week', subq_2.metric_time__day) AS metric_time__week
-            , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('quarter', subq_2.metric_time__day) AS metric_time__quarter
-            , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-            , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-            , EXTRACT(dayofweekiso FROM subq_2.metric_time__day) AS metric_time__extract_dow
-            , EXTRACT(doy FROM subq_2.metric_time__day) AS metric_time__extract_doy
             , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
@@ -204,6 +194,16 @@ FROM (
             , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_1.metric_time__week AS metric_time__week
+            , subq_1.metric_time__month AS metric_time__month
+            , subq_1.metric_time__quarter AS metric_time__quarter
+            , subq_1.metric_time__year AS metric_time__year
+            , subq_1.metric_time__extract_year AS metric_time__extract_year
+            , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_1.metric_time__extract_month AS metric_time__extract_month
+            , subq_1.metric_time__extract_day AS metric_time__extract_day
+            , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_1.metric_time__extract_doy AS metric_time__extract_doy
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Trino/test_offset_metric_with_custom_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Trino/test_offset_metric_with_custom_granularity__plan0.sql
@@ -26,16 +26,6 @@ FROM (
         -- Join to Custom Granularity Dataset
         SELECT
           subq_2.booking__ds__day AS booking__ds__day
-          , DATE_TRUNC('week', subq_2.booking__ds__day) AS booking__ds__week
-          , DATE_TRUNC('month', subq_2.booking__ds__day) AS booking__ds__month
-          , DATE_TRUNC('quarter', subq_2.booking__ds__day) AS booking__ds__quarter
-          , DATE_TRUNC('year', subq_2.booking__ds__day) AS booking__ds__year
-          , EXTRACT(year FROM subq_2.booking__ds__day) AS booking__ds__extract_year
-          , EXTRACT(quarter FROM subq_2.booking__ds__day) AS booking__ds__extract_quarter
-          , EXTRACT(month FROM subq_2.booking__ds__day) AS booking__ds__extract_month
-          , EXTRACT(day FROM subq_2.booking__ds__day) AS booking__ds__extract_day
-          , EXTRACT(DAY_OF_WEEK FROM subq_2.booking__ds__day) AS booking__ds__extract_dow
-          , EXTRACT(doy FROM subq_2.booking__ds__day) AS booking__ds__extract_doy
           , subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
@@ -69,6 +59,16 @@ FROM (
           , subq_1.paid_at__extract_day AS paid_at__extract_day
           , subq_1.paid_at__extract_dow AS paid_at__extract_dow
           , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+          , subq_1.booking__ds__week AS booking__ds__week
+          , subq_1.booking__ds__month AS booking__ds__month
+          , subq_1.booking__ds__quarter AS booking__ds__quarter
+          , subq_1.booking__ds__year AS booking__ds__year
+          , subq_1.booking__ds__extract_year AS booking__ds__extract_year
+          , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
+          , subq_1.booking__ds__extract_month AS booking__ds__extract_month
+          , subq_1.booking__ds__extract_day AS booking__ds__extract_day
+          , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
+          , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
           , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
           , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
           , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Trino/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Trino/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
@@ -26,16 +26,6 @@ FROM (
         SELECT
           subq_5.metric_time__martian_day
           , subq_5.metric_time__day
-          , subq_5.metric_time__week
-          , subq_5.metric_time__month
-          , subq_5.metric_time__quarter
-          , subq_5.metric_time__year
-          , subq_5.metric_time__extract_year
-          , subq_5.metric_time__extract_quarter
-          , subq_5.metric_time__extract_month
-          , subq_5.metric_time__extract_day
-          , subq_5.metric_time__extract_dow
-          , subq_5.metric_time__extract_doy
           , subq_5.ds__day
           , subq_5.ds__week
           , subq_5.ds__month
@@ -102,6 +92,16 @@ FROM (
           , subq_5.booking__paid_at__extract_day
           , subq_5.booking__paid_at__extract_dow
           , subq_5.booking__paid_at__extract_doy
+          , subq_5.metric_time__week
+          , subq_5.metric_time__month
+          , subq_5.metric_time__quarter
+          , subq_5.metric_time__year
+          , subq_5.metric_time__extract_year
+          , subq_5.metric_time__extract_quarter
+          , subq_5.metric_time__extract_month
+          , subq_5.metric_time__extract_day
+          , subq_5.metric_time__extract_dow
+          , subq_5.metric_time__extract_doy
           , subq_5.listing
           , subq_5.guest
           , subq_5.host
@@ -128,16 +128,6 @@ FROM (
           -- Join to Custom Granularity Dataset
           SELECT
             subq_2.metric_time__day AS metric_time__day
-            , DATE_TRUNC('week', subq_2.metric_time__day) AS metric_time__week
-            , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('quarter', subq_2.metric_time__day) AS metric_time__quarter
-            , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-            , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-            , EXTRACT(DAY_OF_WEEK FROM subq_2.metric_time__day) AS metric_time__extract_dow
-            , EXTRACT(doy FROM subq_2.metric_time__day) AS metric_time__extract_doy
             , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
@@ -204,6 +194,16 @@ FROM (
             , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_1.metric_time__week AS metric_time__week
+            , subq_1.metric_time__month AS metric_time__month
+            , subq_1.metric_time__quarter AS metric_time__quarter
+            , subq_1.metric_time__year AS metric_time__year
+            , subq_1.metric_time__extract_year AS metric_time__extract_year
+            , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_1.metric_time__extract_month AS metric_time__extract_month
+            , subq_1.metric_time__extract_day AS metric_time__extract_day
+            , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_1.metric_time__extract_doy AS metric_time__extract_doy
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
@@ -25,16 +25,6 @@ FROM (
         -- Constrain Time Range to [2019-12-19T00:00:00, 2020-01-02T00:00:00]
         SELECT
           subq_7.metric_time__day
-          , subq_7.metric_time__week
-          , subq_7.metric_time__month
-          , subq_7.metric_time__quarter
-          , subq_7.metric_time__year
-          , subq_7.metric_time__extract_year
-          , subq_7.metric_time__extract_quarter
-          , subq_7.metric_time__extract_month
-          , subq_7.metric_time__extract_day
-          , subq_7.metric_time__extract_dow
-          , subq_7.metric_time__extract_doy
           , subq_7.ds__day
           , subq_7.ds__week
           , subq_7.ds__month
@@ -101,6 +91,16 @@ FROM (
           , subq_7.booking__paid_at__extract_day
           , subq_7.booking__paid_at__extract_dow
           , subq_7.booking__paid_at__extract_doy
+          , subq_7.metric_time__week
+          , subq_7.metric_time__month
+          , subq_7.metric_time__quarter
+          , subq_7.metric_time__year
+          , subq_7.metric_time__extract_year
+          , subq_7.metric_time__extract_quarter
+          , subq_7.metric_time__extract_month
+          , subq_7.metric_time__extract_day
+          , subq_7.metric_time__extract_dow
+          , subq_7.metric_time__extract_doy
           , subq_7.listing
           , subq_7.guest
           , subq_7.host
@@ -126,16 +126,6 @@ FROM (
           -- Join to Time Spine Dataset
           SELECT
             subq_5.metric_time__day AS metric_time__day
-            , DATETIME_TRUNC(subq_5.metric_time__day, isoweek) AS metric_time__week
-            , DATETIME_TRUNC(subq_5.metric_time__day, month) AS metric_time__month
-            , DATETIME_TRUNC(subq_5.metric_time__day, quarter) AS metric_time__quarter
-            , DATETIME_TRUNC(subq_5.metric_time__day, year) AS metric_time__year
-            , EXTRACT(year FROM subq_5.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_5.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_5.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_5.metric_time__day) AS metric_time__extract_day
-            , IF(EXTRACT(dayofweek FROM subq_5.metric_time__day) = 1, 7, EXTRACT(dayofweek FROM subq_5.metric_time__day) - 1) AS metric_time__extract_dow
-            , EXTRACT(dayofyear FROM subq_5.metric_time__day) AS metric_time__extract_doy
             , subq_4.ds__day AS ds__day
             , subq_4.ds__week AS ds__week
             , subq_4.ds__month AS ds__month
@@ -202,6 +192,16 @@ FROM (
             , subq_4.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_4.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_4.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_4.metric_time__week AS metric_time__week
+            , subq_4.metric_time__month AS metric_time__month
+            , subq_4.metric_time__quarter AS metric_time__quarter
+            , subq_4.metric_time__year AS metric_time__year
+            , subq_4.metric_time__extract_year AS metric_time__extract_year
+            , subq_4.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_4.metric_time__extract_month AS metric_time__extract_month
+            , subq_4.metric_time__extract_day AS metric_time__extract_day
+            , subq_4.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_4.metric_time__extract_doy AS metric_time__extract_doy
             , subq_4.listing AS listing
             , subq_4.guest AS guest
             , subq_4.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
@@ -25,11 +25,6 @@ FROM (
         -- Join to Time Spine Dataset
         SELECT
           subq_2.metric_time__month AS metric_time__month
-          , DATETIME_TRUNC(subq_2.metric_time__month, quarter) AS metric_time__quarter
-          , DATETIME_TRUNC(subq_2.metric_time__month, year) AS metric_time__year
-          , EXTRACT(year FROM subq_2.metric_time__month) AS metric_time__extract_year
-          , EXTRACT(quarter FROM subq_2.metric_time__month) AS metric_time__extract_quarter
-          , EXTRACT(month FROM subq_2.metric_time__month) AS metric_time__extract_month
           , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
           , subq_1.ds__year AS ds__year
@@ -42,6 +37,11 @@ FROM (
           , subq_1.booking_monthly__ds__extract_year AS booking_monthly__ds__extract_year
           , subq_1.booking_monthly__ds__extract_quarter AS booking_monthly__ds__extract_quarter
           , subq_1.booking_monthly__ds__extract_month AS booking_monthly__ds__extract_month
+          , subq_1.metric_time__quarter AS metric_time__quarter
+          , subq_1.metric_time__year AS metric_time__year
+          , subq_1.metric_time__extract_year AS metric_time__extract_year
+          , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_1.metric_time__extract_month AS metric_time__extract_month
           , subq_1.listing AS listing
           , subq_1.booking_monthly__listing AS booking_monthly__listing
           , subq_1.bookings_monthly AS bookings_monthly

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_to_grain__plan0.sql
@@ -246,16 +246,6 @@ FROM (
           -- Join to Time Spine Dataset
           SELECT
             subq_7.metric_time__day AS metric_time__day
-            , DATETIME_TRUNC(subq_7.metric_time__day, isoweek) AS metric_time__week
-            , DATETIME_TRUNC(subq_7.metric_time__day, month) AS metric_time__month
-            , DATETIME_TRUNC(subq_7.metric_time__day, quarter) AS metric_time__quarter
-            , DATETIME_TRUNC(subq_7.metric_time__day, year) AS metric_time__year
-            , EXTRACT(year FROM subq_7.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_7.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_7.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_7.metric_time__day) AS metric_time__extract_day
-            , IF(EXTRACT(dayofweek FROM subq_7.metric_time__day) = 1, 7, EXTRACT(dayofweek FROM subq_7.metric_time__day) - 1) AS metric_time__extract_dow
-            , EXTRACT(dayofyear FROM subq_7.metric_time__day) AS metric_time__extract_doy
             , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
@@ -322,6 +312,16 @@ FROM (
             , subq_6.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_6.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_6.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_6.metric_time__week AS metric_time__week
+            , subq_6.metric_time__month AS metric_time__month
+            , subq_6.metric_time__quarter AS metric_time__quarter
+            , subq_6.metric_time__year AS metric_time__year
+            , subq_6.metric_time__extract_year AS metric_time__extract_year
+            , subq_6.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_6.metric_time__extract_month AS metric_time__extract_month
+            , subq_6.metric_time__extract_day AS metric_time__extract_day
+            , subq_6.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_6.metric_time__extract_doy AS metric_time__extract_doy
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_to_grain_and_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_to_grain_and_granularity__plan0.sql
@@ -245,17 +245,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_7.metric_time__day AS metric_time__day
-            , DATETIME_TRUNC(subq_7.metric_time__day, isoweek) AS metric_time__week
-            , DATETIME_TRUNC(subq_7.metric_time__day, month) AS metric_time__month
-            , DATETIME_TRUNC(subq_7.metric_time__day, quarter) AS metric_time__quarter
-            , DATETIME_TRUNC(subq_7.metric_time__day, year) AS metric_time__year
-            , EXTRACT(year FROM subq_7.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_7.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_7.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_7.metric_time__day) AS metric_time__extract_day
-            , IF(EXTRACT(dayofweek FROM subq_7.metric_time__day) = 1, 7, EXTRACT(dayofweek FROM subq_7.metric_time__day) - 1) AS metric_time__extract_dow
-            , EXTRACT(dayofyear FROM subq_7.metric_time__day) AS metric_time__extract_doy
+            DATETIME_TRUNC(subq_7.metric_time__day, isoweek) AS metric_time__week
             , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
@@ -322,6 +312,16 @@ FROM (
             , subq_6.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_6.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_6.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_6.metric_time__day AS metric_time__day
+            , subq_6.metric_time__month AS metric_time__month
+            , subq_6.metric_time__quarter AS metric_time__quarter
+            , subq_6.metric_time__year AS metric_time__year
+            , subq_6.metric_time__extract_year AS metric_time__extract_year
+            , subq_6.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_6.metric_time__extract_month AS metric_time__extract_month
+            , subq_6.metric_time__extract_day AS metric_time__extract_day
+            , subq_6.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_6.metric_time__extract_doy AS metric_time__extract_doy
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_window__plan0.sql
@@ -246,16 +246,6 @@ FROM (
           -- Join to Time Spine Dataset
           SELECT
             subq_7.metric_time__day AS metric_time__day
-            , DATETIME_TRUNC(subq_7.metric_time__day, isoweek) AS metric_time__week
-            , DATETIME_TRUNC(subq_7.metric_time__day, month) AS metric_time__month
-            , DATETIME_TRUNC(subq_7.metric_time__day, quarter) AS metric_time__quarter
-            , DATETIME_TRUNC(subq_7.metric_time__day, year) AS metric_time__year
-            , EXTRACT(year FROM subq_7.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_7.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_7.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_7.metric_time__day) AS metric_time__extract_day
-            , IF(EXTRACT(dayofweek FROM subq_7.metric_time__day) = 1, 7, EXTRACT(dayofweek FROM subq_7.metric_time__day) - 1) AS metric_time__extract_dow
-            , EXTRACT(dayofyear FROM subq_7.metric_time__day) AS metric_time__extract_doy
             , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
@@ -322,6 +312,16 @@ FROM (
             , subq_6.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_6.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_6.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_6.metric_time__week AS metric_time__week
+            , subq_6.metric_time__month AS metric_time__month
+            , subq_6.metric_time__quarter AS metric_time__quarter
+            , subq_6.metric_time__year AS metric_time__year
+            , subq_6.metric_time__extract_year AS metric_time__extract_year
+            , subq_6.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_6.metric_time__extract_month AS metric_time__extract_month
+            , subq_6.metric_time__extract_day AS metric_time__extract_day
+            , subq_6.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_6.metric_time__extract_doy AS metric_time__extract_doy
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_window_and_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_window_and_granularity__plan0.sql
@@ -245,17 +245,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_7.metric_time__day AS metric_time__day
-            , DATETIME_TRUNC(subq_7.metric_time__day, isoweek) AS metric_time__week
-            , DATETIME_TRUNC(subq_7.metric_time__day, month) AS metric_time__month
-            , DATETIME_TRUNC(subq_7.metric_time__day, quarter) AS metric_time__quarter
-            , DATETIME_TRUNC(subq_7.metric_time__day, year) AS metric_time__year
-            , EXTRACT(year FROM subq_7.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_7.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_7.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_7.metric_time__day) AS metric_time__extract_day
-            , IF(EXTRACT(dayofweek FROM subq_7.metric_time__day) = 1, 7, EXTRACT(dayofweek FROM subq_7.metric_time__day) - 1) AS metric_time__extract_dow
-            , EXTRACT(dayofyear FROM subq_7.metric_time__day) AS metric_time__extract_doy
+            DATETIME_TRUNC(subq_7.metric_time__day, quarter) AS metric_time__quarter
             , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
@@ -322,6 +312,16 @@ FROM (
             , subq_6.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_6.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_6.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_6.metric_time__day AS metric_time__day
+            , subq_6.metric_time__week AS metric_time__week
+            , subq_6.metric_time__month AS metric_time__month
+            , subq_6.metric_time__year AS metric_time__year
+            , subq_6.metric_time__extract_year AS metric_time__extract_year
+            , subq_6.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_6.metric_time__extract_month AS metric_time__extract_month
+            , subq_6.metric_time__extract_day AS metric_time__extract_day
+            , subq_6.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_6.metric_time__extract_doy AS metric_time__extract_doy
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
@@ -31,16 +31,6 @@ FROM (
           -- Join to Time Spine Dataset
           SELECT
             subq_2.metric_time__day AS metric_time__day
-            , DATETIME_TRUNC(subq_2.metric_time__day, isoweek) AS metric_time__week
-            , DATETIME_TRUNC(subq_2.metric_time__day, month) AS metric_time__month
-            , DATETIME_TRUNC(subq_2.metric_time__day, quarter) AS metric_time__quarter
-            , DATETIME_TRUNC(subq_2.metric_time__day, year) AS metric_time__year
-            , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-            , IF(EXTRACT(dayofweek FROM subq_2.metric_time__day) = 1, 7, EXTRACT(dayofweek FROM subq_2.metric_time__day) - 1) AS metric_time__extract_dow
-            , EXTRACT(dayofyear FROM subq_2.metric_time__day) AS metric_time__extract_doy
             , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
@@ -107,6 +97,16 @@ FROM (
             , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_1.metric_time__week AS metric_time__week
+            , subq_1.metric_time__month AS metric_time__month
+            , subq_1.metric_time__quarter AS metric_time__quarter
+            , subq_1.metric_time__year AS metric_time__year
+            , subq_1.metric_time__extract_year AS metric_time__extract_year
+            , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_1.metric_time__extract_month AS metric_time__extract_month
+            , subq_1.metric_time__extract_day AS metric_time__extract_day
+            , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_1.metric_time__extract_doy AS metric_time__extract_doy
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host
@@ -356,16 +356,6 @@ FROM (
           -- Join to Time Spine Dataset
           SELECT
             subq_10.metric_time__day AS metric_time__day
-            , DATETIME_TRUNC(subq_10.metric_time__day, isoweek) AS metric_time__week
-            , DATETIME_TRUNC(subq_10.metric_time__day, month) AS metric_time__month
-            , DATETIME_TRUNC(subq_10.metric_time__day, quarter) AS metric_time__quarter
-            , DATETIME_TRUNC(subq_10.metric_time__day, year) AS metric_time__year
-            , EXTRACT(year FROM subq_10.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_10.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_10.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_10.metric_time__day) AS metric_time__extract_day
-            , IF(EXTRACT(dayofweek FROM subq_10.metric_time__day) = 1, 7, EXTRACT(dayofweek FROM subq_10.metric_time__day) - 1) AS metric_time__extract_dow
-            , EXTRACT(dayofyear FROM subq_10.metric_time__day) AS metric_time__extract_doy
             , subq_9.ds__day AS ds__day
             , subq_9.ds__week AS ds__week
             , subq_9.ds__month AS ds__month
@@ -432,6 +422,16 @@ FROM (
             , subq_9.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_9.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_9.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_9.metric_time__week AS metric_time__week
+            , subq_9.metric_time__month AS metric_time__month
+            , subq_9.metric_time__quarter AS metric_time__quarter
+            , subq_9.metric_time__year AS metric_time__year
+            , subq_9.metric_time__extract_year AS metric_time__extract_year
+            , subq_9.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_9.metric_time__extract_month AS metric_time__extract_month
+            , subq_9.metric_time__extract_day AS metric_time__extract_day
+            , subq_9.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_9.metric_time__extract_doy AS metric_time__extract_doy
             , subq_9.listing AS listing
             , subq_9.guest AS guest
             , subq_9.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0.sql
@@ -30,17 +30,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_2.metric_time__day AS metric_time__day
-            , DATETIME_TRUNC(subq_2.metric_time__day, isoweek) AS metric_time__week
-            , DATETIME_TRUNC(subq_2.metric_time__day, month) AS metric_time__month
-            , DATETIME_TRUNC(subq_2.metric_time__day, quarter) AS metric_time__quarter
-            , DATETIME_TRUNC(subq_2.metric_time__day, year) AS metric_time__year
-            , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-            , IF(EXTRACT(dayofweek FROM subq_2.metric_time__day) = 1, 7, EXTRACT(dayofweek FROM subq_2.metric_time__day) - 1) AS metric_time__extract_dow
-            , EXTRACT(dayofyear FROM subq_2.metric_time__day) AS metric_time__extract_doy
+            DATETIME_TRUNC(subq_2.metric_time__day, year) AS metric_time__year
             , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
@@ -107,6 +97,16 @@ FROM (
             , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_1.metric_time__day AS metric_time__day
+            , subq_1.metric_time__week AS metric_time__week
+            , subq_1.metric_time__month AS metric_time__month
+            , subq_1.metric_time__quarter AS metric_time__quarter
+            , subq_1.metric_time__extract_year AS metric_time__extract_year
+            , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_1.metric_time__extract_month AS metric_time__extract_month
+            , subq_1.metric_time__extract_day AS metric_time__extract_day
+            , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_1.metric_time__extract_doy AS metric_time__extract_doy
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host
@@ -356,17 +356,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_10.metric_time__day AS metric_time__day
-            , DATETIME_TRUNC(subq_10.metric_time__day, isoweek) AS metric_time__week
-            , DATETIME_TRUNC(subq_10.metric_time__day, month) AS metric_time__month
-            , DATETIME_TRUNC(subq_10.metric_time__day, quarter) AS metric_time__quarter
-            , DATETIME_TRUNC(subq_10.metric_time__day, year) AS metric_time__year
-            , EXTRACT(year FROM subq_10.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_10.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_10.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_10.metric_time__day) AS metric_time__extract_day
-            , IF(EXTRACT(dayofweek FROM subq_10.metric_time__day) = 1, 7, EXTRACT(dayofweek FROM subq_10.metric_time__day) - 1) AS metric_time__extract_dow
-            , EXTRACT(dayofyear FROM subq_10.metric_time__day) AS metric_time__extract_doy
+            DATETIME_TRUNC(subq_10.metric_time__day, year) AS metric_time__year
             , subq_9.ds__day AS ds__day
             , subq_9.ds__week AS ds__week
             , subq_9.ds__month AS ds__month
@@ -433,6 +423,16 @@ FROM (
             , subq_9.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_9.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_9.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_9.metric_time__day AS metric_time__day
+            , subq_9.metric_time__week AS metric_time__week
+            , subq_9.metric_time__month AS metric_time__month
+            , subq_9.metric_time__quarter AS metric_time__quarter
+            , subq_9.metric_time__extract_year AS metric_time__extract_year
+            , subq_9.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_9.metric_time__extract_month AS metric_time__extract_month
+            , subq_9.metric_time__extract_day AS metric_time__extract_day
+            , subq_9.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_9.metric_time__extract_doy AS metric_time__extract_doy
             , subq_9.listing AS listing
             , subq_9.guest AS guest
             , subq_9.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
@@ -349,16 +349,6 @@ FROM (
           -- Constrain Output with WHERE
           SELECT
             subq_10.metric_time__day
-            , subq_10.metric_time__week
-            , subq_10.metric_time__month
-            , subq_10.metric_time__quarter
-            , subq_10.metric_time__year
-            , subq_10.metric_time__extract_year
-            , subq_10.metric_time__extract_quarter
-            , subq_10.metric_time__extract_month
-            , subq_10.metric_time__extract_day
-            , subq_10.metric_time__extract_dow
-            , subq_10.metric_time__extract_doy
             , subq_10.ds__day
             , subq_10.ds__week
             , subq_10.ds__month
@@ -425,6 +415,16 @@ FROM (
             , subq_10.booking__paid_at__extract_day
             , subq_10.booking__paid_at__extract_dow
             , subq_10.booking__paid_at__extract_doy
+            , subq_10.metric_time__week
+            , subq_10.metric_time__month
+            , subq_10.metric_time__quarter
+            , subq_10.metric_time__year
+            , subq_10.metric_time__extract_year
+            , subq_10.metric_time__extract_quarter
+            , subq_10.metric_time__extract_month
+            , subq_10.metric_time__extract_day
+            , subq_10.metric_time__extract_dow
+            , subq_10.metric_time__extract_doy
             , subq_10.listing
             , subq_10.guest
             , subq_10.host
@@ -450,16 +450,6 @@ FROM (
             -- Join to Time Spine Dataset
             SELECT
               subq_8.metric_time__day AS metric_time__day
-              , DATETIME_TRUNC(subq_8.metric_time__day, isoweek) AS metric_time__week
-              , DATETIME_TRUNC(subq_8.metric_time__day, month) AS metric_time__month
-              , DATETIME_TRUNC(subq_8.metric_time__day, quarter) AS metric_time__quarter
-              , DATETIME_TRUNC(subq_8.metric_time__day, year) AS metric_time__year
-              , EXTRACT(year FROM subq_8.metric_time__day) AS metric_time__extract_year
-              , EXTRACT(quarter FROM subq_8.metric_time__day) AS metric_time__extract_quarter
-              , EXTRACT(month FROM subq_8.metric_time__day) AS metric_time__extract_month
-              , EXTRACT(day FROM subq_8.metric_time__day) AS metric_time__extract_day
-              , IF(EXTRACT(dayofweek FROM subq_8.metric_time__day) = 1, 7, EXTRACT(dayofweek FROM subq_8.metric_time__day) - 1) AS metric_time__extract_dow
-              , EXTRACT(dayofyear FROM subq_8.metric_time__day) AS metric_time__extract_doy
               , subq_7.ds__day AS ds__day
               , subq_7.ds__week AS ds__week
               , subq_7.ds__month AS ds__month
@@ -526,6 +516,16 @@ FROM (
               , subq_7.booking__paid_at__extract_day AS booking__paid_at__extract_day
               , subq_7.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
               , subq_7.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+              , subq_7.metric_time__week AS metric_time__week
+              , subq_7.metric_time__month AS metric_time__month
+              , subq_7.metric_time__quarter AS metric_time__quarter
+              , subq_7.metric_time__year AS metric_time__year
+              , subq_7.metric_time__extract_year AS metric_time__extract_year
+              , subq_7.metric_time__extract_quarter AS metric_time__extract_quarter
+              , subq_7.metric_time__extract_month AS metric_time__extract_month
+              , subq_7.metric_time__extract_day AS metric_time__extract_day
+              , subq_7.metric_time__extract_dow AS metric_time__extract_dow
+              , subq_7.metric_time__extract_doy AS metric_time__extract_doy
               , subq_7.listing AS listing
               , subq_7.guest AS guest
               , subq_7.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_offset_cumulative_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_offset_cumulative_metric__plan0.sql
@@ -25,16 +25,6 @@ FROM (
         -- Join to Time Spine Dataset
         SELECT
           subq_5.metric_time__day AS metric_time__day
-          , DATETIME_TRUNC(subq_5.metric_time__day, isoweek) AS metric_time__week
-          , DATETIME_TRUNC(subq_5.metric_time__day, month) AS metric_time__month
-          , DATETIME_TRUNC(subq_5.metric_time__day, quarter) AS metric_time__quarter
-          , DATETIME_TRUNC(subq_5.metric_time__day, year) AS metric_time__year
-          , EXTRACT(year FROM subq_5.metric_time__day) AS metric_time__extract_year
-          , EXTRACT(quarter FROM subq_5.metric_time__day) AS metric_time__extract_quarter
-          , EXTRACT(month FROM subq_5.metric_time__day) AS metric_time__extract_month
-          , EXTRACT(day FROM subq_5.metric_time__day) AS metric_time__extract_day
-          , IF(EXTRACT(dayofweek FROM subq_5.metric_time__day) = 1, 7, EXTRACT(dayofweek FROM subq_5.metric_time__day) - 1) AS metric_time__extract_dow
-          , EXTRACT(dayofyear FROM subq_5.metric_time__day) AS metric_time__extract_doy
           , subq_4.ds__day AS ds__day
           , subq_4.ds__week AS ds__week
           , subq_4.ds__month AS ds__month
@@ -101,6 +91,16 @@ FROM (
           , subq_4.booking__paid_at__extract_day AS booking__paid_at__extract_day
           , subq_4.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
           , subq_4.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+          , subq_4.metric_time__week AS metric_time__week
+          , subq_4.metric_time__month AS metric_time__month
+          , subq_4.metric_time__quarter AS metric_time__quarter
+          , subq_4.metric_time__year AS metric_time__year
+          , subq_4.metric_time__extract_year AS metric_time__extract_year
+          , subq_4.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_4.metric_time__extract_month AS metric_time__extract_month
+          , subq_4.metric_time__extract_day AS metric_time__extract_day
+          , subq_4.metric_time__extract_dow AS metric_time__extract_dow
+          , subq_4.metric_time__extract_doy AS metric_time__extract_doy
           , subq_4.listing AS listing
           , subq_4.guest AS guest
           , subq_4.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_offset_metric_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_offset_metric_with_agg_time_dim__plan0.sql
@@ -31,16 +31,6 @@ FROM (
           -- Join to Time Spine Dataset
           SELECT
             subq_2.booking__ds__day AS booking__ds__day
-            , DATETIME_TRUNC(subq_2.booking__ds__day, isoweek) AS booking__ds__week
-            , DATETIME_TRUNC(subq_2.booking__ds__day, month) AS booking__ds__month
-            , DATETIME_TRUNC(subq_2.booking__ds__day, quarter) AS booking__ds__quarter
-            , DATETIME_TRUNC(subq_2.booking__ds__day, year) AS booking__ds__year
-            , EXTRACT(year FROM subq_2.booking__ds__day) AS booking__ds__extract_year
-            , EXTRACT(quarter FROM subq_2.booking__ds__day) AS booking__ds__extract_quarter
-            , EXTRACT(month FROM subq_2.booking__ds__day) AS booking__ds__extract_month
-            , EXTRACT(day FROM subq_2.booking__ds__day) AS booking__ds__extract_day
-            , IF(EXTRACT(dayofweek FROM subq_2.booking__ds__day) = 1, 7, EXTRACT(dayofweek FROM subq_2.booking__ds__day) - 1) AS booking__ds__extract_dow
-            , EXTRACT(dayofyear FROM subq_2.booking__ds__day) AS booking__ds__extract_doy
             , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
@@ -74,6 +64,16 @@ FROM (
             , subq_1.paid_at__extract_day AS paid_at__extract_day
             , subq_1.paid_at__extract_dow AS paid_at__extract_dow
             , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+            , subq_1.booking__ds__week AS booking__ds__week
+            , subq_1.booking__ds__month AS booking__ds__month
+            , subq_1.booking__ds__quarter AS booking__ds__quarter
+            , subq_1.booking__ds__year AS booking__ds__year
+            , subq_1.booking__ds__extract_year AS booking__ds__extract_year
+            , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
+            , subq_1.booking__ds__extract_month AS booking__ds__extract_month
+            , subq_1.booking__ds__extract_day AS booking__ds__extract_day
+            , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
+            , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
             , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
             , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
             , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_offset_metric_with_one_input_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_offset_metric_with_one_input_metric__plan0.sql
@@ -25,16 +25,6 @@ FROM (
         -- Join to Time Spine Dataset
         SELECT
           subq_2.metric_time__day AS metric_time__day
-          , DATETIME_TRUNC(subq_2.metric_time__day, isoweek) AS metric_time__week
-          , DATETIME_TRUNC(subq_2.metric_time__day, month) AS metric_time__month
-          , DATETIME_TRUNC(subq_2.metric_time__day, quarter) AS metric_time__quarter
-          , DATETIME_TRUNC(subq_2.metric_time__day, year) AS metric_time__year
-          , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-          , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-          , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-          , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-          , IF(EXTRACT(dayofweek FROM subq_2.metric_time__day) = 1, 7, EXTRACT(dayofweek FROM subq_2.metric_time__day) - 1) AS metric_time__extract_dow
-          , EXTRACT(dayofyear FROM subq_2.metric_time__day) AS metric_time__extract_doy
           , subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
@@ -101,6 +91,16 @@ FROM (
           , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
           , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
           , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+          , subq_1.metric_time__week AS metric_time__week
+          , subq_1.metric_time__month AS metric_time__month
+          , subq_1.metric_time__quarter AS metric_time__quarter
+          , subq_1.metric_time__year AS metric_time__year
+          , subq_1.metric_time__extract_year AS metric_time__extract_year
+          , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_1.metric_time__extract_month AS metric_time__extract_month
+          , subq_1.metric_time__extract_day AS metric_time__extract_day
+          , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+          , subq_1.metric_time__extract_doy AS metric_time__extract_doy
           , subq_1.listing AS listing
           , subq_1.guest AS guest
           , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0.sql
@@ -57,16 +57,6 @@ FROM (
                 -- Join to Time Spine Dataset
                 SELECT
                   subq_2.metric_time__day AS metric_time__day
-                  , DATETIME_TRUNC(subq_2.metric_time__day, isoweek) AS metric_time__week
-                  , DATETIME_TRUNC(subq_2.metric_time__day, month) AS metric_time__month
-                  , DATETIME_TRUNC(subq_2.metric_time__day, quarter) AS metric_time__quarter
-                  , DATETIME_TRUNC(subq_2.metric_time__day, year) AS metric_time__year
-                  , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-                  , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-                  , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-                  , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-                  , IF(EXTRACT(dayofweek FROM subq_2.metric_time__day) = 1, 7, EXTRACT(dayofweek FROM subq_2.metric_time__day) - 1) AS metric_time__extract_dow
-                  , EXTRACT(dayofyear FROM subq_2.metric_time__day) AS metric_time__extract_doy
                   , subq_1.ds__day AS ds__day
                   , subq_1.ds__week AS ds__week
                   , subq_1.ds__month AS ds__month
@@ -133,6 +123,16 @@ FROM (
                   , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
                   , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
                   , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                  , subq_1.metric_time__week AS metric_time__week
+                  , subq_1.metric_time__month AS metric_time__month
+                  , subq_1.metric_time__quarter AS metric_time__quarter
+                  , subq_1.metric_time__year AS metric_time__year
+                  , subq_1.metric_time__extract_year AS metric_time__extract_year
+                  , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+                  , subq_1.metric_time__extract_month AS metric_time__extract_month
+                  , subq_1.metric_time__extract_day AS metric_time__extract_day
+                  , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+                  , subq_1.metric_time__extract_doy AS metric_time__extract_doy
                   , subq_1.listing AS listing
                   , subq_1.guest AS guest
                   , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_offsets__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_offsets__plan0.sql
@@ -41,16 +41,6 @@ FROM (
             -- Join to Time Spine Dataset
             SELECT
               subq_2.metric_time__day AS metric_time__day
-              , DATETIME_TRUNC(subq_2.metric_time__day, isoweek) AS metric_time__week
-              , DATETIME_TRUNC(subq_2.metric_time__day, month) AS metric_time__month
-              , DATETIME_TRUNC(subq_2.metric_time__day, quarter) AS metric_time__quarter
-              , DATETIME_TRUNC(subq_2.metric_time__day, year) AS metric_time__year
-              , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-              , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-              , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-              , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-              , IF(EXTRACT(dayofweek FROM subq_2.metric_time__day) = 1, 7, EXTRACT(dayofweek FROM subq_2.metric_time__day) - 1) AS metric_time__extract_dow
-              , EXTRACT(dayofyear FROM subq_2.metric_time__day) AS metric_time__extract_doy
               , subq_1.ds__day AS ds__day
               , subq_1.ds__week AS ds__week
               , subq_1.ds__month AS ds__month
@@ -117,6 +107,16 @@ FROM (
               , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
               , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
               , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+              , subq_1.metric_time__week AS metric_time__week
+              , subq_1.metric_time__month AS metric_time__month
+              , subq_1.metric_time__quarter AS metric_time__quarter
+              , subq_1.metric_time__year AS metric_time__year
+              , subq_1.metric_time__extract_year AS metric_time__extract_year
+              , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+              , subq_1.metric_time__extract_month AS metric_time__extract_month
+              , subq_1.metric_time__extract_day AS metric_time__extract_day
+              , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+              , subq_1.metric_time__extract_doy AS metric_time__extract_doy
               , subq_1.listing AS listing
               , subq_1.guest AS guest
               , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_offsets_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_offsets_with_time_constraint__plan0.sql
@@ -42,16 +42,6 @@ FROM (
             -- Join to Time Spine Dataset
             SELECT
               subq_2.metric_time__day AS metric_time__day
-              , DATETIME_TRUNC(subq_2.metric_time__day, isoweek) AS metric_time__week
-              , DATETIME_TRUNC(subq_2.metric_time__day, month) AS metric_time__month
-              , DATETIME_TRUNC(subq_2.metric_time__day, quarter) AS metric_time__quarter
-              , DATETIME_TRUNC(subq_2.metric_time__day, year) AS metric_time__year
-              , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-              , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-              , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-              , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-              , IF(EXTRACT(dayofweek FROM subq_2.metric_time__day) = 1, 7, EXTRACT(dayofweek FROM subq_2.metric_time__day) - 1) AS metric_time__extract_dow
-              , EXTRACT(dayofyear FROM subq_2.metric_time__day) AS metric_time__extract_doy
               , subq_1.ds__day AS ds__day
               , subq_1.ds__week AS ds__week
               , subq_1.ds__month AS ds__month
@@ -118,6 +108,16 @@ FROM (
               , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
               , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
               , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+              , subq_1.metric_time__week AS metric_time__week
+              , subq_1.metric_time__month AS metric_time__month
+              , subq_1.metric_time__quarter AS metric_time__quarter
+              , subq_1.metric_time__year AS metric_time__year
+              , subq_1.metric_time__extract_year AS metric_time__extract_year
+              , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+              , subq_1.metric_time__extract_month AS metric_time__extract_month
+              , subq_1.metric_time__extract_day AS metric_time__extract_day
+              , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+              , subq_1.metric_time__extract_doy AS metric_time__extract_doy
               , subq_1.listing AS listing
               , subq_1.guest AS guest
               , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_offsets_with_where_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_offsets_with_where_constraint__plan0.sql
@@ -46,16 +46,6 @@ FROM (
               -- Join to Time Spine Dataset
               SELECT
                 subq_2.metric_time__day AS metric_time__day
-                , DATETIME_TRUNC(subq_2.metric_time__day, isoweek) AS metric_time__week
-                , DATETIME_TRUNC(subq_2.metric_time__day, month) AS metric_time__month
-                , DATETIME_TRUNC(subq_2.metric_time__day, quarter) AS metric_time__quarter
-                , DATETIME_TRUNC(subq_2.metric_time__day, year) AS metric_time__year
-                , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-                , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-                , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-                , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-                , IF(EXTRACT(dayofweek FROM subq_2.metric_time__day) = 1, 7, EXTRACT(dayofweek FROM subq_2.metric_time__day) - 1) AS metric_time__extract_dow
-                , EXTRACT(dayofyear FROM subq_2.metric_time__day) AS metric_time__extract_doy
                 , subq_1.ds__day AS ds__day
                 , subq_1.ds__week AS ds__week
                 , subq_1.ds__month AS ds__month
@@ -122,6 +112,16 @@ FROM (
                 , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
                 , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
                 , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                , subq_1.metric_time__week AS metric_time__week
+                , subq_1.metric_time__month AS metric_time__month
+                , subq_1.metric_time__quarter AS metric_time__quarter
+                , subq_1.metric_time__year AS metric_time__year
+                , subq_1.metric_time__extract_year AS metric_time__extract_year
+                , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+                , subq_1.metric_time__extract_month AS metric_time__extract_month
+                , subq_1.metric_time__extract_day AS metric_time__extract_day
+                , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+                , subq_1.metric_time__extract_doy AS metric_time__extract_doy
                 , subq_1.listing AS listing
                 , subq_1.guest AS guest
                 , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0.sql
@@ -26,17 +26,7 @@ FROM (
       FROM (
         -- Constrain Output with WHERE
         SELECT
-          subq_4.metric_time__day
-          , subq_4.metric_time__week
-          , subq_4.metric_time__month
-          , subq_4.metric_time__quarter
-          , subq_4.metric_time__year
-          , subq_4.metric_time__extract_year
-          , subq_4.metric_time__extract_quarter
-          , subq_4.metric_time__extract_month
-          , subq_4.metric_time__extract_day
-          , subq_4.metric_time__extract_dow
-          , subq_4.metric_time__extract_doy
+          subq_4.metric_time__month
           , subq_4.ds__day
           , subq_4.ds__week
           , subq_4.ds__month
@@ -103,6 +93,16 @@ FROM (
           , subq_4.booking__paid_at__extract_day
           , subq_4.booking__paid_at__extract_dow
           , subq_4.booking__paid_at__extract_doy
+          , subq_4.metric_time__day
+          , subq_4.metric_time__week
+          , subq_4.metric_time__quarter
+          , subq_4.metric_time__year
+          , subq_4.metric_time__extract_year
+          , subq_4.metric_time__extract_quarter
+          , subq_4.metric_time__extract_month
+          , subq_4.metric_time__extract_day
+          , subq_4.metric_time__extract_dow
+          , subq_4.metric_time__extract_doy
           , subq_4.listing
           , subq_4.guest
           , subq_4.host
@@ -127,17 +127,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_2.metric_time__day AS metric_time__day
-            , DATETIME_TRUNC(subq_2.metric_time__day, isoweek) AS metric_time__week
-            , DATETIME_TRUNC(subq_2.metric_time__day, month) AS metric_time__month
-            , DATETIME_TRUNC(subq_2.metric_time__day, quarter) AS metric_time__quarter
-            , DATETIME_TRUNC(subq_2.metric_time__day, year) AS metric_time__year
-            , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-            , IF(EXTRACT(dayofweek FROM subq_2.metric_time__day) = 1, 7, EXTRACT(dayofweek FROM subq_2.metric_time__day) - 1) AS metric_time__extract_dow
-            , EXTRACT(dayofyear FROM subq_2.metric_time__day) AS metric_time__extract_doy
+            DATETIME_TRUNC(subq_2.metric_time__day, month) AS metric_time__month
             , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
@@ -204,6 +194,16 @@ FROM (
             , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_1.metric_time__day AS metric_time__day
+            , subq_1.metric_time__week AS metric_time__week
+            , subq_1.metric_time__quarter AS metric_time__quarter
+            , subq_1.metric_time__year AS metric_time__year
+            , subq_1.metric_time__extract_year AS metric_time__extract_year
+            , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_1.metric_time__extract_month AS metric_time__extract_month
+            , subq_1.metric_time__extract_day AS metric_time__extract_day
+            , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_1.metric_time__extract_doy AS metric_time__extract_doy
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
@@ -19,8 +19,8 @@ FROM (
   FROM (
     -- Join to Time Spine Dataset
     SELECT
-      subq_12.ds AS metric_time__day
-      , DATETIME_TRUNC(subq_12.ds, month) AS metric_time__month
+      DATETIME_TRUNC(subq_12.ds, month) AS metric_time__month
+      , subq_10.metric_time__day AS metric_time__day
       , subq_10.bookings AS bookings
     FROM ***************************.mf_time_spine subq_12
     INNER JOIN (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_offset_to_grain_metric_multiple_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_offset_to_grain_metric_multiple_granularities__plan0.sql
@@ -35,16 +35,8 @@ FROM (
         -- Join to Time Spine Dataset
         SELECT
           subq_2.metric_time__day AS metric_time__day
-          , DATETIME_TRUNC(subq_2.metric_time__day, isoweek) AS metric_time__week
           , DATETIME_TRUNC(subq_2.metric_time__day, month) AS metric_time__month
-          , DATETIME_TRUNC(subq_2.metric_time__day, quarter) AS metric_time__quarter
           , DATETIME_TRUNC(subq_2.metric_time__day, year) AS metric_time__year
-          , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-          , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-          , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-          , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-          , IF(EXTRACT(dayofweek FROM subq_2.metric_time__day) = 1, 7, EXTRACT(dayofweek FROM subq_2.metric_time__day) - 1) AS metric_time__extract_dow
-          , EXTRACT(dayofyear FROM subq_2.metric_time__day) AS metric_time__extract_doy
           , subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
@@ -111,6 +103,14 @@ FROM (
           , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
           , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
           , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+          , subq_1.metric_time__week AS metric_time__week
+          , subq_1.metric_time__quarter AS metric_time__quarter
+          , subq_1.metric_time__extract_year AS metric_time__extract_year
+          , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_1.metric_time__extract_month AS metric_time__extract_month
+          , subq_1.metric_time__extract_day AS metric_time__extract_day
+          , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+          , subq_1.metric_time__extract_doy AS metric_time__extract_doy
           , subq_1.listing AS listing
           , subq_1.guest AS guest
           , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_offset_to_grain_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_offset_to_grain_with_agg_time_dim__plan0.sql
@@ -246,16 +246,6 @@ FROM (
           -- Join to Time Spine Dataset
           SELECT
             subq_7.booking__ds__day AS booking__ds__day
-            , DATETIME_TRUNC(subq_7.booking__ds__day, isoweek) AS booking__ds__week
-            , DATETIME_TRUNC(subq_7.booking__ds__day, month) AS booking__ds__month
-            , DATETIME_TRUNC(subq_7.booking__ds__day, quarter) AS booking__ds__quarter
-            , DATETIME_TRUNC(subq_7.booking__ds__day, year) AS booking__ds__year
-            , EXTRACT(year FROM subq_7.booking__ds__day) AS booking__ds__extract_year
-            , EXTRACT(quarter FROM subq_7.booking__ds__day) AS booking__ds__extract_quarter
-            , EXTRACT(month FROM subq_7.booking__ds__day) AS booking__ds__extract_month
-            , EXTRACT(day FROM subq_7.booking__ds__day) AS booking__ds__extract_day
-            , IF(EXTRACT(dayofweek FROM subq_7.booking__ds__day) = 1, 7, EXTRACT(dayofweek FROM subq_7.booking__ds__day) - 1) AS booking__ds__extract_dow
-            , EXTRACT(dayofyear FROM subq_7.booking__ds__day) AS booking__ds__extract_doy
             , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
@@ -289,6 +279,16 @@ FROM (
             , subq_6.paid_at__extract_day AS paid_at__extract_day
             , subq_6.paid_at__extract_dow AS paid_at__extract_dow
             , subq_6.paid_at__extract_doy AS paid_at__extract_doy
+            , subq_6.booking__ds__week AS booking__ds__week
+            , subq_6.booking__ds__month AS booking__ds__month
+            , subq_6.booking__ds__quarter AS booking__ds__quarter
+            , subq_6.booking__ds__year AS booking__ds__year
+            , subq_6.booking__ds__extract_year AS booking__ds__extract_year
+            , subq_6.booking__ds__extract_quarter AS booking__ds__extract_quarter
+            , subq_6.booking__ds__extract_month AS booking__ds__extract_month
+            , subq_6.booking__ds__extract_day AS booking__ds__extract_day
+            , subq_6.booking__ds__extract_dow AS booking__ds__extract_dow
+            , subq_6.booking__ds__extract_doy AS booking__ds__extract_doy
             , subq_6.booking__ds_partitioned__day AS booking__ds_partitioned__day
             , subq_6.booking__ds_partitioned__week AS booking__ds_partitioned__week
             , subq_6.booking__ds_partitioned__month AS booking__ds_partitioned__month

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_offset_window_metric_filter_and_query_have_different_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_offset_window_metric_filter_and_query_have_different_granularities__plan0.sql
@@ -32,17 +32,7 @@ FROM (
         FROM (
           -- Constrain Output with WHERE
           SELECT
-            subq_4.metric_time__day
-            , subq_4.metric_time__week
-            , subq_4.metric_time__month
-            , subq_4.metric_time__quarter
-            , subq_4.metric_time__year
-            , subq_4.metric_time__extract_year
-            , subq_4.metric_time__extract_quarter
-            , subq_4.metric_time__extract_month
-            , subq_4.metric_time__extract_day
-            , subq_4.metric_time__extract_dow
-            , subq_4.metric_time__extract_doy
+            subq_4.metric_time__month
             , subq_4.ds__day
             , subq_4.ds__week
             , subq_4.ds__month
@@ -109,6 +99,16 @@ FROM (
             , subq_4.booking__paid_at__extract_day
             , subq_4.booking__paid_at__extract_dow
             , subq_4.booking__paid_at__extract_doy
+            , subq_4.metric_time__day
+            , subq_4.metric_time__week
+            , subq_4.metric_time__quarter
+            , subq_4.metric_time__year
+            , subq_4.metric_time__extract_year
+            , subq_4.metric_time__extract_quarter
+            , subq_4.metric_time__extract_month
+            , subq_4.metric_time__extract_day
+            , subq_4.metric_time__extract_dow
+            , subq_4.metric_time__extract_doy
             , subq_4.listing
             , subq_4.guest
             , subq_4.host
@@ -133,17 +133,7 @@ FROM (
           FROM (
             -- Join to Time Spine Dataset
             SELECT
-              subq_2.metric_time__day AS metric_time__day
-              , DATETIME_TRUNC(subq_2.metric_time__day, isoweek) AS metric_time__week
-              , DATETIME_TRUNC(subq_2.metric_time__day, month) AS metric_time__month
-              , DATETIME_TRUNC(subq_2.metric_time__day, quarter) AS metric_time__quarter
-              , DATETIME_TRUNC(subq_2.metric_time__day, year) AS metric_time__year
-              , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-              , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-              , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-              , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-              , IF(EXTRACT(dayofweek FROM subq_2.metric_time__day) = 1, 7, EXTRACT(dayofweek FROM subq_2.metric_time__day) - 1) AS metric_time__extract_dow
-              , EXTRACT(dayofyear FROM subq_2.metric_time__day) AS metric_time__extract_doy
+              DATETIME_TRUNC(subq_2.metric_time__day, month) AS metric_time__month
               , subq_1.ds__day AS ds__day
               , subq_1.ds__week AS ds__week
               , subq_1.ds__month AS ds__month
@@ -210,6 +200,16 @@ FROM (
               , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
               , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
               , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+              , subq_1.metric_time__day AS metric_time__day
+              , subq_1.metric_time__week AS metric_time__week
+              , subq_1.metric_time__quarter AS metric_time__quarter
+              , subq_1.metric_time__year AS metric_time__year
+              , subq_1.metric_time__extract_year AS metric_time__extract_year
+              , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+              , subq_1.metric_time__extract_month AS metric_time__extract_month
+              , subq_1.metric_time__extract_day AS metric_time__extract_day
+              , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+              , subq_1.metric_time__extract_doy AS metric_time__extract_doy
               , subq_1.listing AS listing
               , subq_1.guest AS guest
               , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_offset_window_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_offset_window_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
@@ -25,8 +25,8 @@ FROM (
     FROM (
       -- Join to Time Spine Dataset
       SELECT
-        subq_19.ds AS metric_time__day
-        , DATETIME_TRUNC(subq_19.ds, month) AS metric_time__month
+        DATETIME_TRUNC(subq_19.ds, month) AS metric_time__month
+        , DATETIME_TRUNC(bookings_source_src_28000.ds, day) AS metric_time__day
         , bookings_source_src_28000.booking_value AS booking_value
       FROM ***************************.mf_time_spine subq_19
       INNER JOIN

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_offset_window_metric_multiple_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_offset_window_metric_multiple_granularities__plan0.sql
@@ -43,16 +43,8 @@ FROM (
           -- Join to Time Spine Dataset
           SELECT
             subq_2.metric_time__day AS metric_time__day
-            , DATETIME_TRUNC(subq_2.metric_time__day, isoweek) AS metric_time__week
             , DATETIME_TRUNC(subq_2.metric_time__day, month) AS metric_time__month
-            , DATETIME_TRUNC(subq_2.metric_time__day, quarter) AS metric_time__quarter
             , DATETIME_TRUNC(subq_2.metric_time__day, year) AS metric_time__year
-            , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-            , IF(EXTRACT(dayofweek FROM subq_2.metric_time__day) = 1, 7, EXTRACT(dayofweek FROM subq_2.metric_time__day) - 1) AS metric_time__extract_dow
-            , EXTRACT(dayofyear FROM subq_2.metric_time__day) AS metric_time__extract_doy
             , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
@@ -119,6 +111,14 @@ FROM (
             , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_1.metric_time__week AS metric_time__week
+            , subq_1.metric_time__quarter AS metric_time__quarter
+            , subq_1.metric_time__extract_year AS metric_time__extract_year
+            , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_1.metric_time__extract_month AS metric_time__extract_month
+            , subq_1.metric_time__extract_day AS metric_time__extract_day
+            , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_1.metric_time__extract_doy AS metric_time__extract_doy
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_offset_window_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_offset_window_with_agg_time_dim__plan0.sql
@@ -246,16 +246,6 @@ FROM (
           -- Join to Time Spine Dataset
           SELECT
             subq_7.booking__ds__day AS booking__ds__day
-            , DATETIME_TRUNC(subq_7.booking__ds__day, isoweek) AS booking__ds__week
-            , DATETIME_TRUNC(subq_7.booking__ds__day, month) AS booking__ds__month
-            , DATETIME_TRUNC(subq_7.booking__ds__day, quarter) AS booking__ds__quarter
-            , DATETIME_TRUNC(subq_7.booking__ds__day, year) AS booking__ds__year
-            , EXTRACT(year FROM subq_7.booking__ds__day) AS booking__ds__extract_year
-            , EXTRACT(quarter FROM subq_7.booking__ds__day) AS booking__ds__extract_quarter
-            , EXTRACT(month FROM subq_7.booking__ds__day) AS booking__ds__extract_month
-            , EXTRACT(day FROM subq_7.booking__ds__day) AS booking__ds__extract_day
-            , IF(EXTRACT(dayofweek FROM subq_7.booking__ds__day) = 1, 7, EXTRACT(dayofweek FROM subq_7.booking__ds__day) - 1) AS booking__ds__extract_dow
-            , EXTRACT(dayofyear FROM subq_7.booking__ds__day) AS booking__ds__extract_doy
             , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
@@ -289,6 +279,16 @@ FROM (
             , subq_6.paid_at__extract_day AS paid_at__extract_day
             , subq_6.paid_at__extract_dow AS paid_at__extract_dow
             , subq_6.paid_at__extract_doy AS paid_at__extract_doy
+            , subq_6.booking__ds__week AS booking__ds__week
+            , subq_6.booking__ds__month AS booking__ds__month
+            , subq_6.booking__ds__quarter AS booking__ds__quarter
+            , subq_6.booking__ds__year AS booking__ds__year
+            , subq_6.booking__ds__extract_year AS booking__ds__extract_year
+            , subq_6.booking__ds__extract_quarter AS booking__ds__extract_quarter
+            , subq_6.booking__ds__extract_month AS booking__ds__extract_month
+            , subq_6.booking__ds__extract_day AS booking__ds__extract_day
+            , subq_6.booking__ds__extract_dow AS booking__ds__extract_dow
+            , subq_6.booking__ds__extract_doy AS booking__ds__extract_doy
             , subq_6.booking__ds_partitioned__day AS booking__ds_partitioned__day
             , subq_6.booking__ds_partitioned__week AS booking__ds_partitioned__week
             , subq_6.booking__ds_partitioned__month AS booking__ds_partitioned__month

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_time_offset_metric_with_time_constraint__plan0.sql
@@ -25,16 +25,6 @@ FROM (
         -- Join to Time Spine Dataset
         SELECT
           subq_2.metric_time__day AS metric_time__day
-          , DATETIME_TRUNC(subq_2.metric_time__day, isoweek) AS metric_time__week
-          , DATETIME_TRUNC(subq_2.metric_time__day, month) AS metric_time__month
-          , DATETIME_TRUNC(subq_2.metric_time__day, quarter) AS metric_time__quarter
-          , DATETIME_TRUNC(subq_2.metric_time__day, year) AS metric_time__year
-          , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-          , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-          , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-          , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-          , IF(EXTRACT(dayofweek FROM subq_2.metric_time__day) = 1, 7, EXTRACT(dayofweek FROM subq_2.metric_time__day) - 1) AS metric_time__extract_dow
-          , EXTRACT(dayofyear FROM subq_2.metric_time__day) AS metric_time__extract_doy
           , subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
@@ -101,6 +91,16 @@ FROM (
           , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
           , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
           , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+          , subq_1.metric_time__week AS metric_time__week
+          , subq_1.metric_time__month AS metric_time__month
+          , subq_1.metric_time__quarter AS metric_time__quarter
+          , subq_1.metric_time__year AS metric_time__year
+          , subq_1.metric_time__extract_year AS metric_time__extract_year
+          , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_1.metric_time__extract_month AS metric_time__extract_month
+          , subq_1.metric_time__extract_day AS metric_time__extract_day
+          , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+          , subq_1.metric_time__extract_doy AS metric_time__extract_doy
           , subq_1.listing AS listing
           , subq_1.guest AS guest
           , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
@@ -25,16 +25,6 @@ FROM (
         -- Constrain Time Range to [2019-12-19T00:00:00, 2020-01-02T00:00:00]
         SELECT
           subq_7.metric_time__day
-          , subq_7.metric_time__week
-          , subq_7.metric_time__month
-          , subq_7.metric_time__quarter
-          , subq_7.metric_time__year
-          , subq_7.metric_time__extract_year
-          , subq_7.metric_time__extract_quarter
-          , subq_7.metric_time__extract_month
-          , subq_7.metric_time__extract_day
-          , subq_7.metric_time__extract_dow
-          , subq_7.metric_time__extract_doy
           , subq_7.ds__day
           , subq_7.ds__week
           , subq_7.ds__month
@@ -101,6 +91,16 @@ FROM (
           , subq_7.booking__paid_at__extract_day
           , subq_7.booking__paid_at__extract_dow
           , subq_7.booking__paid_at__extract_doy
+          , subq_7.metric_time__week
+          , subq_7.metric_time__month
+          , subq_7.metric_time__quarter
+          , subq_7.metric_time__year
+          , subq_7.metric_time__extract_year
+          , subq_7.metric_time__extract_quarter
+          , subq_7.metric_time__extract_month
+          , subq_7.metric_time__extract_day
+          , subq_7.metric_time__extract_dow
+          , subq_7.metric_time__extract_doy
           , subq_7.listing
           , subq_7.guest
           , subq_7.host
@@ -126,16 +126,6 @@ FROM (
           -- Join to Time Spine Dataset
           SELECT
             subq_5.metric_time__day AS metric_time__day
-            , DATE_TRUNC('week', subq_5.metric_time__day) AS metric_time__week
-            , DATE_TRUNC('month', subq_5.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('quarter', subq_5.metric_time__day) AS metric_time__quarter
-            , DATE_TRUNC('year', subq_5.metric_time__day) AS metric_time__year
-            , EXTRACT(year FROM subq_5.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_5.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_5.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_5.metric_time__day) AS metric_time__extract_day
-            , EXTRACT(DAYOFWEEK_ISO FROM subq_5.metric_time__day) AS metric_time__extract_dow
-            , EXTRACT(doy FROM subq_5.metric_time__day) AS metric_time__extract_doy
             , subq_4.ds__day AS ds__day
             , subq_4.ds__week AS ds__week
             , subq_4.ds__month AS ds__month
@@ -202,6 +192,16 @@ FROM (
             , subq_4.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_4.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_4.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_4.metric_time__week AS metric_time__week
+            , subq_4.metric_time__month AS metric_time__month
+            , subq_4.metric_time__quarter AS metric_time__quarter
+            , subq_4.metric_time__year AS metric_time__year
+            , subq_4.metric_time__extract_year AS metric_time__extract_year
+            , subq_4.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_4.metric_time__extract_month AS metric_time__extract_month
+            , subq_4.metric_time__extract_day AS metric_time__extract_day
+            , subq_4.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_4.metric_time__extract_doy AS metric_time__extract_doy
             , subq_4.listing AS listing
             , subq_4.guest AS guest
             , subq_4.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
@@ -25,11 +25,6 @@ FROM (
         -- Join to Time Spine Dataset
         SELECT
           subq_2.metric_time__month AS metric_time__month
-          , DATE_TRUNC('quarter', subq_2.metric_time__month) AS metric_time__quarter
-          , DATE_TRUNC('year', subq_2.metric_time__month) AS metric_time__year
-          , EXTRACT(year FROM subq_2.metric_time__month) AS metric_time__extract_year
-          , EXTRACT(quarter FROM subq_2.metric_time__month) AS metric_time__extract_quarter
-          , EXTRACT(month FROM subq_2.metric_time__month) AS metric_time__extract_month
           , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
           , subq_1.ds__year AS ds__year
@@ -42,6 +37,11 @@ FROM (
           , subq_1.booking_monthly__ds__extract_year AS booking_monthly__ds__extract_year
           , subq_1.booking_monthly__ds__extract_quarter AS booking_monthly__ds__extract_quarter
           , subq_1.booking_monthly__ds__extract_month AS booking_monthly__ds__extract_month
+          , subq_1.metric_time__quarter AS metric_time__quarter
+          , subq_1.metric_time__year AS metric_time__year
+          , subq_1.metric_time__extract_year AS metric_time__extract_year
+          , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_1.metric_time__extract_month AS metric_time__extract_month
           , subq_1.listing AS listing
           , subq_1.booking_monthly__listing AS booking_monthly__listing
           , subq_1.bookings_monthly AS bookings_monthly

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_to_grain__plan0.sql
@@ -246,16 +246,6 @@ FROM (
           -- Join to Time Spine Dataset
           SELECT
             subq_7.metric_time__day AS metric_time__day
-            , DATE_TRUNC('week', subq_7.metric_time__day) AS metric_time__week
-            , DATE_TRUNC('month', subq_7.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('quarter', subq_7.metric_time__day) AS metric_time__quarter
-            , DATE_TRUNC('year', subq_7.metric_time__day) AS metric_time__year
-            , EXTRACT(year FROM subq_7.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_7.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_7.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_7.metric_time__day) AS metric_time__extract_day
-            , EXTRACT(DAYOFWEEK_ISO FROM subq_7.metric_time__day) AS metric_time__extract_dow
-            , EXTRACT(doy FROM subq_7.metric_time__day) AS metric_time__extract_doy
             , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
@@ -322,6 +312,16 @@ FROM (
             , subq_6.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_6.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_6.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_6.metric_time__week AS metric_time__week
+            , subq_6.metric_time__month AS metric_time__month
+            , subq_6.metric_time__quarter AS metric_time__quarter
+            , subq_6.metric_time__year AS metric_time__year
+            , subq_6.metric_time__extract_year AS metric_time__extract_year
+            , subq_6.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_6.metric_time__extract_month AS metric_time__extract_month
+            , subq_6.metric_time__extract_day AS metric_time__extract_day
+            , subq_6.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_6.metric_time__extract_doy AS metric_time__extract_doy
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_to_grain_and_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_to_grain_and_granularity__plan0.sql
@@ -245,17 +245,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_7.metric_time__day AS metric_time__day
-            , DATE_TRUNC('week', subq_7.metric_time__day) AS metric_time__week
-            , DATE_TRUNC('month', subq_7.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('quarter', subq_7.metric_time__day) AS metric_time__quarter
-            , DATE_TRUNC('year', subq_7.metric_time__day) AS metric_time__year
-            , EXTRACT(year FROM subq_7.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_7.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_7.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_7.metric_time__day) AS metric_time__extract_day
-            , EXTRACT(DAYOFWEEK_ISO FROM subq_7.metric_time__day) AS metric_time__extract_dow
-            , EXTRACT(doy FROM subq_7.metric_time__day) AS metric_time__extract_doy
+            DATE_TRUNC('week', subq_7.metric_time__day) AS metric_time__week
             , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
@@ -322,6 +312,16 @@ FROM (
             , subq_6.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_6.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_6.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_6.metric_time__day AS metric_time__day
+            , subq_6.metric_time__month AS metric_time__month
+            , subq_6.metric_time__quarter AS metric_time__quarter
+            , subq_6.metric_time__year AS metric_time__year
+            , subq_6.metric_time__extract_year AS metric_time__extract_year
+            , subq_6.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_6.metric_time__extract_month AS metric_time__extract_month
+            , subq_6.metric_time__extract_day AS metric_time__extract_day
+            , subq_6.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_6.metric_time__extract_doy AS metric_time__extract_doy
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_window__plan0.sql
@@ -246,16 +246,6 @@ FROM (
           -- Join to Time Spine Dataset
           SELECT
             subq_7.metric_time__day AS metric_time__day
-            , DATE_TRUNC('week', subq_7.metric_time__day) AS metric_time__week
-            , DATE_TRUNC('month', subq_7.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('quarter', subq_7.metric_time__day) AS metric_time__quarter
-            , DATE_TRUNC('year', subq_7.metric_time__day) AS metric_time__year
-            , EXTRACT(year FROM subq_7.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_7.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_7.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_7.metric_time__day) AS metric_time__extract_day
-            , EXTRACT(DAYOFWEEK_ISO FROM subq_7.metric_time__day) AS metric_time__extract_dow
-            , EXTRACT(doy FROM subq_7.metric_time__day) AS metric_time__extract_doy
             , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
@@ -322,6 +312,16 @@ FROM (
             , subq_6.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_6.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_6.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_6.metric_time__week AS metric_time__week
+            , subq_6.metric_time__month AS metric_time__month
+            , subq_6.metric_time__quarter AS metric_time__quarter
+            , subq_6.metric_time__year AS metric_time__year
+            , subq_6.metric_time__extract_year AS metric_time__extract_year
+            , subq_6.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_6.metric_time__extract_month AS metric_time__extract_month
+            , subq_6.metric_time__extract_day AS metric_time__extract_day
+            , subq_6.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_6.metric_time__extract_doy AS metric_time__extract_doy
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_window_and_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_window_and_granularity__plan0.sql
@@ -245,17 +245,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_7.metric_time__day AS metric_time__day
-            , DATE_TRUNC('week', subq_7.metric_time__day) AS metric_time__week
-            , DATE_TRUNC('month', subq_7.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('quarter', subq_7.metric_time__day) AS metric_time__quarter
-            , DATE_TRUNC('year', subq_7.metric_time__day) AS metric_time__year
-            , EXTRACT(year FROM subq_7.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_7.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_7.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_7.metric_time__day) AS metric_time__extract_day
-            , EXTRACT(DAYOFWEEK_ISO FROM subq_7.metric_time__day) AS metric_time__extract_dow
-            , EXTRACT(doy FROM subq_7.metric_time__day) AS metric_time__extract_doy
+            DATE_TRUNC('quarter', subq_7.metric_time__day) AS metric_time__quarter
             , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
@@ -322,6 +312,16 @@ FROM (
             , subq_6.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_6.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_6.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_6.metric_time__day AS metric_time__day
+            , subq_6.metric_time__week AS metric_time__week
+            , subq_6.metric_time__month AS metric_time__month
+            , subq_6.metric_time__year AS metric_time__year
+            , subq_6.metric_time__extract_year AS metric_time__extract_year
+            , subq_6.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_6.metric_time__extract_month AS metric_time__extract_month
+            , subq_6.metric_time__extract_day AS metric_time__extract_day
+            , subq_6.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_6.metric_time__extract_doy AS metric_time__extract_doy
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
@@ -31,16 +31,6 @@ FROM (
           -- Join to Time Spine Dataset
           SELECT
             subq_2.metric_time__day AS metric_time__day
-            , DATE_TRUNC('week', subq_2.metric_time__day) AS metric_time__week
-            , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('quarter', subq_2.metric_time__day) AS metric_time__quarter
-            , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-            , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-            , EXTRACT(DAYOFWEEK_ISO FROM subq_2.metric_time__day) AS metric_time__extract_dow
-            , EXTRACT(doy FROM subq_2.metric_time__day) AS metric_time__extract_doy
             , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
@@ -107,6 +97,16 @@ FROM (
             , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_1.metric_time__week AS metric_time__week
+            , subq_1.metric_time__month AS metric_time__month
+            , subq_1.metric_time__quarter AS metric_time__quarter
+            , subq_1.metric_time__year AS metric_time__year
+            , subq_1.metric_time__extract_year AS metric_time__extract_year
+            , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_1.metric_time__extract_month AS metric_time__extract_month
+            , subq_1.metric_time__extract_day AS metric_time__extract_day
+            , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_1.metric_time__extract_doy AS metric_time__extract_doy
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host
@@ -356,16 +356,6 @@ FROM (
           -- Join to Time Spine Dataset
           SELECT
             subq_10.metric_time__day AS metric_time__day
-            , DATE_TRUNC('week', subq_10.metric_time__day) AS metric_time__week
-            , DATE_TRUNC('month', subq_10.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('quarter', subq_10.metric_time__day) AS metric_time__quarter
-            , DATE_TRUNC('year', subq_10.metric_time__day) AS metric_time__year
-            , EXTRACT(year FROM subq_10.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_10.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_10.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_10.metric_time__day) AS metric_time__extract_day
-            , EXTRACT(DAYOFWEEK_ISO FROM subq_10.metric_time__day) AS metric_time__extract_dow
-            , EXTRACT(doy FROM subq_10.metric_time__day) AS metric_time__extract_doy
             , subq_9.ds__day AS ds__day
             , subq_9.ds__week AS ds__week
             , subq_9.ds__month AS ds__month
@@ -432,6 +422,16 @@ FROM (
             , subq_9.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_9.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_9.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_9.metric_time__week AS metric_time__week
+            , subq_9.metric_time__month AS metric_time__month
+            , subq_9.metric_time__quarter AS metric_time__quarter
+            , subq_9.metric_time__year AS metric_time__year
+            , subq_9.metric_time__extract_year AS metric_time__extract_year
+            , subq_9.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_9.metric_time__extract_month AS metric_time__extract_month
+            , subq_9.metric_time__extract_day AS metric_time__extract_day
+            , subq_9.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_9.metric_time__extract_doy AS metric_time__extract_doy
             , subq_9.listing AS listing
             , subq_9.guest AS guest
             , subq_9.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0.sql
@@ -30,17 +30,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_2.metric_time__day AS metric_time__day
-            , DATE_TRUNC('week', subq_2.metric_time__day) AS metric_time__week
-            , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('quarter', subq_2.metric_time__day) AS metric_time__quarter
-            , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-            , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-            , EXTRACT(DAYOFWEEK_ISO FROM subq_2.metric_time__day) AS metric_time__extract_dow
-            , EXTRACT(doy FROM subq_2.metric_time__day) AS metric_time__extract_doy
+            DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
             , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
@@ -107,6 +97,16 @@ FROM (
             , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_1.metric_time__day AS metric_time__day
+            , subq_1.metric_time__week AS metric_time__week
+            , subq_1.metric_time__month AS metric_time__month
+            , subq_1.metric_time__quarter AS metric_time__quarter
+            , subq_1.metric_time__extract_year AS metric_time__extract_year
+            , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_1.metric_time__extract_month AS metric_time__extract_month
+            , subq_1.metric_time__extract_day AS metric_time__extract_day
+            , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_1.metric_time__extract_doy AS metric_time__extract_doy
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host
@@ -356,17 +356,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_10.metric_time__day AS metric_time__day
-            , DATE_TRUNC('week', subq_10.metric_time__day) AS metric_time__week
-            , DATE_TRUNC('month', subq_10.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('quarter', subq_10.metric_time__day) AS metric_time__quarter
-            , DATE_TRUNC('year', subq_10.metric_time__day) AS metric_time__year
-            , EXTRACT(year FROM subq_10.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_10.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_10.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_10.metric_time__day) AS metric_time__extract_day
-            , EXTRACT(DAYOFWEEK_ISO FROM subq_10.metric_time__day) AS metric_time__extract_dow
-            , EXTRACT(doy FROM subq_10.metric_time__day) AS metric_time__extract_doy
+            DATE_TRUNC('year', subq_10.metric_time__day) AS metric_time__year
             , subq_9.ds__day AS ds__day
             , subq_9.ds__week AS ds__week
             , subq_9.ds__month AS ds__month
@@ -433,6 +423,16 @@ FROM (
             , subq_9.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_9.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_9.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_9.metric_time__day AS metric_time__day
+            , subq_9.metric_time__week AS metric_time__week
+            , subq_9.metric_time__month AS metric_time__month
+            , subq_9.metric_time__quarter AS metric_time__quarter
+            , subq_9.metric_time__extract_year AS metric_time__extract_year
+            , subq_9.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_9.metric_time__extract_month AS metric_time__extract_month
+            , subq_9.metric_time__extract_day AS metric_time__extract_day
+            , subq_9.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_9.metric_time__extract_doy AS metric_time__extract_doy
             , subq_9.listing AS listing
             , subq_9.guest AS guest
             , subq_9.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
@@ -349,16 +349,6 @@ FROM (
           -- Constrain Output with WHERE
           SELECT
             subq_10.metric_time__day
-            , subq_10.metric_time__week
-            , subq_10.metric_time__month
-            , subq_10.metric_time__quarter
-            , subq_10.metric_time__year
-            , subq_10.metric_time__extract_year
-            , subq_10.metric_time__extract_quarter
-            , subq_10.metric_time__extract_month
-            , subq_10.metric_time__extract_day
-            , subq_10.metric_time__extract_dow
-            , subq_10.metric_time__extract_doy
             , subq_10.ds__day
             , subq_10.ds__week
             , subq_10.ds__month
@@ -425,6 +415,16 @@ FROM (
             , subq_10.booking__paid_at__extract_day
             , subq_10.booking__paid_at__extract_dow
             , subq_10.booking__paid_at__extract_doy
+            , subq_10.metric_time__week
+            , subq_10.metric_time__month
+            , subq_10.metric_time__quarter
+            , subq_10.metric_time__year
+            , subq_10.metric_time__extract_year
+            , subq_10.metric_time__extract_quarter
+            , subq_10.metric_time__extract_month
+            , subq_10.metric_time__extract_day
+            , subq_10.metric_time__extract_dow
+            , subq_10.metric_time__extract_doy
             , subq_10.listing
             , subq_10.guest
             , subq_10.host
@@ -450,16 +450,6 @@ FROM (
             -- Join to Time Spine Dataset
             SELECT
               subq_8.metric_time__day AS metric_time__day
-              , DATE_TRUNC('week', subq_8.metric_time__day) AS metric_time__week
-              , DATE_TRUNC('month', subq_8.metric_time__day) AS metric_time__month
-              , DATE_TRUNC('quarter', subq_8.metric_time__day) AS metric_time__quarter
-              , DATE_TRUNC('year', subq_8.metric_time__day) AS metric_time__year
-              , EXTRACT(year FROM subq_8.metric_time__day) AS metric_time__extract_year
-              , EXTRACT(quarter FROM subq_8.metric_time__day) AS metric_time__extract_quarter
-              , EXTRACT(month FROM subq_8.metric_time__day) AS metric_time__extract_month
-              , EXTRACT(day FROM subq_8.metric_time__day) AS metric_time__extract_day
-              , EXTRACT(DAYOFWEEK_ISO FROM subq_8.metric_time__day) AS metric_time__extract_dow
-              , EXTRACT(doy FROM subq_8.metric_time__day) AS metric_time__extract_doy
               , subq_7.ds__day AS ds__day
               , subq_7.ds__week AS ds__week
               , subq_7.ds__month AS ds__month
@@ -526,6 +516,16 @@ FROM (
               , subq_7.booking__paid_at__extract_day AS booking__paid_at__extract_day
               , subq_7.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
               , subq_7.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+              , subq_7.metric_time__week AS metric_time__week
+              , subq_7.metric_time__month AS metric_time__month
+              , subq_7.metric_time__quarter AS metric_time__quarter
+              , subq_7.metric_time__year AS metric_time__year
+              , subq_7.metric_time__extract_year AS metric_time__extract_year
+              , subq_7.metric_time__extract_quarter AS metric_time__extract_quarter
+              , subq_7.metric_time__extract_month AS metric_time__extract_month
+              , subq_7.metric_time__extract_day AS metric_time__extract_day
+              , subq_7.metric_time__extract_dow AS metric_time__extract_dow
+              , subq_7.metric_time__extract_doy AS metric_time__extract_doy
               , subq_7.listing AS listing
               , subq_7.guest AS guest
               , subq_7.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_offset_cumulative_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_offset_cumulative_metric__plan0.sql
@@ -25,16 +25,6 @@ FROM (
         -- Join to Time Spine Dataset
         SELECT
           subq_5.metric_time__day AS metric_time__day
-          , DATE_TRUNC('week', subq_5.metric_time__day) AS metric_time__week
-          , DATE_TRUNC('month', subq_5.metric_time__day) AS metric_time__month
-          , DATE_TRUNC('quarter', subq_5.metric_time__day) AS metric_time__quarter
-          , DATE_TRUNC('year', subq_5.metric_time__day) AS metric_time__year
-          , EXTRACT(year FROM subq_5.metric_time__day) AS metric_time__extract_year
-          , EXTRACT(quarter FROM subq_5.metric_time__day) AS metric_time__extract_quarter
-          , EXTRACT(month FROM subq_5.metric_time__day) AS metric_time__extract_month
-          , EXTRACT(day FROM subq_5.metric_time__day) AS metric_time__extract_day
-          , EXTRACT(DAYOFWEEK_ISO FROM subq_5.metric_time__day) AS metric_time__extract_dow
-          , EXTRACT(doy FROM subq_5.metric_time__day) AS metric_time__extract_doy
           , subq_4.ds__day AS ds__day
           , subq_4.ds__week AS ds__week
           , subq_4.ds__month AS ds__month
@@ -101,6 +91,16 @@ FROM (
           , subq_4.booking__paid_at__extract_day AS booking__paid_at__extract_day
           , subq_4.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
           , subq_4.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+          , subq_4.metric_time__week AS metric_time__week
+          , subq_4.metric_time__month AS metric_time__month
+          , subq_4.metric_time__quarter AS metric_time__quarter
+          , subq_4.metric_time__year AS metric_time__year
+          , subq_4.metric_time__extract_year AS metric_time__extract_year
+          , subq_4.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_4.metric_time__extract_month AS metric_time__extract_month
+          , subq_4.metric_time__extract_day AS metric_time__extract_day
+          , subq_4.metric_time__extract_dow AS metric_time__extract_dow
+          , subq_4.metric_time__extract_doy AS metric_time__extract_doy
           , subq_4.listing AS listing
           , subq_4.guest AS guest
           , subq_4.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_offset_metric_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_offset_metric_with_agg_time_dim__plan0.sql
@@ -31,16 +31,6 @@ FROM (
           -- Join to Time Spine Dataset
           SELECT
             subq_2.booking__ds__day AS booking__ds__day
-            , DATE_TRUNC('week', subq_2.booking__ds__day) AS booking__ds__week
-            , DATE_TRUNC('month', subq_2.booking__ds__day) AS booking__ds__month
-            , DATE_TRUNC('quarter', subq_2.booking__ds__day) AS booking__ds__quarter
-            , DATE_TRUNC('year', subq_2.booking__ds__day) AS booking__ds__year
-            , EXTRACT(year FROM subq_2.booking__ds__day) AS booking__ds__extract_year
-            , EXTRACT(quarter FROM subq_2.booking__ds__day) AS booking__ds__extract_quarter
-            , EXTRACT(month FROM subq_2.booking__ds__day) AS booking__ds__extract_month
-            , EXTRACT(day FROM subq_2.booking__ds__day) AS booking__ds__extract_day
-            , EXTRACT(DAYOFWEEK_ISO FROM subq_2.booking__ds__day) AS booking__ds__extract_dow
-            , EXTRACT(doy FROM subq_2.booking__ds__day) AS booking__ds__extract_doy
             , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
@@ -74,6 +64,16 @@ FROM (
             , subq_1.paid_at__extract_day AS paid_at__extract_day
             , subq_1.paid_at__extract_dow AS paid_at__extract_dow
             , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+            , subq_1.booking__ds__week AS booking__ds__week
+            , subq_1.booking__ds__month AS booking__ds__month
+            , subq_1.booking__ds__quarter AS booking__ds__quarter
+            , subq_1.booking__ds__year AS booking__ds__year
+            , subq_1.booking__ds__extract_year AS booking__ds__extract_year
+            , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
+            , subq_1.booking__ds__extract_month AS booking__ds__extract_month
+            , subq_1.booking__ds__extract_day AS booking__ds__extract_day
+            , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
+            , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
             , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
             , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
             , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_offset_metric_with_one_input_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_offset_metric_with_one_input_metric__plan0.sql
@@ -25,16 +25,6 @@ FROM (
         -- Join to Time Spine Dataset
         SELECT
           subq_2.metric_time__day AS metric_time__day
-          , DATE_TRUNC('week', subq_2.metric_time__day) AS metric_time__week
-          , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-          , DATE_TRUNC('quarter', subq_2.metric_time__day) AS metric_time__quarter
-          , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-          , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-          , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-          , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-          , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-          , EXTRACT(DAYOFWEEK_ISO FROM subq_2.metric_time__day) AS metric_time__extract_dow
-          , EXTRACT(doy FROM subq_2.metric_time__day) AS metric_time__extract_doy
           , subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
@@ -101,6 +91,16 @@ FROM (
           , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
           , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
           , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+          , subq_1.metric_time__week AS metric_time__week
+          , subq_1.metric_time__month AS metric_time__month
+          , subq_1.metric_time__quarter AS metric_time__quarter
+          , subq_1.metric_time__year AS metric_time__year
+          , subq_1.metric_time__extract_year AS metric_time__extract_year
+          , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_1.metric_time__extract_month AS metric_time__extract_month
+          , subq_1.metric_time__extract_day AS metric_time__extract_day
+          , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+          , subq_1.metric_time__extract_doy AS metric_time__extract_doy
           , subq_1.listing AS listing
           , subq_1.guest AS guest
           , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0.sql
@@ -57,16 +57,6 @@ FROM (
                 -- Join to Time Spine Dataset
                 SELECT
                   subq_2.metric_time__day AS metric_time__day
-                  , DATE_TRUNC('week', subq_2.metric_time__day) AS metric_time__week
-                  , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-                  , DATE_TRUNC('quarter', subq_2.metric_time__day) AS metric_time__quarter
-                  , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-                  , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-                  , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-                  , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-                  , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-                  , EXTRACT(DAYOFWEEK_ISO FROM subq_2.metric_time__day) AS metric_time__extract_dow
-                  , EXTRACT(doy FROM subq_2.metric_time__day) AS metric_time__extract_doy
                   , subq_1.ds__day AS ds__day
                   , subq_1.ds__week AS ds__week
                   , subq_1.ds__month AS ds__month
@@ -133,6 +123,16 @@ FROM (
                   , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
                   , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
                   , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                  , subq_1.metric_time__week AS metric_time__week
+                  , subq_1.metric_time__month AS metric_time__month
+                  , subq_1.metric_time__quarter AS metric_time__quarter
+                  , subq_1.metric_time__year AS metric_time__year
+                  , subq_1.metric_time__extract_year AS metric_time__extract_year
+                  , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+                  , subq_1.metric_time__extract_month AS metric_time__extract_month
+                  , subq_1.metric_time__extract_day AS metric_time__extract_day
+                  , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+                  , subq_1.metric_time__extract_doy AS metric_time__extract_doy
                   , subq_1.listing AS listing
                   , subq_1.guest AS guest
                   , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_offsets__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_offsets__plan0.sql
@@ -41,16 +41,6 @@ FROM (
             -- Join to Time Spine Dataset
             SELECT
               subq_2.metric_time__day AS metric_time__day
-              , DATE_TRUNC('week', subq_2.metric_time__day) AS metric_time__week
-              , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-              , DATE_TRUNC('quarter', subq_2.metric_time__day) AS metric_time__quarter
-              , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-              , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-              , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-              , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-              , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-              , EXTRACT(DAYOFWEEK_ISO FROM subq_2.metric_time__day) AS metric_time__extract_dow
-              , EXTRACT(doy FROM subq_2.metric_time__day) AS metric_time__extract_doy
               , subq_1.ds__day AS ds__day
               , subq_1.ds__week AS ds__week
               , subq_1.ds__month AS ds__month
@@ -117,6 +107,16 @@ FROM (
               , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
               , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
               , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+              , subq_1.metric_time__week AS metric_time__week
+              , subq_1.metric_time__month AS metric_time__month
+              , subq_1.metric_time__quarter AS metric_time__quarter
+              , subq_1.metric_time__year AS metric_time__year
+              , subq_1.metric_time__extract_year AS metric_time__extract_year
+              , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+              , subq_1.metric_time__extract_month AS metric_time__extract_month
+              , subq_1.metric_time__extract_day AS metric_time__extract_day
+              , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+              , subq_1.metric_time__extract_doy AS metric_time__extract_doy
               , subq_1.listing AS listing
               , subq_1.guest AS guest
               , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_offsets_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_offsets_with_time_constraint__plan0.sql
@@ -42,16 +42,6 @@ FROM (
             -- Join to Time Spine Dataset
             SELECT
               subq_2.metric_time__day AS metric_time__day
-              , DATE_TRUNC('week', subq_2.metric_time__day) AS metric_time__week
-              , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-              , DATE_TRUNC('quarter', subq_2.metric_time__day) AS metric_time__quarter
-              , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-              , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-              , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-              , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-              , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-              , EXTRACT(DAYOFWEEK_ISO FROM subq_2.metric_time__day) AS metric_time__extract_dow
-              , EXTRACT(doy FROM subq_2.metric_time__day) AS metric_time__extract_doy
               , subq_1.ds__day AS ds__day
               , subq_1.ds__week AS ds__week
               , subq_1.ds__month AS ds__month
@@ -118,6 +108,16 @@ FROM (
               , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
               , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
               , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+              , subq_1.metric_time__week AS metric_time__week
+              , subq_1.metric_time__month AS metric_time__month
+              , subq_1.metric_time__quarter AS metric_time__quarter
+              , subq_1.metric_time__year AS metric_time__year
+              , subq_1.metric_time__extract_year AS metric_time__extract_year
+              , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+              , subq_1.metric_time__extract_month AS metric_time__extract_month
+              , subq_1.metric_time__extract_day AS metric_time__extract_day
+              , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+              , subq_1.metric_time__extract_doy AS metric_time__extract_doy
               , subq_1.listing AS listing
               , subq_1.guest AS guest
               , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_offsets_with_where_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_offsets_with_where_constraint__plan0.sql
@@ -46,16 +46,6 @@ FROM (
               -- Join to Time Spine Dataset
               SELECT
                 subq_2.metric_time__day AS metric_time__day
-                , DATE_TRUNC('week', subq_2.metric_time__day) AS metric_time__week
-                , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-                , DATE_TRUNC('quarter', subq_2.metric_time__day) AS metric_time__quarter
-                , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-                , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-                , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-                , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-                , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-                , EXTRACT(DAYOFWEEK_ISO FROM subq_2.metric_time__day) AS metric_time__extract_dow
-                , EXTRACT(doy FROM subq_2.metric_time__day) AS metric_time__extract_doy
                 , subq_1.ds__day AS ds__day
                 , subq_1.ds__week AS ds__week
                 , subq_1.ds__month AS ds__month
@@ -122,6 +112,16 @@ FROM (
                 , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
                 , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
                 , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                , subq_1.metric_time__week AS metric_time__week
+                , subq_1.metric_time__month AS metric_time__month
+                , subq_1.metric_time__quarter AS metric_time__quarter
+                , subq_1.metric_time__year AS metric_time__year
+                , subq_1.metric_time__extract_year AS metric_time__extract_year
+                , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+                , subq_1.metric_time__extract_month AS metric_time__extract_month
+                , subq_1.metric_time__extract_day AS metric_time__extract_day
+                , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+                , subq_1.metric_time__extract_doy AS metric_time__extract_doy
                 , subq_1.listing AS listing
                 , subq_1.guest AS guest
                 , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0.sql
@@ -26,17 +26,7 @@ FROM (
       FROM (
         -- Constrain Output with WHERE
         SELECT
-          subq_4.metric_time__day
-          , subq_4.metric_time__week
-          , subq_4.metric_time__month
-          , subq_4.metric_time__quarter
-          , subq_4.metric_time__year
-          , subq_4.metric_time__extract_year
-          , subq_4.metric_time__extract_quarter
-          , subq_4.metric_time__extract_month
-          , subq_4.metric_time__extract_day
-          , subq_4.metric_time__extract_dow
-          , subq_4.metric_time__extract_doy
+          subq_4.metric_time__month
           , subq_4.ds__day
           , subq_4.ds__week
           , subq_4.ds__month
@@ -103,6 +93,16 @@ FROM (
           , subq_4.booking__paid_at__extract_day
           , subq_4.booking__paid_at__extract_dow
           , subq_4.booking__paid_at__extract_doy
+          , subq_4.metric_time__day
+          , subq_4.metric_time__week
+          , subq_4.metric_time__quarter
+          , subq_4.metric_time__year
+          , subq_4.metric_time__extract_year
+          , subq_4.metric_time__extract_quarter
+          , subq_4.metric_time__extract_month
+          , subq_4.metric_time__extract_day
+          , subq_4.metric_time__extract_dow
+          , subq_4.metric_time__extract_doy
           , subq_4.listing
           , subq_4.guest
           , subq_4.host
@@ -127,17 +127,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_2.metric_time__day AS metric_time__day
-            , DATE_TRUNC('week', subq_2.metric_time__day) AS metric_time__week
-            , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('quarter', subq_2.metric_time__day) AS metric_time__quarter
-            , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-            , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-            , EXTRACT(DAYOFWEEK_ISO FROM subq_2.metric_time__day) AS metric_time__extract_dow
-            , EXTRACT(doy FROM subq_2.metric_time__day) AS metric_time__extract_doy
+            DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
             , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
@@ -204,6 +194,16 @@ FROM (
             , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_1.metric_time__day AS metric_time__day
+            , subq_1.metric_time__week AS metric_time__week
+            , subq_1.metric_time__quarter AS metric_time__quarter
+            , subq_1.metric_time__year AS metric_time__year
+            , subq_1.metric_time__extract_year AS metric_time__extract_year
+            , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_1.metric_time__extract_month AS metric_time__extract_month
+            , subq_1.metric_time__extract_day AS metric_time__extract_day
+            , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_1.metric_time__extract_doy AS metric_time__extract_doy
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
@@ -19,8 +19,8 @@ FROM (
   FROM (
     -- Join to Time Spine Dataset
     SELECT
-      subq_12.ds AS metric_time__day
-      , DATE_TRUNC('month', subq_12.ds) AS metric_time__month
+      DATE_TRUNC('month', subq_12.ds) AS metric_time__month
+      , subq_10.metric_time__day AS metric_time__day
       , subq_10.bookings AS bookings
     FROM ***************************.mf_time_spine subq_12
     INNER JOIN (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_offset_to_grain_metric_multiple_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_offset_to_grain_metric_multiple_granularities__plan0.sql
@@ -35,16 +35,8 @@ FROM (
         -- Join to Time Spine Dataset
         SELECT
           subq_2.metric_time__day AS metric_time__day
-          , DATE_TRUNC('week', subq_2.metric_time__day) AS metric_time__week
           , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-          , DATE_TRUNC('quarter', subq_2.metric_time__day) AS metric_time__quarter
           , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-          , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-          , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-          , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-          , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-          , EXTRACT(DAYOFWEEK_ISO FROM subq_2.metric_time__day) AS metric_time__extract_dow
-          , EXTRACT(doy FROM subq_2.metric_time__day) AS metric_time__extract_doy
           , subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
@@ -111,6 +103,14 @@ FROM (
           , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
           , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
           , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+          , subq_1.metric_time__week AS metric_time__week
+          , subq_1.metric_time__quarter AS metric_time__quarter
+          , subq_1.metric_time__extract_year AS metric_time__extract_year
+          , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_1.metric_time__extract_month AS metric_time__extract_month
+          , subq_1.metric_time__extract_day AS metric_time__extract_day
+          , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+          , subq_1.metric_time__extract_doy AS metric_time__extract_doy
           , subq_1.listing AS listing
           , subq_1.guest AS guest
           , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_offset_to_grain_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_offset_to_grain_with_agg_time_dim__plan0.sql
@@ -246,16 +246,6 @@ FROM (
           -- Join to Time Spine Dataset
           SELECT
             subq_7.booking__ds__day AS booking__ds__day
-            , DATE_TRUNC('week', subq_7.booking__ds__day) AS booking__ds__week
-            , DATE_TRUNC('month', subq_7.booking__ds__day) AS booking__ds__month
-            , DATE_TRUNC('quarter', subq_7.booking__ds__day) AS booking__ds__quarter
-            , DATE_TRUNC('year', subq_7.booking__ds__day) AS booking__ds__year
-            , EXTRACT(year FROM subq_7.booking__ds__day) AS booking__ds__extract_year
-            , EXTRACT(quarter FROM subq_7.booking__ds__day) AS booking__ds__extract_quarter
-            , EXTRACT(month FROM subq_7.booking__ds__day) AS booking__ds__extract_month
-            , EXTRACT(day FROM subq_7.booking__ds__day) AS booking__ds__extract_day
-            , EXTRACT(DAYOFWEEK_ISO FROM subq_7.booking__ds__day) AS booking__ds__extract_dow
-            , EXTRACT(doy FROM subq_7.booking__ds__day) AS booking__ds__extract_doy
             , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
@@ -289,6 +279,16 @@ FROM (
             , subq_6.paid_at__extract_day AS paid_at__extract_day
             , subq_6.paid_at__extract_dow AS paid_at__extract_dow
             , subq_6.paid_at__extract_doy AS paid_at__extract_doy
+            , subq_6.booking__ds__week AS booking__ds__week
+            , subq_6.booking__ds__month AS booking__ds__month
+            , subq_6.booking__ds__quarter AS booking__ds__quarter
+            , subq_6.booking__ds__year AS booking__ds__year
+            , subq_6.booking__ds__extract_year AS booking__ds__extract_year
+            , subq_6.booking__ds__extract_quarter AS booking__ds__extract_quarter
+            , subq_6.booking__ds__extract_month AS booking__ds__extract_month
+            , subq_6.booking__ds__extract_day AS booking__ds__extract_day
+            , subq_6.booking__ds__extract_dow AS booking__ds__extract_dow
+            , subq_6.booking__ds__extract_doy AS booking__ds__extract_doy
             , subq_6.booking__ds_partitioned__day AS booking__ds_partitioned__day
             , subq_6.booking__ds_partitioned__week AS booking__ds_partitioned__week
             , subq_6.booking__ds_partitioned__month AS booking__ds_partitioned__month

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_offset_window_metric_filter_and_query_have_different_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_offset_window_metric_filter_and_query_have_different_granularities__plan0.sql
@@ -32,17 +32,7 @@ FROM (
         FROM (
           -- Constrain Output with WHERE
           SELECT
-            subq_4.metric_time__day
-            , subq_4.metric_time__week
-            , subq_4.metric_time__month
-            , subq_4.metric_time__quarter
-            , subq_4.metric_time__year
-            , subq_4.metric_time__extract_year
-            , subq_4.metric_time__extract_quarter
-            , subq_4.metric_time__extract_month
-            , subq_4.metric_time__extract_day
-            , subq_4.metric_time__extract_dow
-            , subq_4.metric_time__extract_doy
+            subq_4.metric_time__month
             , subq_4.ds__day
             , subq_4.ds__week
             , subq_4.ds__month
@@ -109,6 +99,16 @@ FROM (
             , subq_4.booking__paid_at__extract_day
             , subq_4.booking__paid_at__extract_dow
             , subq_4.booking__paid_at__extract_doy
+            , subq_4.metric_time__day
+            , subq_4.metric_time__week
+            , subq_4.metric_time__quarter
+            , subq_4.metric_time__year
+            , subq_4.metric_time__extract_year
+            , subq_4.metric_time__extract_quarter
+            , subq_4.metric_time__extract_month
+            , subq_4.metric_time__extract_day
+            , subq_4.metric_time__extract_dow
+            , subq_4.metric_time__extract_doy
             , subq_4.listing
             , subq_4.guest
             , subq_4.host
@@ -133,17 +133,7 @@ FROM (
           FROM (
             -- Join to Time Spine Dataset
             SELECT
-              subq_2.metric_time__day AS metric_time__day
-              , DATE_TRUNC('week', subq_2.metric_time__day) AS metric_time__week
-              , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-              , DATE_TRUNC('quarter', subq_2.metric_time__day) AS metric_time__quarter
-              , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-              , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-              , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-              , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-              , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-              , EXTRACT(DAYOFWEEK_ISO FROM subq_2.metric_time__day) AS metric_time__extract_dow
-              , EXTRACT(doy FROM subq_2.metric_time__day) AS metric_time__extract_doy
+              DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
               , subq_1.ds__day AS ds__day
               , subq_1.ds__week AS ds__week
               , subq_1.ds__month AS ds__month
@@ -210,6 +200,16 @@ FROM (
               , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
               , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
               , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+              , subq_1.metric_time__day AS metric_time__day
+              , subq_1.metric_time__week AS metric_time__week
+              , subq_1.metric_time__quarter AS metric_time__quarter
+              , subq_1.metric_time__year AS metric_time__year
+              , subq_1.metric_time__extract_year AS metric_time__extract_year
+              , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+              , subq_1.metric_time__extract_month AS metric_time__extract_month
+              , subq_1.metric_time__extract_day AS metric_time__extract_day
+              , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+              , subq_1.metric_time__extract_doy AS metric_time__extract_doy
               , subq_1.listing AS listing
               , subq_1.guest AS guest
               , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_offset_window_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_offset_window_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
@@ -25,8 +25,8 @@ FROM (
     FROM (
       -- Join to Time Spine Dataset
       SELECT
-        subq_19.ds AS metric_time__day
-        , DATE_TRUNC('month', subq_19.ds) AS metric_time__month
+        DATE_TRUNC('month', subq_19.ds) AS metric_time__month
+        , DATE_TRUNC('day', bookings_source_src_28000.ds) AS metric_time__day
         , bookings_source_src_28000.booking_value AS booking_value
       FROM ***************************.mf_time_spine subq_19
       INNER JOIN

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_offset_window_metric_multiple_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_offset_window_metric_multiple_granularities__plan0.sql
@@ -43,16 +43,8 @@ FROM (
           -- Join to Time Spine Dataset
           SELECT
             subq_2.metric_time__day AS metric_time__day
-            , DATE_TRUNC('week', subq_2.metric_time__day) AS metric_time__week
             , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('quarter', subq_2.metric_time__day) AS metric_time__quarter
             , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-            , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-            , EXTRACT(DAYOFWEEK_ISO FROM subq_2.metric_time__day) AS metric_time__extract_dow
-            , EXTRACT(doy FROM subq_2.metric_time__day) AS metric_time__extract_doy
             , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
@@ -119,6 +111,14 @@ FROM (
             , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_1.metric_time__week AS metric_time__week
+            , subq_1.metric_time__quarter AS metric_time__quarter
+            , subq_1.metric_time__extract_year AS metric_time__extract_year
+            , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_1.metric_time__extract_month AS metric_time__extract_month
+            , subq_1.metric_time__extract_day AS metric_time__extract_day
+            , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_1.metric_time__extract_doy AS metric_time__extract_doy
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_offset_window_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_offset_window_with_agg_time_dim__plan0.sql
@@ -246,16 +246,6 @@ FROM (
           -- Join to Time Spine Dataset
           SELECT
             subq_7.booking__ds__day AS booking__ds__day
-            , DATE_TRUNC('week', subq_7.booking__ds__day) AS booking__ds__week
-            , DATE_TRUNC('month', subq_7.booking__ds__day) AS booking__ds__month
-            , DATE_TRUNC('quarter', subq_7.booking__ds__day) AS booking__ds__quarter
-            , DATE_TRUNC('year', subq_7.booking__ds__day) AS booking__ds__year
-            , EXTRACT(year FROM subq_7.booking__ds__day) AS booking__ds__extract_year
-            , EXTRACT(quarter FROM subq_7.booking__ds__day) AS booking__ds__extract_quarter
-            , EXTRACT(month FROM subq_7.booking__ds__day) AS booking__ds__extract_month
-            , EXTRACT(day FROM subq_7.booking__ds__day) AS booking__ds__extract_day
-            , EXTRACT(DAYOFWEEK_ISO FROM subq_7.booking__ds__day) AS booking__ds__extract_dow
-            , EXTRACT(doy FROM subq_7.booking__ds__day) AS booking__ds__extract_doy
             , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
@@ -289,6 +279,16 @@ FROM (
             , subq_6.paid_at__extract_day AS paid_at__extract_day
             , subq_6.paid_at__extract_dow AS paid_at__extract_dow
             , subq_6.paid_at__extract_doy AS paid_at__extract_doy
+            , subq_6.booking__ds__week AS booking__ds__week
+            , subq_6.booking__ds__month AS booking__ds__month
+            , subq_6.booking__ds__quarter AS booking__ds__quarter
+            , subq_6.booking__ds__year AS booking__ds__year
+            , subq_6.booking__ds__extract_year AS booking__ds__extract_year
+            , subq_6.booking__ds__extract_quarter AS booking__ds__extract_quarter
+            , subq_6.booking__ds__extract_month AS booking__ds__extract_month
+            , subq_6.booking__ds__extract_day AS booking__ds__extract_day
+            , subq_6.booking__ds__extract_dow AS booking__ds__extract_dow
+            , subq_6.booking__ds__extract_doy AS booking__ds__extract_doy
             , subq_6.booking__ds_partitioned__day AS booking__ds_partitioned__day
             , subq_6.booking__ds_partitioned__week AS booking__ds_partitioned__week
             , subq_6.booking__ds_partitioned__month AS booking__ds_partitioned__month

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_time_offset_metric_with_time_constraint__plan0.sql
@@ -25,16 +25,6 @@ FROM (
         -- Join to Time Spine Dataset
         SELECT
           subq_2.metric_time__day AS metric_time__day
-          , DATE_TRUNC('week', subq_2.metric_time__day) AS metric_time__week
-          , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-          , DATE_TRUNC('quarter', subq_2.metric_time__day) AS metric_time__quarter
-          , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-          , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-          , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-          , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-          , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-          , EXTRACT(DAYOFWEEK_ISO FROM subq_2.metric_time__day) AS metric_time__extract_dow
-          , EXTRACT(doy FROM subq_2.metric_time__day) AS metric_time__extract_doy
           , subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
@@ -101,6 +91,16 @@ FROM (
           , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
           , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
           , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+          , subq_1.metric_time__week AS metric_time__week
+          , subq_1.metric_time__month AS metric_time__month
+          , subq_1.metric_time__quarter AS metric_time__quarter
+          , subq_1.metric_time__year AS metric_time__year
+          , subq_1.metric_time__extract_year AS metric_time__extract_year
+          , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_1.metric_time__extract_month AS metric_time__extract_month
+          , subq_1.metric_time__extract_day AS metric_time__extract_day
+          , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+          , subq_1.metric_time__extract_doy AS metric_time__extract_doy
           , subq_1.listing AS listing
           , subq_1.guest AS guest
           , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
@@ -25,16 +25,6 @@ FROM (
         -- Constrain Time Range to [2019-12-19T00:00:00, 2020-01-02T00:00:00]
         SELECT
           subq_7.metric_time__day
-          , subq_7.metric_time__week
-          , subq_7.metric_time__month
-          , subq_7.metric_time__quarter
-          , subq_7.metric_time__year
-          , subq_7.metric_time__extract_year
-          , subq_7.metric_time__extract_quarter
-          , subq_7.metric_time__extract_month
-          , subq_7.metric_time__extract_day
-          , subq_7.metric_time__extract_dow
-          , subq_7.metric_time__extract_doy
           , subq_7.ds__day
           , subq_7.ds__week
           , subq_7.ds__month
@@ -101,6 +91,16 @@ FROM (
           , subq_7.booking__paid_at__extract_day
           , subq_7.booking__paid_at__extract_dow
           , subq_7.booking__paid_at__extract_doy
+          , subq_7.metric_time__week
+          , subq_7.metric_time__month
+          , subq_7.metric_time__quarter
+          , subq_7.metric_time__year
+          , subq_7.metric_time__extract_year
+          , subq_7.metric_time__extract_quarter
+          , subq_7.metric_time__extract_month
+          , subq_7.metric_time__extract_day
+          , subq_7.metric_time__extract_dow
+          , subq_7.metric_time__extract_doy
           , subq_7.listing
           , subq_7.guest
           , subq_7.host
@@ -126,16 +126,6 @@ FROM (
           -- Join to Time Spine Dataset
           SELECT
             subq_5.metric_time__day AS metric_time__day
-            , DATE_TRUNC('week', subq_5.metric_time__day) AS metric_time__week
-            , DATE_TRUNC('month', subq_5.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('quarter', subq_5.metric_time__day) AS metric_time__quarter
-            , DATE_TRUNC('year', subq_5.metric_time__day) AS metric_time__year
-            , EXTRACT(year FROM subq_5.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_5.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_5.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_5.metric_time__day) AS metric_time__extract_day
-            , EXTRACT(isodow FROM subq_5.metric_time__day) AS metric_time__extract_dow
-            , EXTRACT(doy FROM subq_5.metric_time__day) AS metric_time__extract_doy
             , subq_4.ds__day AS ds__day
             , subq_4.ds__week AS ds__week
             , subq_4.ds__month AS ds__month
@@ -202,6 +192,16 @@ FROM (
             , subq_4.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_4.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_4.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_4.metric_time__week AS metric_time__week
+            , subq_4.metric_time__month AS metric_time__month
+            , subq_4.metric_time__quarter AS metric_time__quarter
+            , subq_4.metric_time__year AS metric_time__year
+            , subq_4.metric_time__extract_year AS metric_time__extract_year
+            , subq_4.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_4.metric_time__extract_month AS metric_time__extract_month
+            , subq_4.metric_time__extract_day AS metric_time__extract_day
+            , subq_4.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_4.metric_time__extract_doy AS metric_time__extract_doy
             , subq_4.listing AS listing
             , subq_4.guest AS guest
             , subq_4.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
@@ -25,11 +25,6 @@ FROM (
         -- Join to Time Spine Dataset
         SELECT
           subq_2.metric_time__month AS metric_time__month
-          , DATE_TRUNC('quarter', subq_2.metric_time__month) AS metric_time__quarter
-          , DATE_TRUNC('year', subq_2.metric_time__month) AS metric_time__year
-          , EXTRACT(year FROM subq_2.metric_time__month) AS metric_time__extract_year
-          , EXTRACT(quarter FROM subq_2.metric_time__month) AS metric_time__extract_quarter
-          , EXTRACT(month FROM subq_2.metric_time__month) AS metric_time__extract_month
           , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
           , subq_1.ds__year AS ds__year
@@ -42,6 +37,11 @@ FROM (
           , subq_1.booking_monthly__ds__extract_year AS booking_monthly__ds__extract_year
           , subq_1.booking_monthly__ds__extract_quarter AS booking_monthly__ds__extract_quarter
           , subq_1.booking_monthly__ds__extract_month AS booking_monthly__ds__extract_month
+          , subq_1.metric_time__quarter AS metric_time__quarter
+          , subq_1.metric_time__year AS metric_time__year
+          , subq_1.metric_time__extract_year AS metric_time__extract_year
+          , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_1.metric_time__extract_month AS metric_time__extract_month
           , subq_1.listing AS listing
           , subq_1.booking_monthly__listing AS booking_monthly__listing
           , subq_1.bookings_monthly AS bookings_monthly

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_to_grain__plan0.sql
@@ -246,16 +246,6 @@ FROM (
           -- Join to Time Spine Dataset
           SELECT
             subq_7.metric_time__day AS metric_time__day
-            , DATE_TRUNC('week', subq_7.metric_time__day) AS metric_time__week
-            , DATE_TRUNC('month', subq_7.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('quarter', subq_7.metric_time__day) AS metric_time__quarter
-            , DATE_TRUNC('year', subq_7.metric_time__day) AS metric_time__year
-            , EXTRACT(year FROM subq_7.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_7.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_7.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_7.metric_time__day) AS metric_time__extract_day
-            , EXTRACT(isodow FROM subq_7.metric_time__day) AS metric_time__extract_dow
-            , EXTRACT(doy FROM subq_7.metric_time__day) AS metric_time__extract_doy
             , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
@@ -322,6 +312,16 @@ FROM (
             , subq_6.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_6.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_6.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_6.metric_time__week AS metric_time__week
+            , subq_6.metric_time__month AS metric_time__month
+            , subq_6.metric_time__quarter AS metric_time__quarter
+            , subq_6.metric_time__year AS metric_time__year
+            , subq_6.metric_time__extract_year AS metric_time__extract_year
+            , subq_6.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_6.metric_time__extract_month AS metric_time__extract_month
+            , subq_6.metric_time__extract_day AS metric_time__extract_day
+            , subq_6.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_6.metric_time__extract_doy AS metric_time__extract_doy
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_to_grain_and_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_to_grain_and_granularity__plan0.sql
@@ -245,17 +245,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_7.metric_time__day AS metric_time__day
-            , DATE_TRUNC('week', subq_7.metric_time__day) AS metric_time__week
-            , DATE_TRUNC('month', subq_7.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('quarter', subq_7.metric_time__day) AS metric_time__quarter
-            , DATE_TRUNC('year', subq_7.metric_time__day) AS metric_time__year
-            , EXTRACT(year FROM subq_7.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_7.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_7.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_7.metric_time__day) AS metric_time__extract_day
-            , EXTRACT(isodow FROM subq_7.metric_time__day) AS metric_time__extract_dow
-            , EXTRACT(doy FROM subq_7.metric_time__day) AS metric_time__extract_doy
+            DATE_TRUNC('week', subq_7.metric_time__day) AS metric_time__week
             , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
@@ -322,6 +312,16 @@ FROM (
             , subq_6.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_6.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_6.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_6.metric_time__day AS metric_time__day
+            , subq_6.metric_time__month AS metric_time__month
+            , subq_6.metric_time__quarter AS metric_time__quarter
+            , subq_6.metric_time__year AS metric_time__year
+            , subq_6.metric_time__extract_year AS metric_time__extract_year
+            , subq_6.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_6.metric_time__extract_month AS metric_time__extract_month
+            , subq_6.metric_time__extract_day AS metric_time__extract_day
+            , subq_6.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_6.metric_time__extract_doy AS metric_time__extract_doy
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_window__plan0.sql
@@ -246,16 +246,6 @@ FROM (
           -- Join to Time Spine Dataset
           SELECT
             subq_7.metric_time__day AS metric_time__day
-            , DATE_TRUNC('week', subq_7.metric_time__day) AS metric_time__week
-            , DATE_TRUNC('month', subq_7.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('quarter', subq_7.metric_time__day) AS metric_time__quarter
-            , DATE_TRUNC('year', subq_7.metric_time__day) AS metric_time__year
-            , EXTRACT(year FROM subq_7.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_7.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_7.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_7.metric_time__day) AS metric_time__extract_day
-            , EXTRACT(isodow FROM subq_7.metric_time__day) AS metric_time__extract_dow
-            , EXTRACT(doy FROM subq_7.metric_time__day) AS metric_time__extract_doy
             , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
@@ -322,6 +312,16 @@ FROM (
             , subq_6.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_6.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_6.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_6.metric_time__week AS metric_time__week
+            , subq_6.metric_time__month AS metric_time__month
+            , subq_6.metric_time__quarter AS metric_time__quarter
+            , subq_6.metric_time__year AS metric_time__year
+            , subq_6.metric_time__extract_year AS metric_time__extract_year
+            , subq_6.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_6.metric_time__extract_month AS metric_time__extract_month
+            , subq_6.metric_time__extract_day AS metric_time__extract_day
+            , subq_6.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_6.metric_time__extract_doy AS metric_time__extract_doy
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_window_and_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_window_and_granularity__plan0.sql
@@ -245,17 +245,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_7.metric_time__day AS metric_time__day
-            , DATE_TRUNC('week', subq_7.metric_time__day) AS metric_time__week
-            , DATE_TRUNC('month', subq_7.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('quarter', subq_7.metric_time__day) AS metric_time__quarter
-            , DATE_TRUNC('year', subq_7.metric_time__day) AS metric_time__year
-            , EXTRACT(year FROM subq_7.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_7.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_7.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_7.metric_time__day) AS metric_time__extract_day
-            , EXTRACT(isodow FROM subq_7.metric_time__day) AS metric_time__extract_dow
-            , EXTRACT(doy FROM subq_7.metric_time__day) AS metric_time__extract_doy
+            DATE_TRUNC('quarter', subq_7.metric_time__day) AS metric_time__quarter
             , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
@@ -322,6 +312,16 @@ FROM (
             , subq_6.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_6.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_6.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_6.metric_time__day AS metric_time__day
+            , subq_6.metric_time__week AS metric_time__week
+            , subq_6.metric_time__month AS metric_time__month
+            , subq_6.metric_time__year AS metric_time__year
+            , subq_6.metric_time__extract_year AS metric_time__extract_year
+            , subq_6.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_6.metric_time__extract_month AS metric_time__extract_month
+            , subq_6.metric_time__extract_day AS metric_time__extract_day
+            , subq_6.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_6.metric_time__extract_doy AS metric_time__extract_doy
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
@@ -31,16 +31,6 @@ FROM (
           -- Join to Time Spine Dataset
           SELECT
             subq_2.metric_time__day AS metric_time__day
-            , DATE_TRUNC('week', subq_2.metric_time__day) AS metric_time__week
-            , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('quarter', subq_2.metric_time__day) AS metric_time__quarter
-            , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-            , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-            , EXTRACT(isodow FROM subq_2.metric_time__day) AS metric_time__extract_dow
-            , EXTRACT(doy FROM subq_2.metric_time__day) AS metric_time__extract_doy
             , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
@@ -107,6 +97,16 @@ FROM (
             , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_1.metric_time__week AS metric_time__week
+            , subq_1.metric_time__month AS metric_time__month
+            , subq_1.metric_time__quarter AS metric_time__quarter
+            , subq_1.metric_time__year AS metric_time__year
+            , subq_1.metric_time__extract_year AS metric_time__extract_year
+            , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_1.metric_time__extract_month AS metric_time__extract_month
+            , subq_1.metric_time__extract_day AS metric_time__extract_day
+            , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_1.metric_time__extract_doy AS metric_time__extract_doy
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host
@@ -356,16 +356,6 @@ FROM (
           -- Join to Time Spine Dataset
           SELECT
             subq_10.metric_time__day AS metric_time__day
-            , DATE_TRUNC('week', subq_10.metric_time__day) AS metric_time__week
-            , DATE_TRUNC('month', subq_10.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('quarter', subq_10.metric_time__day) AS metric_time__quarter
-            , DATE_TRUNC('year', subq_10.metric_time__day) AS metric_time__year
-            , EXTRACT(year FROM subq_10.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_10.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_10.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_10.metric_time__day) AS metric_time__extract_day
-            , EXTRACT(isodow FROM subq_10.metric_time__day) AS metric_time__extract_dow
-            , EXTRACT(doy FROM subq_10.metric_time__day) AS metric_time__extract_doy
             , subq_9.ds__day AS ds__day
             , subq_9.ds__week AS ds__week
             , subq_9.ds__month AS ds__month
@@ -432,6 +422,16 @@ FROM (
             , subq_9.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_9.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_9.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_9.metric_time__week AS metric_time__week
+            , subq_9.metric_time__month AS metric_time__month
+            , subq_9.metric_time__quarter AS metric_time__quarter
+            , subq_9.metric_time__year AS metric_time__year
+            , subq_9.metric_time__extract_year AS metric_time__extract_year
+            , subq_9.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_9.metric_time__extract_month AS metric_time__extract_month
+            , subq_9.metric_time__extract_day AS metric_time__extract_day
+            , subq_9.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_9.metric_time__extract_doy AS metric_time__extract_doy
             , subq_9.listing AS listing
             , subq_9.guest AS guest
             , subq_9.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0.sql
@@ -30,17 +30,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_2.metric_time__day AS metric_time__day
-            , DATE_TRUNC('week', subq_2.metric_time__day) AS metric_time__week
-            , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('quarter', subq_2.metric_time__day) AS metric_time__quarter
-            , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-            , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-            , EXTRACT(isodow FROM subq_2.metric_time__day) AS metric_time__extract_dow
-            , EXTRACT(doy FROM subq_2.metric_time__day) AS metric_time__extract_doy
+            DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
             , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
@@ -107,6 +97,16 @@ FROM (
             , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_1.metric_time__day AS metric_time__day
+            , subq_1.metric_time__week AS metric_time__week
+            , subq_1.metric_time__month AS metric_time__month
+            , subq_1.metric_time__quarter AS metric_time__quarter
+            , subq_1.metric_time__extract_year AS metric_time__extract_year
+            , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_1.metric_time__extract_month AS metric_time__extract_month
+            , subq_1.metric_time__extract_day AS metric_time__extract_day
+            , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_1.metric_time__extract_doy AS metric_time__extract_doy
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host
@@ -356,17 +356,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_10.metric_time__day AS metric_time__day
-            , DATE_TRUNC('week', subq_10.metric_time__day) AS metric_time__week
-            , DATE_TRUNC('month', subq_10.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('quarter', subq_10.metric_time__day) AS metric_time__quarter
-            , DATE_TRUNC('year', subq_10.metric_time__day) AS metric_time__year
-            , EXTRACT(year FROM subq_10.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_10.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_10.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_10.metric_time__day) AS metric_time__extract_day
-            , EXTRACT(isodow FROM subq_10.metric_time__day) AS metric_time__extract_dow
-            , EXTRACT(doy FROM subq_10.metric_time__day) AS metric_time__extract_doy
+            DATE_TRUNC('year', subq_10.metric_time__day) AS metric_time__year
             , subq_9.ds__day AS ds__day
             , subq_9.ds__week AS ds__week
             , subq_9.ds__month AS ds__month
@@ -433,6 +423,16 @@ FROM (
             , subq_9.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_9.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_9.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_9.metric_time__day AS metric_time__day
+            , subq_9.metric_time__week AS metric_time__week
+            , subq_9.metric_time__month AS metric_time__month
+            , subq_9.metric_time__quarter AS metric_time__quarter
+            , subq_9.metric_time__extract_year AS metric_time__extract_year
+            , subq_9.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_9.metric_time__extract_month AS metric_time__extract_month
+            , subq_9.metric_time__extract_day AS metric_time__extract_day
+            , subq_9.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_9.metric_time__extract_doy AS metric_time__extract_doy
             , subq_9.listing AS listing
             , subq_9.guest AS guest
             , subq_9.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
@@ -349,16 +349,6 @@ FROM (
           -- Constrain Output with WHERE
           SELECT
             subq_10.metric_time__day
-            , subq_10.metric_time__week
-            , subq_10.metric_time__month
-            , subq_10.metric_time__quarter
-            , subq_10.metric_time__year
-            , subq_10.metric_time__extract_year
-            , subq_10.metric_time__extract_quarter
-            , subq_10.metric_time__extract_month
-            , subq_10.metric_time__extract_day
-            , subq_10.metric_time__extract_dow
-            , subq_10.metric_time__extract_doy
             , subq_10.ds__day
             , subq_10.ds__week
             , subq_10.ds__month
@@ -425,6 +415,16 @@ FROM (
             , subq_10.booking__paid_at__extract_day
             , subq_10.booking__paid_at__extract_dow
             , subq_10.booking__paid_at__extract_doy
+            , subq_10.metric_time__week
+            , subq_10.metric_time__month
+            , subq_10.metric_time__quarter
+            , subq_10.metric_time__year
+            , subq_10.metric_time__extract_year
+            , subq_10.metric_time__extract_quarter
+            , subq_10.metric_time__extract_month
+            , subq_10.metric_time__extract_day
+            , subq_10.metric_time__extract_dow
+            , subq_10.metric_time__extract_doy
             , subq_10.listing
             , subq_10.guest
             , subq_10.host
@@ -450,16 +450,6 @@ FROM (
             -- Join to Time Spine Dataset
             SELECT
               subq_8.metric_time__day AS metric_time__day
-              , DATE_TRUNC('week', subq_8.metric_time__day) AS metric_time__week
-              , DATE_TRUNC('month', subq_8.metric_time__day) AS metric_time__month
-              , DATE_TRUNC('quarter', subq_8.metric_time__day) AS metric_time__quarter
-              , DATE_TRUNC('year', subq_8.metric_time__day) AS metric_time__year
-              , EXTRACT(year FROM subq_8.metric_time__day) AS metric_time__extract_year
-              , EXTRACT(quarter FROM subq_8.metric_time__day) AS metric_time__extract_quarter
-              , EXTRACT(month FROM subq_8.metric_time__day) AS metric_time__extract_month
-              , EXTRACT(day FROM subq_8.metric_time__day) AS metric_time__extract_day
-              , EXTRACT(isodow FROM subq_8.metric_time__day) AS metric_time__extract_dow
-              , EXTRACT(doy FROM subq_8.metric_time__day) AS metric_time__extract_doy
               , subq_7.ds__day AS ds__day
               , subq_7.ds__week AS ds__week
               , subq_7.ds__month AS ds__month
@@ -526,6 +516,16 @@ FROM (
               , subq_7.booking__paid_at__extract_day AS booking__paid_at__extract_day
               , subq_7.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
               , subq_7.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+              , subq_7.metric_time__week AS metric_time__week
+              , subq_7.metric_time__month AS metric_time__month
+              , subq_7.metric_time__quarter AS metric_time__quarter
+              , subq_7.metric_time__year AS metric_time__year
+              , subq_7.metric_time__extract_year AS metric_time__extract_year
+              , subq_7.metric_time__extract_quarter AS metric_time__extract_quarter
+              , subq_7.metric_time__extract_month AS metric_time__extract_month
+              , subq_7.metric_time__extract_day AS metric_time__extract_day
+              , subq_7.metric_time__extract_dow AS metric_time__extract_dow
+              , subq_7.metric_time__extract_doy AS metric_time__extract_doy
               , subq_7.listing AS listing
               , subq_7.guest AS guest
               , subq_7.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_offset_cumulative_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_offset_cumulative_metric__plan0.sql
@@ -25,16 +25,6 @@ FROM (
         -- Join to Time Spine Dataset
         SELECT
           subq_5.metric_time__day AS metric_time__day
-          , DATE_TRUNC('week', subq_5.metric_time__day) AS metric_time__week
-          , DATE_TRUNC('month', subq_5.metric_time__day) AS metric_time__month
-          , DATE_TRUNC('quarter', subq_5.metric_time__day) AS metric_time__quarter
-          , DATE_TRUNC('year', subq_5.metric_time__day) AS metric_time__year
-          , EXTRACT(year FROM subq_5.metric_time__day) AS metric_time__extract_year
-          , EXTRACT(quarter FROM subq_5.metric_time__day) AS metric_time__extract_quarter
-          , EXTRACT(month FROM subq_5.metric_time__day) AS metric_time__extract_month
-          , EXTRACT(day FROM subq_5.metric_time__day) AS metric_time__extract_day
-          , EXTRACT(isodow FROM subq_5.metric_time__day) AS metric_time__extract_dow
-          , EXTRACT(doy FROM subq_5.metric_time__day) AS metric_time__extract_doy
           , subq_4.ds__day AS ds__day
           , subq_4.ds__week AS ds__week
           , subq_4.ds__month AS ds__month
@@ -101,6 +91,16 @@ FROM (
           , subq_4.booking__paid_at__extract_day AS booking__paid_at__extract_day
           , subq_4.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
           , subq_4.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+          , subq_4.metric_time__week AS metric_time__week
+          , subq_4.metric_time__month AS metric_time__month
+          , subq_4.metric_time__quarter AS metric_time__quarter
+          , subq_4.metric_time__year AS metric_time__year
+          , subq_4.metric_time__extract_year AS metric_time__extract_year
+          , subq_4.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_4.metric_time__extract_month AS metric_time__extract_month
+          , subq_4.metric_time__extract_day AS metric_time__extract_day
+          , subq_4.metric_time__extract_dow AS metric_time__extract_dow
+          , subq_4.metric_time__extract_doy AS metric_time__extract_doy
           , subq_4.listing AS listing
           , subq_4.guest AS guest
           , subq_4.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_offset_metric_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_offset_metric_with_agg_time_dim__plan0.sql
@@ -31,16 +31,6 @@ FROM (
           -- Join to Time Spine Dataset
           SELECT
             subq_2.booking__ds__day AS booking__ds__day
-            , DATE_TRUNC('week', subq_2.booking__ds__day) AS booking__ds__week
-            , DATE_TRUNC('month', subq_2.booking__ds__day) AS booking__ds__month
-            , DATE_TRUNC('quarter', subq_2.booking__ds__day) AS booking__ds__quarter
-            , DATE_TRUNC('year', subq_2.booking__ds__day) AS booking__ds__year
-            , EXTRACT(year FROM subq_2.booking__ds__day) AS booking__ds__extract_year
-            , EXTRACT(quarter FROM subq_2.booking__ds__day) AS booking__ds__extract_quarter
-            , EXTRACT(month FROM subq_2.booking__ds__day) AS booking__ds__extract_month
-            , EXTRACT(day FROM subq_2.booking__ds__day) AS booking__ds__extract_day
-            , EXTRACT(isodow FROM subq_2.booking__ds__day) AS booking__ds__extract_dow
-            , EXTRACT(doy FROM subq_2.booking__ds__day) AS booking__ds__extract_doy
             , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
@@ -74,6 +64,16 @@ FROM (
             , subq_1.paid_at__extract_day AS paid_at__extract_day
             , subq_1.paid_at__extract_dow AS paid_at__extract_dow
             , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+            , subq_1.booking__ds__week AS booking__ds__week
+            , subq_1.booking__ds__month AS booking__ds__month
+            , subq_1.booking__ds__quarter AS booking__ds__quarter
+            , subq_1.booking__ds__year AS booking__ds__year
+            , subq_1.booking__ds__extract_year AS booking__ds__extract_year
+            , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
+            , subq_1.booking__ds__extract_month AS booking__ds__extract_month
+            , subq_1.booking__ds__extract_day AS booking__ds__extract_day
+            , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
+            , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
             , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
             , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
             , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_offset_metric_with_one_input_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_offset_metric_with_one_input_metric__plan0.sql
@@ -25,16 +25,6 @@ FROM (
         -- Join to Time Spine Dataset
         SELECT
           subq_2.metric_time__day AS metric_time__day
-          , DATE_TRUNC('week', subq_2.metric_time__day) AS metric_time__week
-          , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-          , DATE_TRUNC('quarter', subq_2.metric_time__day) AS metric_time__quarter
-          , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-          , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-          , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-          , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-          , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-          , EXTRACT(isodow FROM subq_2.metric_time__day) AS metric_time__extract_dow
-          , EXTRACT(doy FROM subq_2.metric_time__day) AS metric_time__extract_doy
           , subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
@@ -101,6 +91,16 @@ FROM (
           , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
           , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
           , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+          , subq_1.metric_time__week AS metric_time__week
+          , subq_1.metric_time__month AS metric_time__month
+          , subq_1.metric_time__quarter AS metric_time__quarter
+          , subq_1.metric_time__year AS metric_time__year
+          , subq_1.metric_time__extract_year AS metric_time__extract_year
+          , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_1.metric_time__extract_month AS metric_time__extract_month
+          , subq_1.metric_time__extract_day AS metric_time__extract_day
+          , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+          , subq_1.metric_time__extract_doy AS metric_time__extract_doy
           , subq_1.listing AS listing
           , subq_1.guest AS guest
           , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0.sql
@@ -57,16 +57,6 @@ FROM (
                 -- Join to Time Spine Dataset
                 SELECT
                   subq_2.metric_time__day AS metric_time__day
-                  , DATE_TRUNC('week', subq_2.metric_time__day) AS metric_time__week
-                  , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-                  , DATE_TRUNC('quarter', subq_2.metric_time__day) AS metric_time__quarter
-                  , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-                  , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-                  , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-                  , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-                  , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-                  , EXTRACT(isodow FROM subq_2.metric_time__day) AS metric_time__extract_dow
-                  , EXTRACT(doy FROM subq_2.metric_time__day) AS metric_time__extract_doy
                   , subq_1.ds__day AS ds__day
                   , subq_1.ds__week AS ds__week
                   , subq_1.ds__month AS ds__month
@@ -133,6 +123,16 @@ FROM (
                   , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
                   , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
                   , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                  , subq_1.metric_time__week AS metric_time__week
+                  , subq_1.metric_time__month AS metric_time__month
+                  , subq_1.metric_time__quarter AS metric_time__quarter
+                  , subq_1.metric_time__year AS metric_time__year
+                  , subq_1.metric_time__extract_year AS metric_time__extract_year
+                  , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+                  , subq_1.metric_time__extract_month AS metric_time__extract_month
+                  , subq_1.metric_time__extract_day AS metric_time__extract_day
+                  , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+                  , subq_1.metric_time__extract_doy AS metric_time__extract_doy
                   , subq_1.listing AS listing
                   , subq_1.guest AS guest
                   , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_offsets__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_offsets__plan0.sql
@@ -41,16 +41,6 @@ FROM (
             -- Join to Time Spine Dataset
             SELECT
               subq_2.metric_time__day AS metric_time__day
-              , DATE_TRUNC('week', subq_2.metric_time__day) AS metric_time__week
-              , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-              , DATE_TRUNC('quarter', subq_2.metric_time__day) AS metric_time__quarter
-              , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-              , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-              , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-              , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-              , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-              , EXTRACT(isodow FROM subq_2.metric_time__day) AS metric_time__extract_dow
-              , EXTRACT(doy FROM subq_2.metric_time__day) AS metric_time__extract_doy
               , subq_1.ds__day AS ds__day
               , subq_1.ds__week AS ds__week
               , subq_1.ds__month AS ds__month
@@ -117,6 +107,16 @@ FROM (
               , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
               , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
               , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+              , subq_1.metric_time__week AS metric_time__week
+              , subq_1.metric_time__month AS metric_time__month
+              , subq_1.metric_time__quarter AS metric_time__quarter
+              , subq_1.metric_time__year AS metric_time__year
+              , subq_1.metric_time__extract_year AS metric_time__extract_year
+              , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+              , subq_1.metric_time__extract_month AS metric_time__extract_month
+              , subq_1.metric_time__extract_day AS metric_time__extract_day
+              , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+              , subq_1.metric_time__extract_doy AS metric_time__extract_doy
               , subq_1.listing AS listing
               , subq_1.guest AS guest
               , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_offsets_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_offsets_with_time_constraint__plan0.sql
@@ -42,16 +42,6 @@ FROM (
             -- Join to Time Spine Dataset
             SELECT
               subq_2.metric_time__day AS metric_time__day
-              , DATE_TRUNC('week', subq_2.metric_time__day) AS metric_time__week
-              , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-              , DATE_TRUNC('quarter', subq_2.metric_time__day) AS metric_time__quarter
-              , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-              , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-              , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-              , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-              , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-              , EXTRACT(isodow FROM subq_2.metric_time__day) AS metric_time__extract_dow
-              , EXTRACT(doy FROM subq_2.metric_time__day) AS metric_time__extract_doy
               , subq_1.ds__day AS ds__day
               , subq_1.ds__week AS ds__week
               , subq_1.ds__month AS ds__month
@@ -118,6 +108,16 @@ FROM (
               , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
               , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
               , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+              , subq_1.metric_time__week AS metric_time__week
+              , subq_1.metric_time__month AS metric_time__month
+              , subq_1.metric_time__quarter AS metric_time__quarter
+              , subq_1.metric_time__year AS metric_time__year
+              , subq_1.metric_time__extract_year AS metric_time__extract_year
+              , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+              , subq_1.metric_time__extract_month AS metric_time__extract_month
+              , subq_1.metric_time__extract_day AS metric_time__extract_day
+              , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+              , subq_1.metric_time__extract_doy AS metric_time__extract_doy
               , subq_1.listing AS listing
               , subq_1.guest AS guest
               , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_offsets_with_where_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_offsets_with_where_constraint__plan0.sql
@@ -46,16 +46,6 @@ FROM (
               -- Join to Time Spine Dataset
               SELECT
                 subq_2.metric_time__day AS metric_time__day
-                , DATE_TRUNC('week', subq_2.metric_time__day) AS metric_time__week
-                , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-                , DATE_TRUNC('quarter', subq_2.metric_time__day) AS metric_time__quarter
-                , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-                , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-                , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-                , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-                , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-                , EXTRACT(isodow FROM subq_2.metric_time__day) AS metric_time__extract_dow
-                , EXTRACT(doy FROM subq_2.metric_time__day) AS metric_time__extract_doy
                 , subq_1.ds__day AS ds__day
                 , subq_1.ds__week AS ds__week
                 , subq_1.ds__month AS ds__month
@@ -122,6 +112,16 @@ FROM (
                 , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
                 , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
                 , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                , subq_1.metric_time__week AS metric_time__week
+                , subq_1.metric_time__month AS metric_time__month
+                , subq_1.metric_time__quarter AS metric_time__quarter
+                , subq_1.metric_time__year AS metric_time__year
+                , subq_1.metric_time__extract_year AS metric_time__extract_year
+                , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+                , subq_1.metric_time__extract_month AS metric_time__extract_month
+                , subq_1.metric_time__extract_day AS metric_time__extract_day
+                , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+                , subq_1.metric_time__extract_doy AS metric_time__extract_doy
                 , subq_1.listing AS listing
                 , subq_1.guest AS guest
                 , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0.sql
@@ -26,17 +26,7 @@ FROM (
       FROM (
         -- Constrain Output with WHERE
         SELECT
-          subq_4.metric_time__day
-          , subq_4.metric_time__week
-          , subq_4.metric_time__month
-          , subq_4.metric_time__quarter
-          , subq_4.metric_time__year
-          , subq_4.metric_time__extract_year
-          , subq_4.metric_time__extract_quarter
-          , subq_4.metric_time__extract_month
-          , subq_4.metric_time__extract_day
-          , subq_4.metric_time__extract_dow
-          , subq_4.metric_time__extract_doy
+          subq_4.metric_time__month
           , subq_4.ds__day
           , subq_4.ds__week
           , subq_4.ds__month
@@ -103,6 +93,16 @@ FROM (
           , subq_4.booking__paid_at__extract_day
           , subq_4.booking__paid_at__extract_dow
           , subq_4.booking__paid_at__extract_doy
+          , subq_4.metric_time__day
+          , subq_4.metric_time__week
+          , subq_4.metric_time__quarter
+          , subq_4.metric_time__year
+          , subq_4.metric_time__extract_year
+          , subq_4.metric_time__extract_quarter
+          , subq_4.metric_time__extract_month
+          , subq_4.metric_time__extract_day
+          , subq_4.metric_time__extract_dow
+          , subq_4.metric_time__extract_doy
           , subq_4.listing
           , subq_4.guest
           , subq_4.host
@@ -127,17 +127,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_2.metric_time__day AS metric_time__day
-            , DATE_TRUNC('week', subq_2.metric_time__day) AS metric_time__week
-            , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('quarter', subq_2.metric_time__day) AS metric_time__quarter
-            , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-            , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-            , EXTRACT(isodow FROM subq_2.metric_time__day) AS metric_time__extract_dow
-            , EXTRACT(doy FROM subq_2.metric_time__day) AS metric_time__extract_doy
+            DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
             , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
@@ -204,6 +194,16 @@ FROM (
             , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_1.metric_time__day AS metric_time__day
+            , subq_1.metric_time__week AS metric_time__week
+            , subq_1.metric_time__quarter AS metric_time__quarter
+            , subq_1.metric_time__year AS metric_time__year
+            , subq_1.metric_time__extract_year AS metric_time__extract_year
+            , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_1.metric_time__extract_month AS metric_time__extract_month
+            , subq_1.metric_time__extract_day AS metric_time__extract_day
+            , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_1.metric_time__extract_doy AS metric_time__extract_doy
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
@@ -19,8 +19,8 @@ FROM (
   FROM (
     -- Join to Time Spine Dataset
     SELECT
-      subq_12.ds AS metric_time__day
-      , DATE_TRUNC('month', subq_12.ds) AS metric_time__month
+      DATE_TRUNC('month', subq_12.ds) AS metric_time__month
+      , subq_10.metric_time__day AS metric_time__day
       , subq_10.bookings AS bookings
     FROM ***************************.mf_time_spine subq_12
     INNER JOIN (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_offset_to_grain_metric_multiple_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_offset_to_grain_metric_multiple_granularities__plan0.sql
@@ -35,16 +35,8 @@ FROM (
         -- Join to Time Spine Dataset
         SELECT
           subq_2.metric_time__day AS metric_time__day
-          , DATE_TRUNC('week', subq_2.metric_time__day) AS metric_time__week
           , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-          , DATE_TRUNC('quarter', subq_2.metric_time__day) AS metric_time__quarter
           , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-          , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-          , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-          , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-          , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-          , EXTRACT(isodow FROM subq_2.metric_time__day) AS metric_time__extract_dow
-          , EXTRACT(doy FROM subq_2.metric_time__day) AS metric_time__extract_doy
           , subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
@@ -111,6 +103,14 @@ FROM (
           , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
           , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
           , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+          , subq_1.metric_time__week AS metric_time__week
+          , subq_1.metric_time__quarter AS metric_time__quarter
+          , subq_1.metric_time__extract_year AS metric_time__extract_year
+          , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_1.metric_time__extract_month AS metric_time__extract_month
+          , subq_1.metric_time__extract_day AS metric_time__extract_day
+          , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+          , subq_1.metric_time__extract_doy AS metric_time__extract_doy
           , subq_1.listing AS listing
           , subq_1.guest AS guest
           , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_offset_to_grain_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_offset_to_grain_with_agg_time_dim__plan0.sql
@@ -246,16 +246,6 @@ FROM (
           -- Join to Time Spine Dataset
           SELECT
             subq_7.booking__ds__day AS booking__ds__day
-            , DATE_TRUNC('week', subq_7.booking__ds__day) AS booking__ds__week
-            , DATE_TRUNC('month', subq_7.booking__ds__day) AS booking__ds__month
-            , DATE_TRUNC('quarter', subq_7.booking__ds__day) AS booking__ds__quarter
-            , DATE_TRUNC('year', subq_7.booking__ds__day) AS booking__ds__year
-            , EXTRACT(year FROM subq_7.booking__ds__day) AS booking__ds__extract_year
-            , EXTRACT(quarter FROM subq_7.booking__ds__day) AS booking__ds__extract_quarter
-            , EXTRACT(month FROM subq_7.booking__ds__day) AS booking__ds__extract_month
-            , EXTRACT(day FROM subq_7.booking__ds__day) AS booking__ds__extract_day
-            , EXTRACT(isodow FROM subq_7.booking__ds__day) AS booking__ds__extract_dow
-            , EXTRACT(doy FROM subq_7.booking__ds__day) AS booking__ds__extract_doy
             , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
@@ -289,6 +279,16 @@ FROM (
             , subq_6.paid_at__extract_day AS paid_at__extract_day
             , subq_6.paid_at__extract_dow AS paid_at__extract_dow
             , subq_6.paid_at__extract_doy AS paid_at__extract_doy
+            , subq_6.booking__ds__week AS booking__ds__week
+            , subq_6.booking__ds__month AS booking__ds__month
+            , subq_6.booking__ds__quarter AS booking__ds__quarter
+            , subq_6.booking__ds__year AS booking__ds__year
+            , subq_6.booking__ds__extract_year AS booking__ds__extract_year
+            , subq_6.booking__ds__extract_quarter AS booking__ds__extract_quarter
+            , subq_6.booking__ds__extract_month AS booking__ds__extract_month
+            , subq_6.booking__ds__extract_day AS booking__ds__extract_day
+            , subq_6.booking__ds__extract_dow AS booking__ds__extract_dow
+            , subq_6.booking__ds__extract_doy AS booking__ds__extract_doy
             , subq_6.booking__ds_partitioned__day AS booking__ds_partitioned__day
             , subq_6.booking__ds_partitioned__week AS booking__ds_partitioned__week
             , subq_6.booking__ds_partitioned__month AS booking__ds_partitioned__month

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_offset_window_metric_filter_and_query_have_different_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_offset_window_metric_filter_and_query_have_different_granularities__plan0.sql
@@ -32,17 +32,7 @@ FROM (
         FROM (
           -- Constrain Output with WHERE
           SELECT
-            subq_4.metric_time__day
-            , subq_4.metric_time__week
-            , subq_4.metric_time__month
-            , subq_4.metric_time__quarter
-            , subq_4.metric_time__year
-            , subq_4.metric_time__extract_year
-            , subq_4.metric_time__extract_quarter
-            , subq_4.metric_time__extract_month
-            , subq_4.metric_time__extract_day
-            , subq_4.metric_time__extract_dow
-            , subq_4.metric_time__extract_doy
+            subq_4.metric_time__month
             , subq_4.ds__day
             , subq_4.ds__week
             , subq_4.ds__month
@@ -109,6 +99,16 @@ FROM (
             , subq_4.booking__paid_at__extract_day
             , subq_4.booking__paid_at__extract_dow
             , subq_4.booking__paid_at__extract_doy
+            , subq_4.metric_time__day
+            , subq_4.metric_time__week
+            , subq_4.metric_time__quarter
+            , subq_4.metric_time__year
+            , subq_4.metric_time__extract_year
+            , subq_4.metric_time__extract_quarter
+            , subq_4.metric_time__extract_month
+            , subq_4.metric_time__extract_day
+            , subq_4.metric_time__extract_dow
+            , subq_4.metric_time__extract_doy
             , subq_4.listing
             , subq_4.guest
             , subq_4.host
@@ -133,17 +133,7 @@ FROM (
           FROM (
             -- Join to Time Spine Dataset
             SELECT
-              subq_2.metric_time__day AS metric_time__day
-              , DATE_TRUNC('week', subq_2.metric_time__day) AS metric_time__week
-              , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-              , DATE_TRUNC('quarter', subq_2.metric_time__day) AS metric_time__quarter
-              , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-              , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-              , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-              , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-              , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-              , EXTRACT(isodow FROM subq_2.metric_time__day) AS metric_time__extract_dow
-              , EXTRACT(doy FROM subq_2.metric_time__day) AS metric_time__extract_doy
+              DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
               , subq_1.ds__day AS ds__day
               , subq_1.ds__week AS ds__week
               , subq_1.ds__month AS ds__month
@@ -210,6 +200,16 @@ FROM (
               , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
               , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
               , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+              , subq_1.metric_time__day AS metric_time__day
+              , subq_1.metric_time__week AS metric_time__week
+              , subq_1.metric_time__quarter AS metric_time__quarter
+              , subq_1.metric_time__year AS metric_time__year
+              , subq_1.metric_time__extract_year AS metric_time__extract_year
+              , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+              , subq_1.metric_time__extract_month AS metric_time__extract_month
+              , subq_1.metric_time__extract_day AS metric_time__extract_day
+              , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+              , subq_1.metric_time__extract_doy AS metric_time__extract_doy
               , subq_1.listing AS listing
               , subq_1.guest AS guest
               , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_offset_window_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_offset_window_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
@@ -25,8 +25,8 @@ FROM (
     FROM (
       -- Join to Time Spine Dataset
       SELECT
-        subq_19.ds AS metric_time__day
-        , DATE_TRUNC('month', subq_19.ds) AS metric_time__month
+        DATE_TRUNC('month', subq_19.ds) AS metric_time__month
+        , DATE_TRUNC('day', bookings_source_src_28000.ds) AS metric_time__day
         , bookings_source_src_28000.booking_value AS booking_value
       FROM ***************************.mf_time_spine subq_19
       INNER JOIN

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_offset_window_metric_multiple_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_offset_window_metric_multiple_granularities__plan0.sql
@@ -43,16 +43,8 @@ FROM (
           -- Join to Time Spine Dataset
           SELECT
             subq_2.metric_time__day AS metric_time__day
-            , DATE_TRUNC('week', subq_2.metric_time__day) AS metric_time__week
             , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('quarter', subq_2.metric_time__day) AS metric_time__quarter
             , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-            , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-            , EXTRACT(isodow FROM subq_2.metric_time__day) AS metric_time__extract_dow
-            , EXTRACT(doy FROM subq_2.metric_time__day) AS metric_time__extract_doy
             , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
@@ -119,6 +111,14 @@ FROM (
             , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_1.metric_time__week AS metric_time__week
+            , subq_1.metric_time__quarter AS metric_time__quarter
+            , subq_1.metric_time__extract_year AS metric_time__extract_year
+            , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_1.metric_time__extract_month AS metric_time__extract_month
+            , subq_1.metric_time__extract_day AS metric_time__extract_day
+            , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_1.metric_time__extract_doy AS metric_time__extract_doy
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_offset_window_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_offset_window_with_agg_time_dim__plan0.sql
@@ -246,16 +246,6 @@ FROM (
           -- Join to Time Spine Dataset
           SELECT
             subq_7.booking__ds__day AS booking__ds__day
-            , DATE_TRUNC('week', subq_7.booking__ds__day) AS booking__ds__week
-            , DATE_TRUNC('month', subq_7.booking__ds__day) AS booking__ds__month
-            , DATE_TRUNC('quarter', subq_7.booking__ds__day) AS booking__ds__quarter
-            , DATE_TRUNC('year', subq_7.booking__ds__day) AS booking__ds__year
-            , EXTRACT(year FROM subq_7.booking__ds__day) AS booking__ds__extract_year
-            , EXTRACT(quarter FROM subq_7.booking__ds__day) AS booking__ds__extract_quarter
-            , EXTRACT(month FROM subq_7.booking__ds__day) AS booking__ds__extract_month
-            , EXTRACT(day FROM subq_7.booking__ds__day) AS booking__ds__extract_day
-            , EXTRACT(isodow FROM subq_7.booking__ds__day) AS booking__ds__extract_dow
-            , EXTRACT(doy FROM subq_7.booking__ds__day) AS booking__ds__extract_doy
             , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
@@ -289,6 +279,16 @@ FROM (
             , subq_6.paid_at__extract_day AS paid_at__extract_day
             , subq_6.paid_at__extract_dow AS paid_at__extract_dow
             , subq_6.paid_at__extract_doy AS paid_at__extract_doy
+            , subq_6.booking__ds__week AS booking__ds__week
+            , subq_6.booking__ds__month AS booking__ds__month
+            , subq_6.booking__ds__quarter AS booking__ds__quarter
+            , subq_6.booking__ds__year AS booking__ds__year
+            , subq_6.booking__ds__extract_year AS booking__ds__extract_year
+            , subq_6.booking__ds__extract_quarter AS booking__ds__extract_quarter
+            , subq_6.booking__ds__extract_month AS booking__ds__extract_month
+            , subq_6.booking__ds__extract_day AS booking__ds__extract_day
+            , subq_6.booking__ds__extract_dow AS booking__ds__extract_dow
+            , subq_6.booking__ds__extract_doy AS booking__ds__extract_doy
             , subq_6.booking__ds_partitioned__day AS booking__ds_partitioned__day
             , subq_6.booking__ds_partitioned__week AS booking__ds_partitioned__week
             , subq_6.booking__ds_partitioned__month AS booking__ds_partitioned__month

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_time_offset_metric_with_time_constraint__plan0.sql
@@ -25,16 +25,6 @@ FROM (
         -- Join to Time Spine Dataset
         SELECT
           subq_2.metric_time__day AS metric_time__day
-          , DATE_TRUNC('week', subq_2.metric_time__day) AS metric_time__week
-          , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-          , DATE_TRUNC('quarter', subq_2.metric_time__day) AS metric_time__quarter
-          , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-          , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-          , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-          , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-          , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-          , EXTRACT(isodow FROM subq_2.metric_time__day) AS metric_time__extract_dow
-          , EXTRACT(doy FROM subq_2.metric_time__day) AS metric_time__extract_doy
           , subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
@@ -101,6 +91,16 @@ FROM (
           , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
           , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
           , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+          , subq_1.metric_time__week AS metric_time__week
+          , subq_1.metric_time__month AS metric_time__month
+          , subq_1.metric_time__quarter AS metric_time__quarter
+          , subq_1.metric_time__year AS metric_time__year
+          , subq_1.metric_time__extract_year AS metric_time__extract_year
+          , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_1.metric_time__extract_month AS metric_time__extract_month
+          , subq_1.metric_time__extract_day AS metric_time__extract_day
+          , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+          , subq_1.metric_time__extract_doy AS metric_time__extract_doy
           , subq_1.listing AS listing
           , subq_1.guest AS guest
           , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
@@ -25,16 +25,6 @@ FROM (
         -- Constrain Time Range to [2019-12-19T00:00:00, 2020-01-02T00:00:00]
         SELECT
           subq_7.metric_time__day
-          , subq_7.metric_time__week
-          , subq_7.metric_time__month
-          , subq_7.metric_time__quarter
-          , subq_7.metric_time__year
-          , subq_7.metric_time__extract_year
-          , subq_7.metric_time__extract_quarter
-          , subq_7.metric_time__extract_month
-          , subq_7.metric_time__extract_day
-          , subq_7.metric_time__extract_dow
-          , subq_7.metric_time__extract_doy
           , subq_7.ds__day
           , subq_7.ds__week
           , subq_7.ds__month
@@ -101,6 +91,16 @@ FROM (
           , subq_7.booking__paid_at__extract_day
           , subq_7.booking__paid_at__extract_dow
           , subq_7.booking__paid_at__extract_doy
+          , subq_7.metric_time__week
+          , subq_7.metric_time__month
+          , subq_7.metric_time__quarter
+          , subq_7.metric_time__year
+          , subq_7.metric_time__extract_year
+          , subq_7.metric_time__extract_quarter
+          , subq_7.metric_time__extract_month
+          , subq_7.metric_time__extract_day
+          , subq_7.metric_time__extract_dow
+          , subq_7.metric_time__extract_doy
           , subq_7.listing
           , subq_7.guest
           , subq_7.host
@@ -126,16 +126,6 @@ FROM (
           -- Join to Time Spine Dataset
           SELECT
             subq_5.metric_time__day AS metric_time__day
-            , DATE_TRUNC('week', subq_5.metric_time__day) AS metric_time__week
-            , DATE_TRUNC('month', subq_5.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('quarter', subq_5.metric_time__day) AS metric_time__quarter
-            , DATE_TRUNC('year', subq_5.metric_time__day) AS metric_time__year
-            , EXTRACT(year FROM subq_5.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_5.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_5.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_5.metric_time__day) AS metric_time__extract_day
-            , EXTRACT(isodow FROM subq_5.metric_time__day) AS metric_time__extract_dow
-            , EXTRACT(doy FROM subq_5.metric_time__day) AS metric_time__extract_doy
             , subq_4.ds__day AS ds__day
             , subq_4.ds__week AS ds__week
             , subq_4.ds__month AS ds__month
@@ -202,6 +192,16 @@ FROM (
             , subq_4.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_4.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_4.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_4.metric_time__week AS metric_time__week
+            , subq_4.metric_time__month AS metric_time__month
+            , subq_4.metric_time__quarter AS metric_time__quarter
+            , subq_4.metric_time__year AS metric_time__year
+            , subq_4.metric_time__extract_year AS metric_time__extract_year
+            , subq_4.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_4.metric_time__extract_month AS metric_time__extract_month
+            , subq_4.metric_time__extract_day AS metric_time__extract_day
+            , subq_4.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_4.metric_time__extract_doy AS metric_time__extract_doy
             , subq_4.listing AS listing
             , subq_4.guest AS guest
             , subq_4.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
@@ -25,11 +25,6 @@ FROM (
         -- Join to Time Spine Dataset
         SELECT
           subq_2.metric_time__month AS metric_time__month
-          , DATE_TRUNC('quarter', subq_2.metric_time__month) AS metric_time__quarter
-          , DATE_TRUNC('year', subq_2.metric_time__month) AS metric_time__year
-          , EXTRACT(year FROM subq_2.metric_time__month) AS metric_time__extract_year
-          , EXTRACT(quarter FROM subq_2.metric_time__month) AS metric_time__extract_quarter
-          , EXTRACT(month FROM subq_2.metric_time__month) AS metric_time__extract_month
           , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
           , subq_1.ds__year AS ds__year
@@ -42,6 +37,11 @@ FROM (
           , subq_1.booking_monthly__ds__extract_year AS booking_monthly__ds__extract_year
           , subq_1.booking_monthly__ds__extract_quarter AS booking_monthly__ds__extract_quarter
           , subq_1.booking_monthly__ds__extract_month AS booking_monthly__ds__extract_month
+          , subq_1.metric_time__quarter AS metric_time__quarter
+          , subq_1.metric_time__year AS metric_time__year
+          , subq_1.metric_time__extract_year AS metric_time__extract_year
+          , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_1.metric_time__extract_month AS metric_time__extract_month
           , subq_1.listing AS listing
           , subq_1.booking_monthly__listing AS booking_monthly__listing
           , subq_1.bookings_monthly AS bookings_monthly

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_to_grain__plan0.sql
@@ -246,16 +246,6 @@ FROM (
           -- Join to Time Spine Dataset
           SELECT
             subq_7.metric_time__day AS metric_time__day
-            , DATE_TRUNC('week', subq_7.metric_time__day) AS metric_time__week
-            , DATE_TRUNC('month', subq_7.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('quarter', subq_7.metric_time__day) AS metric_time__quarter
-            , DATE_TRUNC('year', subq_7.metric_time__day) AS metric_time__year
-            , EXTRACT(year FROM subq_7.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_7.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_7.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_7.metric_time__day) AS metric_time__extract_day
-            , EXTRACT(isodow FROM subq_7.metric_time__day) AS metric_time__extract_dow
-            , EXTRACT(doy FROM subq_7.metric_time__day) AS metric_time__extract_doy
             , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
@@ -322,6 +312,16 @@ FROM (
             , subq_6.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_6.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_6.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_6.metric_time__week AS metric_time__week
+            , subq_6.metric_time__month AS metric_time__month
+            , subq_6.metric_time__quarter AS metric_time__quarter
+            , subq_6.metric_time__year AS metric_time__year
+            , subq_6.metric_time__extract_year AS metric_time__extract_year
+            , subq_6.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_6.metric_time__extract_month AS metric_time__extract_month
+            , subq_6.metric_time__extract_day AS metric_time__extract_day
+            , subq_6.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_6.metric_time__extract_doy AS metric_time__extract_doy
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_to_grain_and_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_to_grain_and_granularity__plan0.sql
@@ -245,17 +245,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_7.metric_time__day AS metric_time__day
-            , DATE_TRUNC('week', subq_7.metric_time__day) AS metric_time__week
-            , DATE_TRUNC('month', subq_7.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('quarter', subq_7.metric_time__day) AS metric_time__quarter
-            , DATE_TRUNC('year', subq_7.metric_time__day) AS metric_time__year
-            , EXTRACT(year FROM subq_7.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_7.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_7.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_7.metric_time__day) AS metric_time__extract_day
-            , EXTRACT(isodow FROM subq_7.metric_time__day) AS metric_time__extract_dow
-            , EXTRACT(doy FROM subq_7.metric_time__day) AS metric_time__extract_doy
+            DATE_TRUNC('week', subq_7.metric_time__day) AS metric_time__week
             , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
@@ -322,6 +312,16 @@ FROM (
             , subq_6.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_6.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_6.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_6.metric_time__day AS metric_time__day
+            , subq_6.metric_time__month AS metric_time__month
+            , subq_6.metric_time__quarter AS metric_time__quarter
+            , subq_6.metric_time__year AS metric_time__year
+            , subq_6.metric_time__extract_year AS metric_time__extract_year
+            , subq_6.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_6.metric_time__extract_month AS metric_time__extract_month
+            , subq_6.metric_time__extract_day AS metric_time__extract_day
+            , subq_6.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_6.metric_time__extract_doy AS metric_time__extract_doy
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_window__plan0.sql
@@ -246,16 +246,6 @@ FROM (
           -- Join to Time Spine Dataset
           SELECT
             subq_7.metric_time__day AS metric_time__day
-            , DATE_TRUNC('week', subq_7.metric_time__day) AS metric_time__week
-            , DATE_TRUNC('month', subq_7.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('quarter', subq_7.metric_time__day) AS metric_time__quarter
-            , DATE_TRUNC('year', subq_7.metric_time__day) AS metric_time__year
-            , EXTRACT(year FROM subq_7.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_7.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_7.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_7.metric_time__day) AS metric_time__extract_day
-            , EXTRACT(isodow FROM subq_7.metric_time__day) AS metric_time__extract_dow
-            , EXTRACT(doy FROM subq_7.metric_time__day) AS metric_time__extract_doy
             , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
@@ -322,6 +312,16 @@ FROM (
             , subq_6.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_6.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_6.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_6.metric_time__week AS metric_time__week
+            , subq_6.metric_time__month AS metric_time__month
+            , subq_6.metric_time__quarter AS metric_time__quarter
+            , subq_6.metric_time__year AS metric_time__year
+            , subq_6.metric_time__extract_year AS metric_time__extract_year
+            , subq_6.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_6.metric_time__extract_month AS metric_time__extract_month
+            , subq_6.metric_time__extract_day AS metric_time__extract_day
+            , subq_6.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_6.metric_time__extract_doy AS metric_time__extract_doy
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_window_and_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_window_and_granularity__plan0.sql
@@ -245,17 +245,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_7.metric_time__day AS metric_time__day
-            , DATE_TRUNC('week', subq_7.metric_time__day) AS metric_time__week
-            , DATE_TRUNC('month', subq_7.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('quarter', subq_7.metric_time__day) AS metric_time__quarter
-            , DATE_TRUNC('year', subq_7.metric_time__day) AS metric_time__year
-            , EXTRACT(year FROM subq_7.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_7.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_7.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_7.metric_time__day) AS metric_time__extract_day
-            , EXTRACT(isodow FROM subq_7.metric_time__day) AS metric_time__extract_dow
-            , EXTRACT(doy FROM subq_7.metric_time__day) AS metric_time__extract_doy
+            DATE_TRUNC('quarter', subq_7.metric_time__day) AS metric_time__quarter
             , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
@@ -322,6 +312,16 @@ FROM (
             , subq_6.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_6.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_6.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_6.metric_time__day AS metric_time__day
+            , subq_6.metric_time__week AS metric_time__week
+            , subq_6.metric_time__month AS metric_time__month
+            , subq_6.metric_time__year AS metric_time__year
+            , subq_6.metric_time__extract_year AS metric_time__extract_year
+            , subq_6.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_6.metric_time__extract_month AS metric_time__extract_month
+            , subq_6.metric_time__extract_day AS metric_time__extract_day
+            , subq_6.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_6.metric_time__extract_doy AS metric_time__extract_doy
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
@@ -31,16 +31,6 @@ FROM (
           -- Join to Time Spine Dataset
           SELECT
             subq_2.metric_time__day AS metric_time__day
-            , DATE_TRUNC('week', subq_2.metric_time__day) AS metric_time__week
-            , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('quarter', subq_2.metric_time__day) AS metric_time__quarter
-            , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-            , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-            , EXTRACT(isodow FROM subq_2.metric_time__day) AS metric_time__extract_dow
-            , EXTRACT(doy FROM subq_2.metric_time__day) AS metric_time__extract_doy
             , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
@@ -107,6 +97,16 @@ FROM (
             , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_1.metric_time__week AS metric_time__week
+            , subq_1.metric_time__month AS metric_time__month
+            , subq_1.metric_time__quarter AS metric_time__quarter
+            , subq_1.metric_time__year AS metric_time__year
+            , subq_1.metric_time__extract_year AS metric_time__extract_year
+            , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_1.metric_time__extract_month AS metric_time__extract_month
+            , subq_1.metric_time__extract_day AS metric_time__extract_day
+            , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_1.metric_time__extract_doy AS metric_time__extract_doy
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host
@@ -356,16 +356,6 @@ FROM (
           -- Join to Time Spine Dataset
           SELECT
             subq_10.metric_time__day AS metric_time__day
-            , DATE_TRUNC('week', subq_10.metric_time__day) AS metric_time__week
-            , DATE_TRUNC('month', subq_10.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('quarter', subq_10.metric_time__day) AS metric_time__quarter
-            , DATE_TRUNC('year', subq_10.metric_time__day) AS metric_time__year
-            , EXTRACT(year FROM subq_10.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_10.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_10.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_10.metric_time__day) AS metric_time__extract_day
-            , EXTRACT(isodow FROM subq_10.metric_time__day) AS metric_time__extract_dow
-            , EXTRACT(doy FROM subq_10.metric_time__day) AS metric_time__extract_doy
             , subq_9.ds__day AS ds__day
             , subq_9.ds__week AS ds__week
             , subq_9.ds__month AS ds__month
@@ -432,6 +422,16 @@ FROM (
             , subq_9.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_9.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_9.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_9.metric_time__week AS metric_time__week
+            , subq_9.metric_time__month AS metric_time__month
+            , subq_9.metric_time__quarter AS metric_time__quarter
+            , subq_9.metric_time__year AS metric_time__year
+            , subq_9.metric_time__extract_year AS metric_time__extract_year
+            , subq_9.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_9.metric_time__extract_month AS metric_time__extract_month
+            , subq_9.metric_time__extract_day AS metric_time__extract_day
+            , subq_9.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_9.metric_time__extract_doy AS metric_time__extract_doy
             , subq_9.listing AS listing
             , subq_9.guest AS guest
             , subq_9.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0.sql
@@ -30,17 +30,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_2.metric_time__day AS metric_time__day
-            , DATE_TRUNC('week', subq_2.metric_time__day) AS metric_time__week
-            , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('quarter', subq_2.metric_time__day) AS metric_time__quarter
-            , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-            , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-            , EXTRACT(isodow FROM subq_2.metric_time__day) AS metric_time__extract_dow
-            , EXTRACT(doy FROM subq_2.metric_time__day) AS metric_time__extract_doy
+            DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
             , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
@@ -107,6 +97,16 @@ FROM (
             , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_1.metric_time__day AS metric_time__day
+            , subq_1.metric_time__week AS metric_time__week
+            , subq_1.metric_time__month AS metric_time__month
+            , subq_1.metric_time__quarter AS metric_time__quarter
+            , subq_1.metric_time__extract_year AS metric_time__extract_year
+            , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_1.metric_time__extract_month AS metric_time__extract_month
+            , subq_1.metric_time__extract_day AS metric_time__extract_day
+            , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_1.metric_time__extract_doy AS metric_time__extract_doy
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host
@@ -356,17 +356,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_10.metric_time__day AS metric_time__day
-            , DATE_TRUNC('week', subq_10.metric_time__day) AS metric_time__week
-            , DATE_TRUNC('month', subq_10.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('quarter', subq_10.metric_time__day) AS metric_time__quarter
-            , DATE_TRUNC('year', subq_10.metric_time__day) AS metric_time__year
-            , EXTRACT(year FROM subq_10.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_10.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_10.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_10.metric_time__day) AS metric_time__extract_day
-            , EXTRACT(isodow FROM subq_10.metric_time__day) AS metric_time__extract_dow
-            , EXTRACT(doy FROM subq_10.metric_time__day) AS metric_time__extract_doy
+            DATE_TRUNC('year', subq_10.metric_time__day) AS metric_time__year
             , subq_9.ds__day AS ds__day
             , subq_9.ds__week AS ds__week
             , subq_9.ds__month AS ds__month
@@ -433,6 +423,16 @@ FROM (
             , subq_9.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_9.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_9.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_9.metric_time__day AS metric_time__day
+            , subq_9.metric_time__week AS metric_time__week
+            , subq_9.metric_time__month AS metric_time__month
+            , subq_9.metric_time__quarter AS metric_time__quarter
+            , subq_9.metric_time__extract_year AS metric_time__extract_year
+            , subq_9.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_9.metric_time__extract_month AS metric_time__extract_month
+            , subq_9.metric_time__extract_day AS metric_time__extract_day
+            , subq_9.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_9.metric_time__extract_doy AS metric_time__extract_doy
             , subq_9.listing AS listing
             , subq_9.guest AS guest
             , subq_9.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
@@ -349,16 +349,6 @@ FROM (
           -- Constrain Output with WHERE
           SELECT
             subq_10.metric_time__day
-            , subq_10.metric_time__week
-            , subq_10.metric_time__month
-            , subq_10.metric_time__quarter
-            , subq_10.metric_time__year
-            , subq_10.metric_time__extract_year
-            , subq_10.metric_time__extract_quarter
-            , subq_10.metric_time__extract_month
-            , subq_10.metric_time__extract_day
-            , subq_10.metric_time__extract_dow
-            , subq_10.metric_time__extract_doy
             , subq_10.ds__day
             , subq_10.ds__week
             , subq_10.ds__month
@@ -425,6 +415,16 @@ FROM (
             , subq_10.booking__paid_at__extract_day
             , subq_10.booking__paid_at__extract_dow
             , subq_10.booking__paid_at__extract_doy
+            , subq_10.metric_time__week
+            , subq_10.metric_time__month
+            , subq_10.metric_time__quarter
+            , subq_10.metric_time__year
+            , subq_10.metric_time__extract_year
+            , subq_10.metric_time__extract_quarter
+            , subq_10.metric_time__extract_month
+            , subq_10.metric_time__extract_day
+            , subq_10.metric_time__extract_dow
+            , subq_10.metric_time__extract_doy
             , subq_10.listing
             , subq_10.guest
             , subq_10.host
@@ -450,16 +450,6 @@ FROM (
             -- Join to Time Spine Dataset
             SELECT
               subq_8.metric_time__day AS metric_time__day
-              , DATE_TRUNC('week', subq_8.metric_time__day) AS metric_time__week
-              , DATE_TRUNC('month', subq_8.metric_time__day) AS metric_time__month
-              , DATE_TRUNC('quarter', subq_8.metric_time__day) AS metric_time__quarter
-              , DATE_TRUNC('year', subq_8.metric_time__day) AS metric_time__year
-              , EXTRACT(year FROM subq_8.metric_time__day) AS metric_time__extract_year
-              , EXTRACT(quarter FROM subq_8.metric_time__day) AS metric_time__extract_quarter
-              , EXTRACT(month FROM subq_8.metric_time__day) AS metric_time__extract_month
-              , EXTRACT(day FROM subq_8.metric_time__day) AS metric_time__extract_day
-              , EXTRACT(isodow FROM subq_8.metric_time__day) AS metric_time__extract_dow
-              , EXTRACT(doy FROM subq_8.metric_time__day) AS metric_time__extract_doy
               , subq_7.ds__day AS ds__day
               , subq_7.ds__week AS ds__week
               , subq_7.ds__month AS ds__month
@@ -526,6 +516,16 @@ FROM (
               , subq_7.booking__paid_at__extract_day AS booking__paid_at__extract_day
               , subq_7.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
               , subq_7.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+              , subq_7.metric_time__week AS metric_time__week
+              , subq_7.metric_time__month AS metric_time__month
+              , subq_7.metric_time__quarter AS metric_time__quarter
+              , subq_7.metric_time__year AS metric_time__year
+              , subq_7.metric_time__extract_year AS metric_time__extract_year
+              , subq_7.metric_time__extract_quarter AS metric_time__extract_quarter
+              , subq_7.metric_time__extract_month AS metric_time__extract_month
+              , subq_7.metric_time__extract_day AS metric_time__extract_day
+              , subq_7.metric_time__extract_dow AS metric_time__extract_dow
+              , subq_7.metric_time__extract_doy AS metric_time__extract_doy
               , subq_7.listing AS listing
               , subq_7.guest AS guest
               , subq_7.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_offset_cumulative_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_offset_cumulative_metric__plan0.sql
@@ -25,16 +25,6 @@ FROM (
         -- Join to Time Spine Dataset
         SELECT
           subq_5.metric_time__day AS metric_time__day
-          , DATE_TRUNC('week', subq_5.metric_time__day) AS metric_time__week
-          , DATE_TRUNC('month', subq_5.metric_time__day) AS metric_time__month
-          , DATE_TRUNC('quarter', subq_5.metric_time__day) AS metric_time__quarter
-          , DATE_TRUNC('year', subq_5.metric_time__day) AS metric_time__year
-          , EXTRACT(year FROM subq_5.metric_time__day) AS metric_time__extract_year
-          , EXTRACT(quarter FROM subq_5.metric_time__day) AS metric_time__extract_quarter
-          , EXTRACT(month FROM subq_5.metric_time__day) AS metric_time__extract_month
-          , EXTRACT(day FROM subq_5.metric_time__day) AS metric_time__extract_day
-          , EXTRACT(isodow FROM subq_5.metric_time__day) AS metric_time__extract_dow
-          , EXTRACT(doy FROM subq_5.metric_time__day) AS metric_time__extract_doy
           , subq_4.ds__day AS ds__day
           , subq_4.ds__week AS ds__week
           , subq_4.ds__month AS ds__month
@@ -101,6 +91,16 @@ FROM (
           , subq_4.booking__paid_at__extract_day AS booking__paid_at__extract_day
           , subq_4.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
           , subq_4.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+          , subq_4.metric_time__week AS metric_time__week
+          , subq_4.metric_time__month AS metric_time__month
+          , subq_4.metric_time__quarter AS metric_time__quarter
+          , subq_4.metric_time__year AS metric_time__year
+          , subq_4.metric_time__extract_year AS metric_time__extract_year
+          , subq_4.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_4.metric_time__extract_month AS metric_time__extract_month
+          , subq_4.metric_time__extract_day AS metric_time__extract_day
+          , subq_4.metric_time__extract_dow AS metric_time__extract_dow
+          , subq_4.metric_time__extract_doy AS metric_time__extract_doy
           , subq_4.listing AS listing
           , subq_4.guest AS guest
           , subq_4.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_offset_metric_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_offset_metric_with_agg_time_dim__plan0.sql
@@ -31,16 +31,6 @@ FROM (
           -- Join to Time Spine Dataset
           SELECT
             subq_2.booking__ds__day AS booking__ds__day
-            , DATE_TRUNC('week', subq_2.booking__ds__day) AS booking__ds__week
-            , DATE_TRUNC('month', subq_2.booking__ds__day) AS booking__ds__month
-            , DATE_TRUNC('quarter', subq_2.booking__ds__day) AS booking__ds__quarter
-            , DATE_TRUNC('year', subq_2.booking__ds__day) AS booking__ds__year
-            , EXTRACT(year FROM subq_2.booking__ds__day) AS booking__ds__extract_year
-            , EXTRACT(quarter FROM subq_2.booking__ds__day) AS booking__ds__extract_quarter
-            , EXTRACT(month FROM subq_2.booking__ds__day) AS booking__ds__extract_month
-            , EXTRACT(day FROM subq_2.booking__ds__day) AS booking__ds__extract_day
-            , EXTRACT(isodow FROM subq_2.booking__ds__day) AS booking__ds__extract_dow
-            , EXTRACT(doy FROM subq_2.booking__ds__day) AS booking__ds__extract_doy
             , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
@@ -74,6 +64,16 @@ FROM (
             , subq_1.paid_at__extract_day AS paid_at__extract_day
             , subq_1.paid_at__extract_dow AS paid_at__extract_dow
             , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+            , subq_1.booking__ds__week AS booking__ds__week
+            , subq_1.booking__ds__month AS booking__ds__month
+            , subq_1.booking__ds__quarter AS booking__ds__quarter
+            , subq_1.booking__ds__year AS booking__ds__year
+            , subq_1.booking__ds__extract_year AS booking__ds__extract_year
+            , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
+            , subq_1.booking__ds__extract_month AS booking__ds__extract_month
+            , subq_1.booking__ds__extract_day AS booking__ds__extract_day
+            , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
+            , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
             , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
             , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
             , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_offset_metric_with_one_input_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_offset_metric_with_one_input_metric__plan0.sql
@@ -25,16 +25,6 @@ FROM (
         -- Join to Time Spine Dataset
         SELECT
           subq_2.metric_time__day AS metric_time__day
-          , DATE_TRUNC('week', subq_2.metric_time__day) AS metric_time__week
-          , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-          , DATE_TRUNC('quarter', subq_2.metric_time__day) AS metric_time__quarter
-          , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-          , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-          , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-          , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-          , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-          , EXTRACT(isodow FROM subq_2.metric_time__day) AS metric_time__extract_dow
-          , EXTRACT(doy FROM subq_2.metric_time__day) AS metric_time__extract_doy
           , subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
@@ -101,6 +91,16 @@ FROM (
           , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
           , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
           , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+          , subq_1.metric_time__week AS metric_time__week
+          , subq_1.metric_time__month AS metric_time__month
+          , subq_1.metric_time__quarter AS metric_time__quarter
+          , subq_1.metric_time__year AS metric_time__year
+          , subq_1.metric_time__extract_year AS metric_time__extract_year
+          , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_1.metric_time__extract_month AS metric_time__extract_month
+          , subq_1.metric_time__extract_day AS metric_time__extract_day
+          , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+          , subq_1.metric_time__extract_doy AS metric_time__extract_doy
           , subq_1.listing AS listing
           , subq_1.guest AS guest
           , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0.sql
@@ -57,16 +57,6 @@ FROM (
                 -- Join to Time Spine Dataset
                 SELECT
                   subq_2.metric_time__day AS metric_time__day
-                  , DATE_TRUNC('week', subq_2.metric_time__day) AS metric_time__week
-                  , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-                  , DATE_TRUNC('quarter', subq_2.metric_time__day) AS metric_time__quarter
-                  , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-                  , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-                  , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-                  , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-                  , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-                  , EXTRACT(isodow FROM subq_2.metric_time__day) AS metric_time__extract_dow
-                  , EXTRACT(doy FROM subq_2.metric_time__day) AS metric_time__extract_doy
                   , subq_1.ds__day AS ds__day
                   , subq_1.ds__week AS ds__week
                   , subq_1.ds__month AS ds__month
@@ -133,6 +123,16 @@ FROM (
                   , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
                   , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
                   , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                  , subq_1.metric_time__week AS metric_time__week
+                  , subq_1.metric_time__month AS metric_time__month
+                  , subq_1.metric_time__quarter AS metric_time__quarter
+                  , subq_1.metric_time__year AS metric_time__year
+                  , subq_1.metric_time__extract_year AS metric_time__extract_year
+                  , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+                  , subq_1.metric_time__extract_month AS metric_time__extract_month
+                  , subq_1.metric_time__extract_day AS metric_time__extract_day
+                  , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+                  , subq_1.metric_time__extract_doy AS metric_time__extract_doy
                   , subq_1.listing AS listing
                   , subq_1.guest AS guest
                   , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_offsets__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_offsets__plan0.sql
@@ -41,16 +41,6 @@ FROM (
             -- Join to Time Spine Dataset
             SELECT
               subq_2.metric_time__day AS metric_time__day
-              , DATE_TRUNC('week', subq_2.metric_time__day) AS metric_time__week
-              , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-              , DATE_TRUNC('quarter', subq_2.metric_time__day) AS metric_time__quarter
-              , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-              , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-              , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-              , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-              , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-              , EXTRACT(isodow FROM subq_2.metric_time__day) AS metric_time__extract_dow
-              , EXTRACT(doy FROM subq_2.metric_time__day) AS metric_time__extract_doy
               , subq_1.ds__day AS ds__day
               , subq_1.ds__week AS ds__week
               , subq_1.ds__month AS ds__month
@@ -117,6 +107,16 @@ FROM (
               , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
               , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
               , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+              , subq_1.metric_time__week AS metric_time__week
+              , subq_1.metric_time__month AS metric_time__month
+              , subq_1.metric_time__quarter AS metric_time__quarter
+              , subq_1.metric_time__year AS metric_time__year
+              , subq_1.metric_time__extract_year AS metric_time__extract_year
+              , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+              , subq_1.metric_time__extract_month AS metric_time__extract_month
+              , subq_1.metric_time__extract_day AS metric_time__extract_day
+              , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+              , subq_1.metric_time__extract_doy AS metric_time__extract_doy
               , subq_1.listing AS listing
               , subq_1.guest AS guest
               , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_offsets_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_offsets_with_time_constraint__plan0.sql
@@ -42,16 +42,6 @@ FROM (
             -- Join to Time Spine Dataset
             SELECT
               subq_2.metric_time__day AS metric_time__day
-              , DATE_TRUNC('week', subq_2.metric_time__day) AS metric_time__week
-              , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-              , DATE_TRUNC('quarter', subq_2.metric_time__day) AS metric_time__quarter
-              , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-              , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-              , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-              , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-              , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-              , EXTRACT(isodow FROM subq_2.metric_time__day) AS metric_time__extract_dow
-              , EXTRACT(doy FROM subq_2.metric_time__day) AS metric_time__extract_doy
               , subq_1.ds__day AS ds__day
               , subq_1.ds__week AS ds__week
               , subq_1.ds__month AS ds__month
@@ -118,6 +108,16 @@ FROM (
               , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
               , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
               , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+              , subq_1.metric_time__week AS metric_time__week
+              , subq_1.metric_time__month AS metric_time__month
+              , subq_1.metric_time__quarter AS metric_time__quarter
+              , subq_1.metric_time__year AS metric_time__year
+              , subq_1.metric_time__extract_year AS metric_time__extract_year
+              , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+              , subq_1.metric_time__extract_month AS metric_time__extract_month
+              , subq_1.metric_time__extract_day AS metric_time__extract_day
+              , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+              , subq_1.metric_time__extract_doy AS metric_time__extract_doy
               , subq_1.listing AS listing
               , subq_1.guest AS guest
               , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_offsets_with_where_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_offsets_with_where_constraint__plan0.sql
@@ -46,16 +46,6 @@ FROM (
               -- Join to Time Spine Dataset
               SELECT
                 subq_2.metric_time__day AS metric_time__day
-                , DATE_TRUNC('week', subq_2.metric_time__day) AS metric_time__week
-                , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-                , DATE_TRUNC('quarter', subq_2.metric_time__day) AS metric_time__quarter
-                , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-                , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-                , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-                , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-                , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-                , EXTRACT(isodow FROM subq_2.metric_time__day) AS metric_time__extract_dow
-                , EXTRACT(doy FROM subq_2.metric_time__day) AS metric_time__extract_doy
                 , subq_1.ds__day AS ds__day
                 , subq_1.ds__week AS ds__week
                 , subq_1.ds__month AS ds__month
@@ -122,6 +112,16 @@ FROM (
                 , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
                 , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
                 , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                , subq_1.metric_time__week AS metric_time__week
+                , subq_1.metric_time__month AS metric_time__month
+                , subq_1.metric_time__quarter AS metric_time__quarter
+                , subq_1.metric_time__year AS metric_time__year
+                , subq_1.metric_time__extract_year AS metric_time__extract_year
+                , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+                , subq_1.metric_time__extract_month AS metric_time__extract_month
+                , subq_1.metric_time__extract_day AS metric_time__extract_day
+                , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+                , subq_1.metric_time__extract_doy AS metric_time__extract_doy
                 , subq_1.listing AS listing
                 , subq_1.guest AS guest
                 , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0.sql
@@ -26,17 +26,7 @@ FROM (
       FROM (
         -- Constrain Output with WHERE
         SELECT
-          subq_4.metric_time__day
-          , subq_4.metric_time__week
-          , subq_4.metric_time__month
-          , subq_4.metric_time__quarter
-          , subq_4.metric_time__year
-          , subq_4.metric_time__extract_year
-          , subq_4.metric_time__extract_quarter
-          , subq_4.metric_time__extract_month
-          , subq_4.metric_time__extract_day
-          , subq_4.metric_time__extract_dow
-          , subq_4.metric_time__extract_doy
+          subq_4.metric_time__month
           , subq_4.ds__day
           , subq_4.ds__week
           , subq_4.ds__month
@@ -103,6 +93,16 @@ FROM (
           , subq_4.booking__paid_at__extract_day
           , subq_4.booking__paid_at__extract_dow
           , subq_4.booking__paid_at__extract_doy
+          , subq_4.metric_time__day
+          , subq_4.metric_time__week
+          , subq_4.metric_time__quarter
+          , subq_4.metric_time__year
+          , subq_4.metric_time__extract_year
+          , subq_4.metric_time__extract_quarter
+          , subq_4.metric_time__extract_month
+          , subq_4.metric_time__extract_day
+          , subq_4.metric_time__extract_dow
+          , subq_4.metric_time__extract_doy
           , subq_4.listing
           , subq_4.guest
           , subq_4.host
@@ -127,17 +127,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_2.metric_time__day AS metric_time__day
-            , DATE_TRUNC('week', subq_2.metric_time__day) AS metric_time__week
-            , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('quarter', subq_2.metric_time__day) AS metric_time__quarter
-            , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-            , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-            , EXTRACT(isodow FROM subq_2.metric_time__day) AS metric_time__extract_dow
-            , EXTRACT(doy FROM subq_2.metric_time__day) AS metric_time__extract_doy
+            DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
             , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
@@ -204,6 +194,16 @@ FROM (
             , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_1.metric_time__day AS metric_time__day
+            , subq_1.metric_time__week AS metric_time__week
+            , subq_1.metric_time__quarter AS metric_time__quarter
+            , subq_1.metric_time__year AS metric_time__year
+            , subq_1.metric_time__extract_year AS metric_time__extract_year
+            , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_1.metric_time__extract_month AS metric_time__extract_month
+            , subq_1.metric_time__extract_day AS metric_time__extract_day
+            , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_1.metric_time__extract_doy AS metric_time__extract_doy
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
@@ -19,8 +19,8 @@ FROM (
   FROM (
     -- Join to Time Spine Dataset
     SELECT
-      subq_12.ds AS metric_time__day
-      , DATE_TRUNC('month', subq_12.ds) AS metric_time__month
+      DATE_TRUNC('month', subq_12.ds) AS metric_time__month
+      , subq_10.metric_time__day AS metric_time__day
       , subq_10.bookings AS bookings
     FROM ***************************.mf_time_spine subq_12
     INNER JOIN (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_offset_to_grain_metric_multiple_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_offset_to_grain_metric_multiple_granularities__plan0.sql
@@ -35,16 +35,8 @@ FROM (
         -- Join to Time Spine Dataset
         SELECT
           subq_2.metric_time__day AS metric_time__day
-          , DATE_TRUNC('week', subq_2.metric_time__day) AS metric_time__week
           , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-          , DATE_TRUNC('quarter', subq_2.metric_time__day) AS metric_time__quarter
           , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-          , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-          , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-          , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-          , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-          , EXTRACT(isodow FROM subq_2.metric_time__day) AS metric_time__extract_dow
-          , EXTRACT(doy FROM subq_2.metric_time__day) AS metric_time__extract_doy
           , subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
@@ -111,6 +103,14 @@ FROM (
           , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
           , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
           , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+          , subq_1.metric_time__week AS metric_time__week
+          , subq_1.metric_time__quarter AS metric_time__quarter
+          , subq_1.metric_time__extract_year AS metric_time__extract_year
+          , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_1.metric_time__extract_month AS metric_time__extract_month
+          , subq_1.metric_time__extract_day AS metric_time__extract_day
+          , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+          , subq_1.metric_time__extract_doy AS metric_time__extract_doy
           , subq_1.listing AS listing
           , subq_1.guest AS guest
           , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_offset_to_grain_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_offset_to_grain_with_agg_time_dim__plan0.sql
@@ -246,16 +246,6 @@ FROM (
           -- Join to Time Spine Dataset
           SELECT
             subq_7.booking__ds__day AS booking__ds__day
-            , DATE_TRUNC('week', subq_7.booking__ds__day) AS booking__ds__week
-            , DATE_TRUNC('month', subq_7.booking__ds__day) AS booking__ds__month
-            , DATE_TRUNC('quarter', subq_7.booking__ds__day) AS booking__ds__quarter
-            , DATE_TRUNC('year', subq_7.booking__ds__day) AS booking__ds__year
-            , EXTRACT(year FROM subq_7.booking__ds__day) AS booking__ds__extract_year
-            , EXTRACT(quarter FROM subq_7.booking__ds__day) AS booking__ds__extract_quarter
-            , EXTRACT(month FROM subq_7.booking__ds__day) AS booking__ds__extract_month
-            , EXTRACT(day FROM subq_7.booking__ds__day) AS booking__ds__extract_day
-            , EXTRACT(isodow FROM subq_7.booking__ds__day) AS booking__ds__extract_dow
-            , EXTRACT(doy FROM subq_7.booking__ds__day) AS booking__ds__extract_doy
             , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
@@ -289,6 +279,16 @@ FROM (
             , subq_6.paid_at__extract_day AS paid_at__extract_day
             , subq_6.paid_at__extract_dow AS paid_at__extract_dow
             , subq_6.paid_at__extract_doy AS paid_at__extract_doy
+            , subq_6.booking__ds__week AS booking__ds__week
+            , subq_6.booking__ds__month AS booking__ds__month
+            , subq_6.booking__ds__quarter AS booking__ds__quarter
+            , subq_6.booking__ds__year AS booking__ds__year
+            , subq_6.booking__ds__extract_year AS booking__ds__extract_year
+            , subq_6.booking__ds__extract_quarter AS booking__ds__extract_quarter
+            , subq_6.booking__ds__extract_month AS booking__ds__extract_month
+            , subq_6.booking__ds__extract_day AS booking__ds__extract_day
+            , subq_6.booking__ds__extract_dow AS booking__ds__extract_dow
+            , subq_6.booking__ds__extract_doy AS booking__ds__extract_doy
             , subq_6.booking__ds_partitioned__day AS booking__ds_partitioned__day
             , subq_6.booking__ds_partitioned__week AS booking__ds_partitioned__week
             , subq_6.booking__ds_partitioned__month AS booking__ds_partitioned__month

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_offset_window_metric_filter_and_query_have_different_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_offset_window_metric_filter_and_query_have_different_granularities__plan0.sql
@@ -32,17 +32,7 @@ FROM (
         FROM (
           -- Constrain Output with WHERE
           SELECT
-            subq_4.metric_time__day
-            , subq_4.metric_time__week
-            , subq_4.metric_time__month
-            , subq_4.metric_time__quarter
-            , subq_4.metric_time__year
-            , subq_4.metric_time__extract_year
-            , subq_4.metric_time__extract_quarter
-            , subq_4.metric_time__extract_month
-            , subq_4.metric_time__extract_day
-            , subq_4.metric_time__extract_dow
-            , subq_4.metric_time__extract_doy
+            subq_4.metric_time__month
             , subq_4.ds__day
             , subq_4.ds__week
             , subq_4.ds__month
@@ -109,6 +99,16 @@ FROM (
             , subq_4.booking__paid_at__extract_day
             , subq_4.booking__paid_at__extract_dow
             , subq_4.booking__paid_at__extract_doy
+            , subq_4.metric_time__day
+            , subq_4.metric_time__week
+            , subq_4.metric_time__quarter
+            , subq_4.metric_time__year
+            , subq_4.metric_time__extract_year
+            , subq_4.metric_time__extract_quarter
+            , subq_4.metric_time__extract_month
+            , subq_4.metric_time__extract_day
+            , subq_4.metric_time__extract_dow
+            , subq_4.metric_time__extract_doy
             , subq_4.listing
             , subq_4.guest
             , subq_4.host
@@ -133,17 +133,7 @@ FROM (
           FROM (
             -- Join to Time Spine Dataset
             SELECT
-              subq_2.metric_time__day AS metric_time__day
-              , DATE_TRUNC('week', subq_2.metric_time__day) AS metric_time__week
-              , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-              , DATE_TRUNC('quarter', subq_2.metric_time__day) AS metric_time__quarter
-              , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-              , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-              , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-              , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-              , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-              , EXTRACT(isodow FROM subq_2.metric_time__day) AS metric_time__extract_dow
-              , EXTRACT(doy FROM subq_2.metric_time__day) AS metric_time__extract_doy
+              DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
               , subq_1.ds__day AS ds__day
               , subq_1.ds__week AS ds__week
               , subq_1.ds__month AS ds__month
@@ -210,6 +200,16 @@ FROM (
               , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
               , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
               , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+              , subq_1.metric_time__day AS metric_time__day
+              , subq_1.metric_time__week AS metric_time__week
+              , subq_1.metric_time__quarter AS metric_time__quarter
+              , subq_1.metric_time__year AS metric_time__year
+              , subq_1.metric_time__extract_year AS metric_time__extract_year
+              , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+              , subq_1.metric_time__extract_month AS metric_time__extract_month
+              , subq_1.metric_time__extract_day AS metric_time__extract_day
+              , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+              , subq_1.metric_time__extract_doy AS metric_time__extract_doy
               , subq_1.listing AS listing
               , subq_1.guest AS guest
               , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_offset_window_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_offset_window_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
@@ -25,8 +25,8 @@ FROM (
     FROM (
       -- Join to Time Spine Dataset
       SELECT
-        subq_19.ds AS metric_time__day
-        , DATE_TRUNC('month', subq_19.ds) AS metric_time__month
+        DATE_TRUNC('month', subq_19.ds) AS metric_time__month
+        , DATE_TRUNC('day', bookings_source_src_28000.ds) AS metric_time__day
         , bookings_source_src_28000.booking_value AS booking_value
       FROM ***************************.mf_time_spine subq_19
       INNER JOIN

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_offset_window_metric_multiple_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_offset_window_metric_multiple_granularities__plan0.sql
@@ -43,16 +43,8 @@ FROM (
           -- Join to Time Spine Dataset
           SELECT
             subq_2.metric_time__day AS metric_time__day
-            , DATE_TRUNC('week', subq_2.metric_time__day) AS metric_time__week
             , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('quarter', subq_2.metric_time__day) AS metric_time__quarter
             , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-            , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-            , EXTRACT(isodow FROM subq_2.metric_time__day) AS metric_time__extract_dow
-            , EXTRACT(doy FROM subq_2.metric_time__day) AS metric_time__extract_doy
             , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
@@ -119,6 +111,14 @@ FROM (
             , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_1.metric_time__week AS metric_time__week
+            , subq_1.metric_time__quarter AS metric_time__quarter
+            , subq_1.metric_time__extract_year AS metric_time__extract_year
+            , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_1.metric_time__extract_month AS metric_time__extract_month
+            , subq_1.metric_time__extract_day AS metric_time__extract_day
+            , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_1.metric_time__extract_doy AS metric_time__extract_doy
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_offset_window_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_offset_window_with_agg_time_dim__plan0.sql
@@ -246,16 +246,6 @@ FROM (
           -- Join to Time Spine Dataset
           SELECT
             subq_7.booking__ds__day AS booking__ds__day
-            , DATE_TRUNC('week', subq_7.booking__ds__day) AS booking__ds__week
-            , DATE_TRUNC('month', subq_7.booking__ds__day) AS booking__ds__month
-            , DATE_TRUNC('quarter', subq_7.booking__ds__day) AS booking__ds__quarter
-            , DATE_TRUNC('year', subq_7.booking__ds__day) AS booking__ds__year
-            , EXTRACT(year FROM subq_7.booking__ds__day) AS booking__ds__extract_year
-            , EXTRACT(quarter FROM subq_7.booking__ds__day) AS booking__ds__extract_quarter
-            , EXTRACT(month FROM subq_7.booking__ds__day) AS booking__ds__extract_month
-            , EXTRACT(day FROM subq_7.booking__ds__day) AS booking__ds__extract_day
-            , EXTRACT(isodow FROM subq_7.booking__ds__day) AS booking__ds__extract_dow
-            , EXTRACT(doy FROM subq_7.booking__ds__day) AS booking__ds__extract_doy
             , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
@@ -289,6 +279,16 @@ FROM (
             , subq_6.paid_at__extract_day AS paid_at__extract_day
             , subq_6.paid_at__extract_dow AS paid_at__extract_dow
             , subq_6.paid_at__extract_doy AS paid_at__extract_doy
+            , subq_6.booking__ds__week AS booking__ds__week
+            , subq_6.booking__ds__month AS booking__ds__month
+            , subq_6.booking__ds__quarter AS booking__ds__quarter
+            , subq_6.booking__ds__year AS booking__ds__year
+            , subq_6.booking__ds__extract_year AS booking__ds__extract_year
+            , subq_6.booking__ds__extract_quarter AS booking__ds__extract_quarter
+            , subq_6.booking__ds__extract_month AS booking__ds__extract_month
+            , subq_6.booking__ds__extract_day AS booking__ds__extract_day
+            , subq_6.booking__ds__extract_dow AS booking__ds__extract_dow
+            , subq_6.booking__ds__extract_doy AS booking__ds__extract_doy
             , subq_6.booking__ds_partitioned__day AS booking__ds_partitioned__day
             , subq_6.booking__ds_partitioned__week AS booking__ds_partitioned__week
             , subq_6.booking__ds_partitioned__month AS booking__ds_partitioned__month

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_time_offset_metric_with_time_constraint__plan0.sql
@@ -25,16 +25,6 @@ FROM (
         -- Join to Time Spine Dataset
         SELECT
           subq_2.metric_time__day AS metric_time__day
-          , DATE_TRUNC('week', subq_2.metric_time__day) AS metric_time__week
-          , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-          , DATE_TRUNC('quarter', subq_2.metric_time__day) AS metric_time__quarter
-          , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-          , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-          , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-          , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-          , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-          , EXTRACT(isodow FROM subq_2.metric_time__day) AS metric_time__extract_dow
-          , EXTRACT(doy FROM subq_2.metric_time__day) AS metric_time__extract_doy
           , subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
@@ -101,6 +91,16 @@ FROM (
           , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
           , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
           , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+          , subq_1.metric_time__week AS metric_time__week
+          , subq_1.metric_time__month AS metric_time__month
+          , subq_1.metric_time__quarter AS metric_time__quarter
+          , subq_1.metric_time__year AS metric_time__year
+          , subq_1.metric_time__extract_year AS metric_time__extract_year
+          , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_1.metric_time__extract_month AS metric_time__extract_month
+          , subq_1.metric_time__extract_day AS metric_time__extract_day
+          , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+          , subq_1.metric_time__extract_doy AS metric_time__extract_doy
           , subq_1.listing AS listing
           , subq_1.guest AS guest
           , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
@@ -25,16 +25,6 @@ FROM (
         -- Constrain Time Range to [2019-12-19T00:00:00, 2020-01-02T00:00:00]
         SELECT
           subq_7.metric_time__day
-          , subq_7.metric_time__week
-          , subq_7.metric_time__month
-          , subq_7.metric_time__quarter
-          , subq_7.metric_time__year
-          , subq_7.metric_time__extract_year
-          , subq_7.metric_time__extract_quarter
-          , subq_7.metric_time__extract_month
-          , subq_7.metric_time__extract_day
-          , subq_7.metric_time__extract_dow
-          , subq_7.metric_time__extract_doy
           , subq_7.ds__day
           , subq_7.ds__week
           , subq_7.ds__month
@@ -101,6 +91,16 @@ FROM (
           , subq_7.booking__paid_at__extract_day
           , subq_7.booking__paid_at__extract_dow
           , subq_7.booking__paid_at__extract_doy
+          , subq_7.metric_time__week
+          , subq_7.metric_time__month
+          , subq_7.metric_time__quarter
+          , subq_7.metric_time__year
+          , subq_7.metric_time__extract_year
+          , subq_7.metric_time__extract_quarter
+          , subq_7.metric_time__extract_month
+          , subq_7.metric_time__extract_day
+          , subq_7.metric_time__extract_dow
+          , subq_7.metric_time__extract_doy
           , subq_7.listing
           , subq_7.guest
           , subq_7.host
@@ -126,16 +126,6 @@ FROM (
           -- Join to Time Spine Dataset
           SELECT
             subq_5.metric_time__day AS metric_time__day
-            , DATE_TRUNC('week', subq_5.metric_time__day) AS metric_time__week
-            , DATE_TRUNC('month', subq_5.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('quarter', subq_5.metric_time__day) AS metric_time__quarter
-            , DATE_TRUNC('year', subq_5.metric_time__day) AS metric_time__year
-            , EXTRACT(year FROM subq_5.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_5.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_5.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_5.metric_time__day) AS metric_time__extract_day
-            , CASE WHEN EXTRACT(dow FROM subq_5.metric_time__day) = 0 THEN EXTRACT(dow FROM subq_5.metric_time__day) + 7 ELSE EXTRACT(dow FROM subq_5.metric_time__day) END AS metric_time__extract_dow
-            , EXTRACT(doy FROM subq_5.metric_time__day) AS metric_time__extract_doy
             , subq_4.ds__day AS ds__day
             , subq_4.ds__week AS ds__week
             , subq_4.ds__month AS ds__month
@@ -202,6 +192,16 @@ FROM (
             , subq_4.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_4.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_4.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_4.metric_time__week AS metric_time__week
+            , subq_4.metric_time__month AS metric_time__month
+            , subq_4.metric_time__quarter AS metric_time__quarter
+            , subq_4.metric_time__year AS metric_time__year
+            , subq_4.metric_time__extract_year AS metric_time__extract_year
+            , subq_4.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_4.metric_time__extract_month AS metric_time__extract_month
+            , subq_4.metric_time__extract_day AS metric_time__extract_day
+            , subq_4.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_4.metric_time__extract_doy AS metric_time__extract_doy
             , subq_4.listing AS listing
             , subq_4.guest AS guest
             , subq_4.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
@@ -25,11 +25,6 @@ FROM (
         -- Join to Time Spine Dataset
         SELECT
           subq_2.metric_time__month AS metric_time__month
-          , DATE_TRUNC('quarter', subq_2.metric_time__month) AS metric_time__quarter
-          , DATE_TRUNC('year', subq_2.metric_time__month) AS metric_time__year
-          , EXTRACT(year FROM subq_2.metric_time__month) AS metric_time__extract_year
-          , EXTRACT(quarter FROM subq_2.metric_time__month) AS metric_time__extract_quarter
-          , EXTRACT(month FROM subq_2.metric_time__month) AS metric_time__extract_month
           , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
           , subq_1.ds__year AS ds__year
@@ -42,6 +37,11 @@ FROM (
           , subq_1.booking_monthly__ds__extract_year AS booking_monthly__ds__extract_year
           , subq_1.booking_monthly__ds__extract_quarter AS booking_monthly__ds__extract_quarter
           , subq_1.booking_monthly__ds__extract_month AS booking_monthly__ds__extract_month
+          , subq_1.metric_time__quarter AS metric_time__quarter
+          , subq_1.metric_time__year AS metric_time__year
+          , subq_1.metric_time__extract_year AS metric_time__extract_year
+          , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_1.metric_time__extract_month AS metric_time__extract_month
           , subq_1.listing AS listing
           , subq_1.booking_monthly__listing AS booking_monthly__listing
           , subq_1.bookings_monthly AS bookings_monthly

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_to_grain__plan0.sql
@@ -246,16 +246,6 @@ FROM (
           -- Join to Time Spine Dataset
           SELECT
             subq_7.metric_time__day AS metric_time__day
-            , DATE_TRUNC('week', subq_7.metric_time__day) AS metric_time__week
-            , DATE_TRUNC('month', subq_7.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('quarter', subq_7.metric_time__day) AS metric_time__quarter
-            , DATE_TRUNC('year', subq_7.metric_time__day) AS metric_time__year
-            , EXTRACT(year FROM subq_7.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_7.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_7.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_7.metric_time__day) AS metric_time__extract_day
-            , CASE WHEN EXTRACT(dow FROM subq_7.metric_time__day) = 0 THEN EXTRACT(dow FROM subq_7.metric_time__day) + 7 ELSE EXTRACT(dow FROM subq_7.metric_time__day) END AS metric_time__extract_dow
-            , EXTRACT(doy FROM subq_7.metric_time__day) AS metric_time__extract_doy
             , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
@@ -322,6 +312,16 @@ FROM (
             , subq_6.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_6.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_6.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_6.metric_time__week AS metric_time__week
+            , subq_6.metric_time__month AS metric_time__month
+            , subq_6.metric_time__quarter AS metric_time__quarter
+            , subq_6.metric_time__year AS metric_time__year
+            , subq_6.metric_time__extract_year AS metric_time__extract_year
+            , subq_6.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_6.metric_time__extract_month AS metric_time__extract_month
+            , subq_6.metric_time__extract_day AS metric_time__extract_day
+            , subq_6.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_6.metric_time__extract_doy AS metric_time__extract_doy
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_to_grain_and_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_to_grain_and_granularity__plan0.sql
@@ -245,17 +245,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_7.metric_time__day AS metric_time__day
-            , DATE_TRUNC('week', subq_7.metric_time__day) AS metric_time__week
-            , DATE_TRUNC('month', subq_7.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('quarter', subq_7.metric_time__day) AS metric_time__quarter
-            , DATE_TRUNC('year', subq_7.metric_time__day) AS metric_time__year
-            , EXTRACT(year FROM subq_7.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_7.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_7.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_7.metric_time__day) AS metric_time__extract_day
-            , CASE WHEN EXTRACT(dow FROM subq_7.metric_time__day) = 0 THEN EXTRACT(dow FROM subq_7.metric_time__day) + 7 ELSE EXTRACT(dow FROM subq_7.metric_time__day) END AS metric_time__extract_dow
-            , EXTRACT(doy FROM subq_7.metric_time__day) AS metric_time__extract_doy
+            DATE_TRUNC('week', subq_7.metric_time__day) AS metric_time__week
             , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
@@ -322,6 +312,16 @@ FROM (
             , subq_6.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_6.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_6.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_6.metric_time__day AS metric_time__day
+            , subq_6.metric_time__month AS metric_time__month
+            , subq_6.metric_time__quarter AS metric_time__quarter
+            , subq_6.metric_time__year AS metric_time__year
+            , subq_6.metric_time__extract_year AS metric_time__extract_year
+            , subq_6.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_6.metric_time__extract_month AS metric_time__extract_month
+            , subq_6.metric_time__extract_day AS metric_time__extract_day
+            , subq_6.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_6.metric_time__extract_doy AS metric_time__extract_doy
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_window__plan0.sql
@@ -246,16 +246,6 @@ FROM (
           -- Join to Time Spine Dataset
           SELECT
             subq_7.metric_time__day AS metric_time__day
-            , DATE_TRUNC('week', subq_7.metric_time__day) AS metric_time__week
-            , DATE_TRUNC('month', subq_7.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('quarter', subq_7.metric_time__day) AS metric_time__quarter
-            , DATE_TRUNC('year', subq_7.metric_time__day) AS metric_time__year
-            , EXTRACT(year FROM subq_7.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_7.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_7.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_7.metric_time__day) AS metric_time__extract_day
-            , CASE WHEN EXTRACT(dow FROM subq_7.metric_time__day) = 0 THEN EXTRACT(dow FROM subq_7.metric_time__day) + 7 ELSE EXTRACT(dow FROM subq_7.metric_time__day) END AS metric_time__extract_dow
-            , EXTRACT(doy FROM subq_7.metric_time__day) AS metric_time__extract_doy
             , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
@@ -322,6 +312,16 @@ FROM (
             , subq_6.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_6.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_6.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_6.metric_time__week AS metric_time__week
+            , subq_6.metric_time__month AS metric_time__month
+            , subq_6.metric_time__quarter AS metric_time__quarter
+            , subq_6.metric_time__year AS metric_time__year
+            , subq_6.metric_time__extract_year AS metric_time__extract_year
+            , subq_6.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_6.metric_time__extract_month AS metric_time__extract_month
+            , subq_6.metric_time__extract_day AS metric_time__extract_day
+            , subq_6.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_6.metric_time__extract_doy AS metric_time__extract_doy
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_window_and_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_window_and_granularity__plan0.sql
@@ -245,17 +245,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_7.metric_time__day AS metric_time__day
-            , DATE_TRUNC('week', subq_7.metric_time__day) AS metric_time__week
-            , DATE_TRUNC('month', subq_7.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('quarter', subq_7.metric_time__day) AS metric_time__quarter
-            , DATE_TRUNC('year', subq_7.metric_time__day) AS metric_time__year
-            , EXTRACT(year FROM subq_7.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_7.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_7.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_7.metric_time__day) AS metric_time__extract_day
-            , CASE WHEN EXTRACT(dow FROM subq_7.metric_time__day) = 0 THEN EXTRACT(dow FROM subq_7.metric_time__day) + 7 ELSE EXTRACT(dow FROM subq_7.metric_time__day) END AS metric_time__extract_dow
-            , EXTRACT(doy FROM subq_7.metric_time__day) AS metric_time__extract_doy
+            DATE_TRUNC('quarter', subq_7.metric_time__day) AS metric_time__quarter
             , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
@@ -322,6 +312,16 @@ FROM (
             , subq_6.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_6.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_6.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_6.metric_time__day AS metric_time__day
+            , subq_6.metric_time__week AS metric_time__week
+            , subq_6.metric_time__month AS metric_time__month
+            , subq_6.metric_time__year AS metric_time__year
+            , subq_6.metric_time__extract_year AS metric_time__extract_year
+            , subq_6.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_6.metric_time__extract_month AS metric_time__extract_month
+            , subq_6.metric_time__extract_day AS metric_time__extract_day
+            , subq_6.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_6.metric_time__extract_doy AS metric_time__extract_doy
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
@@ -31,16 +31,6 @@ FROM (
           -- Join to Time Spine Dataset
           SELECT
             subq_2.metric_time__day AS metric_time__day
-            , DATE_TRUNC('week', subq_2.metric_time__day) AS metric_time__week
-            , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('quarter', subq_2.metric_time__day) AS metric_time__quarter
-            , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-            , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-            , CASE WHEN EXTRACT(dow FROM subq_2.metric_time__day) = 0 THEN EXTRACT(dow FROM subq_2.metric_time__day) + 7 ELSE EXTRACT(dow FROM subq_2.metric_time__day) END AS metric_time__extract_dow
-            , EXTRACT(doy FROM subq_2.metric_time__day) AS metric_time__extract_doy
             , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
@@ -107,6 +97,16 @@ FROM (
             , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_1.metric_time__week AS metric_time__week
+            , subq_1.metric_time__month AS metric_time__month
+            , subq_1.metric_time__quarter AS metric_time__quarter
+            , subq_1.metric_time__year AS metric_time__year
+            , subq_1.metric_time__extract_year AS metric_time__extract_year
+            , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_1.metric_time__extract_month AS metric_time__extract_month
+            , subq_1.metric_time__extract_day AS metric_time__extract_day
+            , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_1.metric_time__extract_doy AS metric_time__extract_doy
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host
@@ -356,16 +356,6 @@ FROM (
           -- Join to Time Spine Dataset
           SELECT
             subq_10.metric_time__day AS metric_time__day
-            , DATE_TRUNC('week', subq_10.metric_time__day) AS metric_time__week
-            , DATE_TRUNC('month', subq_10.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('quarter', subq_10.metric_time__day) AS metric_time__quarter
-            , DATE_TRUNC('year', subq_10.metric_time__day) AS metric_time__year
-            , EXTRACT(year FROM subq_10.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_10.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_10.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_10.metric_time__day) AS metric_time__extract_day
-            , CASE WHEN EXTRACT(dow FROM subq_10.metric_time__day) = 0 THEN EXTRACT(dow FROM subq_10.metric_time__day) + 7 ELSE EXTRACT(dow FROM subq_10.metric_time__day) END AS metric_time__extract_dow
-            , EXTRACT(doy FROM subq_10.metric_time__day) AS metric_time__extract_doy
             , subq_9.ds__day AS ds__day
             , subq_9.ds__week AS ds__week
             , subq_9.ds__month AS ds__month
@@ -432,6 +422,16 @@ FROM (
             , subq_9.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_9.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_9.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_9.metric_time__week AS metric_time__week
+            , subq_9.metric_time__month AS metric_time__month
+            , subq_9.metric_time__quarter AS metric_time__quarter
+            , subq_9.metric_time__year AS metric_time__year
+            , subq_9.metric_time__extract_year AS metric_time__extract_year
+            , subq_9.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_9.metric_time__extract_month AS metric_time__extract_month
+            , subq_9.metric_time__extract_day AS metric_time__extract_day
+            , subq_9.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_9.metric_time__extract_doy AS metric_time__extract_doy
             , subq_9.listing AS listing
             , subq_9.guest AS guest
             , subq_9.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0.sql
@@ -30,17 +30,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_2.metric_time__day AS metric_time__day
-            , DATE_TRUNC('week', subq_2.metric_time__day) AS metric_time__week
-            , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('quarter', subq_2.metric_time__day) AS metric_time__quarter
-            , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-            , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-            , CASE WHEN EXTRACT(dow FROM subq_2.metric_time__day) = 0 THEN EXTRACT(dow FROM subq_2.metric_time__day) + 7 ELSE EXTRACT(dow FROM subq_2.metric_time__day) END AS metric_time__extract_dow
-            , EXTRACT(doy FROM subq_2.metric_time__day) AS metric_time__extract_doy
+            DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
             , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
@@ -107,6 +97,16 @@ FROM (
             , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_1.metric_time__day AS metric_time__day
+            , subq_1.metric_time__week AS metric_time__week
+            , subq_1.metric_time__month AS metric_time__month
+            , subq_1.metric_time__quarter AS metric_time__quarter
+            , subq_1.metric_time__extract_year AS metric_time__extract_year
+            , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_1.metric_time__extract_month AS metric_time__extract_month
+            , subq_1.metric_time__extract_day AS metric_time__extract_day
+            , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_1.metric_time__extract_doy AS metric_time__extract_doy
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host
@@ -356,17 +356,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_10.metric_time__day AS metric_time__day
-            , DATE_TRUNC('week', subq_10.metric_time__day) AS metric_time__week
-            , DATE_TRUNC('month', subq_10.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('quarter', subq_10.metric_time__day) AS metric_time__quarter
-            , DATE_TRUNC('year', subq_10.metric_time__day) AS metric_time__year
-            , EXTRACT(year FROM subq_10.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_10.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_10.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_10.metric_time__day) AS metric_time__extract_day
-            , CASE WHEN EXTRACT(dow FROM subq_10.metric_time__day) = 0 THEN EXTRACT(dow FROM subq_10.metric_time__day) + 7 ELSE EXTRACT(dow FROM subq_10.metric_time__day) END AS metric_time__extract_dow
-            , EXTRACT(doy FROM subq_10.metric_time__day) AS metric_time__extract_doy
+            DATE_TRUNC('year', subq_10.metric_time__day) AS metric_time__year
             , subq_9.ds__day AS ds__day
             , subq_9.ds__week AS ds__week
             , subq_9.ds__month AS ds__month
@@ -433,6 +423,16 @@ FROM (
             , subq_9.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_9.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_9.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_9.metric_time__day AS metric_time__day
+            , subq_9.metric_time__week AS metric_time__week
+            , subq_9.metric_time__month AS metric_time__month
+            , subq_9.metric_time__quarter AS metric_time__quarter
+            , subq_9.metric_time__extract_year AS metric_time__extract_year
+            , subq_9.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_9.metric_time__extract_month AS metric_time__extract_month
+            , subq_9.metric_time__extract_day AS metric_time__extract_day
+            , subq_9.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_9.metric_time__extract_doy AS metric_time__extract_doy
             , subq_9.listing AS listing
             , subq_9.guest AS guest
             , subq_9.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
@@ -349,16 +349,6 @@ FROM (
           -- Constrain Output with WHERE
           SELECT
             subq_10.metric_time__day
-            , subq_10.metric_time__week
-            , subq_10.metric_time__month
-            , subq_10.metric_time__quarter
-            , subq_10.metric_time__year
-            , subq_10.metric_time__extract_year
-            , subq_10.metric_time__extract_quarter
-            , subq_10.metric_time__extract_month
-            , subq_10.metric_time__extract_day
-            , subq_10.metric_time__extract_dow
-            , subq_10.metric_time__extract_doy
             , subq_10.ds__day
             , subq_10.ds__week
             , subq_10.ds__month
@@ -425,6 +415,16 @@ FROM (
             , subq_10.booking__paid_at__extract_day
             , subq_10.booking__paid_at__extract_dow
             , subq_10.booking__paid_at__extract_doy
+            , subq_10.metric_time__week
+            , subq_10.metric_time__month
+            , subq_10.metric_time__quarter
+            , subq_10.metric_time__year
+            , subq_10.metric_time__extract_year
+            , subq_10.metric_time__extract_quarter
+            , subq_10.metric_time__extract_month
+            , subq_10.metric_time__extract_day
+            , subq_10.metric_time__extract_dow
+            , subq_10.metric_time__extract_doy
             , subq_10.listing
             , subq_10.guest
             , subq_10.host
@@ -450,16 +450,6 @@ FROM (
             -- Join to Time Spine Dataset
             SELECT
               subq_8.metric_time__day AS metric_time__day
-              , DATE_TRUNC('week', subq_8.metric_time__day) AS metric_time__week
-              , DATE_TRUNC('month', subq_8.metric_time__day) AS metric_time__month
-              , DATE_TRUNC('quarter', subq_8.metric_time__day) AS metric_time__quarter
-              , DATE_TRUNC('year', subq_8.metric_time__day) AS metric_time__year
-              , EXTRACT(year FROM subq_8.metric_time__day) AS metric_time__extract_year
-              , EXTRACT(quarter FROM subq_8.metric_time__day) AS metric_time__extract_quarter
-              , EXTRACT(month FROM subq_8.metric_time__day) AS metric_time__extract_month
-              , EXTRACT(day FROM subq_8.metric_time__day) AS metric_time__extract_day
-              , CASE WHEN EXTRACT(dow FROM subq_8.metric_time__day) = 0 THEN EXTRACT(dow FROM subq_8.metric_time__day) + 7 ELSE EXTRACT(dow FROM subq_8.metric_time__day) END AS metric_time__extract_dow
-              , EXTRACT(doy FROM subq_8.metric_time__day) AS metric_time__extract_doy
               , subq_7.ds__day AS ds__day
               , subq_7.ds__week AS ds__week
               , subq_7.ds__month AS ds__month
@@ -526,6 +516,16 @@ FROM (
               , subq_7.booking__paid_at__extract_day AS booking__paid_at__extract_day
               , subq_7.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
               , subq_7.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+              , subq_7.metric_time__week AS metric_time__week
+              , subq_7.metric_time__month AS metric_time__month
+              , subq_7.metric_time__quarter AS metric_time__quarter
+              , subq_7.metric_time__year AS metric_time__year
+              , subq_7.metric_time__extract_year AS metric_time__extract_year
+              , subq_7.metric_time__extract_quarter AS metric_time__extract_quarter
+              , subq_7.metric_time__extract_month AS metric_time__extract_month
+              , subq_7.metric_time__extract_day AS metric_time__extract_day
+              , subq_7.metric_time__extract_dow AS metric_time__extract_dow
+              , subq_7.metric_time__extract_doy AS metric_time__extract_doy
               , subq_7.listing AS listing
               , subq_7.guest AS guest
               , subq_7.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_offset_cumulative_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_offset_cumulative_metric__plan0.sql
@@ -25,16 +25,6 @@ FROM (
         -- Join to Time Spine Dataset
         SELECT
           subq_5.metric_time__day AS metric_time__day
-          , DATE_TRUNC('week', subq_5.metric_time__day) AS metric_time__week
-          , DATE_TRUNC('month', subq_5.metric_time__day) AS metric_time__month
-          , DATE_TRUNC('quarter', subq_5.metric_time__day) AS metric_time__quarter
-          , DATE_TRUNC('year', subq_5.metric_time__day) AS metric_time__year
-          , EXTRACT(year FROM subq_5.metric_time__day) AS metric_time__extract_year
-          , EXTRACT(quarter FROM subq_5.metric_time__day) AS metric_time__extract_quarter
-          , EXTRACT(month FROM subq_5.metric_time__day) AS metric_time__extract_month
-          , EXTRACT(day FROM subq_5.metric_time__day) AS metric_time__extract_day
-          , CASE WHEN EXTRACT(dow FROM subq_5.metric_time__day) = 0 THEN EXTRACT(dow FROM subq_5.metric_time__day) + 7 ELSE EXTRACT(dow FROM subq_5.metric_time__day) END AS metric_time__extract_dow
-          , EXTRACT(doy FROM subq_5.metric_time__day) AS metric_time__extract_doy
           , subq_4.ds__day AS ds__day
           , subq_4.ds__week AS ds__week
           , subq_4.ds__month AS ds__month
@@ -101,6 +91,16 @@ FROM (
           , subq_4.booking__paid_at__extract_day AS booking__paid_at__extract_day
           , subq_4.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
           , subq_4.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+          , subq_4.metric_time__week AS metric_time__week
+          , subq_4.metric_time__month AS metric_time__month
+          , subq_4.metric_time__quarter AS metric_time__quarter
+          , subq_4.metric_time__year AS metric_time__year
+          , subq_4.metric_time__extract_year AS metric_time__extract_year
+          , subq_4.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_4.metric_time__extract_month AS metric_time__extract_month
+          , subq_4.metric_time__extract_day AS metric_time__extract_day
+          , subq_4.metric_time__extract_dow AS metric_time__extract_dow
+          , subq_4.metric_time__extract_doy AS metric_time__extract_doy
           , subq_4.listing AS listing
           , subq_4.guest AS guest
           , subq_4.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_offset_metric_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_offset_metric_with_agg_time_dim__plan0.sql
@@ -31,16 +31,6 @@ FROM (
           -- Join to Time Spine Dataset
           SELECT
             subq_2.booking__ds__day AS booking__ds__day
-            , DATE_TRUNC('week', subq_2.booking__ds__day) AS booking__ds__week
-            , DATE_TRUNC('month', subq_2.booking__ds__day) AS booking__ds__month
-            , DATE_TRUNC('quarter', subq_2.booking__ds__day) AS booking__ds__quarter
-            , DATE_TRUNC('year', subq_2.booking__ds__day) AS booking__ds__year
-            , EXTRACT(year FROM subq_2.booking__ds__day) AS booking__ds__extract_year
-            , EXTRACT(quarter FROM subq_2.booking__ds__day) AS booking__ds__extract_quarter
-            , EXTRACT(month FROM subq_2.booking__ds__day) AS booking__ds__extract_month
-            , EXTRACT(day FROM subq_2.booking__ds__day) AS booking__ds__extract_day
-            , CASE WHEN EXTRACT(dow FROM subq_2.booking__ds__day) = 0 THEN EXTRACT(dow FROM subq_2.booking__ds__day) + 7 ELSE EXTRACT(dow FROM subq_2.booking__ds__day) END AS booking__ds__extract_dow
-            , EXTRACT(doy FROM subq_2.booking__ds__day) AS booking__ds__extract_doy
             , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
@@ -74,6 +64,16 @@ FROM (
             , subq_1.paid_at__extract_day AS paid_at__extract_day
             , subq_1.paid_at__extract_dow AS paid_at__extract_dow
             , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+            , subq_1.booking__ds__week AS booking__ds__week
+            , subq_1.booking__ds__month AS booking__ds__month
+            , subq_1.booking__ds__quarter AS booking__ds__quarter
+            , subq_1.booking__ds__year AS booking__ds__year
+            , subq_1.booking__ds__extract_year AS booking__ds__extract_year
+            , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
+            , subq_1.booking__ds__extract_month AS booking__ds__extract_month
+            , subq_1.booking__ds__extract_day AS booking__ds__extract_day
+            , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
+            , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
             , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
             , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
             , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_offset_metric_with_one_input_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_offset_metric_with_one_input_metric__plan0.sql
@@ -25,16 +25,6 @@ FROM (
         -- Join to Time Spine Dataset
         SELECT
           subq_2.metric_time__day AS metric_time__day
-          , DATE_TRUNC('week', subq_2.metric_time__day) AS metric_time__week
-          , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-          , DATE_TRUNC('quarter', subq_2.metric_time__day) AS metric_time__quarter
-          , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-          , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-          , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-          , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-          , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-          , CASE WHEN EXTRACT(dow FROM subq_2.metric_time__day) = 0 THEN EXTRACT(dow FROM subq_2.metric_time__day) + 7 ELSE EXTRACT(dow FROM subq_2.metric_time__day) END AS metric_time__extract_dow
-          , EXTRACT(doy FROM subq_2.metric_time__day) AS metric_time__extract_doy
           , subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
@@ -101,6 +91,16 @@ FROM (
           , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
           , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
           , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+          , subq_1.metric_time__week AS metric_time__week
+          , subq_1.metric_time__month AS metric_time__month
+          , subq_1.metric_time__quarter AS metric_time__quarter
+          , subq_1.metric_time__year AS metric_time__year
+          , subq_1.metric_time__extract_year AS metric_time__extract_year
+          , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_1.metric_time__extract_month AS metric_time__extract_month
+          , subq_1.metric_time__extract_day AS metric_time__extract_day
+          , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+          , subq_1.metric_time__extract_doy AS metric_time__extract_doy
           , subq_1.listing AS listing
           , subq_1.guest AS guest
           , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0.sql
@@ -57,16 +57,6 @@ FROM (
                 -- Join to Time Spine Dataset
                 SELECT
                   subq_2.metric_time__day AS metric_time__day
-                  , DATE_TRUNC('week', subq_2.metric_time__day) AS metric_time__week
-                  , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-                  , DATE_TRUNC('quarter', subq_2.metric_time__day) AS metric_time__quarter
-                  , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-                  , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-                  , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-                  , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-                  , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-                  , CASE WHEN EXTRACT(dow FROM subq_2.metric_time__day) = 0 THEN EXTRACT(dow FROM subq_2.metric_time__day) + 7 ELSE EXTRACT(dow FROM subq_2.metric_time__day) END AS metric_time__extract_dow
-                  , EXTRACT(doy FROM subq_2.metric_time__day) AS metric_time__extract_doy
                   , subq_1.ds__day AS ds__day
                   , subq_1.ds__week AS ds__week
                   , subq_1.ds__month AS ds__month
@@ -133,6 +123,16 @@ FROM (
                   , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
                   , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
                   , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                  , subq_1.metric_time__week AS metric_time__week
+                  , subq_1.metric_time__month AS metric_time__month
+                  , subq_1.metric_time__quarter AS metric_time__quarter
+                  , subq_1.metric_time__year AS metric_time__year
+                  , subq_1.metric_time__extract_year AS metric_time__extract_year
+                  , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+                  , subq_1.metric_time__extract_month AS metric_time__extract_month
+                  , subq_1.metric_time__extract_day AS metric_time__extract_day
+                  , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+                  , subq_1.metric_time__extract_doy AS metric_time__extract_doy
                   , subq_1.listing AS listing
                   , subq_1.guest AS guest
                   , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_nested_offsets__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_nested_offsets__plan0.sql
@@ -41,16 +41,6 @@ FROM (
             -- Join to Time Spine Dataset
             SELECT
               subq_2.metric_time__day AS metric_time__day
-              , DATE_TRUNC('week', subq_2.metric_time__day) AS metric_time__week
-              , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-              , DATE_TRUNC('quarter', subq_2.metric_time__day) AS metric_time__quarter
-              , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-              , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-              , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-              , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-              , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-              , CASE WHEN EXTRACT(dow FROM subq_2.metric_time__day) = 0 THEN EXTRACT(dow FROM subq_2.metric_time__day) + 7 ELSE EXTRACT(dow FROM subq_2.metric_time__day) END AS metric_time__extract_dow
-              , EXTRACT(doy FROM subq_2.metric_time__day) AS metric_time__extract_doy
               , subq_1.ds__day AS ds__day
               , subq_1.ds__week AS ds__week
               , subq_1.ds__month AS ds__month
@@ -117,6 +107,16 @@ FROM (
               , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
               , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
               , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+              , subq_1.metric_time__week AS metric_time__week
+              , subq_1.metric_time__month AS metric_time__month
+              , subq_1.metric_time__quarter AS metric_time__quarter
+              , subq_1.metric_time__year AS metric_time__year
+              , subq_1.metric_time__extract_year AS metric_time__extract_year
+              , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+              , subq_1.metric_time__extract_month AS metric_time__extract_month
+              , subq_1.metric_time__extract_day AS metric_time__extract_day
+              , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+              , subq_1.metric_time__extract_doy AS metric_time__extract_doy
               , subq_1.listing AS listing
               , subq_1.guest AS guest
               , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_nested_offsets_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_nested_offsets_with_time_constraint__plan0.sql
@@ -42,16 +42,6 @@ FROM (
             -- Join to Time Spine Dataset
             SELECT
               subq_2.metric_time__day AS metric_time__day
-              , DATE_TRUNC('week', subq_2.metric_time__day) AS metric_time__week
-              , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-              , DATE_TRUNC('quarter', subq_2.metric_time__day) AS metric_time__quarter
-              , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-              , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-              , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-              , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-              , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-              , CASE WHEN EXTRACT(dow FROM subq_2.metric_time__day) = 0 THEN EXTRACT(dow FROM subq_2.metric_time__day) + 7 ELSE EXTRACT(dow FROM subq_2.metric_time__day) END AS metric_time__extract_dow
-              , EXTRACT(doy FROM subq_2.metric_time__day) AS metric_time__extract_doy
               , subq_1.ds__day AS ds__day
               , subq_1.ds__week AS ds__week
               , subq_1.ds__month AS ds__month
@@ -118,6 +108,16 @@ FROM (
               , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
               , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
               , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+              , subq_1.metric_time__week AS metric_time__week
+              , subq_1.metric_time__month AS metric_time__month
+              , subq_1.metric_time__quarter AS metric_time__quarter
+              , subq_1.metric_time__year AS metric_time__year
+              , subq_1.metric_time__extract_year AS metric_time__extract_year
+              , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+              , subq_1.metric_time__extract_month AS metric_time__extract_month
+              , subq_1.metric_time__extract_day AS metric_time__extract_day
+              , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+              , subq_1.metric_time__extract_doy AS metric_time__extract_doy
               , subq_1.listing AS listing
               , subq_1.guest AS guest
               , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_nested_offsets_with_where_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_nested_offsets_with_where_constraint__plan0.sql
@@ -46,16 +46,6 @@ FROM (
               -- Join to Time Spine Dataset
               SELECT
                 subq_2.metric_time__day AS metric_time__day
-                , DATE_TRUNC('week', subq_2.metric_time__day) AS metric_time__week
-                , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-                , DATE_TRUNC('quarter', subq_2.metric_time__day) AS metric_time__quarter
-                , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-                , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-                , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-                , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-                , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-                , CASE WHEN EXTRACT(dow FROM subq_2.metric_time__day) = 0 THEN EXTRACT(dow FROM subq_2.metric_time__day) + 7 ELSE EXTRACT(dow FROM subq_2.metric_time__day) END AS metric_time__extract_dow
-                , EXTRACT(doy FROM subq_2.metric_time__day) AS metric_time__extract_doy
                 , subq_1.ds__day AS ds__day
                 , subq_1.ds__week AS ds__week
                 , subq_1.ds__month AS ds__month
@@ -122,6 +112,16 @@ FROM (
                 , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
                 , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
                 , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                , subq_1.metric_time__week AS metric_time__week
+                , subq_1.metric_time__month AS metric_time__month
+                , subq_1.metric_time__quarter AS metric_time__quarter
+                , subq_1.metric_time__year AS metric_time__year
+                , subq_1.metric_time__extract_year AS metric_time__extract_year
+                , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+                , subq_1.metric_time__extract_month AS metric_time__extract_month
+                , subq_1.metric_time__extract_day AS metric_time__extract_day
+                , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+                , subq_1.metric_time__extract_doy AS metric_time__extract_doy
                 , subq_1.listing AS listing
                 , subq_1.guest AS guest
                 , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0.sql
@@ -26,17 +26,7 @@ FROM (
       FROM (
         -- Constrain Output with WHERE
         SELECT
-          subq_4.metric_time__day
-          , subq_4.metric_time__week
-          , subq_4.metric_time__month
-          , subq_4.metric_time__quarter
-          , subq_4.metric_time__year
-          , subq_4.metric_time__extract_year
-          , subq_4.metric_time__extract_quarter
-          , subq_4.metric_time__extract_month
-          , subq_4.metric_time__extract_day
-          , subq_4.metric_time__extract_dow
-          , subq_4.metric_time__extract_doy
+          subq_4.metric_time__month
           , subq_4.ds__day
           , subq_4.ds__week
           , subq_4.ds__month
@@ -103,6 +93,16 @@ FROM (
           , subq_4.booking__paid_at__extract_day
           , subq_4.booking__paid_at__extract_dow
           , subq_4.booking__paid_at__extract_doy
+          , subq_4.metric_time__day
+          , subq_4.metric_time__week
+          , subq_4.metric_time__quarter
+          , subq_4.metric_time__year
+          , subq_4.metric_time__extract_year
+          , subq_4.metric_time__extract_quarter
+          , subq_4.metric_time__extract_month
+          , subq_4.metric_time__extract_day
+          , subq_4.metric_time__extract_dow
+          , subq_4.metric_time__extract_doy
           , subq_4.listing
           , subq_4.guest
           , subq_4.host
@@ -127,17 +127,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_2.metric_time__day AS metric_time__day
-            , DATE_TRUNC('week', subq_2.metric_time__day) AS metric_time__week
-            , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('quarter', subq_2.metric_time__day) AS metric_time__quarter
-            , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-            , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-            , CASE WHEN EXTRACT(dow FROM subq_2.metric_time__day) = 0 THEN EXTRACT(dow FROM subq_2.metric_time__day) + 7 ELSE EXTRACT(dow FROM subq_2.metric_time__day) END AS metric_time__extract_dow
-            , EXTRACT(doy FROM subq_2.metric_time__day) AS metric_time__extract_doy
+            DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
             , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
@@ -204,6 +194,16 @@ FROM (
             , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_1.metric_time__day AS metric_time__day
+            , subq_1.metric_time__week AS metric_time__week
+            , subq_1.metric_time__quarter AS metric_time__quarter
+            , subq_1.metric_time__year AS metric_time__year
+            , subq_1.metric_time__extract_year AS metric_time__extract_year
+            , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_1.metric_time__extract_month AS metric_time__extract_month
+            , subq_1.metric_time__extract_day AS metric_time__extract_day
+            , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_1.metric_time__extract_doy AS metric_time__extract_doy
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
@@ -19,8 +19,8 @@ FROM (
   FROM (
     -- Join to Time Spine Dataset
     SELECT
-      subq_12.ds AS metric_time__day
-      , DATE_TRUNC('month', subq_12.ds) AS metric_time__month
+      DATE_TRUNC('month', subq_12.ds) AS metric_time__month
+      , subq_10.metric_time__day AS metric_time__day
       , subq_10.bookings AS bookings
     FROM ***************************.mf_time_spine subq_12
     INNER JOIN (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_offset_to_grain_metric_multiple_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_offset_to_grain_metric_multiple_granularities__plan0.sql
@@ -35,16 +35,8 @@ FROM (
         -- Join to Time Spine Dataset
         SELECT
           subq_2.metric_time__day AS metric_time__day
-          , DATE_TRUNC('week', subq_2.metric_time__day) AS metric_time__week
           , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-          , DATE_TRUNC('quarter', subq_2.metric_time__day) AS metric_time__quarter
           , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-          , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-          , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-          , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-          , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-          , CASE WHEN EXTRACT(dow FROM subq_2.metric_time__day) = 0 THEN EXTRACT(dow FROM subq_2.metric_time__day) + 7 ELSE EXTRACT(dow FROM subq_2.metric_time__day) END AS metric_time__extract_dow
-          , EXTRACT(doy FROM subq_2.metric_time__day) AS metric_time__extract_doy
           , subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
@@ -111,6 +103,14 @@ FROM (
           , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
           , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
           , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+          , subq_1.metric_time__week AS metric_time__week
+          , subq_1.metric_time__quarter AS metric_time__quarter
+          , subq_1.metric_time__extract_year AS metric_time__extract_year
+          , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_1.metric_time__extract_month AS metric_time__extract_month
+          , subq_1.metric_time__extract_day AS metric_time__extract_day
+          , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+          , subq_1.metric_time__extract_doy AS metric_time__extract_doy
           , subq_1.listing AS listing
           , subq_1.guest AS guest
           , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_offset_to_grain_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_offset_to_grain_with_agg_time_dim__plan0.sql
@@ -246,16 +246,6 @@ FROM (
           -- Join to Time Spine Dataset
           SELECT
             subq_7.booking__ds__day AS booking__ds__day
-            , DATE_TRUNC('week', subq_7.booking__ds__day) AS booking__ds__week
-            , DATE_TRUNC('month', subq_7.booking__ds__day) AS booking__ds__month
-            , DATE_TRUNC('quarter', subq_7.booking__ds__day) AS booking__ds__quarter
-            , DATE_TRUNC('year', subq_7.booking__ds__day) AS booking__ds__year
-            , EXTRACT(year FROM subq_7.booking__ds__day) AS booking__ds__extract_year
-            , EXTRACT(quarter FROM subq_7.booking__ds__day) AS booking__ds__extract_quarter
-            , EXTRACT(month FROM subq_7.booking__ds__day) AS booking__ds__extract_month
-            , EXTRACT(day FROM subq_7.booking__ds__day) AS booking__ds__extract_day
-            , CASE WHEN EXTRACT(dow FROM subq_7.booking__ds__day) = 0 THEN EXTRACT(dow FROM subq_7.booking__ds__day) + 7 ELSE EXTRACT(dow FROM subq_7.booking__ds__day) END AS booking__ds__extract_dow
-            , EXTRACT(doy FROM subq_7.booking__ds__day) AS booking__ds__extract_doy
             , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
@@ -289,6 +279,16 @@ FROM (
             , subq_6.paid_at__extract_day AS paid_at__extract_day
             , subq_6.paid_at__extract_dow AS paid_at__extract_dow
             , subq_6.paid_at__extract_doy AS paid_at__extract_doy
+            , subq_6.booking__ds__week AS booking__ds__week
+            , subq_6.booking__ds__month AS booking__ds__month
+            , subq_6.booking__ds__quarter AS booking__ds__quarter
+            , subq_6.booking__ds__year AS booking__ds__year
+            , subq_6.booking__ds__extract_year AS booking__ds__extract_year
+            , subq_6.booking__ds__extract_quarter AS booking__ds__extract_quarter
+            , subq_6.booking__ds__extract_month AS booking__ds__extract_month
+            , subq_6.booking__ds__extract_day AS booking__ds__extract_day
+            , subq_6.booking__ds__extract_dow AS booking__ds__extract_dow
+            , subq_6.booking__ds__extract_doy AS booking__ds__extract_doy
             , subq_6.booking__ds_partitioned__day AS booking__ds_partitioned__day
             , subq_6.booking__ds_partitioned__week AS booking__ds_partitioned__week
             , subq_6.booking__ds_partitioned__month AS booking__ds_partitioned__month

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_offset_window_metric_filter_and_query_have_different_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_offset_window_metric_filter_and_query_have_different_granularities__plan0.sql
@@ -32,17 +32,7 @@ FROM (
         FROM (
           -- Constrain Output with WHERE
           SELECT
-            subq_4.metric_time__day
-            , subq_4.metric_time__week
-            , subq_4.metric_time__month
-            , subq_4.metric_time__quarter
-            , subq_4.metric_time__year
-            , subq_4.metric_time__extract_year
-            , subq_4.metric_time__extract_quarter
-            , subq_4.metric_time__extract_month
-            , subq_4.metric_time__extract_day
-            , subq_4.metric_time__extract_dow
-            , subq_4.metric_time__extract_doy
+            subq_4.metric_time__month
             , subq_4.ds__day
             , subq_4.ds__week
             , subq_4.ds__month
@@ -109,6 +99,16 @@ FROM (
             , subq_4.booking__paid_at__extract_day
             , subq_4.booking__paid_at__extract_dow
             , subq_4.booking__paid_at__extract_doy
+            , subq_4.metric_time__day
+            , subq_4.metric_time__week
+            , subq_4.metric_time__quarter
+            , subq_4.metric_time__year
+            , subq_4.metric_time__extract_year
+            , subq_4.metric_time__extract_quarter
+            , subq_4.metric_time__extract_month
+            , subq_4.metric_time__extract_day
+            , subq_4.metric_time__extract_dow
+            , subq_4.metric_time__extract_doy
             , subq_4.listing
             , subq_4.guest
             , subq_4.host
@@ -133,17 +133,7 @@ FROM (
           FROM (
             -- Join to Time Spine Dataset
             SELECT
-              subq_2.metric_time__day AS metric_time__day
-              , DATE_TRUNC('week', subq_2.metric_time__day) AS metric_time__week
-              , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-              , DATE_TRUNC('quarter', subq_2.metric_time__day) AS metric_time__quarter
-              , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-              , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-              , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-              , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-              , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-              , CASE WHEN EXTRACT(dow FROM subq_2.metric_time__day) = 0 THEN EXTRACT(dow FROM subq_2.metric_time__day) + 7 ELSE EXTRACT(dow FROM subq_2.metric_time__day) END AS metric_time__extract_dow
-              , EXTRACT(doy FROM subq_2.metric_time__day) AS metric_time__extract_doy
+              DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
               , subq_1.ds__day AS ds__day
               , subq_1.ds__week AS ds__week
               , subq_1.ds__month AS ds__month
@@ -210,6 +200,16 @@ FROM (
               , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
               , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
               , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+              , subq_1.metric_time__day AS metric_time__day
+              , subq_1.metric_time__week AS metric_time__week
+              , subq_1.metric_time__quarter AS metric_time__quarter
+              , subq_1.metric_time__year AS metric_time__year
+              , subq_1.metric_time__extract_year AS metric_time__extract_year
+              , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+              , subq_1.metric_time__extract_month AS metric_time__extract_month
+              , subq_1.metric_time__extract_day AS metric_time__extract_day
+              , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+              , subq_1.metric_time__extract_doy AS metric_time__extract_doy
               , subq_1.listing AS listing
               , subq_1.guest AS guest
               , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_offset_window_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_offset_window_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
@@ -25,8 +25,8 @@ FROM (
     FROM (
       -- Join to Time Spine Dataset
       SELECT
-        subq_19.ds AS metric_time__day
-        , DATE_TRUNC('month', subq_19.ds) AS metric_time__month
+        DATE_TRUNC('month', subq_19.ds) AS metric_time__month
+        , DATE_TRUNC('day', bookings_source_src_28000.ds) AS metric_time__day
         , bookings_source_src_28000.booking_value AS booking_value
       FROM ***************************.mf_time_spine subq_19
       INNER JOIN

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_offset_window_metric_multiple_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_offset_window_metric_multiple_granularities__plan0.sql
@@ -43,16 +43,8 @@ FROM (
           -- Join to Time Spine Dataset
           SELECT
             subq_2.metric_time__day AS metric_time__day
-            , DATE_TRUNC('week', subq_2.metric_time__day) AS metric_time__week
             , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('quarter', subq_2.metric_time__day) AS metric_time__quarter
             , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-            , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-            , CASE WHEN EXTRACT(dow FROM subq_2.metric_time__day) = 0 THEN EXTRACT(dow FROM subq_2.metric_time__day) + 7 ELSE EXTRACT(dow FROM subq_2.metric_time__day) END AS metric_time__extract_dow
-            , EXTRACT(doy FROM subq_2.metric_time__day) AS metric_time__extract_doy
             , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
@@ -119,6 +111,14 @@ FROM (
             , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_1.metric_time__week AS metric_time__week
+            , subq_1.metric_time__quarter AS metric_time__quarter
+            , subq_1.metric_time__extract_year AS metric_time__extract_year
+            , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_1.metric_time__extract_month AS metric_time__extract_month
+            , subq_1.metric_time__extract_day AS metric_time__extract_day
+            , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_1.metric_time__extract_doy AS metric_time__extract_doy
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_offset_window_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_offset_window_with_agg_time_dim__plan0.sql
@@ -246,16 +246,6 @@ FROM (
           -- Join to Time Spine Dataset
           SELECT
             subq_7.booking__ds__day AS booking__ds__day
-            , DATE_TRUNC('week', subq_7.booking__ds__day) AS booking__ds__week
-            , DATE_TRUNC('month', subq_7.booking__ds__day) AS booking__ds__month
-            , DATE_TRUNC('quarter', subq_7.booking__ds__day) AS booking__ds__quarter
-            , DATE_TRUNC('year', subq_7.booking__ds__day) AS booking__ds__year
-            , EXTRACT(year FROM subq_7.booking__ds__day) AS booking__ds__extract_year
-            , EXTRACT(quarter FROM subq_7.booking__ds__day) AS booking__ds__extract_quarter
-            , EXTRACT(month FROM subq_7.booking__ds__day) AS booking__ds__extract_month
-            , EXTRACT(day FROM subq_7.booking__ds__day) AS booking__ds__extract_day
-            , CASE WHEN EXTRACT(dow FROM subq_7.booking__ds__day) = 0 THEN EXTRACT(dow FROM subq_7.booking__ds__day) + 7 ELSE EXTRACT(dow FROM subq_7.booking__ds__day) END AS booking__ds__extract_dow
-            , EXTRACT(doy FROM subq_7.booking__ds__day) AS booking__ds__extract_doy
             , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
@@ -289,6 +279,16 @@ FROM (
             , subq_6.paid_at__extract_day AS paid_at__extract_day
             , subq_6.paid_at__extract_dow AS paid_at__extract_dow
             , subq_6.paid_at__extract_doy AS paid_at__extract_doy
+            , subq_6.booking__ds__week AS booking__ds__week
+            , subq_6.booking__ds__month AS booking__ds__month
+            , subq_6.booking__ds__quarter AS booking__ds__quarter
+            , subq_6.booking__ds__year AS booking__ds__year
+            , subq_6.booking__ds__extract_year AS booking__ds__extract_year
+            , subq_6.booking__ds__extract_quarter AS booking__ds__extract_quarter
+            , subq_6.booking__ds__extract_month AS booking__ds__extract_month
+            , subq_6.booking__ds__extract_day AS booking__ds__extract_day
+            , subq_6.booking__ds__extract_dow AS booking__ds__extract_dow
+            , subq_6.booking__ds__extract_doy AS booking__ds__extract_doy
             , subq_6.booking__ds_partitioned__day AS booking__ds_partitioned__day
             , subq_6.booking__ds_partitioned__week AS booking__ds_partitioned__week
             , subq_6.booking__ds_partitioned__month AS booking__ds_partitioned__month

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_time_offset_metric_with_time_constraint__plan0.sql
@@ -25,16 +25,6 @@ FROM (
         -- Join to Time Spine Dataset
         SELECT
           subq_2.metric_time__day AS metric_time__day
-          , DATE_TRUNC('week', subq_2.metric_time__day) AS metric_time__week
-          , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-          , DATE_TRUNC('quarter', subq_2.metric_time__day) AS metric_time__quarter
-          , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-          , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-          , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-          , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-          , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-          , CASE WHEN EXTRACT(dow FROM subq_2.metric_time__day) = 0 THEN EXTRACT(dow FROM subq_2.metric_time__day) + 7 ELSE EXTRACT(dow FROM subq_2.metric_time__day) END AS metric_time__extract_dow
-          , EXTRACT(doy FROM subq_2.metric_time__day) AS metric_time__extract_doy
           , subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
@@ -101,6 +91,16 @@ FROM (
           , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
           , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
           , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+          , subq_1.metric_time__week AS metric_time__week
+          , subq_1.metric_time__month AS metric_time__month
+          , subq_1.metric_time__quarter AS metric_time__quarter
+          , subq_1.metric_time__year AS metric_time__year
+          , subq_1.metric_time__extract_year AS metric_time__extract_year
+          , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_1.metric_time__extract_month AS metric_time__extract_month
+          , subq_1.metric_time__extract_day AS metric_time__extract_day
+          , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+          , subq_1.metric_time__extract_doy AS metric_time__extract_doy
           , subq_1.listing AS listing
           , subq_1.guest AS guest
           , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
@@ -25,16 +25,6 @@ FROM (
         -- Constrain Time Range to [2019-12-19T00:00:00, 2020-01-02T00:00:00]
         SELECT
           subq_7.metric_time__day
-          , subq_7.metric_time__week
-          , subq_7.metric_time__month
-          , subq_7.metric_time__quarter
-          , subq_7.metric_time__year
-          , subq_7.metric_time__extract_year
-          , subq_7.metric_time__extract_quarter
-          , subq_7.metric_time__extract_month
-          , subq_7.metric_time__extract_day
-          , subq_7.metric_time__extract_dow
-          , subq_7.metric_time__extract_doy
           , subq_7.ds__day
           , subq_7.ds__week
           , subq_7.ds__month
@@ -101,6 +91,16 @@ FROM (
           , subq_7.booking__paid_at__extract_day
           , subq_7.booking__paid_at__extract_dow
           , subq_7.booking__paid_at__extract_doy
+          , subq_7.metric_time__week
+          , subq_7.metric_time__month
+          , subq_7.metric_time__quarter
+          , subq_7.metric_time__year
+          , subq_7.metric_time__extract_year
+          , subq_7.metric_time__extract_quarter
+          , subq_7.metric_time__extract_month
+          , subq_7.metric_time__extract_day
+          , subq_7.metric_time__extract_dow
+          , subq_7.metric_time__extract_doy
           , subq_7.listing
           , subq_7.guest
           , subq_7.host
@@ -126,16 +126,6 @@ FROM (
           -- Join to Time Spine Dataset
           SELECT
             subq_5.metric_time__day AS metric_time__day
-            , DATE_TRUNC('week', subq_5.metric_time__day) AS metric_time__week
-            , DATE_TRUNC('month', subq_5.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('quarter', subq_5.metric_time__day) AS metric_time__quarter
-            , DATE_TRUNC('year', subq_5.metric_time__day) AS metric_time__year
-            , EXTRACT(year FROM subq_5.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_5.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_5.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_5.metric_time__day) AS metric_time__extract_day
-            , EXTRACT(dayofweekiso FROM subq_5.metric_time__day) AS metric_time__extract_dow
-            , EXTRACT(doy FROM subq_5.metric_time__day) AS metric_time__extract_doy
             , subq_4.ds__day AS ds__day
             , subq_4.ds__week AS ds__week
             , subq_4.ds__month AS ds__month
@@ -202,6 +192,16 @@ FROM (
             , subq_4.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_4.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_4.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_4.metric_time__week AS metric_time__week
+            , subq_4.metric_time__month AS metric_time__month
+            , subq_4.metric_time__quarter AS metric_time__quarter
+            , subq_4.metric_time__year AS metric_time__year
+            , subq_4.metric_time__extract_year AS metric_time__extract_year
+            , subq_4.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_4.metric_time__extract_month AS metric_time__extract_month
+            , subq_4.metric_time__extract_day AS metric_time__extract_day
+            , subq_4.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_4.metric_time__extract_doy AS metric_time__extract_doy
             , subq_4.listing AS listing
             , subq_4.guest AS guest
             , subq_4.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
@@ -25,11 +25,6 @@ FROM (
         -- Join to Time Spine Dataset
         SELECT
           subq_2.metric_time__month AS metric_time__month
-          , DATE_TRUNC('quarter', subq_2.metric_time__month) AS metric_time__quarter
-          , DATE_TRUNC('year', subq_2.metric_time__month) AS metric_time__year
-          , EXTRACT(year FROM subq_2.metric_time__month) AS metric_time__extract_year
-          , EXTRACT(quarter FROM subq_2.metric_time__month) AS metric_time__extract_quarter
-          , EXTRACT(month FROM subq_2.metric_time__month) AS metric_time__extract_month
           , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
           , subq_1.ds__year AS ds__year
@@ -42,6 +37,11 @@ FROM (
           , subq_1.booking_monthly__ds__extract_year AS booking_monthly__ds__extract_year
           , subq_1.booking_monthly__ds__extract_quarter AS booking_monthly__ds__extract_quarter
           , subq_1.booking_monthly__ds__extract_month AS booking_monthly__ds__extract_month
+          , subq_1.metric_time__quarter AS metric_time__quarter
+          , subq_1.metric_time__year AS metric_time__year
+          , subq_1.metric_time__extract_year AS metric_time__extract_year
+          , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_1.metric_time__extract_month AS metric_time__extract_month
           , subq_1.listing AS listing
           , subq_1.booking_monthly__listing AS booking_monthly__listing
           , subq_1.bookings_monthly AS bookings_monthly

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_to_grain__plan0.sql
@@ -246,16 +246,6 @@ FROM (
           -- Join to Time Spine Dataset
           SELECT
             subq_7.metric_time__day AS metric_time__day
-            , DATE_TRUNC('week', subq_7.metric_time__day) AS metric_time__week
-            , DATE_TRUNC('month', subq_7.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('quarter', subq_7.metric_time__day) AS metric_time__quarter
-            , DATE_TRUNC('year', subq_7.metric_time__day) AS metric_time__year
-            , EXTRACT(year FROM subq_7.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_7.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_7.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_7.metric_time__day) AS metric_time__extract_day
-            , EXTRACT(dayofweekiso FROM subq_7.metric_time__day) AS metric_time__extract_dow
-            , EXTRACT(doy FROM subq_7.metric_time__day) AS metric_time__extract_doy
             , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
@@ -322,6 +312,16 @@ FROM (
             , subq_6.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_6.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_6.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_6.metric_time__week AS metric_time__week
+            , subq_6.metric_time__month AS metric_time__month
+            , subq_6.metric_time__quarter AS metric_time__quarter
+            , subq_6.metric_time__year AS metric_time__year
+            , subq_6.metric_time__extract_year AS metric_time__extract_year
+            , subq_6.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_6.metric_time__extract_month AS metric_time__extract_month
+            , subq_6.metric_time__extract_day AS metric_time__extract_day
+            , subq_6.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_6.metric_time__extract_doy AS metric_time__extract_doy
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_to_grain_and_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_to_grain_and_granularity__plan0.sql
@@ -245,17 +245,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_7.metric_time__day AS metric_time__day
-            , DATE_TRUNC('week', subq_7.metric_time__day) AS metric_time__week
-            , DATE_TRUNC('month', subq_7.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('quarter', subq_7.metric_time__day) AS metric_time__quarter
-            , DATE_TRUNC('year', subq_7.metric_time__day) AS metric_time__year
-            , EXTRACT(year FROM subq_7.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_7.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_7.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_7.metric_time__day) AS metric_time__extract_day
-            , EXTRACT(dayofweekiso FROM subq_7.metric_time__day) AS metric_time__extract_dow
-            , EXTRACT(doy FROM subq_7.metric_time__day) AS metric_time__extract_doy
+            DATE_TRUNC('week', subq_7.metric_time__day) AS metric_time__week
             , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
@@ -322,6 +312,16 @@ FROM (
             , subq_6.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_6.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_6.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_6.metric_time__day AS metric_time__day
+            , subq_6.metric_time__month AS metric_time__month
+            , subq_6.metric_time__quarter AS metric_time__quarter
+            , subq_6.metric_time__year AS metric_time__year
+            , subq_6.metric_time__extract_year AS metric_time__extract_year
+            , subq_6.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_6.metric_time__extract_month AS metric_time__extract_month
+            , subq_6.metric_time__extract_day AS metric_time__extract_day
+            , subq_6.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_6.metric_time__extract_doy AS metric_time__extract_doy
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_window__plan0.sql
@@ -246,16 +246,6 @@ FROM (
           -- Join to Time Spine Dataset
           SELECT
             subq_7.metric_time__day AS metric_time__day
-            , DATE_TRUNC('week', subq_7.metric_time__day) AS metric_time__week
-            , DATE_TRUNC('month', subq_7.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('quarter', subq_7.metric_time__day) AS metric_time__quarter
-            , DATE_TRUNC('year', subq_7.metric_time__day) AS metric_time__year
-            , EXTRACT(year FROM subq_7.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_7.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_7.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_7.metric_time__day) AS metric_time__extract_day
-            , EXTRACT(dayofweekiso FROM subq_7.metric_time__day) AS metric_time__extract_dow
-            , EXTRACT(doy FROM subq_7.metric_time__day) AS metric_time__extract_doy
             , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
@@ -322,6 +312,16 @@ FROM (
             , subq_6.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_6.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_6.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_6.metric_time__week AS metric_time__week
+            , subq_6.metric_time__month AS metric_time__month
+            , subq_6.metric_time__quarter AS metric_time__quarter
+            , subq_6.metric_time__year AS metric_time__year
+            , subq_6.metric_time__extract_year AS metric_time__extract_year
+            , subq_6.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_6.metric_time__extract_month AS metric_time__extract_month
+            , subq_6.metric_time__extract_day AS metric_time__extract_day
+            , subq_6.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_6.metric_time__extract_doy AS metric_time__extract_doy
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_window_and_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_window_and_granularity__plan0.sql
@@ -245,17 +245,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_7.metric_time__day AS metric_time__day
-            , DATE_TRUNC('week', subq_7.metric_time__day) AS metric_time__week
-            , DATE_TRUNC('month', subq_7.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('quarter', subq_7.metric_time__day) AS metric_time__quarter
-            , DATE_TRUNC('year', subq_7.metric_time__day) AS metric_time__year
-            , EXTRACT(year FROM subq_7.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_7.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_7.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_7.metric_time__day) AS metric_time__extract_day
-            , EXTRACT(dayofweekiso FROM subq_7.metric_time__day) AS metric_time__extract_dow
-            , EXTRACT(doy FROM subq_7.metric_time__day) AS metric_time__extract_doy
+            DATE_TRUNC('quarter', subq_7.metric_time__day) AS metric_time__quarter
             , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
@@ -322,6 +312,16 @@ FROM (
             , subq_6.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_6.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_6.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_6.metric_time__day AS metric_time__day
+            , subq_6.metric_time__week AS metric_time__week
+            , subq_6.metric_time__month AS metric_time__month
+            , subq_6.metric_time__year AS metric_time__year
+            , subq_6.metric_time__extract_year AS metric_time__extract_year
+            , subq_6.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_6.metric_time__extract_month AS metric_time__extract_month
+            , subq_6.metric_time__extract_day AS metric_time__extract_day
+            , subq_6.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_6.metric_time__extract_doy AS metric_time__extract_doy
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
@@ -31,16 +31,6 @@ FROM (
           -- Join to Time Spine Dataset
           SELECT
             subq_2.metric_time__day AS metric_time__day
-            , DATE_TRUNC('week', subq_2.metric_time__day) AS metric_time__week
-            , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('quarter', subq_2.metric_time__day) AS metric_time__quarter
-            , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-            , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-            , EXTRACT(dayofweekiso FROM subq_2.metric_time__day) AS metric_time__extract_dow
-            , EXTRACT(doy FROM subq_2.metric_time__day) AS metric_time__extract_doy
             , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
@@ -107,6 +97,16 @@ FROM (
             , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_1.metric_time__week AS metric_time__week
+            , subq_1.metric_time__month AS metric_time__month
+            , subq_1.metric_time__quarter AS metric_time__quarter
+            , subq_1.metric_time__year AS metric_time__year
+            , subq_1.metric_time__extract_year AS metric_time__extract_year
+            , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_1.metric_time__extract_month AS metric_time__extract_month
+            , subq_1.metric_time__extract_day AS metric_time__extract_day
+            , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_1.metric_time__extract_doy AS metric_time__extract_doy
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host
@@ -356,16 +356,6 @@ FROM (
           -- Join to Time Spine Dataset
           SELECT
             subq_10.metric_time__day AS metric_time__day
-            , DATE_TRUNC('week', subq_10.metric_time__day) AS metric_time__week
-            , DATE_TRUNC('month', subq_10.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('quarter', subq_10.metric_time__day) AS metric_time__quarter
-            , DATE_TRUNC('year', subq_10.metric_time__day) AS metric_time__year
-            , EXTRACT(year FROM subq_10.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_10.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_10.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_10.metric_time__day) AS metric_time__extract_day
-            , EXTRACT(dayofweekiso FROM subq_10.metric_time__day) AS metric_time__extract_dow
-            , EXTRACT(doy FROM subq_10.metric_time__day) AS metric_time__extract_doy
             , subq_9.ds__day AS ds__day
             , subq_9.ds__week AS ds__week
             , subq_9.ds__month AS ds__month
@@ -432,6 +422,16 @@ FROM (
             , subq_9.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_9.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_9.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_9.metric_time__week AS metric_time__week
+            , subq_9.metric_time__month AS metric_time__month
+            , subq_9.metric_time__quarter AS metric_time__quarter
+            , subq_9.metric_time__year AS metric_time__year
+            , subq_9.metric_time__extract_year AS metric_time__extract_year
+            , subq_9.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_9.metric_time__extract_month AS metric_time__extract_month
+            , subq_9.metric_time__extract_day AS metric_time__extract_day
+            , subq_9.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_9.metric_time__extract_doy AS metric_time__extract_doy
             , subq_9.listing AS listing
             , subq_9.guest AS guest
             , subq_9.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0.sql
@@ -30,17 +30,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_2.metric_time__day AS metric_time__day
-            , DATE_TRUNC('week', subq_2.metric_time__day) AS metric_time__week
-            , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('quarter', subq_2.metric_time__day) AS metric_time__quarter
-            , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-            , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-            , EXTRACT(dayofweekiso FROM subq_2.metric_time__day) AS metric_time__extract_dow
-            , EXTRACT(doy FROM subq_2.metric_time__day) AS metric_time__extract_doy
+            DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
             , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
@@ -107,6 +97,16 @@ FROM (
             , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_1.metric_time__day AS metric_time__day
+            , subq_1.metric_time__week AS metric_time__week
+            , subq_1.metric_time__month AS metric_time__month
+            , subq_1.metric_time__quarter AS metric_time__quarter
+            , subq_1.metric_time__extract_year AS metric_time__extract_year
+            , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_1.metric_time__extract_month AS metric_time__extract_month
+            , subq_1.metric_time__extract_day AS metric_time__extract_day
+            , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_1.metric_time__extract_doy AS metric_time__extract_doy
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host
@@ -356,17 +356,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_10.metric_time__day AS metric_time__day
-            , DATE_TRUNC('week', subq_10.metric_time__day) AS metric_time__week
-            , DATE_TRUNC('month', subq_10.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('quarter', subq_10.metric_time__day) AS metric_time__quarter
-            , DATE_TRUNC('year', subq_10.metric_time__day) AS metric_time__year
-            , EXTRACT(year FROM subq_10.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_10.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_10.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_10.metric_time__day) AS metric_time__extract_day
-            , EXTRACT(dayofweekiso FROM subq_10.metric_time__day) AS metric_time__extract_dow
-            , EXTRACT(doy FROM subq_10.metric_time__day) AS metric_time__extract_doy
+            DATE_TRUNC('year', subq_10.metric_time__day) AS metric_time__year
             , subq_9.ds__day AS ds__day
             , subq_9.ds__week AS ds__week
             , subq_9.ds__month AS ds__month
@@ -433,6 +423,16 @@ FROM (
             , subq_9.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_9.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_9.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_9.metric_time__day AS metric_time__day
+            , subq_9.metric_time__week AS metric_time__week
+            , subq_9.metric_time__month AS metric_time__month
+            , subq_9.metric_time__quarter AS metric_time__quarter
+            , subq_9.metric_time__extract_year AS metric_time__extract_year
+            , subq_9.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_9.metric_time__extract_month AS metric_time__extract_month
+            , subq_9.metric_time__extract_day AS metric_time__extract_day
+            , subq_9.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_9.metric_time__extract_doy AS metric_time__extract_doy
             , subq_9.listing AS listing
             , subq_9.guest AS guest
             , subq_9.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
@@ -349,16 +349,6 @@ FROM (
           -- Constrain Output with WHERE
           SELECT
             subq_10.metric_time__day
-            , subq_10.metric_time__week
-            , subq_10.metric_time__month
-            , subq_10.metric_time__quarter
-            , subq_10.metric_time__year
-            , subq_10.metric_time__extract_year
-            , subq_10.metric_time__extract_quarter
-            , subq_10.metric_time__extract_month
-            , subq_10.metric_time__extract_day
-            , subq_10.metric_time__extract_dow
-            , subq_10.metric_time__extract_doy
             , subq_10.ds__day
             , subq_10.ds__week
             , subq_10.ds__month
@@ -425,6 +415,16 @@ FROM (
             , subq_10.booking__paid_at__extract_day
             , subq_10.booking__paid_at__extract_dow
             , subq_10.booking__paid_at__extract_doy
+            , subq_10.metric_time__week
+            , subq_10.metric_time__month
+            , subq_10.metric_time__quarter
+            , subq_10.metric_time__year
+            , subq_10.metric_time__extract_year
+            , subq_10.metric_time__extract_quarter
+            , subq_10.metric_time__extract_month
+            , subq_10.metric_time__extract_day
+            , subq_10.metric_time__extract_dow
+            , subq_10.metric_time__extract_doy
             , subq_10.listing
             , subq_10.guest
             , subq_10.host
@@ -450,16 +450,6 @@ FROM (
             -- Join to Time Spine Dataset
             SELECT
               subq_8.metric_time__day AS metric_time__day
-              , DATE_TRUNC('week', subq_8.metric_time__day) AS metric_time__week
-              , DATE_TRUNC('month', subq_8.metric_time__day) AS metric_time__month
-              , DATE_TRUNC('quarter', subq_8.metric_time__day) AS metric_time__quarter
-              , DATE_TRUNC('year', subq_8.metric_time__day) AS metric_time__year
-              , EXTRACT(year FROM subq_8.metric_time__day) AS metric_time__extract_year
-              , EXTRACT(quarter FROM subq_8.metric_time__day) AS metric_time__extract_quarter
-              , EXTRACT(month FROM subq_8.metric_time__day) AS metric_time__extract_month
-              , EXTRACT(day FROM subq_8.metric_time__day) AS metric_time__extract_day
-              , EXTRACT(dayofweekiso FROM subq_8.metric_time__day) AS metric_time__extract_dow
-              , EXTRACT(doy FROM subq_8.metric_time__day) AS metric_time__extract_doy
               , subq_7.ds__day AS ds__day
               , subq_7.ds__week AS ds__week
               , subq_7.ds__month AS ds__month
@@ -526,6 +516,16 @@ FROM (
               , subq_7.booking__paid_at__extract_day AS booking__paid_at__extract_day
               , subq_7.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
               , subq_7.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+              , subq_7.metric_time__week AS metric_time__week
+              , subq_7.metric_time__month AS metric_time__month
+              , subq_7.metric_time__quarter AS metric_time__quarter
+              , subq_7.metric_time__year AS metric_time__year
+              , subq_7.metric_time__extract_year AS metric_time__extract_year
+              , subq_7.metric_time__extract_quarter AS metric_time__extract_quarter
+              , subq_7.metric_time__extract_month AS metric_time__extract_month
+              , subq_7.metric_time__extract_day AS metric_time__extract_day
+              , subq_7.metric_time__extract_dow AS metric_time__extract_dow
+              , subq_7.metric_time__extract_doy AS metric_time__extract_doy
               , subq_7.listing AS listing
               , subq_7.guest AS guest
               , subq_7.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_offset_cumulative_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_offset_cumulative_metric__plan0.sql
@@ -25,16 +25,6 @@ FROM (
         -- Join to Time Spine Dataset
         SELECT
           subq_5.metric_time__day AS metric_time__day
-          , DATE_TRUNC('week', subq_5.metric_time__day) AS metric_time__week
-          , DATE_TRUNC('month', subq_5.metric_time__day) AS metric_time__month
-          , DATE_TRUNC('quarter', subq_5.metric_time__day) AS metric_time__quarter
-          , DATE_TRUNC('year', subq_5.metric_time__day) AS metric_time__year
-          , EXTRACT(year FROM subq_5.metric_time__day) AS metric_time__extract_year
-          , EXTRACT(quarter FROM subq_5.metric_time__day) AS metric_time__extract_quarter
-          , EXTRACT(month FROM subq_5.metric_time__day) AS metric_time__extract_month
-          , EXTRACT(day FROM subq_5.metric_time__day) AS metric_time__extract_day
-          , EXTRACT(dayofweekiso FROM subq_5.metric_time__day) AS metric_time__extract_dow
-          , EXTRACT(doy FROM subq_5.metric_time__day) AS metric_time__extract_doy
           , subq_4.ds__day AS ds__day
           , subq_4.ds__week AS ds__week
           , subq_4.ds__month AS ds__month
@@ -101,6 +91,16 @@ FROM (
           , subq_4.booking__paid_at__extract_day AS booking__paid_at__extract_day
           , subq_4.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
           , subq_4.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+          , subq_4.metric_time__week AS metric_time__week
+          , subq_4.metric_time__month AS metric_time__month
+          , subq_4.metric_time__quarter AS metric_time__quarter
+          , subq_4.metric_time__year AS metric_time__year
+          , subq_4.metric_time__extract_year AS metric_time__extract_year
+          , subq_4.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_4.metric_time__extract_month AS metric_time__extract_month
+          , subq_4.metric_time__extract_day AS metric_time__extract_day
+          , subq_4.metric_time__extract_dow AS metric_time__extract_dow
+          , subq_4.metric_time__extract_doy AS metric_time__extract_doy
           , subq_4.listing AS listing
           , subq_4.guest AS guest
           , subq_4.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_offset_metric_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_offset_metric_with_agg_time_dim__plan0.sql
@@ -31,16 +31,6 @@ FROM (
           -- Join to Time Spine Dataset
           SELECT
             subq_2.booking__ds__day AS booking__ds__day
-            , DATE_TRUNC('week', subq_2.booking__ds__day) AS booking__ds__week
-            , DATE_TRUNC('month', subq_2.booking__ds__day) AS booking__ds__month
-            , DATE_TRUNC('quarter', subq_2.booking__ds__day) AS booking__ds__quarter
-            , DATE_TRUNC('year', subq_2.booking__ds__day) AS booking__ds__year
-            , EXTRACT(year FROM subq_2.booking__ds__day) AS booking__ds__extract_year
-            , EXTRACT(quarter FROM subq_2.booking__ds__day) AS booking__ds__extract_quarter
-            , EXTRACT(month FROM subq_2.booking__ds__day) AS booking__ds__extract_month
-            , EXTRACT(day FROM subq_2.booking__ds__day) AS booking__ds__extract_day
-            , EXTRACT(dayofweekiso FROM subq_2.booking__ds__day) AS booking__ds__extract_dow
-            , EXTRACT(doy FROM subq_2.booking__ds__day) AS booking__ds__extract_doy
             , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
@@ -74,6 +64,16 @@ FROM (
             , subq_1.paid_at__extract_day AS paid_at__extract_day
             , subq_1.paid_at__extract_dow AS paid_at__extract_dow
             , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+            , subq_1.booking__ds__week AS booking__ds__week
+            , subq_1.booking__ds__month AS booking__ds__month
+            , subq_1.booking__ds__quarter AS booking__ds__quarter
+            , subq_1.booking__ds__year AS booking__ds__year
+            , subq_1.booking__ds__extract_year AS booking__ds__extract_year
+            , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
+            , subq_1.booking__ds__extract_month AS booking__ds__extract_month
+            , subq_1.booking__ds__extract_day AS booking__ds__extract_day
+            , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
+            , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
             , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
             , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
             , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_offset_metric_with_one_input_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_offset_metric_with_one_input_metric__plan0.sql
@@ -25,16 +25,6 @@ FROM (
         -- Join to Time Spine Dataset
         SELECT
           subq_2.metric_time__day AS metric_time__day
-          , DATE_TRUNC('week', subq_2.metric_time__day) AS metric_time__week
-          , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-          , DATE_TRUNC('quarter', subq_2.metric_time__day) AS metric_time__quarter
-          , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-          , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-          , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-          , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-          , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-          , EXTRACT(dayofweekiso FROM subq_2.metric_time__day) AS metric_time__extract_dow
-          , EXTRACT(doy FROM subq_2.metric_time__day) AS metric_time__extract_doy
           , subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
@@ -101,6 +91,16 @@ FROM (
           , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
           , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
           , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+          , subq_1.metric_time__week AS metric_time__week
+          , subq_1.metric_time__month AS metric_time__month
+          , subq_1.metric_time__quarter AS metric_time__quarter
+          , subq_1.metric_time__year AS metric_time__year
+          , subq_1.metric_time__extract_year AS metric_time__extract_year
+          , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_1.metric_time__extract_month AS metric_time__extract_month
+          , subq_1.metric_time__extract_day AS metric_time__extract_day
+          , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+          , subq_1.metric_time__extract_doy AS metric_time__extract_doy
           , subq_1.listing AS listing
           , subq_1.guest AS guest
           , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0.sql
@@ -57,16 +57,6 @@ FROM (
                 -- Join to Time Spine Dataset
                 SELECT
                   subq_2.metric_time__day AS metric_time__day
-                  , DATE_TRUNC('week', subq_2.metric_time__day) AS metric_time__week
-                  , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-                  , DATE_TRUNC('quarter', subq_2.metric_time__day) AS metric_time__quarter
-                  , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-                  , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-                  , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-                  , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-                  , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-                  , EXTRACT(dayofweekiso FROM subq_2.metric_time__day) AS metric_time__extract_dow
-                  , EXTRACT(doy FROM subq_2.metric_time__day) AS metric_time__extract_doy
                   , subq_1.ds__day AS ds__day
                   , subq_1.ds__week AS ds__week
                   , subq_1.ds__month AS ds__month
@@ -133,6 +123,16 @@ FROM (
                   , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
                   , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
                   , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                  , subq_1.metric_time__week AS metric_time__week
+                  , subq_1.metric_time__month AS metric_time__month
+                  , subq_1.metric_time__quarter AS metric_time__quarter
+                  , subq_1.metric_time__year AS metric_time__year
+                  , subq_1.metric_time__extract_year AS metric_time__extract_year
+                  , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+                  , subq_1.metric_time__extract_month AS metric_time__extract_month
+                  , subq_1.metric_time__extract_day AS metric_time__extract_day
+                  , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+                  , subq_1.metric_time__extract_doy AS metric_time__extract_doy
                   , subq_1.listing AS listing
                   , subq_1.guest AS guest
                   , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_nested_offsets__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_nested_offsets__plan0.sql
@@ -41,16 +41,6 @@ FROM (
             -- Join to Time Spine Dataset
             SELECT
               subq_2.metric_time__day AS metric_time__day
-              , DATE_TRUNC('week', subq_2.metric_time__day) AS metric_time__week
-              , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-              , DATE_TRUNC('quarter', subq_2.metric_time__day) AS metric_time__quarter
-              , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-              , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-              , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-              , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-              , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-              , EXTRACT(dayofweekiso FROM subq_2.metric_time__day) AS metric_time__extract_dow
-              , EXTRACT(doy FROM subq_2.metric_time__day) AS metric_time__extract_doy
               , subq_1.ds__day AS ds__day
               , subq_1.ds__week AS ds__week
               , subq_1.ds__month AS ds__month
@@ -117,6 +107,16 @@ FROM (
               , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
               , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
               , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+              , subq_1.metric_time__week AS metric_time__week
+              , subq_1.metric_time__month AS metric_time__month
+              , subq_1.metric_time__quarter AS metric_time__quarter
+              , subq_1.metric_time__year AS metric_time__year
+              , subq_1.metric_time__extract_year AS metric_time__extract_year
+              , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+              , subq_1.metric_time__extract_month AS metric_time__extract_month
+              , subq_1.metric_time__extract_day AS metric_time__extract_day
+              , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+              , subq_1.metric_time__extract_doy AS metric_time__extract_doy
               , subq_1.listing AS listing
               , subq_1.guest AS guest
               , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_nested_offsets_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_nested_offsets_with_time_constraint__plan0.sql
@@ -42,16 +42,6 @@ FROM (
             -- Join to Time Spine Dataset
             SELECT
               subq_2.metric_time__day AS metric_time__day
-              , DATE_TRUNC('week', subq_2.metric_time__day) AS metric_time__week
-              , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-              , DATE_TRUNC('quarter', subq_2.metric_time__day) AS metric_time__quarter
-              , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-              , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-              , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-              , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-              , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-              , EXTRACT(dayofweekiso FROM subq_2.metric_time__day) AS metric_time__extract_dow
-              , EXTRACT(doy FROM subq_2.metric_time__day) AS metric_time__extract_doy
               , subq_1.ds__day AS ds__day
               , subq_1.ds__week AS ds__week
               , subq_1.ds__month AS ds__month
@@ -118,6 +108,16 @@ FROM (
               , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
               , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
               , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+              , subq_1.metric_time__week AS metric_time__week
+              , subq_1.metric_time__month AS metric_time__month
+              , subq_1.metric_time__quarter AS metric_time__quarter
+              , subq_1.metric_time__year AS metric_time__year
+              , subq_1.metric_time__extract_year AS metric_time__extract_year
+              , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+              , subq_1.metric_time__extract_month AS metric_time__extract_month
+              , subq_1.metric_time__extract_day AS metric_time__extract_day
+              , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+              , subq_1.metric_time__extract_doy AS metric_time__extract_doy
               , subq_1.listing AS listing
               , subq_1.guest AS guest
               , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_nested_offsets_with_where_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_nested_offsets_with_where_constraint__plan0.sql
@@ -46,16 +46,6 @@ FROM (
               -- Join to Time Spine Dataset
               SELECT
                 subq_2.metric_time__day AS metric_time__day
-                , DATE_TRUNC('week', subq_2.metric_time__day) AS metric_time__week
-                , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-                , DATE_TRUNC('quarter', subq_2.metric_time__day) AS metric_time__quarter
-                , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-                , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-                , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-                , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-                , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-                , EXTRACT(dayofweekiso FROM subq_2.metric_time__day) AS metric_time__extract_dow
-                , EXTRACT(doy FROM subq_2.metric_time__day) AS metric_time__extract_doy
                 , subq_1.ds__day AS ds__day
                 , subq_1.ds__week AS ds__week
                 , subq_1.ds__month AS ds__month
@@ -122,6 +112,16 @@ FROM (
                 , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
                 , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
                 , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                , subq_1.metric_time__week AS metric_time__week
+                , subq_1.metric_time__month AS metric_time__month
+                , subq_1.metric_time__quarter AS metric_time__quarter
+                , subq_1.metric_time__year AS metric_time__year
+                , subq_1.metric_time__extract_year AS metric_time__extract_year
+                , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+                , subq_1.metric_time__extract_month AS metric_time__extract_month
+                , subq_1.metric_time__extract_day AS metric_time__extract_day
+                , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+                , subq_1.metric_time__extract_doy AS metric_time__extract_doy
                 , subq_1.listing AS listing
                 , subq_1.guest AS guest
                 , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0.sql
@@ -26,17 +26,7 @@ FROM (
       FROM (
         -- Constrain Output with WHERE
         SELECT
-          subq_4.metric_time__day
-          , subq_4.metric_time__week
-          , subq_4.metric_time__month
-          , subq_4.metric_time__quarter
-          , subq_4.metric_time__year
-          , subq_4.metric_time__extract_year
-          , subq_4.metric_time__extract_quarter
-          , subq_4.metric_time__extract_month
-          , subq_4.metric_time__extract_day
-          , subq_4.metric_time__extract_dow
-          , subq_4.metric_time__extract_doy
+          subq_4.metric_time__month
           , subq_4.ds__day
           , subq_4.ds__week
           , subq_4.ds__month
@@ -103,6 +93,16 @@ FROM (
           , subq_4.booking__paid_at__extract_day
           , subq_4.booking__paid_at__extract_dow
           , subq_4.booking__paid_at__extract_doy
+          , subq_4.metric_time__day
+          , subq_4.metric_time__week
+          , subq_4.metric_time__quarter
+          , subq_4.metric_time__year
+          , subq_4.metric_time__extract_year
+          , subq_4.metric_time__extract_quarter
+          , subq_4.metric_time__extract_month
+          , subq_4.metric_time__extract_day
+          , subq_4.metric_time__extract_dow
+          , subq_4.metric_time__extract_doy
           , subq_4.listing
           , subq_4.guest
           , subq_4.host
@@ -127,17 +127,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_2.metric_time__day AS metric_time__day
-            , DATE_TRUNC('week', subq_2.metric_time__day) AS metric_time__week
-            , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('quarter', subq_2.metric_time__day) AS metric_time__quarter
-            , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-            , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-            , EXTRACT(dayofweekiso FROM subq_2.metric_time__day) AS metric_time__extract_dow
-            , EXTRACT(doy FROM subq_2.metric_time__day) AS metric_time__extract_doy
+            DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
             , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
@@ -204,6 +194,16 @@ FROM (
             , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_1.metric_time__day AS metric_time__day
+            , subq_1.metric_time__week AS metric_time__week
+            , subq_1.metric_time__quarter AS metric_time__quarter
+            , subq_1.metric_time__year AS metric_time__year
+            , subq_1.metric_time__extract_year AS metric_time__extract_year
+            , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_1.metric_time__extract_month AS metric_time__extract_month
+            , subq_1.metric_time__extract_day AS metric_time__extract_day
+            , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_1.metric_time__extract_doy AS metric_time__extract_doy
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
@@ -19,8 +19,8 @@ FROM (
   FROM (
     -- Join to Time Spine Dataset
     SELECT
-      subq_12.ds AS metric_time__day
-      , DATE_TRUNC('month', subq_12.ds) AS metric_time__month
+      DATE_TRUNC('month', subq_12.ds) AS metric_time__month
+      , subq_10.metric_time__day AS metric_time__day
       , subq_10.bookings AS bookings
     FROM ***************************.mf_time_spine subq_12
     INNER JOIN (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_offset_to_grain_metric_multiple_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_offset_to_grain_metric_multiple_granularities__plan0.sql
@@ -35,16 +35,8 @@ FROM (
         -- Join to Time Spine Dataset
         SELECT
           subq_2.metric_time__day AS metric_time__day
-          , DATE_TRUNC('week', subq_2.metric_time__day) AS metric_time__week
           , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-          , DATE_TRUNC('quarter', subq_2.metric_time__day) AS metric_time__quarter
           , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-          , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-          , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-          , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-          , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-          , EXTRACT(dayofweekiso FROM subq_2.metric_time__day) AS metric_time__extract_dow
-          , EXTRACT(doy FROM subq_2.metric_time__day) AS metric_time__extract_doy
           , subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
@@ -111,6 +103,14 @@ FROM (
           , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
           , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
           , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+          , subq_1.metric_time__week AS metric_time__week
+          , subq_1.metric_time__quarter AS metric_time__quarter
+          , subq_1.metric_time__extract_year AS metric_time__extract_year
+          , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_1.metric_time__extract_month AS metric_time__extract_month
+          , subq_1.metric_time__extract_day AS metric_time__extract_day
+          , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+          , subq_1.metric_time__extract_doy AS metric_time__extract_doy
           , subq_1.listing AS listing
           , subq_1.guest AS guest
           , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_offset_to_grain_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_offset_to_grain_with_agg_time_dim__plan0.sql
@@ -246,16 +246,6 @@ FROM (
           -- Join to Time Spine Dataset
           SELECT
             subq_7.booking__ds__day AS booking__ds__day
-            , DATE_TRUNC('week', subq_7.booking__ds__day) AS booking__ds__week
-            , DATE_TRUNC('month', subq_7.booking__ds__day) AS booking__ds__month
-            , DATE_TRUNC('quarter', subq_7.booking__ds__day) AS booking__ds__quarter
-            , DATE_TRUNC('year', subq_7.booking__ds__day) AS booking__ds__year
-            , EXTRACT(year FROM subq_7.booking__ds__day) AS booking__ds__extract_year
-            , EXTRACT(quarter FROM subq_7.booking__ds__day) AS booking__ds__extract_quarter
-            , EXTRACT(month FROM subq_7.booking__ds__day) AS booking__ds__extract_month
-            , EXTRACT(day FROM subq_7.booking__ds__day) AS booking__ds__extract_day
-            , EXTRACT(dayofweekiso FROM subq_7.booking__ds__day) AS booking__ds__extract_dow
-            , EXTRACT(doy FROM subq_7.booking__ds__day) AS booking__ds__extract_doy
             , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
@@ -289,6 +279,16 @@ FROM (
             , subq_6.paid_at__extract_day AS paid_at__extract_day
             , subq_6.paid_at__extract_dow AS paid_at__extract_dow
             , subq_6.paid_at__extract_doy AS paid_at__extract_doy
+            , subq_6.booking__ds__week AS booking__ds__week
+            , subq_6.booking__ds__month AS booking__ds__month
+            , subq_6.booking__ds__quarter AS booking__ds__quarter
+            , subq_6.booking__ds__year AS booking__ds__year
+            , subq_6.booking__ds__extract_year AS booking__ds__extract_year
+            , subq_6.booking__ds__extract_quarter AS booking__ds__extract_quarter
+            , subq_6.booking__ds__extract_month AS booking__ds__extract_month
+            , subq_6.booking__ds__extract_day AS booking__ds__extract_day
+            , subq_6.booking__ds__extract_dow AS booking__ds__extract_dow
+            , subq_6.booking__ds__extract_doy AS booking__ds__extract_doy
             , subq_6.booking__ds_partitioned__day AS booking__ds_partitioned__day
             , subq_6.booking__ds_partitioned__week AS booking__ds_partitioned__week
             , subq_6.booking__ds_partitioned__month AS booking__ds_partitioned__month

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_offset_window_metric_filter_and_query_have_different_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_offset_window_metric_filter_and_query_have_different_granularities__plan0.sql
@@ -32,17 +32,7 @@ FROM (
         FROM (
           -- Constrain Output with WHERE
           SELECT
-            subq_4.metric_time__day
-            , subq_4.metric_time__week
-            , subq_4.metric_time__month
-            , subq_4.metric_time__quarter
-            , subq_4.metric_time__year
-            , subq_4.metric_time__extract_year
-            , subq_4.metric_time__extract_quarter
-            , subq_4.metric_time__extract_month
-            , subq_4.metric_time__extract_day
-            , subq_4.metric_time__extract_dow
-            , subq_4.metric_time__extract_doy
+            subq_4.metric_time__month
             , subq_4.ds__day
             , subq_4.ds__week
             , subq_4.ds__month
@@ -109,6 +99,16 @@ FROM (
             , subq_4.booking__paid_at__extract_day
             , subq_4.booking__paid_at__extract_dow
             , subq_4.booking__paid_at__extract_doy
+            , subq_4.metric_time__day
+            , subq_4.metric_time__week
+            , subq_4.metric_time__quarter
+            , subq_4.metric_time__year
+            , subq_4.metric_time__extract_year
+            , subq_4.metric_time__extract_quarter
+            , subq_4.metric_time__extract_month
+            , subq_4.metric_time__extract_day
+            , subq_4.metric_time__extract_dow
+            , subq_4.metric_time__extract_doy
             , subq_4.listing
             , subq_4.guest
             , subq_4.host
@@ -133,17 +133,7 @@ FROM (
           FROM (
             -- Join to Time Spine Dataset
             SELECT
-              subq_2.metric_time__day AS metric_time__day
-              , DATE_TRUNC('week', subq_2.metric_time__day) AS metric_time__week
-              , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-              , DATE_TRUNC('quarter', subq_2.metric_time__day) AS metric_time__quarter
-              , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-              , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-              , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-              , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-              , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-              , EXTRACT(dayofweekiso FROM subq_2.metric_time__day) AS metric_time__extract_dow
-              , EXTRACT(doy FROM subq_2.metric_time__day) AS metric_time__extract_doy
+              DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
               , subq_1.ds__day AS ds__day
               , subq_1.ds__week AS ds__week
               , subq_1.ds__month AS ds__month
@@ -210,6 +200,16 @@ FROM (
               , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
               , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
               , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+              , subq_1.metric_time__day AS metric_time__day
+              , subq_1.metric_time__week AS metric_time__week
+              , subq_1.metric_time__quarter AS metric_time__quarter
+              , subq_1.metric_time__year AS metric_time__year
+              , subq_1.metric_time__extract_year AS metric_time__extract_year
+              , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+              , subq_1.metric_time__extract_month AS metric_time__extract_month
+              , subq_1.metric_time__extract_day AS metric_time__extract_day
+              , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+              , subq_1.metric_time__extract_doy AS metric_time__extract_doy
               , subq_1.listing AS listing
               , subq_1.guest AS guest
               , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_offset_window_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_offset_window_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
@@ -25,8 +25,8 @@ FROM (
     FROM (
       -- Join to Time Spine Dataset
       SELECT
-        subq_19.ds AS metric_time__day
-        , DATE_TRUNC('month', subq_19.ds) AS metric_time__month
+        DATE_TRUNC('month', subq_19.ds) AS metric_time__month
+        , DATE_TRUNC('day', bookings_source_src_28000.ds) AS metric_time__day
         , bookings_source_src_28000.booking_value AS booking_value
       FROM ***************************.mf_time_spine subq_19
       INNER JOIN

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_offset_window_metric_multiple_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_offset_window_metric_multiple_granularities__plan0.sql
@@ -43,16 +43,8 @@ FROM (
           -- Join to Time Spine Dataset
           SELECT
             subq_2.metric_time__day AS metric_time__day
-            , DATE_TRUNC('week', subq_2.metric_time__day) AS metric_time__week
             , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('quarter', subq_2.metric_time__day) AS metric_time__quarter
             , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-            , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-            , EXTRACT(dayofweekiso FROM subq_2.metric_time__day) AS metric_time__extract_dow
-            , EXTRACT(doy FROM subq_2.metric_time__day) AS metric_time__extract_doy
             , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
@@ -119,6 +111,14 @@ FROM (
             , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_1.metric_time__week AS metric_time__week
+            , subq_1.metric_time__quarter AS metric_time__quarter
+            , subq_1.metric_time__extract_year AS metric_time__extract_year
+            , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_1.metric_time__extract_month AS metric_time__extract_month
+            , subq_1.metric_time__extract_day AS metric_time__extract_day
+            , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_1.metric_time__extract_doy AS metric_time__extract_doy
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_offset_window_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_offset_window_with_agg_time_dim__plan0.sql
@@ -246,16 +246,6 @@ FROM (
           -- Join to Time Spine Dataset
           SELECT
             subq_7.booking__ds__day AS booking__ds__day
-            , DATE_TRUNC('week', subq_7.booking__ds__day) AS booking__ds__week
-            , DATE_TRUNC('month', subq_7.booking__ds__day) AS booking__ds__month
-            , DATE_TRUNC('quarter', subq_7.booking__ds__day) AS booking__ds__quarter
-            , DATE_TRUNC('year', subq_7.booking__ds__day) AS booking__ds__year
-            , EXTRACT(year FROM subq_7.booking__ds__day) AS booking__ds__extract_year
-            , EXTRACT(quarter FROM subq_7.booking__ds__day) AS booking__ds__extract_quarter
-            , EXTRACT(month FROM subq_7.booking__ds__day) AS booking__ds__extract_month
-            , EXTRACT(day FROM subq_7.booking__ds__day) AS booking__ds__extract_day
-            , EXTRACT(dayofweekiso FROM subq_7.booking__ds__day) AS booking__ds__extract_dow
-            , EXTRACT(doy FROM subq_7.booking__ds__day) AS booking__ds__extract_doy
             , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
@@ -289,6 +279,16 @@ FROM (
             , subq_6.paid_at__extract_day AS paid_at__extract_day
             , subq_6.paid_at__extract_dow AS paid_at__extract_dow
             , subq_6.paid_at__extract_doy AS paid_at__extract_doy
+            , subq_6.booking__ds__week AS booking__ds__week
+            , subq_6.booking__ds__month AS booking__ds__month
+            , subq_6.booking__ds__quarter AS booking__ds__quarter
+            , subq_6.booking__ds__year AS booking__ds__year
+            , subq_6.booking__ds__extract_year AS booking__ds__extract_year
+            , subq_6.booking__ds__extract_quarter AS booking__ds__extract_quarter
+            , subq_6.booking__ds__extract_month AS booking__ds__extract_month
+            , subq_6.booking__ds__extract_day AS booking__ds__extract_day
+            , subq_6.booking__ds__extract_dow AS booking__ds__extract_dow
+            , subq_6.booking__ds__extract_doy AS booking__ds__extract_doy
             , subq_6.booking__ds_partitioned__day AS booking__ds_partitioned__day
             , subq_6.booking__ds_partitioned__week AS booking__ds_partitioned__week
             , subq_6.booking__ds_partitioned__month AS booking__ds_partitioned__month

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_time_offset_metric_with_time_constraint__plan0.sql
@@ -25,16 +25,6 @@ FROM (
         -- Join to Time Spine Dataset
         SELECT
           subq_2.metric_time__day AS metric_time__day
-          , DATE_TRUNC('week', subq_2.metric_time__day) AS metric_time__week
-          , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-          , DATE_TRUNC('quarter', subq_2.metric_time__day) AS metric_time__quarter
-          , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-          , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-          , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-          , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-          , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-          , EXTRACT(dayofweekiso FROM subq_2.metric_time__day) AS metric_time__extract_dow
-          , EXTRACT(doy FROM subq_2.metric_time__day) AS metric_time__extract_doy
           , subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
@@ -101,6 +91,16 @@ FROM (
           , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
           , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
           , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+          , subq_1.metric_time__week AS metric_time__week
+          , subq_1.metric_time__month AS metric_time__month
+          , subq_1.metric_time__quarter AS metric_time__quarter
+          , subq_1.metric_time__year AS metric_time__year
+          , subq_1.metric_time__extract_year AS metric_time__extract_year
+          , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_1.metric_time__extract_month AS metric_time__extract_month
+          , subq_1.metric_time__extract_day AS metric_time__extract_day
+          , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+          , subq_1.metric_time__extract_doy AS metric_time__extract_doy
           , subq_1.listing AS listing
           , subq_1.guest AS guest
           , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
@@ -25,16 +25,6 @@ FROM (
         -- Constrain Time Range to [2019-12-19T00:00:00, 2020-01-02T00:00:00]
         SELECT
           subq_7.metric_time__day
-          , subq_7.metric_time__week
-          , subq_7.metric_time__month
-          , subq_7.metric_time__quarter
-          , subq_7.metric_time__year
-          , subq_7.metric_time__extract_year
-          , subq_7.metric_time__extract_quarter
-          , subq_7.metric_time__extract_month
-          , subq_7.metric_time__extract_day
-          , subq_7.metric_time__extract_dow
-          , subq_7.metric_time__extract_doy
           , subq_7.ds__day
           , subq_7.ds__week
           , subq_7.ds__month
@@ -101,6 +91,16 @@ FROM (
           , subq_7.booking__paid_at__extract_day
           , subq_7.booking__paid_at__extract_dow
           , subq_7.booking__paid_at__extract_doy
+          , subq_7.metric_time__week
+          , subq_7.metric_time__month
+          , subq_7.metric_time__quarter
+          , subq_7.metric_time__year
+          , subq_7.metric_time__extract_year
+          , subq_7.metric_time__extract_quarter
+          , subq_7.metric_time__extract_month
+          , subq_7.metric_time__extract_day
+          , subq_7.metric_time__extract_dow
+          , subq_7.metric_time__extract_doy
           , subq_7.listing
           , subq_7.guest
           , subq_7.host
@@ -126,16 +126,6 @@ FROM (
           -- Join to Time Spine Dataset
           SELECT
             subq_5.metric_time__day AS metric_time__day
-            , DATE_TRUNC('week', subq_5.metric_time__day) AS metric_time__week
-            , DATE_TRUNC('month', subq_5.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('quarter', subq_5.metric_time__day) AS metric_time__quarter
-            , DATE_TRUNC('year', subq_5.metric_time__day) AS metric_time__year
-            , EXTRACT(year FROM subq_5.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_5.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_5.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_5.metric_time__day) AS metric_time__extract_day
-            , EXTRACT(DAY_OF_WEEK FROM subq_5.metric_time__day) AS metric_time__extract_dow
-            , EXTRACT(doy FROM subq_5.metric_time__day) AS metric_time__extract_doy
             , subq_4.ds__day AS ds__day
             , subq_4.ds__week AS ds__week
             , subq_4.ds__month AS ds__month
@@ -202,6 +192,16 @@ FROM (
             , subq_4.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_4.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_4.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_4.metric_time__week AS metric_time__week
+            , subq_4.metric_time__month AS metric_time__month
+            , subq_4.metric_time__quarter AS metric_time__quarter
+            , subq_4.metric_time__year AS metric_time__year
+            , subq_4.metric_time__extract_year AS metric_time__extract_year
+            , subq_4.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_4.metric_time__extract_month AS metric_time__extract_month
+            , subq_4.metric_time__extract_day AS metric_time__extract_day
+            , subq_4.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_4.metric_time__extract_doy AS metric_time__extract_doy
             , subq_4.listing AS listing
             , subq_4.guest AS guest
             , subq_4.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
@@ -25,11 +25,6 @@ FROM (
         -- Join to Time Spine Dataset
         SELECT
           subq_2.metric_time__month AS metric_time__month
-          , DATE_TRUNC('quarter', subq_2.metric_time__month) AS metric_time__quarter
-          , DATE_TRUNC('year', subq_2.metric_time__month) AS metric_time__year
-          , EXTRACT(year FROM subq_2.metric_time__month) AS metric_time__extract_year
-          , EXTRACT(quarter FROM subq_2.metric_time__month) AS metric_time__extract_quarter
-          , EXTRACT(month FROM subq_2.metric_time__month) AS metric_time__extract_month
           , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
           , subq_1.ds__year AS ds__year
@@ -42,6 +37,11 @@ FROM (
           , subq_1.booking_monthly__ds__extract_year AS booking_monthly__ds__extract_year
           , subq_1.booking_monthly__ds__extract_quarter AS booking_monthly__ds__extract_quarter
           , subq_1.booking_monthly__ds__extract_month AS booking_monthly__ds__extract_month
+          , subq_1.metric_time__quarter AS metric_time__quarter
+          , subq_1.metric_time__year AS metric_time__year
+          , subq_1.metric_time__extract_year AS metric_time__extract_year
+          , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_1.metric_time__extract_month AS metric_time__extract_month
           , subq_1.listing AS listing
           , subq_1.booking_monthly__listing AS booking_monthly__listing
           , subq_1.bookings_monthly AS bookings_monthly

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_metric_with_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_metric_with_offset_to_grain__plan0.sql
@@ -246,16 +246,6 @@ FROM (
           -- Join to Time Spine Dataset
           SELECT
             subq_7.metric_time__day AS metric_time__day
-            , DATE_TRUNC('week', subq_7.metric_time__day) AS metric_time__week
-            , DATE_TRUNC('month', subq_7.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('quarter', subq_7.metric_time__day) AS metric_time__quarter
-            , DATE_TRUNC('year', subq_7.metric_time__day) AS metric_time__year
-            , EXTRACT(year FROM subq_7.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_7.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_7.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_7.metric_time__day) AS metric_time__extract_day
-            , EXTRACT(DAY_OF_WEEK FROM subq_7.metric_time__day) AS metric_time__extract_dow
-            , EXTRACT(doy FROM subq_7.metric_time__day) AS metric_time__extract_doy
             , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
@@ -322,6 +312,16 @@ FROM (
             , subq_6.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_6.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_6.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_6.metric_time__week AS metric_time__week
+            , subq_6.metric_time__month AS metric_time__month
+            , subq_6.metric_time__quarter AS metric_time__quarter
+            , subq_6.metric_time__year AS metric_time__year
+            , subq_6.metric_time__extract_year AS metric_time__extract_year
+            , subq_6.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_6.metric_time__extract_month AS metric_time__extract_month
+            , subq_6.metric_time__extract_day AS metric_time__extract_day
+            , subq_6.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_6.metric_time__extract_doy AS metric_time__extract_doy
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_metric_with_offset_to_grain_and_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_metric_with_offset_to_grain_and_granularity__plan0.sql
@@ -245,17 +245,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_7.metric_time__day AS metric_time__day
-            , DATE_TRUNC('week', subq_7.metric_time__day) AS metric_time__week
-            , DATE_TRUNC('month', subq_7.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('quarter', subq_7.metric_time__day) AS metric_time__quarter
-            , DATE_TRUNC('year', subq_7.metric_time__day) AS metric_time__year
-            , EXTRACT(year FROM subq_7.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_7.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_7.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_7.metric_time__day) AS metric_time__extract_day
-            , EXTRACT(DAY_OF_WEEK FROM subq_7.metric_time__day) AS metric_time__extract_dow
-            , EXTRACT(doy FROM subq_7.metric_time__day) AS metric_time__extract_doy
+            DATE_TRUNC('week', subq_7.metric_time__day) AS metric_time__week
             , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
@@ -322,6 +312,16 @@ FROM (
             , subq_6.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_6.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_6.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_6.metric_time__day AS metric_time__day
+            , subq_6.metric_time__month AS metric_time__month
+            , subq_6.metric_time__quarter AS metric_time__quarter
+            , subq_6.metric_time__year AS metric_time__year
+            , subq_6.metric_time__extract_year AS metric_time__extract_year
+            , subq_6.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_6.metric_time__extract_month AS metric_time__extract_month
+            , subq_6.metric_time__extract_day AS metric_time__extract_day
+            , subq_6.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_6.metric_time__extract_doy AS metric_time__extract_doy
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_metric_with_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_metric_with_offset_window__plan0.sql
@@ -246,16 +246,6 @@ FROM (
           -- Join to Time Spine Dataset
           SELECT
             subq_7.metric_time__day AS metric_time__day
-            , DATE_TRUNC('week', subq_7.metric_time__day) AS metric_time__week
-            , DATE_TRUNC('month', subq_7.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('quarter', subq_7.metric_time__day) AS metric_time__quarter
-            , DATE_TRUNC('year', subq_7.metric_time__day) AS metric_time__year
-            , EXTRACT(year FROM subq_7.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_7.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_7.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_7.metric_time__day) AS metric_time__extract_day
-            , EXTRACT(DAY_OF_WEEK FROM subq_7.metric_time__day) AS metric_time__extract_dow
-            , EXTRACT(doy FROM subq_7.metric_time__day) AS metric_time__extract_doy
             , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
@@ -322,6 +312,16 @@ FROM (
             , subq_6.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_6.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_6.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_6.metric_time__week AS metric_time__week
+            , subq_6.metric_time__month AS metric_time__month
+            , subq_6.metric_time__quarter AS metric_time__quarter
+            , subq_6.metric_time__year AS metric_time__year
+            , subq_6.metric_time__extract_year AS metric_time__extract_year
+            , subq_6.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_6.metric_time__extract_month AS metric_time__extract_month
+            , subq_6.metric_time__extract_day AS metric_time__extract_day
+            , subq_6.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_6.metric_time__extract_doy AS metric_time__extract_doy
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_metric_with_offset_window_and_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_metric_with_offset_window_and_granularity__plan0.sql
@@ -245,17 +245,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_7.metric_time__day AS metric_time__day
-            , DATE_TRUNC('week', subq_7.metric_time__day) AS metric_time__week
-            , DATE_TRUNC('month', subq_7.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('quarter', subq_7.metric_time__day) AS metric_time__quarter
-            , DATE_TRUNC('year', subq_7.metric_time__day) AS metric_time__year
-            , EXTRACT(year FROM subq_7.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_7.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_7.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_7.metric_time__day) AS metric_time__extract_day
-            , EXTRACT(DAY_OF_WEEK FROM subq_7.metric_time__day) AS metric_time__extract_dow
-            , EXTRACT(doy FROM subq_7.metric_time__day) AS metric_time__extract_doy
+            DATE_TRUNC('quarter', subq_7.metric_time__day) AS metric_time__quarter
             , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
@@ -322,6 +312,16 @@ FROM (
             , subq_6.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_6.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_6.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_6.metric_time__day AS metric_time__day
+            , subq_6.metric_time__week AS metric_time__week
+            , subq_6.metric_time__month AS metric_time__month
+            , subq_6.metric_time__year AS metric_time__year
+            , subq_6.metric_time__extract_year AS metric_time__extract_year
+            , subq_6.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_6.metric_time__extract_month AS metric_time__extract_month
+            , subq_6.metric_time__extract_day AS metric_time__extract_day
+            , subq_6.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_6.metric_time__extract_doy AS metric_time__extract_doy
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
@@ -31,16 +31,6 @@ FROM (
           -- Join to Time Spine Dataset
           SELECT
             subq_2.metric_time__day AS metric_time__day
-            , DATE_TRUNC('week', subq_2.metric_time__day) AS metric_time__week
-            , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('quarter', subq_2.metric_time__day) AS metric_time__quarter
-            , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-            , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-            , EXTRACT(DAY_OF_WEEK FROM subq_2.metric_time__day) AS metric_time__extract_dow
-            , EXTRACT(doy FROM subq_2.metric_time__day) AS metric_time__extract_doy
             , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
@@ -107,6 +97,16 @@ FROM (
             , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_1.metric_time__week AS metric_time__week
+            , subq_1.metric_time__month AS metric_time__month
+            , subq_1.metric_time__quarter AS metric_time__quarter
+            , subq_1.metric_time__year AS metric_time__year
+            , subq_1.metric_time__extract_year AS metric_time__extract_year
+            , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_1.metric_time__extract_month AS metric_time__extract_month
+            , subq_1.metric_time__extract_day AS metric_time__extract_day
+            , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_1.metric_time__extract_doy AS metric_time__extract_doy
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host
@@ -356,16 +356,6 @@ FROM (
           -- Join to Time Spine Dataset
           SELECT
             subq_10.metric_time__day AS metric_time__day
-            , DATE_TRUNC('week', subq_10.metric_time__day) AS metric_time__week
-            , DATE_TRUNC('month', subq_10.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('quarter', subq_10.metric_time__day) AS metric_time__quarter
-            , DATE_TRUNC('year', subq_10.metric_time__day) AS metric_time__year
-            , EXTRACT(year FROM subq_10.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_10.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_10.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_10.metric_time__day) AS metric_time__extract_day
-            , EXTRACT(DAY_OF_WEEK FROM subq_10.metric_time__day) AS metric_time__extract_dow
-            , EXTRACT(doy FROM subq_10.metric_time__day) AS metric_time__extract_doy
             , subq_9.ds__day AS ds__day
             , subq_9.ds__week AS ds__week
             , subq_9.ds__month AS ds__month
@@ -432,6 +422,16 @@ FROM (
             , subq_9.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_9.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_9.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_9.metric_time__week AS metric_time__week
+            , subq_9.metric_time__month AS metric_time__month
+            , subq_9.metric_time__quarter AS metric_time__quarter
+            , subq_9.metric_time__year AS metric_time__year
+            , subq_9.metric_time__extract_year AS metric_time__extract_year
+            , subq_9.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_9.metric_time__extract_month AS metric_time__extract_month
+            , subq_9.metric_time__extract_day AS metric_time__extract_day
+            , subq_9.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_9.metric_time__extract_doy AS metric_time__extract_doy
             , subq_9.listing AS listing
             , subq_9.guest AS guest
             , subq_9.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0.sql
@@ -30,17 +30,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_2.metric_time__day AS metric_time__day
-            , DATE_TRUNC('week', subq_2.metric_time__day) AS metric_time__week
-            , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('quarter', subq_2.metric_time__day) AS metric_time__quarter
-            , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-            , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-            , EXTRACT(DAY_OF_WEEK FROM subq_2.metric_time__day) AS metric_time__extract_dow
-            , EXTRACT(doy FROM subq_2.metric_time__day) AS metric_time__extract_doy
+            DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
             , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
@@ -107,6 +97,16 @@ FROM (
             , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_1.metric_time__day AS metric_time__day
+            , subq_1.metric_time__week AS metric_time__week
+            , subq_1.metric_time__month AS metric_time__month
+            , subq_1.metric_time__quarter AS metric_time__quarter
+            , subq_1.metric_time__extract_year AS metric_time__extract_year
+            , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_1.metric_time__extract_month AS metric_time__extract_month
+            , subq_1.metric_time__extract_day AS metric_time__extract_day
+            , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_1.metric_time__extract_doy AS metric_time__extract_doy
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host
@@ -356,17 +356,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_10.metric_time__day AS metric_time__day
-            , DATE_TRUNC('week', subq_10.metric_time__day) AS metric_time__week
-            , DATE_TRUNC('month', subq_10.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('quarter', subq_10.metric_time__day) AS metric_time__quarter
-            , DATE_TRUNC('year', subq_10.metric_time__day) AS metric_time__year
-            , EXTRACT(year FROM subq_10.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_10.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_10.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_10.metric_time__day) AS metric_time__extract_day
-            , EXTRACT(DAY_OF_WEEK FROM subq_10.metric_time__day) AS metric_time__extract_dow
-            , EXTRACT(doy FROM subq_10.metric_time__day) AS metric_time__extract_doy
+            DATE_TRUNC('year', subq_10.metric_time__day) AS metric_time__year
             , subq_9.ds__day AS ds__day
             , subq_9.ds__week AS ds__week
             , subq_9.ds__month AS ds__month
@@ -433,6 +423,16 @@ FROM (
             , subq_9.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_9.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_9.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_9.metric_time__day AS metric_time__day
+            , subq_9.metric_time__week AS metric_time__week
+            , subq_9.metric_time__month AS metric_time__month
+            , subq_9.metric_time__quarter AS metric_time__quarter
+            , subq_9.metric_time__extract_year AS metric_time__extract_year
+            , subq_9.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_9.metric_time__extract_month AS metric_time__extract_month
+            , subq_9.metric_time__extract_day AS metric_time__extract_day
+            , subq_9.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_9.metric_time__extract_doy AS metric_time__extract_doy
             , subq_9.listing AS listing
             , subq_9.guest AS guest
             , subq_9.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
@@ -349,16 +349,6 @@ FROM (
           -- Constrain Output with WHERE
           SELECT
             subq_10.metric_time__day
-            , subq_10.metric_time__week
-            , subq_10.metric_time__month
-            , subq_10.metric_time__quarter
-            , subq_10.metric_time__year
-            , subq_10.metric_time__extract_year
-            , subq_10.metric_time__extract_quarter
-            , subq_10.metric_time__extract_month
-            , subq_10.metric_time__extract_day
-            , subq_10.metric_time__extract_dow
-            , subq_10.metric_time__extract_doy
             , subq_10.ds__day
             , subq_10.ds__week
             , subq_10.ds__month
@@ -425,6 +415,16 @@ FROM (
             , subq_10.booking__paid_at__extract_day
             , subq_10.booking__paid_at__extract_dow
             , subq_10.booking__paid_at__extract_doy
+            , subq_10.metric_time__week
+            , subq_10.metric_time__month
+            , subq_10.metric_time__quarter
+            , subq_10.metric_time__year
+            , subq_10.metric_time__extract_year
+            , subq_10.metric_time__extract_quarter
+            , subq_10.metric_time__extract_month
+            , subq_10.metric_time__extract_day
+            , subq_10.metric_time__extract_dow
+            , subq_10.metric_time__extract_doy
             , subq_10.listing
             , subq_10.guest
             , subq_10.host
@@ -450,16 +450,6 @@ FROM (
             -- Join to Time Spine Dataset
             SELECT
               subq_8.metric_time__day AS metric_time__day
-              , DATE_TRUNC('week', subq_8.metric_time__day) AS metric_time__week
-              , DATE_TRUNC('month', subq_8.metric_time__day) AS metric_time__month
-              , DATE_TRUNC('quarter', subq_8.metric_time__day) AS metric_time__quarter
-              , DATE_TRUNC('year', subq_8.metric_time__day) AS metric_time__year
-              , EXTRACT(year FROM subq_8.metric_time__day) AS metric_time__extract_year
-              , EXTRACT(quarter FROM subq_8.metric_time__day) AS metric_time__extract_quarter
-              , EXTRACT(month FROM subq_8.metric_time__day) AS metric_time__extract_month
-              , EXTRACT(day FROM subq_8.metric_time__day) AS metric_time__extract_day
-              , EXTRACT(DAY_OF_WEEK FROM subq_8.metric_time__day) AS metric_time__extract_dow
-              , EXTRACT(doy FROM subq_8.metric_time__day) AS metric_time__extract_doy
               , subq_7.ds__day AS ds__day
               , subq_7.ds__week AS ds__week
               , subq_7.ds__month AS ds__month
@@ -526,6 +516,16 @@ FROM (
               , subq_7.booking__paid_at__extract_day AS booking__paid_at__extract_day
               , subq_7.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
               , subq_7.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+              , subq_7.metric_time__week AS metric_time__week
+              , subq_7.metric_time__month AS metric_time__month
+              , subq_7.metric_time__quarter AS metric_time__quarter
+              , subq_7.metric_time__year AS metric_time__year
+              , subq_7.metric_time__extract_year AS metric_time__extract_year
+              , subq_7.metric_time__extract_quarter AS metric_time__extract_quarter
+              , subq_7.metric_time__extract_month AS metric_time__extract_month
+              , subq_7.metric_time__extract_day AS metric_time__extract_day
+              , subq_7.metric_time__extract_dow AS metric_time__extract_dow
+              , subq_7.metric_time__extract_doy AS metric_time__extract_doy
               , subq_7.listing AS listing
               , subq_7.guest AS guest
               , subq_7.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_offset_cumulative_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_offset_cumulative_metric__plan0.sql
@@ -25,16 +25,6 @@ FROM (
         -- Join to Time Spine Dataset
         SELECT
           subq_5.metric_time__day AS metric_time__day
-          , DATE_TRUNC('week', subq_5.metric_time__day) AS metric_time__week
-          , DATE_TRUNC('month', subq_5.metric_time__day) AS metric_time__month
-          , DATE_TRUNC('quarter', subq_5.metric_time__day) AS metric_time__quarter
-          , DATE_TRUNC('year', subq_5.metric_time__day) AS metric_time__year
-          , EXTRACT(year FROM subq_5.metric_time__day) AS metric_time__extract_year
-          , EXTRACT(quarter FROM subq_5.metric_time__day) AS metric_time__extract_quarter
-          , EXTRACT(month FROM subq_5.metric_time__day) AS metric_time__extract_month
-          , EXTRACT(day FROM subq_5.metric_time__day) AS metric_time__extract_day
-          , EXTRACT(DAY_OF_WEEK FROM subq_5.metric_time__day) AS metric_time__extract_dow
-          , EXTRACT(doy FROM subq_5.metric_time__day) AS metric_time__extract_doy
           , subq_4.ds__day AS ds__day
           , subq_4.ds__week AS ds__week
           , subq_4.ds__month AS ds__month
@@ -101,6 +91,16 @@ FROM (
           , subq_4.booking__paid_at__extract_day AS booking__paid_at__extract_day
           , subq_4.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
           , subq_4.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+          , subq_4.metric_time__week AS metric_time__week
+          , subq_4.metric_time__month AS metric_time__month
+          , subq_4.metric_time__quarter AS metric_time__quarter
+          , subq_4.metric_time__year AS metric_time__year
+          , subq_4.metric_time__extract_year AS metric_time__extract_year
+          , subq_4.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_4.metric_time__extract_month AS metric_time__extract_month
+          , subq_4.metric_time__extract_day AS metric_time__extract_day
+          , subq_4.metric_time__extract_dow AS metric_time__extract_dow
+          , subq_4.metric_time__extract_doy AS metric_time__extract_doy
           , subq_4.listing AS listing
           , subq_4.guest AS guest
           , subq_4.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_offset_metric_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_offset_metric_with_agg_time_dim__plan0.sql
@@ -31,16 +31,6 @@ FROM (
           -- Join to Time Spine Dataset
           SELECT
             subq_2.booking__ds__day AS booking__ds__day
-            , DATE_TRUNC('week', subq_2.booking__ds__day) AS booking__ds__week
-            , DATE_TRUNC('month', subq_2.booking__ds__day) AS booking__ds__month
-            , DATE_TRUNC('quarter', subq_2.booking__ds__day) AS booking__ds__quarter
-            , DATE_TRUNC('year', subq_2.booking__ds__day) AS booking__ds__year
-            , EXTRACT(year FROM subq_2.booking__ds__day) AS booking__ds__extract_year
-            , EXTRACT(quarter FROM subq_2.booking__ds__day) AS booking__ds__extract_quarter
-            , EXTRACT(month FROM subq_2.booking__ds__day) AS booking__ds__extract_month
-            , EXTRACT(day FROM subq_2.booking__ds__day) AS booking__ds__extract_day
-            , EXTRACT(DAY_OF_WEEK FROM subq_2.booking__ds__day) AS booking__ds__extract_dow
-            , EXTRACT(doy FROM subq_2.booking__ds__day) AS booking__ds__extract_doy
             , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
@@ -74,6 +64,16 @@ FROM (
             , subq_1.paid_at__extract_day AS paid_at__extract_day
             , subq_1.paid_at__extract_dow AS paid_at__extract_dow
             , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+            , subq_1.booking__ds__week AS booking__ds__week
+            , subq_1.booking__ds__month AS booking__ds__month
+            , subq_1.booking__ds__quarter AS booking__ds__quarter
+            , subq_1.booking__ds__year AS booking__ds__year
+            , subq_1.booking__ds__extract_year AS booking__ds__extract_year
+            , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
+            , subq_1.booking__ds__extract_month AS booking__ds__extract_month
+            , subq_1.booking__ds__extract_day AS booking__ds__extract_day
+            , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
+            , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
             , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
             , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
             , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_offset_metric_with_one_input_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_offset_metric_with_one_input_metric__plan0.sql
@@ -25,16 +25,6 @@ FROM (
         -- Join to Time Spine Dataset
         SELECT
           subq_2.metric_time__day AS metric_time__day
-          , DATE_TRUNC('week', subq_2.metric_time__day) AS metric_time__week
-          , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-          , DATE_TRUNC('quarter', subq_2.metric_time__day) AS metric_time__quarter
-          , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-          , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-          , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-          , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-          , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-          , EXTRACT(DAY_OF_WEEK FROM subq_2.metric_time__day) AS metric_time__extract_dow
-          , EXTRACT(doy FROM subq_2.metric_time__day) AS metric_time__extract_doy
           , subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
@@ -101,6 +91,16 @@ FROM (
           , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
           , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
           , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+          , subq_1.metric_time__week AS metric_time__week
+          , subq_1.metric_time__month AS metric_time__month
+          , subq_1.metric_time__quarter AS metric_time__quarter
+          , subq_1.metric_time__year AS metric_time__year
+          , subq_1.metric_time__extract_year AS metric_time__extract_year
+          , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_1.metric_time__extract_month AS metric_time__extract_month
+          , subq_1.metric_time__extract_day AS metric_time__extract_day
+          , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+          , subq_1.metric_time__extract_doy AS metric_time__extract_doy
           , subq_1.listing AS listing
           , subq_1.guest AS guest
           , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0.sql
@@ -57,16 +57,6 @@ FROM (
                 -- Join to Time Spine Dataset
                 SELECT
                   subq_2.metric_time__day AS metric_time__day
-                  , DATE_TRUNC('week', subq_2.metric_time__day) AS metric_time__week
-                  , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-                  , DATE_TRUNC('quarter', subq_2.metric_time__day) AS metric_time__quarter
-                  , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-                  , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-                  , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-                  , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-                  , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-                  , EXTRACT(DAY_OF_WEEK FROM subq_2.metric_time__day) AS metric_time__extract_dow
-                  , EXTRACT(doy FROM subq_2.metric_time__day) AS metric_time__extract_doy
                   , subq_1.ds__day AS ds__day
                   , subq_1.ds__week AS ds__week
                   , subq_1.ds__month AS ds__month
@@ -133,6 +123,16 @@ FROM (
                   , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
                   , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
                   , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                  , subq_1.metric_time__week AS metric_time__week
+                  , subq_1.metric_time__month AS metric_time__month
+                  , subq_1.metric_time__quarter AS metric_time__quarter
+                  , subq_1.metric_time__year AS metric_time__year
+                  , subq_1.metric_time__extract_year AS metric_time__extract_year
+                  , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+                  , subq_1.metric_time__extract_month AS metric_time__extract_month
+                  , subq_1.metric_time__extract_day AS metric_time__extract_day
+                  , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+                  , subq_1.metric_time__extract_doy AS metric_time__extract_doy
                   , subq_1.listing AS listing
                   , subq_1.guest AS guest
                   , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_nested_offsets__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_nested_offsets__plan0.sql
@@ -41,16 +41,6 @@ FROM (
             -- Join to Time Spine Dataset
             SELECT
               subq_2.metric_time__day AS metric_time__day
-              , DATE_TRUNC('week', subq_2.metric_time__day) AS metric_time__week
-              , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-              , DATE_TRUNC('quarter', subq_2.metric_time__day) AS metric_time__quarter
-              , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-              , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-              , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-              , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-              , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-              , EXTRACT(DAY_OF_WEEK FROM subq_2.metric_time__day) AS metric_time__extract_dow
-              , EXTRACT(doy FROM subq_2.metric_time__day) AS metric_time__extract_doy
               , subq_1.ds__day AS ds__day
               , subq_1.ds__week AS ds__week
               , subq_1.ds__month AS ds__month
@@ -117,6 +107,16 @@ FROM (
               , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
               , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
               , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+              , subq_1.metric_time__week AS metric_time__week
+              , subq_1.metric_time__month AS metric_time__month
+              , subq_1.metric_time__quarter AS metric_time__quarter
+              , subq_1.metric_time__year AS metric_time__year
+              , subq_1.metric_time__extract_year AS metric_time__extract_year
+              , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+              , subq_1.metric_time__extract_month AS metric_time__extract_month
+              , subq_1.metric_time__extract_day AS metric_time__extract_day
+              , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+              , subq_1.metric_time__extract_doy AS metric_time__extract_doy
               , subq_1.listing AS listing
               , subq_1.guest AS guest
               , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_nested_offsets_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_nested_offsets_with_time_constraint__plan0.sql
@@ -42,16 +42,6 @@ FROM (
             -- Join to Time Spine Dataset
             SELECT
               subq_2.metric_time__day AS metric_time__day
-              , DATE_TRUNC('week', subq_2.metric_time__day) AS metric_time__week
-              , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-              , DATE_TRUNC('quarter', subq_2.metric_time__day) AS metric_time__quarter
-              , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-              , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-              , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-              , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-              , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-              , EXTRACT(DAY_OF_WEEK FROM subq_2.metric_time__day) AS metric_time__extract_dow
-              , EXTRACT(doy FROM subq_2.metric_time__day) AS metric_time__extract_doy
               , subq_1.ds__day AS ds__day
               , subq_1.ds__week AS ds__week
               , subq_1.ds__month AS ds__month
@@ -118,6 +108,16 @@ FROM (
               , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
               , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
               , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+              , subq_1.metric_time__week AS metric_time__week
+              , subq_1.metric_time__month AS metric_time__month
+              , subq_1.metric_time__quarter AS metric_time__quarter
+              , subq_1.metric_time__year AS metric_time__year
+              , subq_1.metric_time__extract_year AS metric_time__extract_year
+              , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+              , subq_1.metric_time__extract_month AS metric_time__extract_month
+              , subq_1.metric_time__extract_day AS metric_time__extract_day
+              , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+              , subq_1.metric_time__extract_doy AS metric_time__extract_doy
               , subq_1.listing AS listing
               , subq_1.guest AS guest
               , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_nested_offsets_with_where_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_nested_offsets_with_where_constraint__plan0.sql
@@ -46,16 +46,6 @@ FROM (
               -- Join to Time Spine Dataset
               SELECT
                 subq_2.metric_time__day AS metric_time__day
-                , DATE_TRUNC('week', subq_2.metric_time__day) AS metric_time__week
-                , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-                , DATE_TRUNC('quarter', subq_2.metric_time__day) AS metric_time__quarter
-                , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-                , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-                , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-                , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-                , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-                , EXTRACT(DAY_OF_WEEK FROM subq_2.metric_time__day) AS metric_time__extract_dow
-                , EXTRACT(doy FROM subq_2.metric_time__day) AS metric_time__extract_doy
                 , subq_1.ds__day AS ds__day
                 , subq_1.ds__week AS ds__week
                 , subq_1.ds__month AS ds__month
@@ -122,6 +112,16 @@ FROM (
                 , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
                 , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
                 , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                , subq_1.metric_time__week AS metric_time__week
+                , subq_1.metric_time__month AS metric_time__month
+                , subq_1.metric_time__quarter AS metric_time__quarter
+                , subq_1.metric_time__year AS metric_time__year
+                , subq_1.metric_time__extract_year AS metric_time__extract_year
+                , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+                , subq_1.metric_time__extract_month AS metric_time__extract_month
+                , subq_1.metric_time__extract_day AS metric_time__extract_day
+                , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+                , subq_1.metric_time__extract_doy AS metric_time__extract_doy
                 , subq_1.listing AS listing
                 , subq_1.guest AS guest
                 , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0.sql
@@ -26,17 +26,7 @@ FROM (
       FROM (
         -- Constrain Output with WHERE
         SELECT
-          subq_4.metric_time__day
-          , subq_4.metric_time__week
-          , subq_4.metric_time__month
-          , subq_4.metric_time__quarter
-          , subq_4.metric_time__year
-          , subq_4.metric_time__extract_year
-          , subq_4.metric_time__extract_quarter
-          , subq_4.metric_time__extract_month
-          , subq_4.metric_time__extract_day
-          , subq_4.metric_time__extract_dow
-          , subq_4.metric_time__extract_doy
+          subq_4.metric_time__month
           , subq_4.ds__day
           , subq_4.ds__week
           , subq_4.ds__month
@@ -103,6 +93,16 @@ FROM (
           , subq_4.booking__paid_at__extract_day
           , subq_4.booking__paid_at__extract_dow
           , subq_4.booking__paid_at__extract_doy
+          , subq_4.metric_time__day
+          , subq_4.metric_time__week
+          , subq_4.metric_time__quarter
+          , subq_4.metric_time__year
+          , subq_4.metric_time__extract_year
+          , subq_4.metric_time__extract_quarter
+          , subq_4.metric_time__extract_month
+          , subq_4.metric_time__extract_day
+          , subq_4.metric_time__extract_dow
+          , subq_4.metric_time__extract_doy
           , subq_4.listing
           , subq_4.guest
           , subq_4.host
@@ -127,17 +127,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_2.metric_time__day AS metric_time__day
-            , DATE_TRUNC('week', subq_2.metric_time__day) AS metric_time__week
-            , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('quarter', subq_2.metric_time__day) AS metric_time__quarter
-            , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-            , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-            , EXTRACT(DAY_OF_WEEK FROM subq_2.metric_time__day) AS metric_time__extract_dow
-            , EXTRACT(doy FROM subq_2.metric_time__day) AS metric_time__extract_doy
+            DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
             , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
@@ -204,6 +194,16 @@ FROM (
             , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_1.metric_time__day AS metric_time__day
+            , subq_1.metric_time__week AS metric_time__week
+            , subq_1.metric_time__quarter AS metric_time__quarter
+            , subq_1.metric_time__year AS metric_time__year
+            , subq_1.metric_time__extract_year AS metric_time__extract_year
+            , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_1.metric_time__extract_month AS metric_time__extract_month
+            , subq_1.metric_time__extract_day AS metric_time__extract_day
+            , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_1.metric_time__extract_doy AS metric_time__extract_doy
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
@@ -19,8 +19,8 @@ FROM (
   FROM (
     -- Join to Time Spine Dataset
     SELECT
-      subq_12.ds AS metric_time__day
-      , DATE_TRUNC('month', subq_12.ds) AS metric_time__month
+      DATE_TRUNC('month', subq_12.ds) AS metric_time__month
+      , subq_10.metric_time__day AS metric_time__day
       , subq_10.bookings AS bookings
     FROM ***************************.mf_time_spine subq_12
     INNER JOIN (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_offset_to_grain_metric_multiple_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_offset_to_grain_metric_multiple_granularities__plan0.sql
@@ -35,16 +35,8 @@ FROM (
         -- Join to Time Spine Dataset
         SELECT
           subq_2.metric_time__day AS metric_time__day
-          , DATE_TRUNC('week', subq_2.metric_time__day) AS metric_time__week
           , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-          , DATE_TRUNC('quarter', subq_2.metric_time__day) AS metric_time__quarter
           , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-          , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-          , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-          , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-          , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-          , EXTRACT(DAY_OF_WEEK FROM subq_2.metric_time__day) AS metric_time__extract_dow
-          , EXTRACT(doy FROM subq_2.metric_time__day) AS metric_time__extract_doy
           , subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
@@ -111,6 +103,14 @@ FROM (
           , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
           , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
           , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+          , subq_1.metric_time__week AS metric_time__week
+          , subq_1.metric_time__quarter AS metric_time__quarter
+          , subq_1.metric_time__extract_year AS metric_time__extract_year
+          , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_1.metric_time__extract_month AS metric_time__extract_month
+          , subq_1.metric_time__extract_day AS metric_time__extract_day
+          , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+          , subq_1.metric_time__extract_doy AS metric_time__extract_doy
           , subq_1.listing AS listing
           , subq_1.guest AS guest
           , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_offset_to_grain_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_offset_to_grain_with_agg_time_dim__plan0.sql
@@ -246,16 +246,6 @@ FROM (
           -- Join to Time Spine Dataset
           SELECT
             subq_7.booking__ds__day AS booking__ds__day
-            , DATE_TRUNC('week', subq_7.booking__ds__day) AS booking__ds__week
-            , DATE_TRUNC('month', subq_7.booking__ds__day) AS booking__ds__month
-            , DATE_TRUNC('quarter', subq_7.booking__ds__day) AS booking__ds__quarter
-            , DATE_TRUNC('year', subq_7.booking__ds__day) AS booking__ds__year
-            , EXTRACT(year FROM subq_7.booking__ds__day) AS booking__ds__extract_year
-            , EXTRACT(quarter FROM subq_7.booking__ds__day) AS booking__ds__extract_quarter
-            , EXTRACT(month FROM subq_7.booking__ds__day) AS booking__ds__extract_month
-            , EXTRACT(day FROM subq_7.booking__ds__day) AS booking__ds__extract_day
-            , EXTRACT(DAY_OF_WEEK FROM subq_7.booking__ds__day) AS booking__ds__extract_dow
-            , EXTRACT(doy FROM subq_7.booking__ds__day) AS booking__ds__extract_doy
             , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
@@ -289,6 +279,16 @@ FROM (
             , subq_6.paid_at__extract_day AS paid_at__extract_day
             , subq_6.paid_at__extract_dow AS paid_at__extract_dow
             , subq_6.paid_at__extract_doy AS paid_at__extract_doy
+            , subq_6.booking__ds__week AS booking__ds__week
+            , subq_6.booking__ds__month AS booking__ds__month
+            , subq_6.booking__ds__quarter AS booking__ds__quarter
+            , subq_6.booking__ds__year AS booking__ds__year
+            , subq_6.booking__ds__extract_year AS booking__ds__extract_year
+            , subq_6.booking__ds__extract_quarter AS booking__ds__extract_quarter
+            , subq_6.booking__ds__extract_month AS booking__ds__extract_month
+            , subq_6.booking__ds__extract_day AS booking__ds__extract_day
+            , subq_6.booking__ds__extract_dow AS booking__ds__extract_dow
+            , subq_6.booking__ds__extract_doy AS booking__ds__extract_doy
             , subq_6.booking__ds_partitioned__day AS booking__ds_partitioned__day
             , subq_6.booking__ds_partitioned__week AS booking__ds_partitioned__week
             , subq_6.booking__ds_partitioned__month AS booking__ds_partitioned__month

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_offset_window_metric_filter_and_query_have_different_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_offset_window_metric_filter_and_query_have_different_granularities__plan0.sql
@@ -32,17 +32,7 @@ FROM (
         FROM (
           -- Constrain Output with WHERE
           SELECT
-            subq_4.metric_time__day
-            , subq_4.metric_time__week
-            , subq_4.metric_time__month
-            , subq_4.metric_time__quarter
-            , subq_4.metric_time__year
-            , subq_4.metric_time__extract_year
-            , subq_4.metric_time__extract_quarter
-            , subq_4.metric_time__extract_month
-            , subq_4.metric_time__extract_day
-            , subq_4.metric_time__extract_dow
-            , subq_4.metric_time__extract_doy
+            subq_4.metric_time__month
             , subq_4.ds__day
             , subq_4.ds__week
             , subq_4.ds__month
@@ -109,6 +99,16 @@ FROM (
             , subq_4.booking__paid_at__extract_day
             , subq_4.booking__paid_at__extract_dow
             , subq_4.booking__paid_at__extract_doy
+            , subq_4.metric_time__day
+            , subq_4.metric_time__week
+            , subq_4.metric_time__quarter
+            , subq_4.metric_time__year
+            , subq_4.metric_time__extract_year
+            , subq_4.metric_time__extract_quarter
+            , subq_4.metric_time__extract_month
+            , subq_4.metric_time__extract_day
+            , subq_4.metric_time__extract_dow
+            , subq_4.metric_time__extract_doy
             , subq_4.listing
             , subq_4.guest
             , subq_4.host
@@ -133,17 +133,7 @@ FROM (
           FROM (
             -- Join to Time Spine Dataset
             SELECT
-              subq_2.metric_time__day AS metric_time__day
-              , DATE_TRUNC('week', subq_2.metric_time__day) AS metric_time__week
-              , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-              , DATE_TRUNC('quarter', subq_2.metric_time__day) AS metric_time__quarter
-              , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-              , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-              , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-              , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-              , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-              , EXTRACT(DAY_OF_WEEK FROM subq_2.metric_time__day) AS metric_time__extract_dow
-              , EXTRACT(doy FROM subq_2.metric_time__day) AS metric_time__extract_doy
+              DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
               , subq_1.ds__day AS ds__day
               , subq_1.ds__week AS ds__week
               , subq_1.ds__month AS ds__month
@@ -210,6 +200,16 @@ FROM (
               , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
               , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
               , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+              , subq_1.metric_time__day AS metric_time__day
+              , subq_1.metric_time__week AS metric_time__week
+              , subq_1.metric_time__quarter AS metric_time__quarter
+              , subq_1.metric_time__year AS metric_time__year
+              , subq_1.metric_time__extract_year AS metric_time__extract_year
+              , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+              , subq_1.metric_time__extract_month AS metric_time__extract_month
+              , subq_1.metric_time__extract_day AS metric_time__extract_day
+              , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+              , subq_1.metric_time__extract_doy AS metric_time__extract_doy
               , subq_1.listing AS listing
               , subq_1.guest AS guest
               , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_offset_window_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_offset_window_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
@@ -25,8 +25,8 @@ FROM (
     FROM (
       -- Join to Time Spine Dataset
       SELECT
-        subq_19.ds AS metric_time__day
-        , DATE_TRUNC('month', subq_19.ds) AS metric_time__month
+        DATE_TRUNC('month', subq_19.ds) AS metric_time__month
+        , DATE_TRUNC('day', bookings_source_src_28000.ds) AS metric_time__day
         , bookings_source_src_28000.booking_value AS booking_value
       FROM ***************************.mf_time_spine subq_19
       INNER JOIN

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_offset_window_metric_multiple_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_offset_window_metric_multiple_granularities__plan0.sql
@@ -43,16 +43,8 @@ FROM (
           -- Join to Time Spine Dataset
           SELECT
             subq_2.metric_time__day AS metric_time__day
-            , DATE_TRUNC('week', subq_2.metric_time__day) AS metric_time__week
             , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('quarter', subq_2.metric_time__day) AS metric_time__quarter
             , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-            , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-            , EXTRACT(DAY_OF_WEEK FROM subq_2.metric_time__day) AS metric_time__extract_dow
-            , EXTRACT(doy FROM subq_2.metric_time__day) AS metric_time__extract_doy
             , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
@@ -119,6 +111,14 @@ FROM (
             , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_1.metric_time__week AS metric_time__week
+            , subq_1.metric_time__quarter AS metric_time__quarter
+            , subq_1.metric_time__extract_year AS metric_time__extract_year
+            , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_1.metric_time__extract_month AS metric_time__extract_month
+            , subq_1.metric_time__extract_day AS metric_time__extract_day
+            , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_1.metric_time__extract_doy AS metric_time__extract_doy
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_offset_window_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_offset_window_with_agg_time_dim__plan0.sql
@@ -246,16 +246,6 @@ FROM (
           -- Join to Time Spine Dataset
           SELECT
             subq_7.booking__ds__day AS booking__ds__day
-            , DATE_TRUNC('week', subq_7.booking__ds__day) AS booking__ds__week
-            , DATE_TRUNC('month', subq_7.booking__ds__day) AS booking__ds__month
-            , DATE_TRUNC('quarter', subq_7.booking__ds__day) AS booking__ds__quarter
-            , DATE_TRUNC('year', subq_7.booking__ds__day) AS booking__ds__year
-            , EXTRACT(year FROM subq_7.booking__ds__day) AS booking__ds__extract_year
-            , EXTRACT(quarter FROM subq_7.booking__ds__day) AS booking__ds__extract_quarter
-            , EXTRACT(month FROM subq_7.booking__ds__day) AS booking__ds__extract_month
-            , EXTRACT(day FROM subq_7.booking__ds__day) AS booking__ds__extract_day
-            , EXTRACT(DAY_OF_WEEK FROM subq_7.booking__ds__day) AS booking__ds__extract_dow
-            , EXTRACT(doy FROM subq_7.booking__ds__day) AS booking__ds__extract_doy
             , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
@@ -289,6 +279,16 @@ FROM (
             , subq_6.paid_at__extract_day AS paid_at__extract_day
             , subq_6.paid_at__extract_dow AS paid_at__extract_dow
             , subq_6.paid_at__extract_doy AS paid_at__extract_doy
+            , subq_6.booking__ds__week AS booking__ds__week
+            , subq_6.booking__ds__month AS booking__ds__month
+            , subq_6.booking__ds__quarter AS booking__ds__quarter
+            , subq_6.booking__ds__year AS booking__ds__year
+            , subq_6.booking__ds__extract_year AS booking__ds__extract_year
+            , subq_6.booking__ds__extract_quarter AS booking__ds__extract_quarter
+            , subq_6.booking__ds__extract_month AS booking__ds__extract_month
+            , subq_6.booking__ds__extract_day AS booking__ds__extract_day
+            , subq_6.booking__ds__extract_dow AS booking__ds__extract_dow
+            , subq_6.booking__ds__extract_doy AS booking__ds__extract_doy
             , subq_6.booking__ds_partitioned__day AS booking__ds_partitioned__day
             , subq_6.booking__ds_partitioned__week AS booking__ds_partitioned__week
             , subq_6.booking__ds_partitioned__month AS booking__ds_partitioned__month

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_time_offset_metric_with_time_constraint__plan0.sql
@@ -25,16 +25,6 @@ FROM (
         -- Join to Time Spine Dataset
         SELECT
           subq_2.metric_time__day AS metric_time__day
-          , DATE_TRUNC('week', subq_2.metric_time__day) AS metric_time__week
-          , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-          , DATE_TRUNC('quarter', subq_2.metric_time__day) AS metric_time__quarter
-          , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-          , EXTRACT(year FROM subq_2.metric_time__day) AS metric_time__extract_year
-          , EXTRACT(quarter FROM subq_2.metric_time__day) AS metric_time__extract_quarter
-          , EXTRACT(month FROM subq_2.metric_time__day) AS metric_time__extract_month
-          , EXTRACT(day FROM subq_2.metric_time__day) AS metric_time__extract_day
-          , EXTRACT(DAY_OF_WEEK FROM subq_2.metric_time__day) AS metric_time__extract_dow
-          , EXTRACT(doy FROM subq_2.metric_time__day) AS metric_time__extract_doy
           , subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
@@ -101,6 +91,16 @@ FROM (
           , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
           , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
           , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+          , subq_1.metric_time__week AS metric_time__week
+          , subq_1.metric_time__month AS metric_time__month
+          , subq_1.metric_time__quarter AS metric_time__quarter
+          , subq_1.metric_time__year AS metric_time__year
+          , subq_1.metric_time__extract_year AS metric_time__extract_year
+          , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_1.metric_time__extract_month AS metric_time__extract_month
+          , subq_1.metric_time__extract_day AS metric_time__extract_day
+          , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+          , subq_1.metric_time__extract_doy AS metric_time__extract_doy
           , subq_1.listing AS listing
           , subq_1.guest AS guest
           , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/BigQuery/test_derived_fill_nulls_for_one_input_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/BigQuery/test_derived_fill_nulls_for_one_input_metric__plan0.sql
@@ -260,16 +260,6 @@ FROM (
           -- Join to Time Spine Dataset
           SELECT
             subq_10.metric_time__day AS metric_time__day
-            , DATETIME_TRUNC(subq_10.metric_time__day, isoweek) AS metric_time__week
-            , DATETIME_TRUNC(subq_10.metric_time__day, month) AS metric_time__month
-            , DATETIME_TRUNC(subq_10.metric_time__day, quarter) AS metric_time__quarter
-            , DATETIME_TRUNC(subq_10.metric_time__day, year) AS metric_time__year
-            , EXTRACT(year FROM subq_10.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_10.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_10.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_10.metric_time__day) AS metric_time__extract_day
-            , IF(EXTRACT(dayofweek FROM subq_10.metric_time__day) = 1, 7, EXTRACT(dayofweek FROM subq_10.metric_time__day) - 1) AS metric_time__extract_dow
-            , EXTRACT(dayofyear FROM subq_10.metric_time__day) AS metric_time__extract_doy
             , subq_9.ds__day AS ds__day
             , subq_9.ds__week AS ds__week
             , subq_9.ds__month AS ds__month
@@ -336,6 +326,16 @@ FROM (
             , subq_9.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_9.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_9.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_9.metric_time__week AS metric_time__week
+            , subq_9.metric_time__month AS metric_time__month
+            , subq_9.metric_time__quarter AS metric_time__quarter
+            , subq_9.metric_time__year AS metric_time__year
+            , subq_9.metric_time__extract_year AS metric_time__extract_year
+            , subq_9.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_9.metric_time__extract_month AS metric_time__extract_month
+            , subq_9.metric_time__extract_day AS metric_time__extract_day
+            , subq_9.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_9.metric_time__extract_doy AS metric_time__extract_doy
             , subq_9.listing AS listing
             , subq_9.guest AS guest
             , subq_9.host AS host

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Databricks/test_derived_fill_nulls_for_one_input_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Databricks/test_derived_fill_nulls_for_one_input_metric__plan0.sql
@@ -260,16 +260,6 @@ FROM (
           -- Join to Time Spine Dataset
           SELECT
             subq_10.metric_time__day AS metric_time__day
-            , DATE_TRUNC('week', subq_10.metric_time__day) AS metric_time__week
-            , DATE_TRUNC('month', subq_10.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('quarter', subq_10.metric_time__day) AS metric_time__quarter
-            , DATE_TRUNC('year', subq_10.metric_time__day) AS metric_time__year
-            , EXTRACT(year FROM subq_10.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_10.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_10.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_10.metric_time__day) AS metric_time__extract_day
-            , EXTRACT(DAYOFWEEK_ISO FROM subq_10.metric_time__day) AS metric_time__extract_dow
-            , EXTRACT(doy FROM subq_10.metric_time__day) AS metric_time__extract_doy
             , subq_9.ds__day AS ds__day
             , subq_9.ds__week AS ds__week
             , subq_9.ds__month AS ds__month
@@ -336,6 +326,16 @@ FROM (
             , subq_9.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_9.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_9.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_9.metric_time__week AS metric_time__week
+            , subq_9.metric_time__month AS metric_time__month
+            , subq_9.metric_time__quarter AS metric_time__quarter
+            , subq_9.metric_time__year AS metric_time__year
+            , subq_9.metric_time__extract_year AS metric_time__extract_year
+            , subq_9.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_9.metric_time__extract_month AS metric_time__extract_month
+            , subq_9.metric_time__extract_day AS metric_time__extract_day
+            , subq_9.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_9.metric_time__extract_doy AS metric_time__extract_doy
             , subq_9.listing AS listing
             , subq_9.guest AS guest
             , subq_9.host AS host

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/DuckDB/test_derived_fill_nulls_for_one_input_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/DuckDB/test_derived_fill_nulls_for_one_input_metric__plan0.sql
@@ -260,16 +260,6 @@ FROM (
           -- Join to Time Spine Dataset
           SELECT
             subq_10.metric_time__day AS metric_time__day
-            , DATE_TRUNC('week', subq_10.metric_time__day) AS metric_time__week
-            , DATE_TRUNC('month', subq_10.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('quarter', subq_10.metric_time__day) AS metric_time__quarter
-            , DATE_TRUNC('year', subq_10.metric_time__day) AS metric_time__year
-            , EXTRACT(year FROM subq_10.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_10.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_10.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_10.metric_time__day) AS metric_time__extract_day
-            , EXTRACT(isodow FROM subq_10.metric_time__day) AS metric_time__extract_dow
-            , EXTRACT(doy FROM subq_10.metric_time__day) AS metric_time__extract_doy
             , subq_9.ds__day AS ds__day
             , subq_9.ds__week AS ds__week
             , subq_9.ds__month AS ds__month
@@ -336,6 +326,16 @@ FROM (
             , subq_9.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_9.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_9.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_9.metric_time__week AS metric_time__week
+            , subq_9.metric_time__month AS metric_time__month
+            , subq_9.metric_time__quarter AS metric_time__quarter
+            , subq_9.metric_time__year AS metric_time__year
+            , subq_9.metric_time__extract_year AS metric_time__extract_year
+            , subq_9.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_9.metric_time__extract_month AS metric_time__extract_month
+            , subq_9.metric_time__extract_day AS metric_time__extract_day
+            , subq_9.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_9.metric_time__extract_doy AS metric_time__extract_doy
             , subq_9.listing AS listing
             , subq_9.guest AS guest
             , subq_9.host AS host

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Postgres/test_derived_fill_nulls_for_one_input_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Postgres/test_derived_fill_nulls_for_one_input_metric__plan0.sql
@@ -260,16 +260,6 @@ FROM (
           -- Join to Time Spine Dataset
           SELECT
             subq_10.metric_time__day AS metric_time__day
-            , DATE_TRUNC('week', subq_10.metric_time__day) AS metric_time__week
-            , DATE_TRUNC('month', subq_10.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('quarter', subq_10.metric_time__day) AS metric_time__quarter
-            , DATE_TRUNC('year', subq_10.metric_time__day) AS metric_time__year
-            , EXTRACT(year FROM subq_10.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_10.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_10.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_10.metric_time__day) AS metric_time__extract_day
-            , EXTRACT(isodow FROM subq_10.metric_time__day) AS metric_time__extract_dow
-            , EXTRACT(doy FROM subq_10.metric_time__day) AS metric_time__extract_doy
             , subq_9.ds__day AS ds__day
             , subq_9.ds__week AS ds__week
             , subq_9.ds__month AS ds__month
@@ -336,6 +326,16 @@ FROM (
             , subq_9.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_9.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_9.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_9.metric_time__week AS metric_time__week
+            , subq_9.metric_time__month AS metric_time__month
+            , subq_9.metric_time__quarter AS metric_time__quarter
+            , subq_9.metric_time__year AS metric_time__year
+            , subq_9.metric_time__extract_year AS metric_time__extract_year
+            , subq_9.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_9.metric_time__extract_month AS metric_time__extract_month
+            , subq_9.metric_time__extract_day AS metric_time__extract_day
+            , subq_9.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_9.metric_time__extract_doy AS metric_time__extract_doy
             , subq_9.listing AS listing
             , subq_9.guest AS guest
             , subq_9.host AS host

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Redshift/test_derived_fill_nulls_for_one_input_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Redshift/test_derived_fill_nulls_for_one_input_metric__plan0.sql
@@ -260,16 +260,6 @@ FROM (
           -- Join to Time Spine Dataset
           SELECT
             subq_10.metric_time__day AS metric_time__day
-            , DATE_TRUNC('week', subq_10.metric_time__day) AS metric_time__week
-            , DATE_TRUNC('month', subq_10.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('quarter', subq_10.metric_time__day) AS metric_time__quarter
-            , DATE_TRUNC('year', subq_10.metric_time__day) AS metric_time__year
-            , EXTRACT(year FROM subq_10.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_10.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_10.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_10.metric_time__day) AS metric_time__extract_day
-            , CASE WHEN EXTRACT(dow FROM subq_10.metric_time__day) = 0 THEN EXTRACT(dow FROM subq_10.metric_time__day) + 7 ELSE EXTRACT(dow FROM subq_10.metric_time__day) END AS metric_time__extract_dow
-            , EXTRACT(doy FROM subq_10.metric_time__day) AS metric_time__extract_doy
             , subq_9.ds__day AS ds__day
             , subq_9.ds__week AS ds__week
             , subq_9.ds__month AS ds__month
@@ -336,6 +326,16 @@ FROM (
             , subq_9.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_9.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_9.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_9.metric_time__week AS metric_time__week
+            , subq_9.metric_time__month AS metric_time__month
+            , subq_9.metric_time__quarter AS metric_time__quarter
+            , subq_9.metric_time__year AS metric_time__year
+            , subq_9.metric_time__extract_year AS metric_time__extract_year
+            , subq_9.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_9.metric_time__extract_month AS metric_time__extract_month
+            , subq_9.metric_time__extract_day AS metric_time__extract_day
+            , subq_9.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_9.metric_time__extract_doy AS metric_time__extract_doy
             , subq_9.listing AS listing
             , subq_9.guest AS guest
             , subq_9.host AS host

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Snowflake/test_derived_fill_nulls_for_one_input_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Snowflake/test_derived_fill_nulls_for_one_input_metric__plan0.sql
@@ -260,16 +260,6 @@ FROM (
           -- Join to Time Spine Dataset
           SELECT
             subq_10.metric_time__day AS metric_time__day
-            , DATE_TRUNC('week', subq_10.metric_time__day) AS metric_time__week
-            , DATE_TRUNC('month', subq_10.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('quarter', subq_10.metric_time__day) AS metric_time__quarter
-            , DATE_TRUNC('year', subq_10.metric_time__day) AS metric_time__year
-            , EXTRACT(year FROM subq_10.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_10.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_10.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_10.metric_time__day) AS metric_time__extract_day
-            , EXTRACT(dayofweekiso FROM subq_10.metric_time__day) AS metric_time__extract_dow
-            , EXTRACT(doy FROM subq_10.metric_time__day) AS metric_time__extract_doy
             , subq_9.ds__day AS ds__day
             , subq_9.ds__week AS ds__week
             , subq_9.ds__month AS ds__month
@@ -336,6 +326,16 @@ FROM (
             , subq_9.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_9.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_9.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_9.metric_time__week AS metric_time__week
+            , subq_9.metric_time__month AS metric_time__month
+            , subq_9.metric_time__quarter AS metric_time__quarter
+            , subq_9.metric_time__year AS metric_time__year
+            , subq_9.metric_time__extract_year AS metric_time__extract_year
+            , subq_9.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_9.metric_time__extract_month AS metric_time__extract_month
+            , subq_9.metric_time__extract_day AS metric_time__extract_day
+            , subq_9.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_9.metric_time__extract_doy AS metric_time__extract_doy
             , subq_9.listing AS listing
             , subq_9.guest AS guest
             , subq_9.host AS host

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Trino/test_derived_fill_nulls_for_one_input_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Trino/test_derived_fill_nulls_for_one_input_metric__plan0.sql
@@ -260,16 +260,6 @@ FROM (
           -- Join to Time Spine Dataset
           SELECT
             subq_10.metric_time__day AS metric_time__day
-            , DATE_TRUNC('week', subq_10.metric_time__day) AS metric_time__week
-            , DATE_TRUNC('month', subq_10.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('quarter', subq_10.metric_time__day) AS metric_time__quarter
-            , DATE_TRUNC('year', subq_10.metric_time__day) AS metric_time__year
-            , EXTRACT(year FROM subq_10.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_10.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_10.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_10.metric_time__day) AS metric_time__extract_day
-            , EXTRACT(DAY_OF_WEEK FROM subq_10.metric_time__day) AS metric_time__extract_dow
-            , EXTRACT(doy FROM subq_10.metric_time__day) AS metric_time__extract_doy
             , subq_9.ds__day AS ds__day
             , subq_9.ds__week AS ds__week
             , subq_9.ds__month AS ds__month
@@ -336,6 +326,16 @@ FROM (
             , subq_9.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_9.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_9.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_9.metric_time__week AS metric_time__week
+            , subq_9.metric_time__month AS metric_time__month
+            , subq_9.metric_time__quarter AS metric_time__quarter
+            , subq_9.metric_time__year AS metric_time__year
+            , subq_9.metric_time__extract_year AS metric_time__extract_year
+            , subq_9.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_9.metric_time__extract_month AS metric_time__extract_month
+            , subq_9.metric_time__extract_day AS metric_time__extract_day
+            , subq_9.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_9.metric_time__extract_doy AS metric_time__extract_doy
             , subq_9.listing AS listing
             , subq_9.guest AS guest
             , subq_9.host AS host

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/BigQuery/test_offset_window_with_date_part__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/BigQuery/test_offset_window_with_date_part__plan0.sql
@@ -245,17 +245,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_7.metric_time__day AS metric_time__day
-            , DATETIME_TRUNC(subq_7.metric_time__day, isoweek) AS metric_time__week
-            , DATETIME_TRUNC(subq_7.metric_time__day, month) AS metric_time__month
-            , DATETIME_TRUNC(subq_7.metric_time__day, quarter) AS metric_time__quarter
-            , DATETIME_TRUNC(subq_7.metric_time__day, year) AS metric_time__year
-            , EXTRACT(year FROM subq_7.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_7.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_7.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_7.metric_time__day) AS metric_time__extract_day
-            , IF(EXTRACT(dayofweek FROM subq_7.metric_time__day) = 1, 7, EXTRACT(dayofweek FROM subq_7.metric_time__day) - 1) AS metric_time__extract_dow
-            , EXTRACT(dayofyear FROM subq_7.metric_time__day) AS metric_time__extract_doy
+            IF(EXTRACT(dayofweek FROM subq_7.metric_time__day) = 1, 7, EXTRACT(dayofweek FROM subq_7.metric_time__day) - 1) AS metric_time__extract_dow
             , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
@@ -322,6 +312,16 @@ FROM (
             , subq_6.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_6.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_6.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_6.metric_time__day AS metric_time__day
+            , subq_6.metric_time__week AS metric_time__week
+            , subq_6.metric_time__month AS metric_time__month
+            , subq_6.metric_time__quarter AS metric_time__quarter
+            , subq_6.metric_time__year AS metric_time__year
+            , subq_6.metric_time__extract_year AS metric_time__extract_year
+            , subq_6.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_6.metric_time__extract_month AS metric_time__extract_month
+            , subq_6.metric_time__extract_day AS metric_time__extract_day
+            , subq_6.metric_time__extract_doy AS metric_time__extract_doy
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/BigQuery/test_subdaily_offset_to_grain_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/BigQuery/test_subdaily_offset_to_grain_metric__plan0.sql
@@ -25,17 +25,6 @@ FROM (
         -- Join to Time Spine Dataset
         SELECT
           subq_2.metric_time__hour AS metric_time__hour
-          , DATETIME_TRUNC(subq_2.metric_time__hour, day) AS metric_time__day
-          , DATETIME_TRUNC(subq_2.metric_time__hour, isoweek) AS metric_time__week
-          , DATETIME_TRUNC(subq_2.metric_time__hour, month) AS metric_time__month
-          , DATETIME_TRUNC(subq_2.metric_time__hour, quarter) AS metric_time__quarter
-          , DATETIME_TRUNC(subq_2.metric_time__hour, year) AS metric_time__year
-          , EXTRACT(year FROM subq_2.metric_time__hour) AS metric_time__extract_year
-          , EXTRACT(quarter FROM subq_2.metric_time__hour) AS metric_time__extract_quarter
-          , EXTRACT(month FROM subq_2.metric_time__hour) AS metric_time__extract_month
-          , EXTRACT(day FROM subq_2.metric_time__hour) AS metric_time__extract_day
-          , IF(EXTRACT(dayofweek FROM subq_2.metric_time__hour) = 1, 7, EXTRACT(dayofweek FROM subq_2.metric_time__hour) - 1) AS metric_time__extract_dow
-          , EXTRACT(dayofyear FROM subq_2.metric_time__hour) AS metric_time__extract_doy
           , subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
@@ -210,6 +199,17 @@ FROM (
           , subq_1.user__archived_at__extract_day AS user__archived_at__extract_day
           , subq_1.user__archived_at__extract_dow AS user__archived_at__extract_dow
           , subq_1.user__archived_at__extract_doy AS user__archived_at__extract_doy
+          , subq_1.metric_time__day AS metric_time__day
+          , subq_1.metric_time__week AS metric_time__week
+          , subq_1.metric_time__month AS metric_time__month
+          , subq_1.metric_time__quarter AS metric_time__quarter
+          , subq_1.metric_time__year AS metric_time__year
+          , subq_1.metric_time__extract_year AS metric_time__extract_year
+          , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_1.metric_time__extract_month AS metric_time__extract_month
+          , subq_1.metric_time__extract_day AS metric_time__extract_day
+          , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+          , subq_1.metric_time__extract_doy AS metric_time__extract_doy
           , subq_1.user AS user
           , subq_1.home_state AS home_state
           , subq_1.user__home_state AS user__home_state

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/BigQuery/test_subdaily_offset_window_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/BigQuery/test_subdaily_offset_window_metric__plan0.sql
@@ -25,17 +25,6 @@ FROM (
         -- Join to Time Spine Dataset
         SELECT
           subq_2.metric_time__hour AS metric_time__hour
-          , DATETIME_TRUNC(subq_2.metric_time__hour, day) AS metric_time__day
-          , DATETIME_TRUNC(subq_2.metric_time__hour, isoweek) AS metric_time__week
-          , DATETIME_TRUNC(subq_2.metric_time__hour, month) AS metric_time__month
-          , DATETIME_TRUNC(subq_2.metric_time__hour, quarter) AS metric_time__quarter
-          , DATETIME_TRUNC(subq_2.metric_time__hour, year) AS metric_time__year
-          , EXTRACT(year FROM subq_2.metric_time__hour) AS metric_time__extract_year
-          , EXTRACT(quarter FROM subq_2.metric_time__hour) AS metric_time__extract_quarter
-          , EXTRACT(month FROM subq_2.metric_time__hour) AS metric_time__extract_month
-          , EXTRACT(day FROM subq_2.metric_time__hour) AS metric_time__extract_day
-          , IF(EXTRACT(dayofweek FROM subq_2.metric_time__hour) = 1, 7, EXTRACT(dayofweek FROM subq_2.metric_time__hour) - 1) AS metric_time__extract_dow
-          , EXTRACT(dayofyear FROM subq_2.metric_time__hour) AS metric_time__extract_doy
           , subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
@@ -210,6 +199,17 @@ FROM (
           , subq_1.user__archived_at__extract_day AS user__archived_at__extract_day
           , subq_1.user__archived_at__extract_dow AS user__archived_at__extract_dow
           , subq_1.user__archived_at__extract_doy AS user__archived_at__extract_doy
+          , subq_1.metric_time__day AS metric_time__day
+          , subq_1.metric_time__week AS metric_time__week
+          , subq_1.metric_time__month AS metric_time__month
+          , subq_1.metric_time__quarter AS metric_time__quarter
+          , subq_1.metric_time__year AS metric_time__year
+          , subq_1.metric_time__extract_year AS metric_time__extract_year
+          , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_1.metric_time__extract_month AS metric_time__extract_month
+          , subq_1.metric_time__extract_day AS metric_time__extract_day
+          , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+          , subq_1.metric_time__extract_doy AS metric_time__extract_doy
           , subq_1.user AS user
           , subq_1.home_state AS home_state
           , subq_1.user__home_state AS user__home_state

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Databricks/test_offset_window_with_date_part__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Databricks/test_offset_window_with_date_part__plan0.sql
@@ -245,17 +245,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_7.metric_time__day AS metric_time__day
-            , DATE_TRUNC('week', subq_7.metric_time__day) AS metric_time__week
-            , DATE_TRUNC('month', subq_7.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('quarter', subq_7.metric_time__day) AS metric_time__quarter
-            , DATE_TRUNC('year', subq_7.metric_time__day) AS metric_time__year
-            , EXTRACT(year FROM subq_7.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_7.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_7.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_7.metric_time__day) AS metric_time__extract_day
-            , EXTRACT(DAYOFWEEK_ISO FROM subq_7.metric_time__day) AS metric_time__extract_dow
-            , EXTRACT(doy FROM subq_7.metric_time__day) AS metric_time__extract_doy
+            EXTRACT(DAYOFWEEK_ISO FROM subq_7.metric_time__day) AS metric_time__extract_dow
             , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
@@ -322,6 +312,16 @@ FROM (
             , subq_6.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_6.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_6.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_6.metric_time__day AS metric_time__day
+            , subq_6.metric_time__week AS metric_time__week
+            , subq_6.metric_time__month AS metric_time__month
+            , subq_6.metric_time__quarter AS metric_time__quarter
+            , subq_6.metric_time__year AS metric_time__year
+            , subq_6.metric_time__extract_year AS metric_time__extract_year
+            , subq_6.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_6.metric_time__extract_month AS metric_time__extract_month
+            , subq_6.metric_time__extract_day AS metric_time__extract_day
+            , subq_6.metric_time__extract_doy AS metric_time__extract_doy
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Databricks/test_subdaily_offset_to_grain_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Databricks/test_subdaily_offset_to_grain_metric__plan0.sql
@@ -25,17 +25,6 @@ FROM (
         -- Join to Time Spine Dataset
         SELECT
           subq_2.metric_time__hour AS metric_time__hour
-          , DATE_TRUNC('day', subq_2.metric_time__hour) AS metric_time__day
-          , DATE_TRUNC('week', subq_2.metric_time__hour) AS metric_time__week
-          , DATE_TRUNC('month', subq_2.metric_time__hour) AS metric_time__month
-          , DATE_TRUNC('quarter', subq_2.metric_time__hour) AS metric_time__quarter
-          , DATE_TRUNC('year', subq_2.metric_time__hour) AS metric_time__year
-          , EXTRACT(year FROM subq_2.metric_time__hour) AS metric_time__extract_year
-          , EXTRACT(quarter FROM subq_2.metric_time__hour) AS metric_time__extract_quarter
-          , EXTRACT(month FROM subq_2.metric_time__hour) AS metric_time__extract_month
-          , EXTRACT(day FROM subq_2.metric_time__hour) AS metric_time__extract_day
-          , EXTRACT(DAYOFWEEK_ISO FROM subq_2.metric_time__hour) AS metric_time__extract_dow
-          , EXTRACT(doy FROM subq_2.metric_time__hour) AS metric_time__extract_doy
           , subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
@@ -210,6 +199,17 @@ FROM (
           , subq_1.user__archived_at__extract_day AS user__archived_at__extract_day
           , subq_1.user__archived_at__extract_dow AS user__archived_at__extract_dow
           , subq_1.user__archived_at__extract_doy AS user__archived_at__extract_doy
+          , subq_1.metric_time__day AS metric_time__day
+          , subq_1.metric_time__week AS metric_time__week
+          , subq_1.metric_time__month AS metric_time__month
+          , subq_1.metric_time__quarter AS metric_time__quarter
+          , subq_1.metric_time__year AS metric_time__year
+          , subq_1.metric_time__extract_year AS metric_time__extract_year
+          , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_1.metric_time__extract_month AS metric_time__extract_month
+          , subq_1.metric_time__extract_day AS metric_time__extract_day
+          , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+          , subq_1.metric_time__extract_doy AS metric_time__extract_doy
           , subq_1.user AS user
           , subq_1.home_state AS home_state
           , subq_1.user__home_state AS user__home_state

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Databricks/test_subdaily_offset_window_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Databricks/test_subdaily_offset_window_metric__plan0.sql
@@ -25,17 +25,6 @@ FROM (
         -- Join to Time Spine Dataset
         SELECT
           subq_2.metric_time__hour AS metric_time__hour
-          , DATE_TRUNC('day', subq_2.metric_time__hour) AS metric_time__day
-          , DATE_TRUNC('week', subq_2.metric_time__hour) AS metric_time__week
-          , DATE_TRUNC('month', subq_2.metric_time__hour) AS metric_time__month
-          , DATE_TRUNC('quarter', subq_2.metric_time__hour) AS metric_time__quarter
-          , DATE_TRUNC('year', subq_2.metric_time__hour) AS metric_time__year
-          , EXTRACT(year FROM subq_2.metric_time__hour) AS metric_time__extract_year
-          , EXTRACT(quarter FROM subq_2.metric_time__hour) AS metric_time__extract_quarter
-          , EXTRACT(month FROM subq_2.metric_time__hour) AS metric_time__extract_month
-          , EXTRACT(day FROM subq_2.metric_time__hour) AS metric_time__extract_day
-          , EXTRACT(DAYOFWEEK_ISO FROM subq_2.metric_time__hour) AS metric_time__extract_dow
-          , EXTRACT(doy FROM subq_2.metric_time__hour) AS metric_time__extract_doy
           , subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
@@ -210,6 +199,17 @@ FROM (
           , subq_1.user__archived_at__extract_day AS user__archived_at__extract_day
           , subq_1.user__archived_at__extract_dow AS user__archived_at__extract_dow
           , subq_1.user__archived_at__extract_doy AS user__archived_at__extract_doy
+          , subq_1.metric_time__day AS metric_time__day
+          , subq_1.metric_time__week AS metric_time__week
+          , subq_1.metric_time__month AS metric_time__month
+          , subq_1.metric_time__quarter AS metric_time__quarter
+          , subq_1.metric_time__year AS metric_time__year
+          , subq_1.metric_time__extract_year AS metric_time__extract_year
+          , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_1.metric_time__extract_month AS metric_time__extract_month
+          , subq_1.metric_time__extract_day AS metric_time__extract_day
+          , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+          , subq_1.metric_time__extract_doy AS metric_time__extract_doy
           , subq_1.user AS user
           , subq_1.home_state AS home_state
           , subq_1.user__home_state AS user__home_state

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/DuckDB/test_offset_window_with_date_part__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/DuckDB/test_offset_window_with_date_part__plan0.sql
@@ -245,17 +245,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_7.metric_time__day AS metric_time__day
-            , DATE_TRUNC('week', subq_7.metric_time__day) AS metric_time__week
-            , DATE_TRUNC('month', subq_7.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('quarter', subq_7.metric_time__day) AS metric_time__quarter
-            , DATE_TRUNC('year', subq_7.metric_time__day) AS metric_time__year
-            , EXTRACT(year FROM subq_7.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_7.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_7.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_7.metric_time__day) AS metric_time__extract_day
-            , EXTRACT(isodow FROM subq_7.metric_time__day) AS metric_time__extract_dow
-            , EXTRACT(doy FROM subq_7.metric_time__day) AS metric_time__extract_doy
+            EXTRACT(isodow FROM subq_7.metric_time__day) AS metric_time__extract_dow
             , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
@@ -322,6 +312,16 @@ FROM (
             , subq_6.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_6.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_6.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_6.metric_time__day AS metric_time__day
+            , subq_6.metric_time__week AS metric_time__week
+            , subq_6.metric_time__month AS metric_time__month
+            , subq_6.metric_time__quarter AS metric_time__quarter
+            , subq_6.metric_time__year AS metric_time__year
+            , subq_6.metric_time__extract_year AS metric_time__extract_year
+            , subq_6.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_6.metric_time__extract_month AS metric_time__extract_month
+            , subq_6.metric_time__extract_day AS metric_time__extract_day
+            , subq_6.metric_time__extract_doy AS metric_time__extract_doy
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/DuckDB/test_subdaily_offset_to_grain_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/DuckDB/test_subdaily_offset_to_grain_metric__plan0.sql
@@ -25,17 +25,6 @@ FROM (
         -- Join to Time Spine Dataset
         SELECT
           subq_2.metric_time__hour AS metric_time__hour
-          , DATE_TRUNC('day', subq_2.metric_time__hour) AS metric_time__day
-          , DATE_TRUNC('week', subq_2.metric_time__hour) AS metric_time__week
-          , DATE_TRUNC('month', subq_2.metric_time__hour) AS metric_time__month
-          , DATE_TRUNC('quarter', subq_2.metric_time__hour) AS metric_time__quarter
-          , DATE_TRUNC('year', subq_2.metric_time__hour) AS metric_time__year
-          , EXTRACT(year FROM subq_2.metric_time__hour) AS metric_time__extract_year
-          , EXTRACT(quarter FROM subq_2.metric_time__hour) AS metric_time__extract_quarter
-          , EXTRACT(month FROM subq_2.metric_time__hour) AS metric_time__extract_month
-          , EXTRACT(day FROM subq_2.metric_time__hour) AS metric_time__extract_day
-          , EXTRACT(isodow FROM subq_2.metric_time__hour) AS metric_time__extract_dow
-          , EXTRACT(doy FROM subq_2.metric_time__hour) AS metric_time__extract_doy
           , subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
@@ -210,6 +199,17 @@ FROM (
           , subq_1.user__archived_at__extract_day AS user__archived_at__extract_day
           , subq_1.user__archived_at__extract_dow AS user__archived_at__extract_dow
           , subq_1.user__archived_at__extract_doy AS user__archived_at__extract_doy
+          , subq_1.metric_time__day AS metric_time__day
+          , subq_1.metric_time__week AS metric_time__week
+          , subq_1.metric_time__month AS metric_time__month
+          , subq_1.metric_time__quarter AS metric_time__quarter
+          , subq_1.metric_time__year AS metric_time__year
+          , subq_1.metric_time__extract_year AS metric_time__extract_year
+          , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_1.metric_time__extract_month AS metric_time__extract_month
+          , subq_1.metric_time__extract_day AS metric_time__extract_day
+          , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+          , subq_1.metric_time__extract_doy AS metric_time__extract_doy
           , subq_1.user AS user
           , subq_1.home_state AS home_state
           , subq_1.user__home_state AS user__home_state

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/DuckDB/test_subdaily_offset_window_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/DuckDB/test_subdaily_offset_window_metric__plan0.sql
@@ -25,17 +25,6 @@ FROM (
         -- Join to Time Spine Dataset
         SELECT
           subq_2.metric_time__hour AS metric_time__hour
-          , DATE_TRUNC('day', subq_2.metric_time__hour) AS metric_time__day
-          , DATE_TRUNC('week', subq_2.metric_time__hour) AS metric_time__week
-          , DATE_TRUNC('month', subq_2.metric_time__hour) AS metric_time__month
-          , DATE_TRUNC('quarter', subq_2.metric_time__hour) AS metric_time__quarter
-          , DATE_TRUNC('year', subq_2.metric_time__hour) AS metric_time__year
-          , EXTRACT(year FROM subq_2.metric_time__hour) AS metric_time__extract_year
-          , EXTRACT(quarter FROM subq_2.metric_time__hour) AS metric_time__extract_quarter
-          , EXTRACT(month FROM subq_2.metric_time__hour) AS metric_time__extract_month
-          , EXTRACT(day FROM subq_2.metric_time__hour) AS metric_time__extract_day
-          , EXTRACT(isodow FROM subq_2.metric_time__hour) AS metric_time__extract_dow
-          , EXTRACT(doy FROM subq_2.metric_time__hour) AS metric_time__extract_doy
           , subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
@@ -210,6 +199,17 @@ FROM (
           , subq_1.user__archived_at__extract_day AS user__archived_at__extract_day
           , subq_1.user__archived_at__extract_dow AS user__archived_at__extract_dow
           , subq_1.user__archived_at__extract_doy AS user__archived_at__extract_doy
+          , subq_1.metric_time__day AS metric_time__day
+          , subq_1.metric_time__week AS metric_time__week
+          , subq_1.metric_time__month AS metric_time__month
+          , subq_1.metric_time__quarter AS metric_time__quarter
+          , subq_1.metric_time__year AS metric_time__year
+          , subq_1.metric_time__extract_year AS metric_time__extract_year
+          , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_1.metric_time__extract_month AS metric_time__extract_month
+          , subq_1.metric_time__extract_day AS metric_time__extract_day
+          , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+          , subq_1.metric_time__extract_doy AS metric_time__extract_doy
           , subq_1.user AS user
           , subq_1.home_state AS home_state
           , subq_1.user__home_state AS user__home_state

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Postgres/test_offset_window_with_date_part__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Postgres/test_offset_window_with_date_part__plan0.sql
@@ -245,17 +245,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_7.metric_time__day AS metric_time__day
-            , DATE_TRUNC('week', subq_7.metric_time__day) AS metric_time__week
-            , DATE_TRUNC('month', subq_7.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('quarter', subq_7.metric_time__day) AS metric_time__quarter
-            , DATE_TRUNC('year', subq_7.metric_time__day) AS metric_time__year
-            , EXTRACT(year FROM subq_7.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_7.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_7.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_7.metric_time__day) AS metric_time__extract_day
-            , EXTRACT(isodow FROM subq_7.metric_time__day) AS metric_time__extract_dow
-            , EXTRACT(doy FROM subq_7.metric_time__day) AS metric_time__extract_doy
+            EXTRACT(isodow FROM subq_7.metric_time__day) AS metric_time__extract_dow
             , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
@@ -322,6 +312,16 @@ FROM (
             , subq_6.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_6.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_6.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_6.metric_time__day AS metric_time__day
+            , subq_6.metric_time__week AS metric_time__week
+            , subq_6.metric_time__month AS metric_time__month
+            , subq_6.metric_time__quarter AS metric_time__quarter
+            , subq_6.metric_time__year AS metric_time__year
+            , subq_6.metric_time__extract_year AS metric_time__extract_year
+            , subq_6.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_6.metric_time__extract_month AS metric_time__extract_month
+            , subq_6.metric_time__extract_day AS metric_time__extract_day
+            , subq_6.metric_time__extract_doy AS metric_time__extract_doy
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Postgres/test_subdaily_offset_to_grain_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Postgres/test_subdaily_offset_to_grain_metric__plan0.sql
@@ -25,17 +25,6 @@ FROM (
         -- Join to Time Spine Dataset
         SELECT
           subq_2.metric_time__hour AS metric_time__hour
-          , DATE_TRUNC('day', subq_2.metric_time__hour) AS metric_time__day
-          , DATE_TRUNC('week', subq_2.metric_time__hour) AS metric_time__week
-          , DATE_TRUNC('month', subq_2.metric_time__hour) AS metric_time__month
-          , DATE_TRUNC('quarter', subq_2.metric_time__hour) AS metric_time__quarter
-          , DATE_TRUNC('year', subq_2.metric_time__hour) AS metric_time__year
-          , EXTRACT(year FROM subq_2.metric_time__hour) AS metric_time__extract_year
-          , EXTRACT(quarter FROM subq_2.metric_time__hour) AS metric_time__extract_quarter
-          , EXTRACT(month FROM subq_2.metric_time__hour) AS metric_time__extract_month
-          , EXTRACT(day FROM subq_2.metric_time__hour) AS metric_time__extract_day
-          , EXTRACT(isodow FROM subq_2.metric_time__hour) AS metric_time__extract_dow
-          , EXTRACT(doy FROM subq_2.metric_time__hour) AS metric_time__extract_doy
           , subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
@@ -210,6 +199,17 @@ FROM (
           , subq_1.user__archived_at__extract_day AS user__archived_at__extract_day
           , subq_1.user__archived_at__extract_dow AS user__archived_at__extract_dow
           , subq_1.user__archived_at__extract_doy AS user__archived_at__extract_doy
+          , subq_1.metric_time__day AS metric_time__day
+          , subq_1.metric_time__week AS metric_time__week
+          , subq_1.metric_time__month AS metric_time__month
+          , subq_1.metric_time__quarter AS metric_time__quarter
+          , subq_1.metric_time__year AS metric_time__year
+          , subq_1.metric_time__extract_year AS metric_time__extract_year
+          , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_1.metric_time__extract_month AS metric_time__extract_month
+          , subq_1.metric_time__extract_day AS metric_time__extract_day
+          , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+          , subq_1.metric_time__extract_doy AS metric_time__extract_doy
           , subq_1.user AS user
           , subq_1.home_state AS home_state
           , subq_1.user__home_state AS user__home_state

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Postgres/test_subdaily_offset_window_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Postgres/test_subdaily_offset_window_metric__plan0.sql
@@ -25,17 +25,6 @@ FROM (
         -- Join to Time Spine Dataset
         SELECT
           subq_2.metric_time__hour AS metric_time__hour
-          , DATE_TRUNC('day', subq_2.metric_time__hour) AS metric_time__day
-          , DATE_TRUNC('week', subq_2.metric_time__hour) AS metric_time__week
-          , DATE_TRUNC('month', subq_2.metric_time__hour) AS metric_time__month
-          , DATE_TRUNC('quarter', subq_2.metric_time__hour) AS metric_time__quarter
-          , DATE_TRUNC('year', subq_2.metric_time__hour) AS metric_time__year
-          , EXTRACT(year FROM subq_2.metric_time__hour) AS metric_time__extract_year
-          , EXTRACT(quarter FROM subq_2.metric_time__hour) AS metric_time__extract_quarter
-          , EXTRACT(month FROM subq_2.metric_time__hour) AS metric_time__extract_month
-          , EXTRACT(day FROM subq_2.metric_time__hour) AS metric_time__extract_day
-          , EXTRACT(isodow FROM subq_2.metric_time__hour) AS metric_time__extract_dow
-          , EXTRACT(doy FROM subq_2.metric_time__hour) AS metric_time__extract_doy
           , subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
@@ -210,6 +199,17 @@ FROM (
           , subq_1.user__archived_at__extract_day AS user__archived_at__extract_day
           , subq_1.user__archived_at__extract_dow AS user__archived_at__extract_dow
           , subq_1.user__archived_at__extract_doy AS user__archived_at__extract_doy
+          , subq_1.metric_time__day AS metric_time__day
+          , subq_1.metric_time__week AS metric_time__week
+          , subq_1.metric_time__month AS metric_time__month
+          , subq_1.metric_time__quarter AS metric_time__quarter
+          , subq_1.metric_time__year AS metric_time__year
+          , subq_1.metric_time__extract_year AS metric_time__extract_year
+          , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_1.metric_time__extract_month AS metric_time__extract_month
+          , subq_1.metric_time__extract_day AS metric_time__extract_day
+          , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+          , subq_1.metric_time__extract_doy AS metric_time__extract_doy
           , subq_1.user AS user
           , subq_1.home_state AS home_state
           , subq_1.user__home_state AS user__home_state

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Redshift/test_offset_window_with_date_part__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Redshift/test_offset_window_with_date_part__plan0.sql
@@ -245,17 +245,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_7.metric_time__day AS metric_time__day
-            , DATE_TRUNC('week', subq_7.metric_time__day) AS metric_time__week
-            , DATE_TRUNC('month', subq_7.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('quarter', subq_7.metric_time__day) AS metric_time__quarter
-            , DATE_TRUNC('year', subq_7.metric_time__day) AS metric_time__year
-            , EXTRACT(year FROM subq_7.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_7.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_7.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_7.metric_time__day) AS metric_time__extract_day
-            , CASE WHEN EXTRACT(dow FROM subq_7.metric_time__day) = 0 THEN EXTRACT(dow FROM subq_7.metric_time__day) + 7 ELSE EXTRACT(dow FROM subq_7.metric_time__day) END AS metric_time__extract_dow
-            , EXTRACT(doy FROM subq_7.metric_time__day) AS metric_time__extract_doy
+            CASE WHEN EXTRACT(dow FROM subq_7.metric_time__day) = 0 THEN EXTRACT(dow FROM subq_7.metric_time__day) + 7 ELSE EXTRACT(dow FROM subq_7.metric_time__day) END AS metric_time__extract_dow
             , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
@@ -322,6 +312,16 @@ FROM (
             , subq_6.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_6.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_6.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_6.metric_time__day AS metric_time__day
+            , subq_6.metric_time__week AS metric_time__week
+            , subq_6.metric_time__month AS metric_time__month
+            , subq_6.metric_time__quarter AS metric_time__quarter
+            , subq_6.metric_time__year AS metric_time__year
+            , subq_6.metric_time__extract_year AS metric_time__extract_year
+            , subq_6.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_6.metric_time__extract_month AS metric_time__extract_month
+            , subq_6.metric_time__extract_day AS metric_time__extract_day
+            , subq_6.metric_time__extract_doy AS metric_time__extract_doy
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Redshift/test_subdaily_offset_to_grain_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Redshift/test_subdaily_offset_to_grain_metric__plan0.sql
@@ -25,17 +25,6 @@ FROM (
         -- Join to Time Spine Dataset
         SELECT
           subq_2.metric_time__hour AS metric_time__hour
-          , DATE_TRUNC('day', subq_2.metric_time__hour) AS metric_time__day
-          , DATE_TRUNC('week', subq_2.metric_time__hour) AS metric_time__week
-          , DATE_TRUNC('month', subq_2.metric_time__hour) AS metric_time__month
-          , DATE_TRUNC('quarter', subq_2.metric_time__hour) AS metric_time__quarter
-          , DATE_TRUNC('year', subq_2.metric_time__hour) AS metric_time__year
-          , EXTRACT(year FROM subq_2.metric_time__hour) AS metric_time__extract_year
-          , EXTRACT(quarter FROM subq_2.metric_time__hour) AS metric_time__extract_quarter
-          , EXTRACT(month FROM subq_2.metric_time__hour) AS metric_time__extract_month
-          , EXTRACT(day FROM subq_2.metric_time__hour) AS metric_time__extract_day
-          , CASE WHEN EXTRACT(dow FROM subq_2.metric_time__hour) = 0 THEN EXTRACT(dow FROM subq_2.metric_time__hour) + 7 ELSE EXTRACT(dow FROM subq_2.metric_time__hour) END AS metric_time__extract_dow
-          , EXTRACT(doy FROM subq_2.metric_time__hour) AS metric_time__extract_doy
           , subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
@@ -210,6 +199,17 @@ FROM (
           , subq_1.user__archived_at__extract_day AS user__archived_at__extract_day
           , subq_1.user__archived_at__extract_dow AS user__archived_at__extract_dow
           , subq_1.user__archived_at__extract_doy AS user__archived_at__extract_doy
+          , subq_1.metric_time__day AS metric_time__day
+          , subq_1.metric_time__week AS metric_time__week
+          , subq_1.metric_time__month AS metric_time__month
+          , subq_1.metric_time__quarter AS metric_time__quarter
+          , subq_1.metric_time__year AS metric_time__year
+          , subq_1.metric_time__extract_year AS metric_time__extract_year
+          , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_1.metric_time__extract_month AS metric_time__extract_month
+          , subq_1.metric_time__extract_day AS metric_time__extract_day
+          , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+          , subq_1.metric_time__extract_doy AS metric_time__extract_doy
           , subq_1.user AS user
           , subq_1.home_state AS home_state
           , subq_1.user__home_state AS user__home_state

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Redshift/test_subdaily_offset_window_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Redshift/test_subdaily_offset_window_metric__plan0.sql
@@ -25,17 +25,6 @@ FROM (
         -- Join to Time Spine Dataset
         SELECT
           subq_2.metric_time__hour AS metric_time__hour
-          , DATE_TRUNC('day', subq_2.metric_time__hour) AS metric_time__day
-          , DATE_TRUNC('week', subq_2.metric_time__hour) AS metric_time__week
-          , DATE_TRUNC('month', subq_2.metric_time__hour) AS metric_time__month
-          , DATE_TRUNC('quarter', subq_2.metric_time__hour) AS metric_time__quarter
-          , DATE_TRUNC('year', subq_2.metric_time__hour) AS metric_time__year
-          , EXTRACT(year FROM subq_2.metric_time__hour) AS metric_time__extract_year
-          , EXTRACT(quarter FROM subq_2.metric_time__hour) AS metric_time__extract_quarter
-          , EXTRACT(month FROM subq_2.metric_time__hour) AS metric_time__extract_month
-          , EXTRACT(day FROM subq_2.metric_time__hour) AS metric_time__extract_day
-          , CASE WHEN EXTRACT(dow FROM subq_2.metric_time__hour) = 0 THEN EXTRACT(dow FROM subq_2.metric_time__hour) + 7 ELSE EXTRACT(dow FROM subq_2.metric_time__hour) END AS metric_time__extract_dow
-          , EXTRACT(doy FROM subq_2.metric_time__hour) AS metric_time__extract_doy
           , subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
@@ -210,6 +199,17 @@ FROM (
           , subq_1.user__archived_at__extract_day AS user__archived_at__extract_day
           , subq_1.user__archived_at__extract_dow AS user__archived_at__extract_dow
           , subq_1.user__archived_at__extract_doy AS user__archived_at__extract_doy
+          , subq_1.metric_time__day AS metric_time__day
+          , subq_1.metric_time__week AS metric_time__week
+          , subq_1.metric_time__month AS metric_time__month
+          , subq_1.metric_time__quarter AS metric_time__quarter
+          , subq_1.metric_time__year AS metric_time__year
+          , subq_1.metric_time__extract_year AS metric_time__extract_year
+          , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_1.metric_time__extract_month AS metric_time__extract_month
+          , subq_1.metric_time__extract_day AS metric_time__extract_day
+          , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+          , subq_1.metric_time__extract_doy AS metric_time__extract_doy
           , subq_1.user AS user
           , subq_1.home_state AS home_state
           , subq_1.user__home_state AS user__home_state

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Snowflake/test_offset_window_with_date_part__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Snowflake/test_offset_window_with_date_part__plan0.sql
@@ -245,17 +245,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_7.metric_time__day AS metric_time__day
-            , DATE_TRUNC('week', subq_7.metric_time__day) AS metric_time__week
-            , DATE_TRUNC('month', subq_7.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('quarter', subq_7.metric_time__day) AS metric_time__quarter
-            , DATE_TRUNC('year', subq_7.metric_time__day) AS metric_time__year
-            , EXTRACT(year FROM subq_7.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_7.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_7.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_7.metric_time__day) AS metric_time__extract_day
-            , EXTRACT(dayofweekiso FROM subq_7.metric_time__day) AS metric_time__extract_dow
-            , EXTRACT(doy FROM subq_7.metric_time__day) AS metric_time__extract_doy
+            EXTRACT(dayofweekiso FROM subq_7.metric_time__day) AS metric_time__extract_dow
             , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
@@ -322,6 +312,16 @@ FROM (
             , subq_6.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_6.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_6.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_6.metric_time__day AS metric_time__day
+            , subq_6.metric_time__week AS metric_time__week
+            , subq_6.metric_time__month AS metric_time__month
+            , subq_6.metric_time__quarter AS metric_time__quarter
+            , subq_6.metric_time__year AS metric_time__year
+            , subq_6.metric_time__extract_year AS metric_time__extract_year
+            , subq_6.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_6.metric_time__extract_month AS metric_time__extract_month
+            , subq_6.metric_time__extract_day AS metric_time__extract_day
+            , subq_6.metric_time__extract_doy AS metric_time__extract_doy
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Snowflake/test_subdaily_offset_to_grain_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Snowflake/test_subdaily_offset_to_grain_metric__plan0.sql
@@ -25,17 +25,6 @@ FROM (
         -- Join to Time Spine Dataset
         SELECT
           subq_2.metric_time__hour AS metric_time__hour
-          , DATE_TRUNC('day', subq_2.metric_time__hour) AS metric_time__day
-          , DATE_TRUNC('week', subq_2.metric_time__hour) AS metric_time__week
-          , DATE_TRUNC('month', subq_2.metric_time__hour) AS metric_time__month
-          , DATE_TRUNC('quarter', subq_2.metric_time__hour) AS metric_time__quarter
-          , DATE_TRUNC('year', subq_2.metric_time__hour) AS metric_time__year
-          , EXTRACT(year FROM subq_2.metric_time__hour) AS metric_time__extract_year
-          , EXTRACT(quarter FROM subq_2.metric_time__hour) AS metric_time__extract_quarter
-          , EXTRACT(month FROM subq_2.metric_time__hour) AS metric_time__extract_month
-          , EXTRACT(day FROM subq_2.metric_time__hour) AS metric_time__extract_day
-          , EXTRACT(dayofweekiso FROM subq_2.metric_time__hour) AS metric_time__extract_dow
-          , EXTRACT(doy FROM subq_2.metric_time__hour) AS metric_time__extract_doy
           , subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
@@ -210,6 +199,17 @@ FROM (
           , subq_1.user__archived_at__extract_day AS user__archived_at__extract_day
           , subq_1.user__archived_at__extract_dow AS user__archived_at__extract_dow
           , subq_1.user__archived_at__extract_doy AS user__archived_at__extract_doy
+          , subq_1.metric_time__day AS metric_time__day
+          , subq_1.metric_time__week AS metric_time__week
+          , subq_1.metric_time__month AS metric_time__month
+          , subq_1.metric_time__quarter AS metric_time__quarter
+          , subq_1.metric_time__year AS metric_time__year
+          , subq_1.metric_time__extract_year AS metric_time__extract_year
+          , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_1.metric_time__extract_month AS metric_time__extract_month
+          , subq_1.metric_time__extract_day AS metric_time__extract_day
+          , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+          , subq_1.metric_time__extract_doy AS metric_time__extract_doy
           , subq_1.user AS user
           , subq_1.home_state AS home_state
           , subq_1.user__home_state AS user__home_state

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Snowflake/test_subdaily_offset_window_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Snowflake/test_subdaily_offset_window_metric__plan0.sql
@@ -25,17 +25,6 @@ FROM (
         -- Join to Time Spine Dataset
         SELECT
           subq_2.metric_time__hour AS metric_time__hour
-          , DATE_TRUNC('day', subq_2.metric_time__hour) AS metric_time__day
-          , DATE_TRUNC('week', subq_2.metric_time__hour) AS metric_time__week
-          , DATE_TRUNC('month', subq_2.metric_time__hour) AS metric_time__month
-          , DATE_TRUNC('quarter', subq_2.metric_time__hour) AS metric_time__quarter
-          , DATE_TRUNC('year', subq_2.metric_time__hour) AS metric_time__year
-          , EXTRACT(year FROM subq_2.metric_time__hour) AS metric_time__extract_year
-          , EXTRACT(quarter FROM subq_2.metric_time__hour) AS metric_time__extract_quarter
-          , EXTRACT(month FROM subq_2.metric_time__hour) AS metric_time__extract_month
-          , EXTRACT(day FROM subq_2.metric_time__hour) AS metric_time__extract_day
-          , EXTRACT(dayofweekiso FROM subq_2.metric_time__hour) AS metric_time__extract_dow
-          , EXTRACT(doy FROM subq_2.metric_time__hour) AS metric_time__extract_doy
           , subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
@@ -210,6 +199,17 @@ FROM (
           , subq_1.user__archived_at__extract_day AS user__archived_at__extract_day
           , subq_1.user__archived_at__extract_dow AS user__archived_at__extract_dow
           , subq_1.user__archived_at__extract_doy AS user__archived_at__extract_doy
+          , subq_1.metric_time__day AS metric_time__day
+          , subq_1.metric_time__week AS metric_time__week
+          , subq_1.metric_time__month AS metric_time__month
+          , subq_1.metric_time__quarter AS metric_time__quarter
+          , subq_1.metric_time__year AS metric_time__year
+          , subq_1.metric_time__extract_year AS metric_time__extract_year
+          , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_1.metric_time__extract_month AS metric_time__extract_month
+          , subq_1.metric_time__extract_day AS metric_time__extract_day
+          , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+          , subq_1.metric_time__extract_doy AS metric_time__extract_doy
           , subq_1.user AS user
           , subq_1.home_state AS home_state
           , subq_1.user__home_state AS user__home_state

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Trino/test_offset_window_with_date_part__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Trino/test_offset_window_with_date_part__plan0.sql
@@ -245,17 +245,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_7.metric_time__day AS metric_time__day
-            , DATE_TRUNC('week', subq_7.metric_time__day) AS metric_time__week
-            , DATE_TRUNC('month', subq_7.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('quarter', subq_7.metric_time__day) AS metric_time__quarter
-            , DATE_TRUNC('year', subq_7.metric_time__day) AS metric_time__year
-            , EXTRACT(year FROM subq_7.metric_time__day) AS metric_time__extract_year
-            , EXTRACT(quarter FROM subq_7.metric_time__day) AS metric_time__extract_quarter
-            , EXTRACT(month FROM subq_7.metric_time__day) AS metric_time__extract_month
-            , EXTRACT(day FROM subq_7.metric_time__day) AS metric_time__extract_day
-            , EXTRACT(DAY_OF_WEEK FROM subq_7.metric_time__day) AS metric_time__extract_dow
-            , EXTRACT(doy FROM subq_7.metric_time__day) AS metric_time__extract_doy
+            EXTRACT(DAY_OF_WEEK FROM subq_7.metric_time__day) AS metric_time__extract_dow
             , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
@@ -322,6 +312,16 @@ FROM (
             , subq_6.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_6.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_6.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_6.metric_time__day AS metric_time__day
+            , subq_6.metric_time__week AS metric_time__week
+            , subq_6.metric_time__month AS metric_time__month
+            , subq_6.metric_time__quarter AS metric_time__quarter
+            , subq_6.metric_time__year AS metric_time__year
+            , subq_6.metric_time__extract_year AS metric_time__extract_year
+            , subq_6.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_6.metric_time__extract_month AS metric_time__extract_month
+            , subq_6.metric_time__extract_day AS metric_time__extract_day
+            , subq_6.metric_time__extract_doy AS metric_time__extract_doy
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Trino/test_subdaily_offset_to_grain_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Trino/test_subdaily_offset_to_grain_metric__plan0.sql
@@ -25,17 +25,6 @@ FROM (
         -- Join to Time Spine Dataset
         SELECT
           subq_2.metric_time__hour AS metric_time__hour
-          , DATE_TRUNC('day', subq_2.metric_time__hour) AS metric_time__day
-          , DATE_TRUNC('week', subq_2.metric_time__hour) AS metric_time__week
-          , DATE_TRUNC('month', subq_2.metric_time__hour) AS metric_time__month
-          , DATE_TRUNC('quarter', subq_2.metric_time__hour) AS metric_time__quarter
-          , DATE_TRUNC('year', subq_2.metric_time__hour) AS metric_time__year
-          , EXTRACT(year FROM subq_2.metric_time__hour) AS metric_time__extract_year
-          , EXTRACT(quarter FROM subq_2.metric_time__hour) AS metric_time__extract_quarter
-          , EXTRACT(month FROM subq_2.metric_time__hour) AS metric_time__extract_month
-          , EXTRACT(day FROM subq_2.metric_time__hour) AS metric_time__extract_day
-          , EXTRACT(DAY_OF_WEEK FROM subq_2.metric_time__hour) AS metric_time__extract_dow
-          , EXTRACT(doy FROM subq_2.metric_time__hour) AS metric_time__extract_doy
           , subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
@@ -210,6 +199,17 @@ FROM (
           , subq_1.user__archived_at__extract_day AS user__archived_at__extract_day
           , subq_1.user__archived_at__extract_dow AS user__archived_at__extract_dow
           , subq_1.user__archived_at__extract_doy AS user__archived_at__extract_doy
+          , subq_1.metric_time__day AS metric_time__day
+          , subq_1.metric_time__week AS metric_time__week
+          , subq_1.metric_time__month AS metric_time__month
+          , subq_1.metric_time__quarter AS metric_time__quarter
+          , subq_1.metric_time__year AS metric_time__year
+          , subq_1.metric_time__extract_year AS metric_time__extract_year
+          , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_1.metric_time__extract_month AS metric_time__extract_month
+          , subq_1.metric_time__extract_day AS metric_time__extract_day
+          , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+          , subq_1.metric_time__extract_doy AS metric_time__extract_doy
           , subq_1.user AS user
           , subq_1.home_state AS home_state
           , subq_1.user__home_state AS user__home_state

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Trino/test_subdaily_offset_window_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Trino/test_subdaily_offset_window_metric__plan0.sql
@@ -25,17 +25,6 @@ FROM (
         -- Join to Time Spine Dataset
         SELECT
           subq_2.metric_time__hour AS metric_time__hour
-          , DATE_TRUNC('day', subq_2.metric_time__hour) AS metric_time__day
-          , DATE_TRUNC('week', subq_2.metric_time__hour) AS metric_time__week
-          , DATE_TRUNC('month', subq_2.metric_time__hour) AS metric_time__month
-          , DATE_TRUNC('quarter', subq_2.metric_time__hour) AS metric_time__quarter
-          , DATE_TRUNC('year', subq_2.metric_time__hour) AS metric_time__year
-          , EXTRACT(year FROM subq_2.metric_time__hour) AS metric_time__extract_year
-          , EXTRACT(quarter FROM subq_2.metric_time__hour) AS metric_time__extract_quarter
-          , EXTRACT(month FROM subq_2.metric_time__hour) AS metric_time__extract_month
-          , EXTRACT(day FROM subq_2.metric_time__hour) AS metric_time__extract_day
-          , EXTRACT(DAY_OF_WEEK FROM subq_2.metric_time__hour) AS metric_time__extract_dow
-          , EXTRACT(doy FROM subq_2.metric_time__hour) AS metric_time__extract_doy
           , subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
@@ -210,6 +199,17 @@ FROM (
           , subq_1.user__archived_at__extract_day AS user__archived_at__extract_day
           , subq_1.user__archived_at__extract_dow AS user__archived_at__extract_dow
           , subq_1.user__archived_at__extract_doy AS user__archived_at__extract_doy
+          , subq_1.metric_time__day AS metric_time__day
+          , subq_1.metric_time__week AS metric_time__week
+          , subq_1.metric_time__month AS metric_time__month
+          , subq_1.metric_time__quarter AS metric_time__quarter
+          , subq_1.metric_time__year AS metric_time__year
+          , subq_1.metric_time__extract_year AS metric_time__extract_year
+          , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_1.metric_time__extract_month AS metric_time__extract_month
+          , subq_1.metric_time__extract_day AS metric_time__extract_day
+          , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+          , subq_1.metric_time__extract_doy AS metric_time__extract_doy
           , subq_1.user AS user
           , subq_1.home_state AS home_state
           , subq_1.user__home_state AS user__home_state

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
@@ -633,16 +633,6 @@ FROM (
             -- Constrain Output with WHERE
             SELECT
               subq_21.metric_time__day
-              , subq_21.metric_time__week
-              , subq_21.metric_time__month
-              , subq_21.metric_time__quarter
-              , subq_21.metric_time__year
-              , subq_21.metric_time__extract_year
-              , subq_21.metric_time__extract_quarter
-              , subq_21.metric_time__extract_month
-              , subq_21.metric_time__extract_day
-              , subq_21.metric_time__extract_dow
-              , subq_21.metric_time__extract_doy
               , subq_21.ds__day
               , subq_21.ds__week
               , subq_21.ds__month
@@ -709,6 +699,16 @@ FROM (
               , subq_21.booking__paid_at__extract_day
               , subq_21.booking__paid_at__extract_dow
               , subq_21.booking__paid_at__extract_doy
+              , subq_21.metric_time__week
+              , subq_21.metric_time__month
+              , subq_21.metric_time__quarter
+              , subq_21.metric_time__year
+              , subq_21.metric_time__extract_year
+              , subq_21.metric_time__extract_quarter
+              , subq_21.metric_time__extract_month
+              , subq_21.metric_time__extract_day
+              , subq_21.metric_time__extract_dow
+              , subq_21.metric_time__extract_doy
               , subq_21.listing
               , subq_21.guest
               , subq_21.host
@@ -736,16 +736,6 @@ FROM (
               SELECT
                 subq_20.country_latest AS listing__country_latest
                 , subq_17.metric_time__day AS metric_time__day
-                , subq_17.metric_time__week AS metric_time__week
-                , subq_17.metric_time__month AS metric_time__month
-                , subq_17.metric_time__quarter AS metric_time__quarter
-                , subq_17.metric_time__year AS metric_time__year
-                , subq_17.metric_time__extract_year AS metric_time__extract_year
-                , subq_17.metric_time__extract_quarter AS metric_time__extract_quarter
-                , subq_17.metric_time__extract_month AS metric_time__extract_month
-                , subq_17.metric_time__extract_day AS metric_time__extract_day
-                , subq_17.metric_time__extract_dow AS metric_time__extract_dow
-                , subq_17.metric_time__extract_doy AS metric_time__extract_doy
                 , subq_17.ds__day AS ds__day
                 , subq_17.ds__week AS ds__week
                 , subq_17.ds__month AS ds__month
@@ -812,6 +802,16 @@ FROM (
                 , subq_17.booking__paid_at__extract_day AS booking__paid_at__extract_day
                 , subq_17.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
                 , subq_17.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                , subq_17.metric_time__week AS metric_time__week
+                , subq_17.metric_time__month AS metric_time__month
+                , subq_17.metric_time__quarter AS metric_time__quarter
+                , subq_17.metric_time__year AS metric_time__year
+                , subq_17.metric_time__extract_year AS metric_time__extract_year
+                , subq_17.metric_time__extract_quarter AS metric_time__extract_quarter
+                , subq_17.metric_time__extract_month AS metric_time__extract_month
+                , subq_17.metric_time__extract_day AS metric_time__extract_day
+                , subq_17.metric_time__extract_dow AS metric_time__extract_dow
+                , subq_17.metric_time__extract_doy AS metric_time__extract_doy
                 , subq_17.listing AS listing
                 , subq_17.guest AS guest
                 , subq_17.host AS host
@@ -837,16 +837,6 @@ FROM (
                 -- Join to Time Spine Dataset
                 SELECT
                   subq_15.metric_time__day AS metric_time__day
-                  , DATETIME_TRUNC(subq_15.metric_time__day, isoweek) AS metric_time__week
-                  , DATETIME_TRUNC(subq_15.metric_time__day, month) AS metric_time__month
-                  , DATETIME_TRUNC(subq_15.metric_time__day, quarter) AS metric_time__quarter
-                  , DATETIME_TRUNC(subq_15.metric_time__day, year) AS metric_time__year
-                  , EXTRACT(year FROM subq_15.metric_time__day) AS metric_time__extract_year
-                  , EXTRACT(quarter FROM subq_15.metric_time__day) AS metric_time__extract_quarter
-                  , EXTRACT(month FROM subq_15.metric_time__day) AS metric_time__extract_month
-                  , EXTRACT(day FROM subq_15.metric_time__day) AS metric_time__extract_day
-                  , IF(EXTRACT(dayofweek FROM subq_15.metric_time__day) = 1, 7, EXTRACT(dayofweek FROM subq_15.metric_time__day) - 1) AS metric_time__extract_dow
-                  , EXTRACT(dayofyear FROM subq_15.metric_time__day) AS metric_time__extract_doy
                   , subq_14.ds__day AS ds__day
                   , subq_14.ds__week AS ds__week
                   , subq_14.ds__month AS ds__month
@@ -913,6 +903,16 @@ FROM (
                   , subq_14.booking__paid_at__extract_day AS booking__paid_at__extract_day
                   , subq_14.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
                   , subq_14.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                  , subq_14.metric_time__week AS metric_time__week
+                  , subq_14.metric_time__month AS metric_time__month
+                  , subq_14.metric_time__quarter AS metric_time__quarter
+                  , subq_14.metric_time__year AS metric_time__year
+                  , subq_14.metric_time__extract_year AS metric_time__extract_year
+                  , subq_14.metric_time__extract_quarter AS metric_time__extract_quarter
+                  , subq_14.metric_time__extract_month AS metric_time__extract_month
+                  , subq_14.metric_time__extract_day AS metric_time__extract_day
+                  , subq_14.metric_time__extract_dow AS metric_time__extract_dow
+                  , subq_14.metric_time__extract_doy AS metric_time__extract_doy
                   , subq_14.listing AS listing
                   , subq_14.guest AS guest
                   , subq_14.host AS host

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_offset_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_offset_metric_with_query_time_filters__plan0.sql
@@ -606,16 +606,6 @@ FROM (
           -- Constrain Output with WHERE
           SELECT
             subq_18.metric_time__day
-            , subq_18.metric_time__week
-            , subq_18.metric_time__month
-            , subq_18.metric_time__quarter
-            , subq_18.metric_time__year
-            , subq_18.metric_time__extract_year
-            , subq_18.metric_time__extract_quarter
-            , subq_18.metric_time__extract_month
-            , subq_18.metric_time__extract_day
-            , subq_18.metric_time__extract_dow
-            , subq_18.metric_time__extract_doy
             , subq_18.ds__day
             , subq_18.ds__week
             , subq_18.ds__month
@@ -682,6 +672,16 @@ FROM (
             , subq_18.booking__paid_at__extract_day
             , subq_18.booking__paid_at__extract_dow
             , subq_18.booking__paid_at__extract_doy
+            , subq_18.metric_time__week
+            , subq_18.metric_time__month
+            , subq_18.metric_time__quarter
+            , subq_18.metric_time__year
+            , subq_18.metric_time__extract_year
+            , subq_18.metric_time__extract_quarter
+            , subq_18.metric_time__extract_month
+            , subq_18.metric_time__extract_day
+            , subq_18.metric_time__extract_dow
+            , subq_18.metric_time__extract_doy
             , subq_18.listing
             , subq_18.guest
             , subq_18.host
@@ -709,16 +709,6 @@ FROM (
             SELECT
               subq_17.country_latest AS listing__country_latest
               , subq_14.metric_time__day AS metric_time__day
-              , subq_14.metric_time__week AS metric_time__week
-              , subq_14.metric_time__month AS metric_time__month
-              , subq_14.metric_time__quarter AS metric_time__quarter
-              , subq_14.metric_time__year AS metric_time__year
-              , subq_14.metric_time__extract_year AS metric_time__extract_year
-              , subq_14.metric_time__extract_quarter AS metric_time__extract_quarter
-              , subq_14.metric_time__extract_month AS metric_time__extract_month
-              , subq_14.metric_time__extract_day AS metric_time__extract_day
-              , subq_14.metric_time__extract_dow AS metric_time__extract_dow
-              , subq_14.metric_time__extract_doy AS metric_time__extract_doy
               , subq_14.ds__day AS ds__day
               , subq_14.ds__week AS ds__week
               , subq_14.ds__month AS ds__month
@@ -785,6 +775,16 @@ FROM (
               , subq_14.booking__paid_at__extract_day AS booking__paid_at__extract_day
               , subq_14.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
               , subq_14.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+              , subq_14.metric_time__week AS metric_time__week
+              , subq_14.metric_time__month AS metric_time__month
+              , subq_14.metric_time__quarter AS metric_time__quarter
+              , subq_14.metric_time__year AS metric_time__year
+              , subq_14.metric_time__extract_year AS metric_time__extract_year
+              , subq_14.metric_time__extract_quarter AS metric_time__extract_quarter
+              , subq_14.metric_time__extract_month AS metric_time__extract_month
+              , subq_14.metric_time__extract_day AS metric_time__extract_day
+              , subq_14.metric_time__extract_dow AS metric_time__extract_dow
+              , subq_14.metric_time__extract_doy AS metric_time__extract_doy
               , subq_14.listing AS listing
               , subq_14.guest AS guest
               , subq_14.host AS host
@@ -810,16 +810,6 @@ FROM (
               -- Join to Time Spine Dataset
               SELECT
                 subq_12.metric_time__day AS metric_time__day
-                , DATETIME_TRUNC(subq_12.metric_time__day, isoweek) AS metric_time__week
-                , DATETIME_TRUNC(subq_12.metric_time__day, month) AS metric_time__month
-                , DATETIME_TRUNC(subq_12.metric_time__day, quarter) AS metric_time__quarter
-                , DATETIME_TRUNC(subq_12.metric_time__day, year) AS metric_time__year
-                , EXTRACT(year FROM subq_12.metric_time__day) AS metric_time__extract_year
-                , EXTRACT(quarter FROM subq_12.metric_time__day) AS metric_time__extract_quarter
-                , EXTRACT(month FROM subq_12.metric_time__day) AS metric_time__extract_month
-                , EXTRACT(day FROM subq_12.metric_time__day) AS metric_time__extract_day
-                , IF(EXTRACT(dayofweek FROM subq_12.metric_time__day) = 1, 7, EXTRACT(dayofweek FROM subq_12.metric_time__day) - 1) AS metric_time__extract_dow
-                , EXTRACT(dayofyear FROM subq_12.metric_time__day) AS metric_time__extract_doy
                 , subq_11.ds__day AS ds__day
                 , subq_11.ds__week AS ds__week
                 , subq_11.ds__month AS ds__month
@@ -886,6 +876,16 @@ FROM (
                 , subq_11.booking__paid_at__extract_day AS booking__paid_at__extract_day
                 , subq_11.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
                 , subq_11.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                , subq_11.metric_time__week AS metric_time__week
+                , subq_11.metric_time__month AS metric_time__month
+                , subq_11.metric_time__quarter AS metric_time__quarter
+                , subq_11.metric_time__year AS metric_time__year
+                , subq_11.metric_time__extract_year AS metric_time__extract_year
+                , subq_11.metric_time__extract_quarter AS metric_time__extract_quarter
+                , subq_11.metric_time__extract_month AS metric_time__extract_month
+                , subq_11.metric_time__extract_day AS metric_time__extract_day
+                , subq_11.metric_time__extract_dow AS metric_time__extract_dow
+                , subq_11.metric_time__extract_doy AS metric_time__extract_doy
                 , subq_11.listing AS listing
                 , subq_11.guest AS guest
                 , subq_11.host AS host

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
@@ -633,16 +633,6 @@ FROM (
             -- Constrain Output with WHERE
             SELECT
               subq_21.metric_time__day
-              , subq_21.metric_time__week
-              , subq_21.metric_time__month
-              , subq_21.metric_time__quarter
-              , subq_21.metric_time__year
-              , subq_21.metric_time__extract_year
-              , subq_21.metric_time__extract_quarter
-              , subq_21.metric_time__extract_month
-              , subq_21.metric_time__extract_day
-              , subq_21.metric_time__extract_dow
-              , subq_21.metric_time__extract_doy
               , subq_21.ds__day
               , subq_21.ds__week
               , subq_21.ds__month
@@ -709,6 +699,16 @@ FROM (
               , subq_21.booking__paid_at__extract_day
               , subq_21.booking__paid_at__extract_dow
               , subq_21.booking__paid_at__extract_doy
+              , subq_21.metric_time__week
+              , subq_21.metric_time__month
+              , subq_21.metric_time__quarter
+              , subq_21.metric_time__year
+              , subq_21.metric_time__extract_year
+              , subq_21.metric_time__extract_quarter
+              , subq_21.metric_time__extract_month
+              , subq_21.metric_time__extract_day
+              , subq_21.metric_time__extract_dow
+              , subq_21.metric_time__extract_doy
               , subq_21.listing
               , subq_21.guest
               , subq_21.host
@@ -736,16 +736,6 @@ FROM (
               SELECT
                 subq_20.country_latest AS listing__country_latest
                 , subq_17.metric_time__day AS metric_time__day
-                , subq_17.metric_time__week AS metric_time__week
-                , subq_17.metric_time__month AS metric_time__month
-                , subq_17.metric_time__quarter AS metric_time__quarter
-                , subq_17.metric_time__year AS metric_time__year
-                , subq_17.metric_time__extract_year AS metric_time__extract_year
-                , subq_17.metric_time__extract_quarter AS metric_time__extract_quarter
-                , subq_17.metric_time__extract_month AS metric_time__extract_month
-                , subq_17.metric_time__extract_day AS metric_time__extract_day
-                , subq_17.metric_time__extract_dow AS metric_time__extract_dow
-                , subq_17.metric_time__extract_doy AS metric_time__extract_doy
                 , subq_17.ds__day AS ds__day
                 , subq_17.ds__week AS ds__week
                 , subq_17.ds__month AS ds__month
@@ -812,6 +802,16 @@ FROM (
                 , subq_17.booking__paid_at__extract_day AS booking__paid_at__extract_day
                 , subq_17.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
                 , subq_17.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                , subq_17.metric_time__week AS metric_time__week
+                , subq_17.metric_time__month AS metric_time__month
+                , subq_17.metric_time__quarter AS metric_time__quarter
+                , subq_17.metric_time__year AS metric_time__year
+                , subq_17.metric_time__extract_year AS metric_time__extract_year
+                , subq_17.metric_time__extract_quarter AS metric_time__extract_quarter
+                , subq_17.metric_time__extract_month AS metric_time__extract_month
+                , subq_17.metric_time__extract_day AS metric_time__extract_day
+                , subq_17.metric_time__extract_dow AS metric_time__extract_dow
+                , subq_17.metric_time__extract_doy AS metric_time__extract_doy
                 , subq_17.listing AS listing
                 , subq_17.guest AS guest
                 , subq_17.host AS host
@@ -837,16 +837,6 @@ FROM (
                 -- Join to Time Spine Dataset
                 SELECT
                   subq_15.metric_time__day AS metric_time__day
-                  , DATE_TRUNC('week', subq_15.metric_time__day) AS metric_time__week
-                  , DATE_TRUNC('month', subq_15.metric_time__day) AS metric_time__month
-                  , DATE_TRUNC('quarter', subq_15.metric_time__day) AS metric_time__quarter
-                  , DATE_TRUNC('year', subq_15.metric_time__day) AS metric_time__year
-                  , EXTRACT(year FROM subq_15.metric_time__day) AS metric_time__extract_year
-                  , EXTRACT(quarter FROM subq_15.metric_time__day) AS metric_time__extract_quarter
-                  , EXTRACT(month FROM subq_15.metric_time__day) AS metric_time__extract_month
-                  , EXTRACT(day FROM subq_15.metric_time__day) AS metric_time__extract_day
-                  , EXTRACT(DAYOFWEEK_ISO FROM subq_15.metric_time__day) AS metric_time__extract_dow
-                  , EXTRACT(doy FROM subq_15.metric_time__day) AS metric_time__extract_doy
                   , subq_14.ds__day AS ds__day
                   , subq_14.ds__week AS ds__week
                   , subq_14.ds__month AS ds__month
@@ -913,6 +903,16 @@ FROM (
                   , subq_14.booking__paid_at__extract_day AS booking__paid_at__extract_day
                   , subq_14.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
                   , subq_14.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                  , subq_14.metric_time__week AS metric_time__week
+                  , subq_14.metric_time__month AS metric_time__month
+                  , subq_14.metric_time__quarter AS metric_time__quarter
+                  , subq_14.metric_time__year AS metric_time__year
+                  , subq_14.metric_time__extract_year AS metric_time__extract_year
+                  , subq_14.metric_time__extract_quarter AS metric_time__extract_quarter
+                  , subq_14.metric_time__extract_month AS metric_time__extract_month
+                  , subq_14.metric_time__extract_day AS metric_time__extract_day
+                  , subq_14.metric_time__extract_dow AS metric_time__extract_dow
+                  , subq_14.metric_time__extract_doy AS metric_time__extract_doy
                   , subq_14.listing AS listing
                   , subq_14.guest AS guest
                   , subq_14.host AS host

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_offset_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_offset_metric_with_query_time_filters__plan0.sql
@@ -606,16 +606,6 @@ FROM (
           -- Constrain Output with WHERE
           SELECT
             subq_18.metric_time__day
-            , subq_18.metric_time__week
-            , subq_18.metric_time__month
-            , subq_18.metric_time__quarter
-            , subq_18.metric_time__year
-            , subq_18.metric_time__extract_year
-            , subq_18.metric_time__extract_quarter
-            , subq_18.metric_time__extract_month
-            , subq_18.metric_time__extract_day
-            , subq_18.metric_time__extract_dow
-            , subq_18.metric_time__extract_doy
             , subq_18.ds__day
             , subq_18.ds__week
             , subq_18.ds__month
@@ -682,6 +672,16 @@ FROM (
             , subq_18.booking__paid_at__extract_day
             , subq_18.booking__paid_at__extract_dow
             , subq_18.booking__paid_at__extract_doy
+            , subq_18.metric_time__week
+            , subq_18.metric_time__month
+            , subq_18.metric_time__quarter
+            , subq_18.metric_time__year
+            , subq_18.metric_time__extract_year
+            , subq_18.metric_time__extract_quarter
+            , subq_18.metric_time__extract_month
+            , subq_18.metric_time__extract_day
+            , subq_18.metric_time__extract_dow
+            , subq_18.metric_time__extract_doy
             , subq_18.listing
             , subq_18.guest
             , subq_18.host
@@ -709,16 +709,6 @@ FROM (
             SELECT
               subq_17.country_latest AS listing__country_latest
               , subq_14.metric_time__day AS metric_time__day
-              , subq_14.metric_time__week AS metric_time__week
-              , subq_14.metric_time__month AS metric_time__month
-              , subq_14.metric_time__quarter AS metric_time__quarter
-              , subq_14.metric_time__year AS metric_time__year
-              , subq_14.metric_time__extract_year AS metric_time__extract_year
-              , subq_14.metric_time__extract_quarter AS metric_time__extract_quarter
-              , subq_14.metric_time__extract_month AS metric_time__extract_month
-              , subq_14.metric_time__extract_day AS metric_time__extract_day
-              , subq_14.metric_time__extract_dow AS metric_time__extract_dow
-              , subq_14.metric_time__extract_doy AS metric_time__extract_doy
               , subq_14.ds__day AS ds__day
               , subq_14.ds__week AS ds__week
               , subq_14.ds__month AS ds__month
@@ -785,6 +775,16 @@ FROM (
               , subq_14.booking__paid_at__extract_day AS booking__paid_at__extract_day
               , subq_14.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
               , subq_14.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+              , subq_14.metric_time__week AS metric_time__week
+              , subq_14.metric_time__month AS metric_time__month
+              , subq_14.metric_time__quarter AS metric_time__quarter
+              , subq_14.metric_time__year AS metric_time__year
+              , subq_14.metric_time__extract_year AS metric_time__extract_year
+              , subq_14.metric_time__extract_quarter AS metric_time__extract_quarter
+              , subq_14.metric_time__extract_month AS metric_time__extract_month
+              , subq_14.metric_time__extract_day AS metric_time__extract_day
+              , subq_14.metric_time__extract_dow AS metric_time__extract_dow
+              , subq_14.metric_time__extract_doy AS metric_time__extract_doy
               , subq_14.listing AS listing
               , subq_14.guest AS guest
               , subq_14.host AS host
@@ -810,16 +810,6 @@ FROM (
               -- Join to Time Spine Dataset
               SELECT
                 subq_12.metric_time__day AS metric_time__day
-                , DATE_TRUNC('week', subq_12.metric_time__day) AS metric_time__week
-                , DATE_TRUNC('month', subq_12.metric_time__day) AS metric_time__month
-                , DATE_TRUNC('quarter', subq_12.metric_time__day) AS metric_time__quarter
-                , DATE_TRUNC('year', subq_12.metric_time__day) AS metric_time__year
-                , EXTRACT(year FROM subq_12.metric_time__day) AS metric_time__extract_year
-                , EXTRACT(quarter FROM subq_12.metric_time__day) AS metric_time__extract_quarter
-                , EXTRACT(month FROM subq_12.metric_time__day) AS metric_time__extract_month
-                , EXTRACT(day FROM subq_12.metric_time__day) AS metric_time__extract_day
-                , EXTRACT(DAYOFWEEK_ISO FROM subq_12.metric_time__day) AS metric_time__extract_dow
-                , EXTRACT(doy FROM subq_12.metric_time__day) AS metric_time__extract_doy
                 , subq_11.ds__day AS ds__day
                 , subq_11.ds__week AS ds__week
                 , subq_11.ds__month AS ds__month
@@ -886,6 +876,16 @@ FROM (
                 , subq_11.booking__paid_at__extract_day AS booking__paid_at__extract_day
                 , subq_11.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
                 , subq_11.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                , subq_11.metric_time__week AS metric_time__week
+                , subq_11.metric_time__month AS metric_time__month
+                , subq_11.metric_time__quarter AS metric_time__quarter
+                , subq_11.metric_time__year AS metric_time__year
+                , subq_11.metric_time__extract_year AS metric_time__extract_year
+                , subq_11.metric_time__extract_quarter AS metric_time__extract_quarter
+                , subq_11.metric_time__extract_month AS metric_time__extract_month
+                , subq_11.metric_time__extract_day AS metric_time__extract_day
+                , subq_11.metric_time__extract_dow AS metric_time__extract_dow
+                , subq_11.metric_time__extract_doy AS metric_time__extract_doy
                 , subq_11.listing AS listing
                 , subq_11.guest AS guest
                 , subq_11.host AS host

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
@@ -633,16 +633,6 @@ FROM (
             -- Constrain Output with WHERE
             SELECT
               subq_21.metric_time__day
-              , subq_21.metric_time__week
-              , subq_21.metric_time__month
-              , subq_21.metric_time__quarter
-              , subq_21.metric_time__year
-              , subq_21.metric_time__extract_year
-              , subq_21.metric_time__extract_quarter
-              , subq_21.metric_time__extract_month
-              , subq_21.metric_time__extract_day
-              , subq_21.metric_time__extract_dow
-              , subq_21.metric_time__extract_doy
               , subq_21.ds__day
               , subq_21.ds__week
               , subq_21.ds__month
@@ -709,6 +699,16 @@ FROM (
               , subq_21.booking__paid_at__extract_day
               , subq_21.booking__paid_at__extract_dow
               , subq_21.booking__paid_at__extract_doy
+              , subq_21.metric_time__week
+              , subq_21.metric_time__month
+              , subq_21.metric_time__quarter
+              , subq_21.metric_time__year
+              , subq_21.metric_time__extract_year
+              , subq_21.metric_time__extract_quarter
+              , subq_21.metric_time__extract_month
+              , subq_21.metric_time__extract_day
+              , subq_21.metric_time__extract_dow
+              , subq_21.metric_time__extract_doy
               , subq_21.listing
               , subq_21.guest
               , subq_21.host
@@ -736,16 +736,6 @@ FROM (
               SELECT
                 subq_20.country_latest AS listing__country_latest
                 , subq_17.metric_time__day AS metric_time__day
-                , subq_17.metric_time__week AS metric_time__week
-                , subq_17.metric_time__month AS metric_time__month
-                , subq_17.metric_time__quarter AS metric_time__quarter
-                , subq_17.metric_time__year AS metric_time__year
-                , subq_17.metric_time__extract_year AS metric_time__extract_year
-                , subq_17.metric_time__extract_quarter AS metric_time__extract_quarter
-                , subq_17.metric_time__extract_month AS metric_time__extract_month
-                , subq_17.metric_time__extract_day AS metric_time__extract_day
-                , subq_17.metric_time__extract_dow AS metric_time__extract_dow
-                , subq_17.metric_time__extract_doy AS metric_time__extract_doy
                 , subq_17.ds__day AS ds__day
                 , subq_17.ds__week AS ds__week
                 , subq_17.ds__month AS ds__month
@@ -812,6 +802,16 @@ FROM (
                 , subq_17.booking__paid_at__extract_day AS booking__paid_at__extract_day
                 , subq_17.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
                 , subq_17.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                , subq_17.metric_time__week AS metric_time__week
+                , subq_17.metric_time__month AS metric_time__month
+                , subq_17.metric_time__quarter AS metric_time__quarter
+                , subq_17.metric_time__year AS metric_time__year
+                , subq_17.metric_time__extract_year AS metric_time__extract_year
+                , subq_17.metric_time__extract_quarter AS metric_time__extract_quarter
+                , subq_17.metric_time__extract_month AS metric_time__extract_month
+                , subq_17.metric_time__extract_day AS metric_time__extract_day
+                , subq_17.metric_time__extract_dow AS metric_time__extract_dow
+                , subq_17.metric_time__extract_doy AS metric_time__extract_doy
                 , subq_17.listing AS listing
                 , subq_17.guest AS guest
                 , subq_17.host AS host
@@ -837,16 +837,6 @@ FROM (
                 -- Join to Time Spine Dataset
                 SELECT
                   subq_15.metric_time__day AS metric_time__day
-                  , DATE_TRUNC('week', subq_15.metric_time__day) AS metric_time__week
-                  , DATE_TRUNC('month', subq_15.metric_time__day) AS metric_time__month
-                  , DATE_TRUNC('quarter', subq_15.metric_time__day) AS metric_time__quarter
-                  , DATE_TRUNC('year', subq_15.metric_time__day) AS metric_time__year
-                  , EXTRACT(year FROM subq_15.metric_time__day) AS metric_time__extract_year
-                  , EXTRACT(quarter FROM subq_15.metric_time__day) AS metric_time__extract_quarter
-                  , EXTRACT(month FROM subq_15.metric_time__day) AS metric_time__extract_month
-                  , EXTRACT(day FROM subq_15.metric_time__day) AS metric_time__extract_day
-                  , EXTRACT(isodow FROM subq_15.metric_time__day) AS metric_time__extract_dow
-                  , EXTRACT(doy FROM subq_15.metric_time__day) AS metric_time__extract_doy
                   , subq_14.ds__day AS ds__day
                   , subq_14.ds__week AS ds__week
                   , subq_14.ds__month AS ds__month
@@ -913,6 +903,16 @@ FROM (
                   , subq_14.booking__paid_at__extract_day AS booking__paid_at__extract_day
                   , subq_14.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
                   , subq_14.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                  , subq_14.metric_time__week AS metric_time__week
+                  , subq_14.metric_time__month AS metric_time__month
+                  , subq_14.metric_time__quarter AS metric_time__quarter
+                  , subq_14.metric_time__year AS metric_time__year
+                  , subq_14.metric_time__extract_year AS metric_time__extract_year
+                  , subq_14.metric_time__extract_quarter AS metric_time__extract_quarter
+                  , subq_14.metric_time__extract_month AS metric_time__extract_month
+                  , subq_14.metric_time__extract_day AS metric_time__extract_day
+                  , subq_14.metric_time__extract_dow AS metric_time__extract_dow
+                  , subq_14.metric_time__extract_doy AS metric_time__extract_doy
                   , subq_14.listing AS listing
                   , subq_14.guest AS guest
                   , subq_14.host AS host

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_offset_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_offset_metric_with_query_time_filters__plan0.sql
@@ -606,16 +606,6 @@ FROM (
           -- Constrain Output with WHERE
           SELECT
             subq_18.metric_time__day
-            , subq_18.metric_time__week
-            , subq_18.metric_time__month
-            , subq_18.metric_time__quarter
-            , subq_18.metric_time__year
-            , subq_18.metric_time__extract_year
-            , subq_18.metric_time__extract_quarter
-            , subq_18.metric_time__extract_month
-            , subq_18.metric_time__extract_day
-            , subq_18.metric_time__extract_dow
-            , subq_18.metric_time__extract_doy
             , subq_18.ds__day
             , subq_18.ds__week
             , subq_18.ds__month
@@ -682,6 +672,16 @@ FROM (
             , subq_18.booking__paid_at__extract_day
             , subq_18.booking__paid_at__extract_dow
             , subq_18.booking__paid_at__extract_doy
+            , subq_18.metric_time__week
+            , subq_18.metric_time__month
+            , subq_18.metric_time__quarter
+            , subq_18.metric_time__year
+            , subq_18.metric_time__extract_year
+            , subq_18.metric_time__extract_quarter
+            , subq_18.metric_time__extract_month
+            , subq_18.metric_time__extract_day
+            , subq_18.metric_time__extract_dow
+            , subq_18.metric_time__extract_doy
             , subq_18.listing
             , subq_18.guest
             , subq_18.host
@@ -709,16 +709,6 @@ FROM (
             SELECT
               subq_17.country_latest AS listing__country_latest
               , subq_14.metric_time__day AS metric_time__day
-              , subq_14.metric_time__week AS metric_time__week
-              , subq_14.metric_time__month AS metric_time__month
-              , subq_14.metric_time__quarter AS metric_time__quarter
-              , subq_14.metric_time__year AS metric_time__year
-              , subq_14.metric_time__extract_year AS metric_time__extract_year
-              , subq_14.metric_time__extract_quarter AS metric_time__extract_quarter
-              , subq_14.metric_time__extract_month AS metric_time__extract_month
-              , subq_14.metric_time__extract_day AS metric_time__extract_day
-              , subq_14.metric_time__extract_dow AS metric_time__extract_dow
-              , subq_14.metric_time__extract_doy AS metric_time__extract_doy
               , subq_14.ds__day AS ds__day
               , subq_14.ds__week AS ds__week
               , subq_14.ds__month AS ds__month
@@ -785,6 +775,16 @@ FROM (
               , subq_14.booking__paid_at__extract_day AS booking__paid_at__extract_day
               , subq_14.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
               , subq_14.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+              , subq_14.metric_time__week AS metric_time__week
+              , subq_14.metric_time__month AS metric_time__month
+              , subq_14.metric_time__quarter AS metric_time__quarter
+              , subq_14.metric_time__year AS metric_time__year
+              , subq_14.metric_time__extract_year AS metric_time__extract_year
+              , subq_14.metric_time__extract_quarter AS metric_time__extract_quarter
+              , subq_14.metric_time__extract_month AS metric_time__extract_month
+              , subq_14.metric_time__extract_day AS metric_time__extract_day
+              , subq_14.metric_time__extract_dow AS metric_time__extract_dow
+              , subq_14.metric_time__extract_doy AS metric_time__extract_doy
               , subq_14.listing AS listing
               , subq_14.guest AS guest
               , subq_14.host AS host
@@ -810,16 +810,6 @@ FROM (
               -- Join to Time Spine Dataset
               SELECT
                 subq_12.metric_time__day AS metric_time__day
-                , DATE_TRUNC('week', subq_12.metric_time__day) AS metric_time__week
-                , DATE_TRUNC('month', subq_12.metric_time__day) AS metric_time__month
-                , DATE_TRUNC('quarter', subq_12.metric_time__day) AS metric_time__quarter
-                , DATE_TRUNC('year', subq_12.metric_time__day) AS metric_time__year
-                , EXTRACT(year FROM subq_12.metric_time__day) AS metric_time__extract_year
-                , EXTRACT(quarter FROM subq_12.metric_time__day) AS metric_time__extract_quarter
-                , EXTRACT(month FROM subq_12.metric_time__day) AS metric_time__extract_month
-                , EXTRACT(day FROM subq_12.metric_time__day) AS metric_time__extract_day
-                , EXTRACT(isodow FROM subq_12.metric_time__day) AS metric_time__extract_dow
-                , EXTRACT(doy FROM subq_12.metric_time__day) AS metric_time__extract_doy
                 , subq_11.ds__day AS ds__day
                 , subq_11.ds__week AS ds__week
                 , subq_11.ds__month AS ds__month
@@ -886,6 +876,16 @@ FROM (
                 , subq_11.booking__paid_at__extract_day AS booking__paid_at__extract_day
                 , subq_11.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
                 , subq_11.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                , subq_11.metric_time__week AS metric_time__week
+                , subq_11.metric_time__month AS metric_time__month
+                , subq_11.metric_time__quarter AS metric_time__quarter
+                , subq_11.metric_time__year AS metric_time__year
+                , subq_11.metric_time__extract_year AS metric_time__extract_year
+                , subq_11.metric_time__extract_quarter AS metric_time__extract_quarter
+                , subq_11.metric_time__extract_month AS metric_time__extract_month
+                , subq_11.metric_time__extract_day AS metric_time__extract_day
+                , subq_11.metric_time__extract_dow AS metric_time__extract_dow
+                , subq_11.metric_time__extract_doy AS metric_time__extract_doy
                 , subq_11.listing AS listing
                 , subq_11.guest AS guest
                 , subq_11.host AS host

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
@@ -633,16 +633,6 @@ FROM (
             -- Constrain Output with WHERE
             SELECT
               subq_21.metric_time__day
-              , subq_21.metric_time__week
-              , subq_21.metric_time__month
-              , subq_21.metric_time__quarter
-              , subq_21.metric_time__year
-              , subq_21.metric_time__extract_year
-              , subq_21.metric_time__extract_quarter
-              , subq_21.metric_time__extract_month
-              , subq_21.metric_time__extract_day
-              , subq_21.metric_time__extract_dow
-              , subq_21.metric_time__extract_doy
               , subq_21.ds__day
               , subq_21.ds__week
               , subq_21.ds__month
@@ -709,6 +699,16 @@ FROM (
               , subq_21.booking__paid_at__extract_day
               , subq_21.booking__paid_at__extract_dow
               , subq_21.booking__paid_at__extract_doy
+              , subq_21.metric_time__week
+              , subq_21.metric_time__month
+              , subq_21.metric_time__quarter
+              , subq_21.metric_time__year
+              , subq_21.metric_time__extract_year
+              , subq_21.metric_time__extract_quarter
+              , subq_21.metric_time__extract_month
+              , subq_21.metric_time__extract_day
+              , subq_21.metric_time__extract_dow
+              , subq_21.metric_time__extract_doy
               , subq_21.listing
               , subq_21.guest
               , subq_21.host
@@ -736,16 +736,6 @@ FROM (
               SELECT
                 subq_20.country_latest AS listing__country_latest
                 , subq_17.metric_time__day AS metric_time__day
-                , subq_17.metric_time__week AS metric_time__week
-                , subq_17.metric_time__month AS metric_time__month
-                , subq_17.metric_time__quarter AS metric_time__quarter
-                , subq_17.metric_time__year AS metric_time__year
-                , subq_17.metric_time__extract_year AS metric_time__extract_year
-                , subq_17.metric_time__extract_quarter AS metric_time__extract_quarter
-                , subq_17.metric_time__extract_month AS metric_time__extract_month
-                , subq_17.metric_time__extract_day AS metric_time__extract_day
-                , subq_17.metric_time__extract_dow AS metric_time__extract_dow
-                , subq_17.metric_time__extract_doy AS metric_time__extract_doy
                 , subq_17.ds__day AS ds__day
                 , subq_17.ds__week AS ds__week
                 , subq_17.ds__month AS ds__month
@@ -812,6 +802,16 @@ FROM (
                 , subq_17.booking__paid_at__extract_day AS booking__paid_at__extract_day
                 , subq_17.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
                 , subq_17.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                , subq_17.metric_time__week AS metric_time__week
+                , subq_17.metric_time__month AS metric_time__month
+                , subq_17.metric_time__quarter AS metric_time__quarter
+                , subq_17.metric_time__year AS metric_time__year
+                , subq_17.metric_time__extract_year AS metric_time__extract_year
+                , subq_17.metric_time__extract_quarter AS metric_time__extract_quarter
+                , subq_17.metric_time__extract_month AS metric_time__extract_month
+                , subq_17.metric_time__extract_day AS metric_time__extract_day
+                , subq_17.metric_time__extract_dow AS metric_time__extract_dow
+                , subq_17.metric_time__extract_doy AS metric_time__extract_doy
                 , subq_17.listing AS listing
                 , subq_17.guest AS guest
                 , subq_17.host AS host
@@ -837,16 +837,6 @@ FROM (
                 -- Join to Time Spine Dataset
                 SELECT
                   subq_15.metric_time__day AS metric_time__day
-                  , DATE_TRUNC('week', subq_15.metric_time__day) AS metric_time__week
-                  , DATE_TRUNC('month', subq_15.metric_time__day) AS metric_time__month
-                  , DATE_TRUNC('quarter', subq_15.metric_time__day) AS metric_time__quarter
-                  , DATE_TRUNC('year', subq_15.metric_time__day) AS metric_time__year
-                  , EXTRACT(year FROM subq_15.metric_time__day) AS metric_time__extract_year
-                  , EXTRACT(quarter FROM subq_15.metric_time__day) AS metric_time__extract_quarter
-                  , EXTRACT(month FROM subq_15.metric_time__day) AS metric_time__extract_month
-                  , EXTRACT(day FROM subq_15.metric_time__day) AS metric_time__extract_day
-                  , EXTRACT(isodow FROM subq_15.metric_time__day) AS metric_time__extract_dow
-                  , EXTRACT(doy FROM subq_15.metric_time__day) AS metric_time__extract_doy
                   , subq_14.ds__day AS ds__day
                   , subq_14.ds__week AS ds__week
                   , subq_14.ds__month AS ds__month
@@ -913,6 +903,16 @@ FROM (
                   , subq_14.booking__paid_at__extract_day AS booking__paid_at__extract_day
                   , subq_14.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
                   , subq_14.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                  , subq_14.metric_time__week AS metric_time__week
+                  , subq_14.metric_time__month AS metric_time__month
+                  , subq_14.metric_time__quarter AS metric_time__quarter
+                  , subq_14.metric_time__year AS metric_time__year
+                  , subq_14.metric_time__extract_year AS metric_time__extract_year
+                  , subq_14.metric_time__extract_quarter AS metric_time__extract_quarter
+                  , subq_14.metric_time__extract_month AS metric_time__extract_month
+                  , subq_14.metric_time__extract_day AS metric_time__extract_day
+                  , subq_14.metric_time__extract_dow AS metric_time__extract_dow
+                  , subq_14.metric_time__extract_doy AS metric_time__extract_doy
                   , subq_14.listing AS listing
                   , subq_14.guest AS guest
                   , subq_14.host AS host

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_offset_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_offset_metric_with_query_time_filters__plan0.sql
@@ -606,16 +606,6 @@ FROM (
           -- Constrain Output with WHERE
           SELECT
             subq_18.metric_time__day
-            , subq_18.metric_time__week
-            , subq_18.metric_time__month
-            , subq_18.metric_time__quarter
-            , subq_18.metric_time__year
-            , subq_18.metric_time__extract_year
-            , subq_18.metric_time__extract_quarter
-            , subq_18.metric_time__extract_month
-            , subq_18.metric_time__extract_day
-            , subq_18.metric_time__extract_dow
-            , subq_18.metric_time__extract_doy
             , subq_18.ds__day
             , subq_18.ds__week
             , subq_18.ds__month
@@ -682,6 +672,16 @@ FROM (
             , subq_18.booking__paid_at__extract_day
             , subq_18.booking__paid_at__extract_dow
             , subq_18.booking__paid_at__extract_doy
+            , subq_18.metric_time__week
+            , subq_18.metric_time__month
+            , subq_18.metric_time__quarter
+            , subq_18.metric_time__year
+            , subq_18.metric_time__extract_year
+            , subq_18.metric_time__extract_quarter
+            , subq_18.metric_time__extract_month
+            , subq_18.metric_time__extract_day
+            , subq_18.metric_time__extract_dow
+            , subq_18.metric_time__extract_doy
             , subq_18.listing
             , subq_18.guest
             , subq_18.host
@@ -709,16 +709,6 @@ FROM (
             SELECT
               subq_17.country_latest AS listing__country_latest
               , subq_14.metric_time__day AS metric_time__day
-              , subq_14.metric_time__week AS metric_time__week
-              , subq_14.metric_time__month AS metric_time__month
-              , subq_14.metric_time__quarter AS metric_time__quarter
-              , subq_14.metric_time__year AS metric_time__year
-              , subq_14.metric_time__extract_year AS metric_time__extract_year
-              , subq_14.metric_time__extract_quarter AS metric_time__extract_quarter
-              , subq_14.metric_time__extract_month AS metric_time__extract_month
-              , subq_14.metric_time__extract_day AS metric_time__extract_day
-              , subq_14.metric_time__extract_dow AS metric_time__extract_dow
-              , subq_14.metric_time__extract_doy AS metric_time__extract_doy
               , subq_14.ds__day AS ds__day
               , subq_14.ds__week AS ds__week
               , subq_14.ds__month AS ds__month
@@ -785,6 +775,16 @@ FROM (
               , subq_14.booking__paid_at__extract_day AS booking__paid_at__extract_day
               , subq_14.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
               , subq_14.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+              , subq_14.metric_time__week AS metric_time__week
+              , subq_14.metric_time__month AS metric_time__month
+              , subq_14.metric_time__quarter AS metric_time__quarter
+              , subq_14.metric_time__year AS metric_time__year
+              , subq_14.metric_time__extract_year AS metric_time__extract_year
+              , subq_14.metric_time__extract_quarter AS metric_time__extract_quarter
+              , subq_14.metric_time__extract_month AS metric_time__extract_month
+              , subq_14.metric_time__extract_day AS metric_time__extract_day
+              , subq_14.metric_time__extract_dow AS metric_time__extract_dow
+              , subq_14.metric_time__extract_doy AS metric_time__extract_doy
               , subq_14.listing AS listing
               , subq_14.guest AS guest
               , subq_14.host AS host
@@ -810,16 +810,6 @@ FROM (
               -- Join to Time Spine Dataset
               SELECT
                 subq_12.metric_time__day AS metric_time__day
-                , DATE_TRUNC('week', subq_12.metric_time__day) AS metric_time__week
-                , DATE_TRUNC('month', subq_12.metric_time__day) AS metric_time__month
-                , DATE_TRUNC('quarter', subq_12.metric_time__day) AS metric_time__quarter
-                , DATE_TRUNC('year', subq_12.metric_time__day) AS metric_time__year
-                , EXTRACT(year FROM subq_12.metric_time__day) AS metric_time__extract_year
-                , EXTRACT(quarter FROM subq_12.metric_time__day) AS metric_time__extract_quarter
-                , EXTRACT(month FROM subq_12.metric_time__day) AS metric_time__extract_month
-                , EXTRACT(day FROM subq_12.metric_time__day) AS metric_time__extract_day
-                , EXTRACT(isodow FROM subq_12.metric_time__day) AS metric_time__extract_dow
-                , EXTRACT(doy FROM subq_12.metric_time__day) AS metric_time__extract_doy
                 , subq_11.ds__day AS ds__day
                 , subq_11.ds__week AS ds__week
                 , subq_11.ds__month AS ds__month
@@ -886,6 +876,16 @@ FROM (
                 , subq_11.booking__paid_at__extract_day AS booking__paid_at__extract_day
                 , subq_11.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
                 , subq_11.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                , subq_11.metric_time__week AS metric_time__week
+                , subq_11.metric_time__month AS metric_time__month
+                , subq_11.metric_time__quarter AS metric_time__quarter
+                , subq_11.metric_time__year AS metric_time__year
+                , subq_11.metric_time__extract_year AS metric_time__extract_year
+                , subq_11.metric_time__extract_quarter AS metric_time__extract_quarter
+                , subq_11.metric_time__extract_month AS metric_time__extract_month
+                , subq_11.metric_time__extract_day AS metric_time__extract_day
+                , subq_11.metric_time__extract_dow AS metric_time__extract_dow
+                , subq_11.metric_time__extract_doy AS metric_time__extract_doy
                 , subq_11.listing AS listing
                 , subq_11.guest AS guest
                 , subq_11.host AS host

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
@@ -633,16 +633,6 @@ FROM (
             -- Constrain Output with WHERE
             SELECT
               subq_21.metric_time__day
-              , subq_21.metric_time__week
-              , subq_21.metric_time__month
-              , subq_21.metric_time__quarter
-              , subq_21.metric_time__year
-              , subq_21.metric_time__extract_year
-              , subq_21.metric_time__extract_quarter
-              , subq_21.metric_time__extract_month
-              , subq_21.metric_time__extract_day
-              , subq_21.metric_time__extract_dow
-              , subq_21.metric_time__extract_doy
               , subq_21.ds__day
               , subq_21.ds__week
               , subq_21.ds__month
@@ -709,6 +699,16 @@ FROM (
               , subq_21.booking__paid_at__extract_day
               , subq_21.booking__paid_at__extract_dow
               , subq_21.booking__paid_at__extract_doy
+              , subq_21.metric_time__week
+              , subq_21.metric_time__month
+              , subq_21.metric_time__quarter
+              , subq_21.metric_time__year
+              , subq_21.metric_time__extract_year
+              , subq_21.metric_time__extract_quarter
+              , subq_21.metric_time__extract_month
+              , subq_21.metric_time__extract_day
+              , subq_21.metric_time__extract_dow
+              , subq_21.metric_time__extract_doy
               , subq_21.listing
               , subq_21.guest
               , subq_21.host
@@ -736,16 +736,6 @@ FROM (
               SELECT
                 subq_20.country_latest AS listing__country_latest
                 , subq_17.metric_time__day AS metric_time__day
-                , subq_17.metric_time__week AS metric_time__week
-                , subq_17.metric_time__month AS metric_time__month
-                , subq_17.metric_time__quarter AS metric_time__quarter
-                , subq_17.metric_time__year AS metric_time__year
-                , subq_17.metric_time__extract_year AS metric_time__extract_year
-                , subq_17.metric_time__extract_quarter AS metric_time__extract_quarter
-                , subq_17.metric_time__extract_month AS metric_time__extract_month
-                , subq_17.metric_time__extract_day AS metric_time__extract_day
-                , subq_17.metric_time__extract_dow AS metric_time__extract_dow
-                , subq_17.metric_time__extract_doy AS metric_time__extract_doy
                 , subq_17.ds__day AS ds__day
                 , subq_17.ds__week AS ds__week
                 , subq_17.ds__month AS ds__month
@@ -812,6 +802,16 @@ FROM (
                 , subq_17.booking__paid_at__extract_day AS booking__paid_at__extract_day
                 , subq_17.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
                 , subq_17.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                , subq_17.metric_time__week AS metric_time__week
+                , subq_17.metric_time__month AS metric_time__month
+                , subq_17.metric_time__quarter AS metric_time__quarter
+                , subq_17.metric_time__year AS metric_time__year
+                , subq_17.metric_time__extract_year AS metric_time__extract_year
+                , subq_17.metric_time__extract_quarter AS metric_time__extract_quarter
+                , subq_17.metric_time__extract_month AS metric_time__extract_month
+                , subq_17.metric_time__extract_day AS metric_time__extract_day
+                , subq_17.metric_time__extract_dow AS metric_time__extract_dow
+                , subq_17.metric_time__extract_doy AS metric_time__extract_doy
                 , subq_17.listing AS listing
                 , subq_17.guest AS guest
                 , subq_17.host AS host
@@ -837,16 +837,6 @@ FROM (
                 -- Join to Time Spine Dataset
                 SELECT
                   subq_15.metric_time__day AS metric_time__day
-                  , DATE_TRUNC('week', subq_15.metric_time__day) AS metric_time__week
-                  , DATE_TRUNC('month', subq_15.metric_time__day) AS metric_time__month
-                  , DATE_TRUNC('quarter', subq_15.metric_time__day) AS metric_time__quarter
-                  , DATE_TRUNC('year', subq_15.metric_time__day) AS metric_time__year
-                  , EXTRACT(year FROM subq_15.metric_time__day) AS metric_time__extract_year
-                  , EXTRACT(quarter FROM subq_15.metric_time__day) AS metric_time__extract_quarter
-                  , EXTRACT(month FROM subq_15.metric_time__day) AS metric_time__extract_month
-                  , EXTRACT(day FROM subq_15.metric_time__day) AS metric_time__extract_day
-                  , CASE WHEN EXTRACT(dow FROM subq_15.metric_time__day) = 0 THEN EXTRACT(dow FROM subq_15.metric_time__day) + 7 ELSE EXTRACT(dow FROM subq_15.metric_time__day) END AS metric_time__extract_dow
-                  , EXTRACT(doy FROM subq_15.metric_time__day) AS metric_time__extract_doy
                   , subq_14.ds__day AS ds__day
                   , subq_14.ds__week AS ds__week
                   , subq_14.ds__month AS ds__month
@@ -913,6 +903,16 @@ FROM (
                   , subq_14.booking__paid_at__extract_day AS booking__paid_at__extract_day
                   , subq_14.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
                   , subq_14.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                  , subq_14.metric_time__week AS metric_time__week
+                  , subq_14.metric_time__month AS metric_time__month
+                  , subq_14.metric_time__quarter AS metric_time__quarter
+                  , subq_14.metric_time__year AS metric_time__year
+                  , subq_14.metric_time__extract_year AS metric_time__extract_year
+                  , subq_14.metric_time__extract_quarter AS metric_time__extract_quarter
+                  , subq_14.metric_time__extract_month AS metric_time__extract_month
+                  , subq_14.metric_time__extract_day AS metric_time__extract_day
+                  , subq_14.metric_time__extract_dow AS metric_time__extract_dow
+                  , subq_14.metric_time__extract_doy AS metric_time__extract_doy
                   , subq_14.listing AS listing
                   , subq_14.guest AS guest
                   , subq_14.host AS host

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_offset_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_offset_metric_with_query_time_filters__plan0.sql
@@ -606,16 +606,6 @@ FROM (
           -- Constrain Output with WHERE
           SELECT
             subq_18.metric_time__day
-            , subq_18.metric_time__week
-            , subq_18.metric_time__month
-            , subq_18.metric_time__quarter
-            , subq_18.metric_time__year
-            , subq_18.metric_time__extract_year
-            , subq_18.metric_time__extract_quarter
-            , subq_18.metric_time__extract_month
-            , subq_18.metric_time__extract_day
-            , subq_18.metric_time__extract_dow
-            , subq_18.metric_time__extract_doy
             , subq_18.ds__day
             , subq_18.ds__week
             , subq_18.ds__month
@@ -682,6 +672,16 @@ FROM (
             , subq_18.booking__paid_at__extract_day
             , subq_18.booking__paid_at__extract_dow
             , subq_18.booking__paid_at__extract_doy
+            , subq_18.metric_time__week
+            , subq_18.metric_time__month
+            , subq_18.metric_time__quarter
+            , subq_18.metric_time__year
+            , subq_18.metric_time__extract_year
+            , subq_18.metric_time__extract_quarter
+            , subq_18.metric_time__extract_month
+            , subq_18.metric_time__extract_day
+            , subq_18.metric_time__extract_dow
+            , subq_18.metric_time__extract_doy
             , subq_18.listing
             , subq_18.guest
             , subq_18.host
@@ -709,16 +709,6 @@ FROM (
             SELECT
               subq_17.country_latest AS listing__country_latest
               , subq_14.metric_time__day AS metric_time__day
-              , subq_14.metric_time__week AS metric_time__week
-              , subq_14.metric_time__month AS metric_time__month
-              , subq_14.metric_time__quarter AS metric_time__quarter
-              , subq_14.metric_time__year AS metric_time__year
-              , subq_14.metric_time__extract_year AS metric_time__extract_year
-              , subq_14.metric_time__extract_quarter AS metric_time__extract_quarter
-              , subq_14.metric_time__extract_month AS metric_time__extract_month
-              , subq_14.metric_time__extract_day AS metric_time__extract_day
-              , subq_14.metric_time__extract_dow AS metric_time__extract_dow
-              , subq_14.metric_time__extract_doy AS metric_time__extract_doy
               , subq_14.ds__day AS ds__day
               , subq_14.ds__week AS ds__week
               , subq_14.ds__month AS ds__month
@@ -785,6 +775,16 @@ FROM (
               , subq_14.booking__paid_at__extract_day AS booking__paid_at__extract_day
               , subq_14.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
               , subq_14.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+              , subq_14.metric_time__week AS metric_time__week
+              , subq_14.metric_time__month AS metric_time__month
+              , subq_14.metric_time__quarter AS metric_time__quarter
+              , subq_14.metric_time__year AS metric_time__year
+              , subq_14.metric_time__extract_year AS metric_time__extract_year
+              , subq_14.metric_time__extract_quarter AS metric_time__extract_quarter
+              , subq_14.metric_time__extract_month AS metric_time__extract_month
+              , subq_14.metric_time__extract_day AS metric_time__extract_day
+              , subq_14.metric_time__extract_dow AS metric_time__extract_dow
+              , subq_14.metric_time__extract_doy AS metric_time__extract_doy
               , subq_14.listing AS listing
               , subq_14.guest AS guest
               , subq_14.host AS host
@@ -810,16 +810,6 @@ FROM (
               -- Join to Time Spine Dataset
               SELECT
                 subq_12.metric_time__day AS metric_time__day
-                , DATE_TRUNC('week', subq_12.metric_time__day) AS metric_time__week
-                , DATE_TRUNC('month', subq_12.metric_time__day) AS metric_time__month
-                , DATE_TRUNC('quarter', subq_12.metric_time__day) AS metric_time__quarter
-                , DATE_TRUNC('year', subq_12.metric_time__day) AS metric_time__year
-                , EXTRACT(year FROM subq_12.metric_time__day) AS metric_time__extract_year
-                , EXTRACT(quarter FROM subq_12.metric_time__day) AS metric_time__extract_quarter
-                , EXTRACT(month FROM subq_12.metric_time__day) AS metric_time__extract_month
-                , EXTRACT(day FROM subq_12.metric_time__day) AS metric_time__extract_day
-                , CASE WHEN EXTRACT(dow FROM subq_12.metric_time__day) = 0 THEN EXTRACT(dow FROM subq_12.metric_time__day) + 7 ELSE EXTRACT(dow FROM subq_12.metric_time__day) END AS metric_time__extract_dow
-                , EXTRACT(doy FROM subq_12.metric_time__day) AS metric_time__extract_doy
                 , subq_11.ds__day AS ds__day
                 , subq_11.ds__week AS ds__week
                 , subq_11.ds__month AS ds__month
@@ -886,6 +876,16 @@ FROM (
                 , subq_11.booking__paid_at__extract_day AS booking__paid_at__extract_day
                 , subq_11.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
                 , subq_11.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                , subq_11.metric_time__week AS metric_time__week
+                , subq_11.metric_time__month AS metric_time__month
+                , subq_11.metric_time__quarter AS metric_time__quarter
+                , subq_11.metric_time__year AS metric_time__year
+                , subq_11.metric_time__extract_year AS metric_time__extract_year
+                , subq_11.metric_time__extract_quarter AS metric_time__extract_quarter
+                , subq_11.metric_time__extract_month AS metric_time__extract_month
+                , subq_11.metric_time__extract_day AS metric_time__extract_day
+                , subq_11.metric_time__extract_dow AS metric_time__extract_dow
+                , subq_11.metric_time__extract_doy AS metric_time__extract_doy
                 , subq_11.listing AS listing
                 , subq_11.guest AS guest
                 , subq_11.host AS host

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
@@ -633,16 +633,6 @@ FROM (
             -- Constrain Output with WHERE
             SELECT
               subq_21.metric_time__day
-              , subq_21.metric_time__week
-              , subq_21.metric_time__month
-              , subq_21.metric_time__quarter
-              , subq_21.metric_time__year
-              , subq_21.metric_time__extract_year
-              , subq_21.metric_time__extract_quarter
-              , subq_21.metric_time__extract_month
-              , subq_21.metric_time__extract_day
-              , subq_21.metric_time__extract_dow
-              , subq_21.metric_time__extract_doy
               , subq_21.ds__day
               , subq_21.ds__week
               , subq_21.ds__month
@@ -709,6 +699,16 @@ FROM (
               , subq_21.booking__paid_at__extract_day
               , subq_21.booking__paid_at__extract_dow
               , subq_21.booking__paid_at__extract_doy
+              , subq_21.metric_time__week
+              , subq_21.metric_time__month
+              , subq_21.metric_time__quarter
+              , subq_21.metric_time__year
+              , subq_21.metric_time__extract_year
+              , subq_21.metric_time__extract_quarter
+              , subq_21.metric_time__extract_month
+              , subq_21.metric_time__extract_day
+              , subq_21.metric_time__extract_dow
+              , subq_21.metric_time__extract_doy
               , subq_21.listing
               , subq_21.guest
               , subq_21.host
@@ -736,16 +736,6 @@ FROM (
               SELECT
                 subq_20.country_latest AS listing__country_latest
                 , subq_17.metric_time__day AS metric_time__day
-                , subq_17.metric_time__week AS metric_time__week
-                , subq_17.metric_time__month AS metric_time__month
-                , subq_17.metric_time__quarter AS metric_time__quarter
-                , subq_17.metric_time__year AS metric_time__year
-                , subq_17.metric_time__extract_year AS metric_time__extract_year
-                , subq_17.metric_time__extract_quarter AS metric_time__extract_quarter
-                , subq_17.metric_time__extract_month AS metric_time__extract_month
-                , subq_17.metric_time__extract_day AS metric_time__extract_day
-                , subq_17.metric_time__extract_dow AS metric_time__extract_dow
-                , subq_17.metric_time__extract_doy AS metric_time__extract_doy
                 , subq_17.ds__day AS ds__day
                 , subq_17.ds__week AS ds__week
                 , subq_17.ds__month AS ds__month
@@ -812,6 +802,16 @@ FROM (
                 , subq_17.booking__paid_at__extract_day AS booking__paid_at__extract_day
                 , subq_17.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
                 , subq_17.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                , subq_17.metric_time__week AS metric_time__week
+                , subq_17.metric_time__month AS metric_time__month
+                , subq_17.metric_time__quarter AS metric_time__quarter
+                , subq_17.metric_time__year AS metric_time__year
+                , subq_17.metric_time__extract_year AS metric_time__extract_year
+                , subq_17.metric_time__extract_quarter AS metric_time__extract_quarter
+                , subq_17.metric_time__extract_month AS metric_time__extract_month
+                , subq_17.metric_time__extract_day AS metric_time__extract_day
+                , subq_17.metric_time__extract_dow AS metric_time__extract_dow
+                , subq_17.metric_time__extract_doy AS metric_time__extract_doy
                 , subq_17.listing AS listing
                 , subq_17.guest AS guest
                 , subq_17.host AS host
@@ -837,16 +837,6 @@ FROM (
                 -- Join to Time Spine Dataset
                 SELECT
                   subq_15.metric_time__day AS metric_time__day
-                  , DATE_TRUNC('week', subq_15.metric_time__day) AS metric_time__week
-                  , DATE_TRUNC('month', subq_15.metric_time__day) AS metric_time__month
-                  , DATE_TRUNC('quarter', subq_15.metric_time__day) AS metric_time__quarter
-                  , DATE_TRUNC('year', subq_15.metric_time__day) AS metric_time__year
-                  , EXTRACT(year FROM subq_15.metric_time__day) AS metric_time__extract_year
-                  , EXTRACT(quarter FROM subq_15.metric_time__day) AS metric_time__extract_quarter
-                  , EXTRACT(month FROM subq_15.metric_time__day) AS metric_time__extract_month
-                  , EXTRACT(day FROM subq_15.metric_time__day) AS metric_time__extract_day
-                  , EXTRACT(dayofweekiso FROM subq_15.metric_time__day) AS metric_time__extract_dow
-                  , EXTRACT(doy FROM subq_15.metric_time__day) AS metric_time__extract_doy
                   , subq_14.ds__day AS ds__day
                   , subq_14.ds__week AS ds__week
                   , subq_14.ds__month AS ds__month
@@ -913,6 +903,16 @@ FROM (
                   , subq_14.booking__paid_at__extract_day AS booking__paid_at__extract_day
                   , subq_14.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
                   , subq_14.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                  , subq_14.metric_time__week AS metric_time__week
+                  , subq_14.metric_time__month AS metric_time__month
+                  , subq_14.metric_time__quarter AS metric_time__quarter
+                  , subq_14.metric_time__year AS metric_time__year
+                  , subq_14.metric_time__extract_year AS metric_time__extract_year
+                  , subq_14.metric_time__extract_quarter AS metric_time__extract_quarter
+                  , subq_14.metric_time__extract_month AS metric_time__extract_month
+                  , subq_14.metric_time__extract_day AS metric_time__extract_day
+                  , subq_14.metric_time__extract_dow AS metric_time__extract_dow
+                  , subq_14.metric_time__extract_doy AS metric_time__extract_doy
                   , subq_14.listing AS listing
                   , subq_14.guest AS guest
                   , subq_14.host AS host

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_offset_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_offset_metric_with_query_time_filters__plan0.sql
@@ -606,16 +606,6 @@ FROM (
           -- Constrain Output with WHERE
           SELECT
             subq_18.metric_time__day
-            , subq_18.metric_time__week
-            , subq_18.metric_time__month
-            , subq_18.metric_time__quarter
-            , subq_18.metric_time__year
-            , subq_18.metric_time__extract_year
-            , subq_18.metric_time__extract_quarter
-            , subq_18.metric_time__extract_month
-            , subq_18.metric_time__extract_day
-            , subq_18.metric_time__extract_dow
-            , subq_18.metric_time__extract_doy
             , subq_18.ds__day
             , subq_18.ds__week
             , subq_18.ds__month
@@ -682,6 +672,16 @@ FROM (
             , subq_18.booking__paid_at__extract_day
             , subq_18.booking__paid_at__extract_dow
             , subq_18.booking__paid_at__extract_doy
+            , subq_18.metric_time__week
+            , subq_18.metric_time__month
+            , subq_18.metric_time__quarter
+            , subq_18.metric_time__year
+            , subq_18.metric_time__extract_year
+            , subq_18.metric_time__extract_quarter
+            , subq_18.metric_time__extract_month
+            , subq_18.metric_time__extract_day
+            , subq_18.metric_time__extract_dow
+            , subq_18.metric_time__extract_doy
             , subq_18.listing
             , subq_18.guest
             , subq_18.host
@@ -709,16 +709,6 @@ FROM (
             SELECT
               subq_17.country_latest AS listing__country_latest
               , subq_14.metric_time__day AS metric_time__day
-              , subq_14.metric_time__week AS metric_time__week
-              , subq_14.metric_time__month AS metric_time__month
-              , subq_14.metric_time__quarter AS metric_time__quarter
-              , subq_14.metric_time__year AS metric_time__year
-              , subq_14.metric_time__extract_year AS metric_time__extract_year
-              , subq_14.metric_time__extract_quarter AS metric_time__extract_quarter
-              , subq_14.metric_time__extract_month AS metric_time__extract_month
-              , subq_14.metric_time__extract_day AS metric_time__extract_day
-              , subq_14.metric_time__extract_dow AS metric_time__extract_dow
-              , subq_14.metric_time__extract_doy AS metric_time__extract_doy
               , subq_14.ds__day AS ds__day
               , subq_14.ds__week AS ds__week
               , subq_14.ds__month AS ds__month
@@ -785,6 +775,16 @@ FROM (
               , subq_14.booking__paid_at__extract_day AS booking__paid_at__extract_day
               , subq_14.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
               , subq_14.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+              , subq_14.metric_time__week AS metric_time__week
+              , subq_14.metric_time__month AS metric_time__month
+              , subq_14.metric_time__quarter AS metric_time__quarter
+              , subq_14.metric_time__year AS metric_time__year
+              , subq_14.metric_time__extract_year AS metric_time__extract_year
+              , subq_14.metric_time__extract_quarter AS metric_time__extract_quarter
+              , subq_14.metric_time__extract_month AS metric_time__extract_month
+              , subq_14.metric_time__extract_day AS metric_time__extract_day
+              , subq_14.metric_time__extract_dow AS metric_time__extract_dow
+              , subq_14.metric_time__extract_doy AS metric_time__extract_doy
               , subq_14.listing AS listing
               , subq_14.guest AS guest
               , subq_14.host AS host
@@ -810,16 +810,6 @@ FROM (
               -- Join to Time Spine Dataset
               SELECT
                 subq_12.metric_time__day AS metric_time__day
-                , DATE_TRUNC('week', subq_12.metric_time__day) AS metric_time__week
-                , DATE_TRUNC('month', subq_12.metric_time__day) AS metric_time__month
-                , DATE_TRUNC('quarter', subq_12.metric_time__day) AS metric_time__quarter
-                , DATE_TRUNC('year', subq_12.metric_time__day) AS metric_time__year
-                , EXTRACT(year FROM subq_12.metric_time__day) AS metric_time__extract_year
-                , EXTRACT(quarter FROM subq_12.metric_time__day) AS metric_time__extract_quarter
-                , EXTRACT(month FROM subq_12.metric_time__day) AS metric_time__extract_month
-                , EXTRACT(day FROM subq_12.metric_time__day) AS metric_time__extract_day
-                , EXTRACT(dayofweekiso FROM subq_12.metric_time__day) AS metric_time__extract_dow
-                , EXTRACT(doy FROM subq_12.metric_time__day) AS metric_time__extract_doy
                 , subq_11.ds__day AS ds__day
                 , subq_11.ds__week AS ds__week
                 , subq_11.ds__month AS ds__month
@@ -886,6 +876,16 @@ FROM (
                 , subq_11.booking__paid_at__extract_day AS booking__paid_at__extract_day
                 , subq_11.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
                 , subq_11.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                , subq_11.metric_time__week AS metric_time__week
+                , subq_11.metric_time__month AS metric_time__month
+                , subq_11.metric_time__quarter AS metric_time__quarter
+                , subq_11.metric_time__year AS metric_time__year
+                , subq_11.metric_time__extract_year AS metric_time__extract_year
+                , subq_11.metric_time__extract_quarter AS metric_time__extract_quarter
+                , subq_11.metric_time__extract_month AS metric_time__extract_month
+                , subq_11.metric_time__extract_day AS metric_time__extract_day
+                , subq_11.metric_time__extract_dow AS metric_time__extract_dow
+                , subq_11.metric_time__extract_doy AS metric_time__extract_doy
                 , subq_11.listing AS listing
                 , subq_11.guest AS guest
                 , subq_11.host AS host

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
@@ -633,16 +633,6 @@ FROM (
             -- Constrain Output with WHERE
             SELECT
               subq_21.metric_time__day
-              , subq_21.metric_time__week
-              , subq_21.metric_time__month
-              , subq_21.metric_time__quarter
-              , subq_21.metric_time__year
-              , subq_21.metric_time__extract_year
-              , subq_21.metric_time__extract_quarter
-              , subq_21.metric_time__extract_month
-              , subq_21.metric_time__extract_day
-              , subq_21.metric_time__extract_dow
-              , subq_21.metric_time__extract_doy
               , subq_21.ds__day
               , subq_21.ds__week
               , subq_21.ds__month
@@ -709,6 +699,16 @@ FROM (
               , subq_21.booking__paid_at__extract_day
               , subq_21.booking__paid_at__extract_dow
               , subq_21.booking__paid_at__extract_doy
+              , subq_21.metric_time__week
+              , subq_21.metric_time__month
+              , subq_21.metric_time__quarter
+              , subq_21.metric_time__year
+              , subq_21.metric_time__extract_year
+              , subq_21.metric_time__extract_quarter
+              , subq_21.metric_time__extract_month
+              , subq_21.metric_time__extract_day
+              , subq_21.metric_time__extract_dow
+              , subq_21.metric_time__extract_doy
               , subq_21.listing
               , subq_21.guest
               , subq_21.host
@@ -736,16 +736,6 @@ FROM (
               SELECT
                 subq_20.country_latest AS listing__country_latest
                 , subq_17.metric_time__day AS metric_time__day
-                , subq_17.metric_time__week AS metric_time__week
-                , subq_17.metric_time__month AS metric_time__month
-                , subq_17.metric_time__quarter AS metric_time__quarter
-                , subq_17.metric_time__year AS metric_time__year
-                , subq_17.metric_time__extract_year AS metric_time__extract_year
-                , subq_17.metric_time__extract_quarter AS metric_time__extract_quarter
-                , subq_17.metric_time__extract_month AS metric_time__extract_month
-                , subq_17.metric_time__extract_day AS metric_time__extract_day
-                , subq_17.metric_time__extract_dow AS metric_time__extract_dow
-                , subq_17.metric_time__extract_doy AS metric_time__extract_doy
                 , subq_17.ds__day AS ds__day
                 , subq_17.ds__week AS ds__week
                 , subq_17.ds__month AS ds__month
@@ -812,6 +802,16 @@ FROM (
                 , subq_17.booking__paid_at__extract_day AS booking__paid_at__extract_day
                 , subq_17.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
                 , subq_17.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                , subq_17.metric_time__week AS metric_time__week
+                , subq_17.metric_time__month AS metric_time__month
+                , subq_17.metric_time__quarter AS metric_time__quarter
+                , subq_17.metric_time__year AS metric_time__year
+                , subq_17.metric_time__extract_year AS metric_time__extract_year
+                , subq_17.metric_time__extract_quarter AS metric_time__extract_quarter
+                , subq_17.metric_time__extract_month AS metric_time__extract_month
+                , subq_17.metric_time__extract_day AS metric_time__extract_day
+                , subq_17.metric_time__extract_dow AS metric_time__extract_dow
+                , subq_17.metric_time__extract_doy AS metric_time__extract_doy
                 , subq_17.listing AS listing
                 , subq_17.guest AS guest
                 , subq_17.host AS host
@@ -837,16 +837,6 @@ FROM (
                 -- Join to Time Spine Dataset
                 SELECT
                   subq_15.metric_time__day AS metric_time__day
-                  , DATE_TRUNC('week', subq_15.metric_time__day) AS metric_time__week
-                  , DATE_TRUNC('month', subq_15.metric_time__day) AS metric_time__month
-                  , DATE_TRUNC('quarter', subq_15.metric_time__day) AS metric_time__quarter
-                  , DATE_TRUNC('year', subq_15.metric_time__day) AS metric_time__year
-                  , EXTRACT(year FROM subq_15.metric_time__day) AS metric_time__extract_year
-                  , EXTRACT(quarter FROM subq_15.metric_time__day) AS metric_time__extract_quarter
-                  , EXTRACT(month FROM subq_15.metric_time__day) AS metric_time__extract_month
-                  , EXTRACT(day FROM subq_15.metric_time__day) AS metric_time__extract_day
-                  , EXTRACT(DAY_OF_WEEK FROM subq_15.metric_time__day) AS metric_time__extract_dow
-                  , EXTRACT(doy FROM subq_15.metric_time__day) AS metric_time__extract_doy
                   , subq_14.ds__day AS ds__day
                   , subq_14.ds__week AS ds__week
                   , subq_14.ds__month AS ds__month
@@ -913,6 +903,16 @@ FROM (
                   , subq_14.booking__paid_at__extract_day AS booking__paid_at__extract_day
                   , subq_14.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
                   , subq_14.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                  , subq_14.metric_time__week AS metric_time__week
+                  , subq_14.metric_time__month AS metric_time__month
+                  , subq_14.metric_time__quarter AS metric_time__quarter
+                  , subq_14.metric_time__year AS metric_time__year
+                  , subq_14.metric_time__extract_year AS metric_time__extract_year
+                  , subq_14.metric_time__extract_quarter AS metric_time__extract_quarter
+                  , subq_14.metric_time__extract_month AS metric_time__extract_month
+                  , subq_14.metric_time__extract_day AS metric_time__extract_day
+                  , subq_14.metric_time__extract_dow AS metric_time__extract_dow
+                  , subq_14.metric_time__extract_doy AS metric_time__extract_doy
                   , subq_14.listing AS listing
                   , subq_14.guest AS guest
                   , subq_14.host AS host

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_offset_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_offset_metric_with_query_time_filters__plan0.sql
@@ -606,16 +606,6 @@ FROM (
           -- Constrain Output with WHERE
           SELECT
             subq_18.metric_time__day
-            , subq_18.metric_time__week
-            , subq_18.metric_time__month
-            , subq_18.metric_time__quarter
-            , subq_18.metric_time__year
-            , subq_18.metric_time__extract_year
-            , subq_18.metric_time__extract_quarter
-            , subq_18.metric_time__extract_month
-            , subq_18.metric_time__extract_day
-            , subq_18.metric_time__extract_dow
-            , subq_18.metric_time__extract_doy
             , subq_18.ds__day
             , subq_18.ds__week
             , subq_18.ds__month
@@ -682,6 +672,16 @@ FROM (
             , subq_18.booking__paid_at__extract_day
             , subq_18.booking__paid_at__extract_dow
             , subq_18.booking__paid_at__extract_doy
+            , subq_18.metric_time__week
+            , subq_18.metric_time__month
+            , subq_18.metric_time__quarter
+            , subq_18.metric_time__year
+            , subq_18.metric_time__extract_year
+            , subq_18.metric_time__extract_quarter
+            , subq_18.metric_time__extract_month
+            , subq_18.metric_time__extract_day
+            , subq_18.metric_time__extract_dow
+            , subq_18.metric_time__extract_doy
             , subq_18.listing
             , subq_18.guest
             , subq_18.host
@@ -709,16 +709,6 @@ FROM (
             SELECT
               subq_17.country_latest AS listing__country_latest
               , subq_14.metric_time__day AS metric_time__day
-              , subq_14.metric_time__week AS metric_time__week
-              , subq_14.metric_time__month AS metric_time__month
-              , subq_14.metric_time__quarter AS metric_time__quarter
-              , subq_14.metric_time__year AS metric_time__year
-              , subq_14.metric_time__extract_year AS metric_time__extract_year
-              , subq_14.metric_time__extract_quarter AS metric_time__extract_quarter
-              , subq_14.metric_time__extract_month AS metric_time__extract_month
-              , subq_14.metric_time__extract_day AS metric_time__extract_day
-              , subq_14.metric_time__extract_dow AS metric_time__extract_dow
-              , subq_14.metric_time__extract_doy AS metric_time__extract_doy
               , subq_14.ds__day AS ds__day
               , subq_14.ds__week AS ds__week
               , subq_14.ds__month AS ds__month
@@ -785,6 +775,16 @@ FROM (
               , subq_14.booking__paid_at__extract_day AS booking__paid_at__extract_day
               , subq_14.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
               , subq_14.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+              , subq_14.metric_time__week AS metric_time__week
+              , subq_14.metric_time__month AS metric_time__month
+              , subq_14.metric_time__quarter AS metric_time__quarter
+              , subq_14.metric_time__year AS metric_time__year
+              , subq_14.metric_time__extract_year AS metric_time__extract_year
+              , subq_14.metric_time__extract_quarter AS metric_time__extract_quarter
+              , subq_14.metric_time__extract_month AS metric_time__extract_month
+              , subq_14.metric_time__extract_day AS metric_time__extract_day
+              , subq_14.metric_time__extract_dow AS metric_time__extract_dow
+              , subq_14.metric_time__extract_doy AS metric_time__extract_doy
               , subq_14.listing AS listing
               , subq_14.guest AS guest
               , subq_14.host AS host
@@ -810,16 +810,6 @@ FROM (
               -- Join to Time Spine Dataset
               SELECT
                 subq_12.metric_time__day AS metric_time__day
-                , DATE_TRUNC('week', subq_12.metric_time__day) AS metric_time__week
-                , DATE_TRUNC('month', subq_12.metric_time__day) AS metric_time__month
-                , DATE_TRUNC('quarter', subq_12.metric_time__day) AS metric_time__quarter
-                , DATE_TRUNC('year', subq_12.metric_time__day) AS metric_time__year
-                , EXTRACT(year FROM subq_12.metric_time__day) AS metric_time__extract_year
-                , EXTRACT(quarter FROM subq_12.metric_time__day) AS metric_time__extract_quarter
-                , EXTRACT(month FROM subq_12.metric_time__day) AS metric_time__extract_month
-                , EXTRACT(day FROM subq_12.metric_time__day) AS metric_time__extract_day
-                , EXTRACT(DAY_OF_WEEK FROM subq_12.metric_time__day) AS metric_time__extract_dow
-                , EXTRACT(doy FROM subq_12.metric_time__day) AS metric_time__extract_doy
                 , subq_11.ds__day AS ds__day
                 , subq_11.ds__week AS ds__week
                 , subq_11.ds__month AS ds__month
@@ -886,6 +876,16 @@ FROM (
                 , subq_11.booking__paid_at__extract_day AS booking__paid_at__extract_day
                 , subq_11.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
                 , subq_11.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                , subq_11.metric_time__week AS metric_time__week
+                , subq_11.metric_time__month AS metric_time__month
+                , subq_11.metric_time__quarter AS metric_time__quarter
+                , subq_11.metric_time__year AS metric_time__year
+                , subq_11.metric_time__extract_year AS metric_time__extract_year
+                , subq_11.metric_time__extract_quarter AS metric_time__extract_quarter
+                , subq_11.metric_time__extract_month AS metric_time__extract_month
+                , subq_11.metric_time__extract_day AS metric_time__extract_day
+                , subq_11.metric_time__extract_dow AS metric_time__extract_dow
+                , subq_11.metric_time__extract_doy AS metric_time__extract_doy
                 , subq_11.listing AS listing
                 , subq_11.guest AS guest
                 , subq_11.host AS host


### PR DESCRIPTION
We had previously made a product decision about the behavior of the `JoinToTimeSpineNode` that we later decided was not correct. This is specifically related to what happens if you query with both `metric_time` and the `agg_time_dimension` (e.g., `booking__ds`). If you query with just one or the other, we would use the time spine to fulfill that dimension. But if you queried with both, there was different behavior.

Previous behavior when querying with both:
- Treat `metric_time` as the time spine dimension and fulfill those values with a time spine column
- Treat `agg_time_dimension` as any other dimension, and fulfill those values from the semantic model source table

This behavior felt inconsistent, since you might get different values when querying the `agg_time_dimension` depending on if you included `metric_time` in the query or not. This could be especially confusing if you included `agg_time_dimension` only in the group by, and `metric_time` in the where filter.

New behavior when querying with both:
- Treat `metric_time` and `agg_time_dimension` the same. Fulfill both dimensions with values from the time spine.

PR notes:
- I recommend reviewing by commit.
- I tried to isolate the changes related to the bug fix, but it was not as easy as I'd hoped. Hopefully it isn't too difficult to understand the changes, but let me know if you want to sync to discuss.
- There are a bunch of SQL changes here, but only a few are in optimized snapshots. The optimized ones more clearly demonstrate the actual behavior change.