### PR TITLE
Simplify `JoinToTimeSpineNode`

### DIFF
--- a/metricflow/dataflow/builder/dataflow_plan_builder.py
+++ b/metricflow/dataflow/builder/dataflow_plan_builder.py
@@ -656,7 +656,6 @@ class DataflowPlanBuilder:
             output_node = JoinToTimeSpineNode.create(
                 parent_node=output_node,
                 requested_agg_time_dimension_specs=queried_agg_time_dimension_specs,
-                use_custom_agg_time_dimension=not queried_linkable_specs.contains_metric_time,
                 time_range_constraint=predicate_pushdown_state.time_range_constraint,
                 offset_window=metric_spec.offset_window,
                 offset_to_grain=metric_spec.offset_to_grain,
@@ -1646,7 +1645,6 @@ class DataflowPlanBuilder:
             unaggregated_measure_node = JoinToTimeSpineNode.create(
                 parent_node=unaggregated_measure_node,
                 requested_agg_time_dimension_specs=base_agg_time_dimension_specs,
-                use_custom_agg_time_dimension=not queried_linkable_specs.contains_metric_time,
                 time_range_constraint=predicate_pushdown_state.time_range_constraint,
                 offset_window=before_aggregation_time_spine_join_description.offset_window,
                 offset_to_grain=before_aggregation_time_spine_join_description.offset_to_grain,
@@ -1721,7 +1719,6 @@ class DataflowPlanBuilder:
             output_node: DataflowPlanNode = JoinToTimeSpineNode.create(
                 parent_node=aggregate_measures_node,
                 requested_agg_time_dimension_specs=queried_agg_time_dimension_specs,
-                use_custom_agg_time_dimension=not queried_linkable_specs.contains_metric_time,
                 join_type=after_aggregation_time_spine_join_description.join_type,
                 time_range_constraint=predicate_pushdown_state.time_range_constraint,
                 offset_window=after_aggregation_time_spine_join_description.offset_window,

--- a/metricflow/dataflow/nodes/join_to_time_spine.py
+++ b/metricflow/dataflow/nodes/join_to_time_spine.py
@@ -24,7 +24,6 @@ class JoinToTimeSpineNode(DataflowPlanNode, ABC):
 
     Attributes:
         requested_agg_time_dimension_specs: Time dimensions requested in the query.
-        use_custom_agg_time_dimension: Indicates if agg_time_dimension should be used in join. If false, uses metric_time.
         join_type: Join type to use when joining to time spine.
         time_range_constraint: Time range to constrain the time spine to.
         offset_window: Time window to offset the parent dataset by when joining to time spine.
@@ -32,7 +31,6 @@ class JoinToTimeSpineNode(DataflowPlanNode, ABC):
     """
 
     requested_agg_time_dimension_specs: Sequence[TimeDimensionSpec]
-    use_custom_agg_time_dimension: bool
     join_type: SqlJoinType
     time_range_constraint: Optional[TimeRangeConstraint]
     offset_window: Optional[MetricTimeWindow]
@@ -54,7 +52,6 @@ class JoinToTimeSpineNode(DataflowPlanNode, ABC):
     def create(  # noqa: D102
         parent_node: DataflowPlanNode,
         requested_agg_time_dimension_specs: Sequence[TimeDimensionSpec],
-        use_custom_agg_time_dimension: bool,
         join_type: SqlJoinType,
         time_range_constraint: Optional[TimeRangeConstraint] = None,
         offset_window: Optional[MetricTimeWindow] = None,
@@ -64,7 +61,6 @@ class JoinToTimeSpineNode(DataflowPlanNode, ABC):
         return JoinToTimeSpineNode(
             parent_nodes=(parent_node,),
             requested_agg_time_dimension_specs=tuple(requested_agg_time_dimension_specs),
-            use_custom_agg_time_dimension=use_custom_agg_time_dimension,
             join_type=join_type,
             time_range_constraint=time_range_constraint,
             offset_window=offset_window,
@@ -87,7 +83,6 @@ class JoinToTimeSpineNode(DataflowPlanNode, ABC):
     def displayed_properties(self) -> Sequence[DisplayedProperty]:  # noqa: D102
         props = tuple(super().displayed_properties) + (
             DisplayedProperty("requested_agg_time_dimension_specs", self.requested_agg_time_dimension_specs),
-            DisplayedProperty("use_custom_agg_time_dimension", self.use_custom_agg_time_dimension),
             DisplayedProperty("join_type", self.join_type),
         )
         if self.offset_window:
@@ -115,7 +110,6 @@ class JoinToTimeSpineNode(DataflowPlanNode, ABC):
             and other_node.offset_window == self.offset_window
             and other_node.offset_to_grain == self.offset_to_grain
             and other_node.requested_agg_time_dimension_specs == self.requested_agg_time_dimension_specs
-            and other_node.use_custom_agg_time_dimension == self.use_custom_agg_time_dimension
             and other_node.join_type == self.join_type
             and other_node.time_spine_filters == self.time_spine_filters
         )
@@ -125,7 +119,6 @@ class JoinToTimeSpineNode(DataflowPlanNode, ABC):
         return JoinToTimeSpineNode.create(
             parent_node=new_parent_nodes[0],
             requested_agg_time_dimension_specs=self.requested_agg_time_dimension_specs,
-            use_custom_agg_time_dimension=self.use_custom_agg_time_dimension,
             time_range_constraint=self.time_range_constraint,
             offset_window=self.offset_window,
             offset_to_grain=self.offset_to_grain,

--- a/metricflow/plan_conversion/dataflow_to_sql.py
+++ b/metricflow/plan_conversion/dataflow_to_sql.py
@@ -325,16 +325,16 @@ class DataflowNodeToSqlSubqueryVisitor(DataflowPlanNodeVisitor[SqlDataSet]):
         """
         time_spine_table_alias = self._next_unique_table_alias()
 
-        queried_specs = {instance.spec for instance in agg_time_dimension_instances}
-        specs_required_for_where_constraints = {
+        queried_specs = [instance.spec for instance in agg_time_dimension_instances]
+        queried_specs_set = set(queried_specs)
+        specs_required_for_where_constraints = [
             spec
             for constraint in time_spine_where_constraints
             for spec in constraint.linkable_spec_set.time_dimension_specs
-        }
-        required_specs = sorted(  # sorted for consistency in snapshots
-            queried_specs.union(specs_required_for_where_constraints),
-            key=lambda spec: (spec.element_name, spec.time_granularity.base_granularity.to_int()),
-        )
+            if spec not in queried_specs_set
+        ]
+        required_specs = queried_specs + specs_required_for_where_constraints
+
         time_spine_sources = TimeSpineSource.choose_time_spine_sources(
             required_time_spine_specs=required_specs, time_spine_sources=self._time_spine_sources
         )

--- a/tests_metricflow/plan_conversion/test_dataflow_to_sql_plan.py
+++ b/tests_metricflow/plan_conversion/test_dataflow_to_sql_plan.py
@@ -607,7 +607,6 @@ def test_join_to_time_spine_node_without_offset(
     join_to_time_spine_node = JoinToTimeSpineNode.create(
         parent_node=compute_metrics_node,
         requested_agg_time_dimension_specs=[MTD_SPEC_DAY],
-        use_custom_agg_time_dimension=False,
         time_range_constraint=TimeRangeConstraint(
             start_time=as_datetime("2020-01-01"), end_time=as_datetime("2021-01-01")
         ),
@@ -681,7 +680,6 @@ def test_join_to_time_spine_node_with_offset_window(
     join_to_time_spine_node = JoinToTimeSpineNode.create(
         parent_node=compute_metrics_node,
         requested_agg_time_dimension_specs=[MTD_SPEC_DAY],
-        use_custom_agg_time_dimension=False,
         time_range_constraint=TimeRangeConstraint(
             start_time=as_datetime("2020-01-01"), end_time=as_datetime("2021-01-01")
         ),
@@ -756,7 +754,6 @@ def test_join_to_time_spine_node_with_offset_to_grain(
     join_to_time_spine_node = JoinToTimeSpineNode.create(
         parent_node=compute_metrics_node,
         requested_agg_time_dimension_specs=[MTD_SPEC_DAY],
-        use_custom_agg_time_dimension=False,
         time_range_constraint=TimeRangeConstraint(
             start_time=as_datetime("2020-01-01"), end_time=as_datetime("2021-01-01")
         ),

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_window_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_window_metric_with_non_default_grains__plan0.sql
@@ -33,14 +33,16 @@ FROM (
     FROM (
       -- Join to Time Spine Dataset
       SELECT
-        DATETIME_TRUNC(subq_7.metric_time__day, month) AS booking__ds__month
+        subq_7.booking__ds__month AS booking__ds__month
         , subq_7.metric_time__day AS metric_time__day
-        , DATETIME_TRUNC(subq_7.metric_time__day, isoweek) AS metric_time__week
+        , subq_7.metric_time__week AS metric_time__week
         , subq_6.bookers AS bookers
       FROM (
         -- Time Spine
         SELECT
-          subq_8.ds AS metric_time__day
+          DATETIME_TRUNC(subq_8.ds, month) AS booking__ds__month
+          , subq_8.ds AS metric_time__day
+          , DATETIME_TRUNC(subq_8.ds, isoweek) AS metric_time__week
         FROM ***************************.mf_time_spine subq_8
       ) subq_7
       LEFT OUTER JOIN (

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_window_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_window_metric_with_non_default_grains__plan0.sql
@@ -33,14 +33,16 @@ FROM (
     FROM (
       -- Join to Time Spine Dataset
       SELECT
-        DATE_TRUNC('month', subq_7.metric_time__day) AS booking__ds__month
+        subq_7.booking__ds__month AS booking__ds__month
         , subq_7.metric_time__day AS metric_time__day
-        , DATE_TRUNC('week', subq_7.metric_time__day) AS metric_time__week
+        , subq_7.metric_time__week AS metric_time__week
         , subq_6.bookers AS bookers
       FROM (
         -- Time Spine
         SELECT
-          subq_8.ds AS metric_time__day
+          DATE_TRUNC('month', subq_8.ds) AS booking__ds__month
+          , subq_8.ds AS metric_time__day
+          , DATE_TRUNC('week', subq_8.ds) AS metric_time__week
         FROM ***************************.mf_time_spine subq_8
       ) subq_7
       LEFT OUTER JOIN (

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_window_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_window_metric_with_non_default_grains__plan0.sql
@@ -33,14 +33,16 @@ FROM (
     FROM (
       -- Join to Time Spine Dataset
       SELECT
-        DATE_TRUNC('month', subq_7.metric_time__day) AS booking__ds__month
+        subq_7.booking__ds__month AS booking__ds__month
         , subq_7.metric_time__day AS metric_time__day
-        , DATE_TRUNC('week', subq_7.metric_time__day) AS metric_time__week
+        , subq_7.metric_time__week AS metric_time__week
         , subq_6.bookers AS bookers
       FROM (
         -- Time Spine
         SELECT
-          subq_8.ds AS metric_time__day
+          DATE_TRUNC('month', subq_8.ds) AS booking__ds__month
+          , subq_8.ds AS metric_time__day
+          , DATE_TRUNC('week', subq_8.ds) AS metric_time__week
         FROM ***************************.mf_time_spine subq_8
       ) subq_7
       LEFT OUTER JOIN (

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_window_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_window_metric_with_non_default_grains__plan0.sql
@@ -33,14 +33,16 @@ FROM (
     FROM (
       -- Join to Time Spine Dataset
       SELECT
-        DATE_TRUNC('month', subq_7.metric_time__day) AS booking__ds__month
+        subq_7.booking__ds__month AS booking__ds__month
         , subq_7.metric_time__day AS metric_time__day
-        , DATE_TRUNC('week', subq_7.metric_time__day) AS metric_time__week
+        , subq_7.metric_time__week AS metric_time__week
         , subq_6.bookers AS bookers
       FROM (
         -- Time Spine
         SELECT
-          subq_8.ds AS metric_time__day
+          DATE_TRUNC('month', subq_8.ds) AS booking__ds__month
+          , subq_8.ds AS metric_time__day
+          , DATE_TRUNC('week', subq_8.ds) AS metric_time__week
         FROM ***************************.mf_time_spine subq_8
       ) subq_7
       LEFT OUTER JOIN (

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_window_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_window_metric_with_non_default_grains__plan0.sql
@@ -33,14 +33,16 @@ FROM (
     FROM (
       -- Join to Time Spine Dataset
       SELECT
-        DATE_TRUNC('month', subq_7.metric_time__day) AS booking__ds__month
+        subq_7.booking__ds__month AS booking__ds__month
         , subq_7.metric_time__day AS metric_time__day
-        , DATE_TRUNC('week', subq_7.metric_time__day) AS metric_time__week
+        , subq_7.metric_time__week AS metric_time__week
         , subq_6.bookers AS bookers
       FROM (
         -- Time Spine
         SELECT
-          subq_8.ds AS metric_time__day
+          DATE_TRUNC('month', subq_8.ds) AS booking__ds__month
+          , subq_8.ds AS metric_time__day
+          , DATE_TRUNC('week', subq_8.ds) AS metric_time__week
         FROM ***************************.mf_time_spine subq_8
       ) subq_7
       LEFT OUTER JOIN (

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_window_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_window_metric_with_non_default_grains__plan0.sql
@@ -33,14 +33,16 @@ FROM (
     FROM (
       -- Join to Time Spine Dataset
       SELECT
-        DATE_TRUNC('month', subq_7.metric_time__day) AS booking__ds__month
+        subq_7.booking__ds__month AS booking__ds__month
         , subq_7.metric_time__day AS metric_time__day
-        , DATE_TRUNC('week', subq_7.metric_time__day) AS metric_time__week
+        , subq_7.metric_time__week AS metric_time__week
         , subq_6.bookers AS bookers
       FROM (
         -- Time Spine
         SELECT
-          subq_8.ds AS metric_time__day
+          DATE_TRUNC('month', subq_8.ds) AS booking__ds__month
+          , subq_8.ds AS metric_time__day
+          , DATE_TRUNC('week', subq_8.ds) AS metric_time__week
         FROM ***************************.mf_time_spine subq_8
       ) subq_7
       LEFT OUTER JOIN (

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_window_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_window_metric_with_non_default_grains__plan0.sql
@@ -33,14 +33,16 @@ FROM (
     FROM (
       -- Join to Time Spine Dataset
       SELECT
-        DATE_TRUNC('month', subq_7.metric_time__day) AS booking__ds__month
+        subq_7.booking__ds__month AS booking__ds__month
         , subq_7.metric_time__day AS metric_time__day
-        , DATE_TRUNC('week', subq_7.metric_time__day) AS metric_time__week
+        , subq_7.metric_time__week AS metric_time__week
         , subq_6.bookers AS bookers
       FROM (
         -- Time Spine
         SELECT
-          subq_8.ds AS metric_time__day
+          DATE_TRUNC('month', subq_8.ds) AS booking__ds__month
+          , subq_8.ds AS metric_time__day
+          , DATE_TRUNC('week', subq_8.ds) AS metric_time__week
         FROM ***************************.mf_time_spine subq_8
       ) subq_7
       LEFT OUTER JOIN (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/BigQuery/test_offset_metric_with_custom_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/BigQuery/test_offset_metric_with_custom_granularity__plan0.sql
@@ -25,8 +25,7 @@ FROM (
         -- Join to Time Spine Dataset
         -- Join to Custom Granularity Dataset
         SELECT
-          subq_2.booking__ds__day AS booking__ds__day
-          , subq_1.ds__day AS ds__day
+          subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
@@ -102,6 +101,7 @@ FROM (
           , subq_1.metric_time__extract_day AS metric_time__extract_day
           , subq_1.metric_time__extract_dow AS metric_time__extract_dow
           , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+          , subq_2.booking__ds__day AS booking__ds__day
           , subq_1.listing AS listing
           , subq_1.guest AS guest
           , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/BigQuery/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/BigQuery/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
@@ -127,8 +127,7 @@ FROM (
           -- Join to Time Spine Dataset
           -- Join to Custom Granularity Dataset
           SELECT
-            subq_2.metric_time__day AS metric_time__day
-            , subq_1.ds__day AS ds__day
+            subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -204,6 +203,7 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_2.metric_time__day AS metric_time__day
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Databricks/test_offset_metric_with_custom_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Databricks/test_offset_metric_with_custom_granularity__plan0.sql
@@ -25,8 +25,7 @@ FROM (
         -- Join to Time Spine Dataset
         -- Join to Custom Granularity Dataset
         SELECT
-          subq_2.booking__ds__day AS booking__ds__day
-          , subq_1.ds__day AS ds__day
+          subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
@@ -102,6 +101,7 @@ FROM (
           , subq_1.metric_time__extract_day AS metric_time__extract_day
           , subq_1.metric_time__extract_dow AS metric_time__extract_dow
           , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+          , subq_2.booking__ds__day AS booking__ds__day
           , subq_1.listing AS listing
           , subq_1.guest AS guest
           , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Databricks/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Databricks/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
@@ -127,8 +127,7 @@ FROM (
           -- Join to Time Spine Dataset
           -- Join to Custom Granularity Dataset
           SELECT
-            subq_2.metric_time__day AS metric_time__day
-            , subq_1.ds__day AS ds__day
+            subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -204,6 +203,7 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_2.metric_time__day AS metric_time__day
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/DuckDB/test_offset_metric_with_custom_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/DuckDB/test_offset_metric_with_custom_granularity__plan0.sql
@@ -25,8 +25,7 @@ FROM (
         -- Join to Time Spine Dataset
         -- Join to Custom Granularity Dataset
         SELECT
-          subq_2.booking__ds__day AS booking__ds__day
-          , subq_1.ds__day AS ds__day
+          subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
@@ -102,6 +101,7 @@ FROM (
           , subq_1.metric_time__extract_day AS metric_time__extract_day
           , subq_1.metric_time__extract_dow AS metric_time__extract_dow
           , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+          , subq_2.booking__ds__day AS booking__ds__day
           , subq_1.listing AS listing
           , subq_1.guest AS guest
           , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/DuckDB/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/DuckDB/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
@@ -127,8 +127,7 @@ FROM (
           -- Join to Time Spine Dataset
           -- Join to Custom Granularity Dataset
           SELECT
-            subq_2.metric_time__day AS metric_time__day
-            , subq_1.ds__day AS ds__day
+            subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -204,6 +203,7 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_2.metric_time__day AS metric_time__day
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Postgres/test_offset_metric_with_custom_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Postgres/test_offset_metric_with_custom_granularity__plan0.sql
@@ -25,8 +25,7 @@ FROM (
         -- Join to Time Spine Dataset
         -- Join to Custom Granularity Dataset
         SELECT
-          subq_2.booking__ds__day AS booking__ds__day
-          , subq_1.ds__day AS ds__day
+          subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
@@ -102,6 +101,7 @@ FROM (
           , subq_1.metric_time__extract_day AS metric_time__extract_day
           , subq_1.metric_time__extract_dow AS metric_time__extract_dow
           , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+          , subq_2.booking__ds__day AS booking__ds__day
           , subq_1.listing AS listing
           , subq_1.guest AS guest
           , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Postgres/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Postgres/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
@@ -127,8 +127,7 @@ FROM (
           -- Join to Time Spine Dataset
           -- Join to Custom Granularity Dataset
           SELECT
-            subq_2.metric_time__day AS metric_time__day
-            , subq_1.ds__day AS ds__day
+            subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -204,6 +203,7 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_2.metric_time__day AS metric_time__day
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Redshift/test_offset_metric_with_custom_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Redshift/test_offset_metric_with_custom_granularity__plan0.sql
@@ -25,8 +25,7 @@ FROM (
         -- Join to Time Spine Dataset
         -- Join to Custom Granularity Dataset
         SELECT
-          subq_2.booking__ds__day AS booking__ds__day
-          , subq_1.ds__day AS ds__day
+          subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
@@ -102,6 +101,7 @@ FROM (
           , subq_1.metric_time__extract_day AS metric_time__extract_day
           , subq_1.metric_time__extract_dow AS metric_time__extract_dow
           , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+          , subq_2.booking__ds__day AS booking__ds__day
           , subq_1.listing AS listing
           , subq_1.guest AS guest
           , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Redshift/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Redshift/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
@@ -127,8 +127,7 @@ FROM (
           -- Join to Time Spine Dataset
           -- Join to Custom Granularity Dataset
           SELECT
-            subq_2.metric_time__day AS metric_time__day
-            , subq_1.ds__day AS ds__day
+            subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -204,6 +203,7 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_2.metric_time__day AS metric_time__day
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Snowflake/test_offset_metric_with_custom_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Snowflake/test_offset_metric_with_custom_granularity__plan0.sql
@@ -25,8 +25,7 @@ FROM (
         -- Join to Time Spine Dataset
         -- Join to Custom Granularity Dataset
         SELECT
-          subq_2.booking__ds__day AS booking__ds__day
-          , subq_1.ds__day AS ds__day
+          subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
@@ -102,6 +101,7 @@ FROM (
           , subq_1.metric_time__extract_day AS metric_time__extract_day
           , subq_1.metric_time__extract_dow AS metric_time__extract_dow
           , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+          , subq_2.booking__ds__day AS booking__ds__day
           , subq_1.listing AS listing
           , subq_1.guest AS guest
           , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Snowflake/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Snowflake/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
@@ -127,8 +127,7 @@ FROM (
           -- Join to Time Spine Dataset
           -- Join to Custom Granularity Dataset
           SELECT
-            subq_2.metric_time__day AS metric_time__day
-            , subq_1.ds__day AS ds__day
+            subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -204,6 +203,7 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_2.metric_time__day AS metric_time__day
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Trino/test_offset_metric_with_custom_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Trino/test_offset_metric_with_custom_granularity__plan0.sql
@@ -25,8 +25,7 @@ FROM (
         -- Join to Time Spine Dataset
         -- Join to Custom Granularity Dataset
         SELECT
-          subq_2.booking__ds__day AS booking__ds__day
-          , subq_1.ds__day AS ds__day
+          subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
@@ -102,6 +101,7 @@ FROM (
           , subq_1.metric_time__extract_day AS metric_time__extract_day
           , subq_1.metric_time__extract_dow AS metric_time__extract_dow
           , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+          , subq_2.booking__ds__day AS booking__ds__day
           , subq_1.listing AS listing
           , subq_1.guest AS guest
           , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Trino/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Trino/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
@@ -127,8 +127,7 @@ FROM (
           -- Join to Time Spine Dataset
           -- Join to Custom Granularity Dataset
           SELECT
-            subq_2.metric_time__day AS metric_time__day
-            , subq_1.ds__day AS ds__day
+            subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -204,6 +203,7 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_2.metric_time__day AS metric_time__day
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_metric_offset_to_grain__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_metric_offset_to_grain__dfp_0.xml
@@ -78,7 +78,6 @@ docstring:
                                 <!--       time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
                                 <!--     ),                                                                            -->
                                 <!--   )                                                                               -->
-                                <!-- use_custom_agg_time_dimension = False -->
                                 <!-- join_type = INNER -->
                                 <!-- offset_to_grain = MONTH -->
                                 <MetricTimeDimensionTransformNode>

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_metric_offset_window__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_metric_offset_window__dfp_0.xml
@@ -44,7 +44,6 @@ docstring:
                             <!--       time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
                             <!--     ),                                                                            -->
                             <!--   )                                                                               -->
-                            <!-- use_custom_agg_time_dimension = False -->
                             <!-- join_type = INNER -->
                             <!-- offset_window = PydanticMetricTimeWindow(count=5, granularity='day') -->
                             <MetricTimeDimensionTransformNode>

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_metric_offset_with_granularity__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_metric_offset_with_granularity__dfp_0.xml
@@ -42,7 +42,6 @@ test_filename: test_dataflow_plan_builder.py
                             <!--       time_granularity=ExpandedTimeGranularity(name='month', base_granularity=MONTH), -->
                             <!--     ),                                                                                -->
                             <!--   )                                                                                   -->
-                            <!-- use_custom_agg_time_dimension = False -->
                             <!-- join_type = INNER -->
                             <!-- offset_window = PydanticMetricTimeWindow(count=5, granularity='day') -->
                             <MetricTimeDimensionTransformNode>

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_offset_cumulative_metric__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_offset_cumulative_metric__dfp_0.xml
@@ -43,7 +43,6 @@ test_filename: test_dataflow_plan_builder.py
                             <!--       time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
                             <!--     ),                                                                            -->
                             <!--   )                                                                               -->
-                            <!-- use_custom_agg_time_dimension = False -->
                             <!-- join_type = INNER -->
                             <!-- offset_window = PydanticMetricTimeWindow(count=2, granularity='day') -->
                             <JoinOverTimeRangeNode>

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_join_to_time_spine_derived_metric__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_join_to_time_spine_derived_metric__dfp_0.xml
@@ -31,7 +31,6 @@ test_filename: test_dataflow_plan_builder.py
                         <!--       time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
                         <!--     ),                                                                            -->
                         <!--   )                                                                               -->
-                        <!-- use_custom_agg_time_dimension = False -->
                         <!-- join_type = LEFT_OUTER -->
                         <AggregateMeasuresNode>
                             <!-- description = 'Aggregate Measures' -->
@@ -80,7 +79,6 @@ test_filename: test_dataflow_plan_builder.py
                         <!--       time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
                         <!--     ),                                                                            -->
                         <!--   )                                                                               -->
-                        <!-- use_custom_agg_time_dimension = False -->
                         <!-- join_type = LEFT_OUTER -->
                         <AggregateMeasuresNode>
                             <!-- description = 'Aggregate Measures' -->
@@ -105,7 +103,6 @@ test_filename: test_dataflow_plan_builder.py
                                     <!--       time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
                                     <!--     ),                                                                            -->
                                     <!--   )                                                                               -->
-                                    <!-- use_custom_agg_time_dimension = False -->
                                     <!-- join_type = INNER -->
                                     <!-- offset_window = PydanticMetricTimeWindow(count=14, granularity='day') -->
                                     <MetricTimeDimensionTransformNode>

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_join_to_time_spine_with_filters__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_join_to_time_spine_with_filters__dfp_0.xml
@@ -71,7 +71,6 @@ docstring:
                     <!--       time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
                     <!--     ),                                                                            -->
                     <!--   )                                                                               -->
-                    <!-- use_custom_agg_time_dimension = False -->
                     <!-- join_type = LEFT_OUTER -->
                     <!-- time_range_constraint =                             -->
                     <!--   TimeRangeConstraint(                              -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_join_to_time_spine_with_metric_time__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_join_to_time_spine_with_metric_time__dfp_0.xml
@@ -20,7 +20,6 @@ test_filename: test_dataflow_plan_builder.py
                 <!--       time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
                 <!--     ),                                                                            -->
                 <!--   )                                                                               -->
-                <!-- use_custom_agg_time_dimension = False -->
                 <!-- join_type = LEFT_OUTER -->
                 <AggregateMeasuresNode>
                     <!-- description = 'Aggregate Measures' -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_nested_derived_metric_with_outer_offset__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_nested_derived_metric_with_outer_offset__dfp_0.xml
@@ -19,7 +19,6 @@ test_filename: test_dataflow_plan_builder.py
                 <!--       time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
                 <!--     ),                                                                            -->
                 <!--   )                                                                               -->
-                <!-- use_custom_agg_time_dimension = False -->
                 <!-- join_type = INNER -->
                 <!-- offset_window = PydanticMetricTimeWindow(count=2, granularity='day') -->
                 <ComputeMetricsNode>
@@ -63,7 +62,6 @@ test_filename: test_dataflow_plan_builder.py
                                     <!--       time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
                                     <!--     ),                                                                            -->
                                     <!--   )                                                                               -->
-                                    <!-- use_custom_agg_time_dimension = False -->
                                     <!-- join_type = INNER -->
                                     <!-- offset_window = PydanticMetricTimeWindow(count=5, granularity='day') -->
                                     <MetricTimeDimensionTransformNode>

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_offset_to_grain_metric_filter_and_query_have_different_granularities__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_offset_to_grain_metric_filter_and_query_have_different_granularities__dfp_0.xml
@@ -170,7 +170,6 @@ docstring:
                                 <!--       time_granularity=ExpandedTimeGranularity(name='month', base_granularity=MONTH), -->
                                 <!--     ),                                                                                -->
                                 <!--   )                                                                                   -->
-                                <!-- use_custom_agg_time_dimension = False -->
                                 <!-- join_type = INNER -->
                                 <!-- offset_to_grain = MONTH -->
                                 <MetricTimeDimensionTransformNode>

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_offset_window_metric_filter_and_query_have_different_granularities__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_offset_window_metric_filter_and_query_have_different_granularities__dfp_0.xml
@@ -175,7 +175,6 @@ docstring:
                                     <!--       ),                                        -->
                                     <!--     ),                                          -->
                                     <!--   )                                             -->
-                                    <!-- use_custom_agg_time_dimension = False -->
                                     <!-- join_type = INNER -->
                                     <!-- offset_window = PydanticMetricTimeWindow(count=1, granularity='week') -->
                                     <MetricTimeDimensionTransformNode>

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/DataflowPlan/test_join_to_time_spine_node_with_offset_to_grain__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/DataflowPlan/test_join_to_time_spine_node_with_offset_to_grain__plan0.xml
@@ -17,7 +17,6 @@ docstring:
             <!--       time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
             <!--     ),                                                                            -->
             <!--   )                                                                               -->
-            <!-- use_custom_agg_time_dimension = False -->
             <!-- join_type = INNER -->
             <!-- offset_to_grain = MONTH -->
             <!-- time_range_constraint =                             -->

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/DataflowPlan/test_join_to_time_spine_node_with_offset_window__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/DataflowPlan/test_join_to_time_spine_node_with_offset_window__plan0.xml
@@ -17,7 +17,6 @@ docstring:
             <!--       time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
             <!--     ),                                                                            -->
             <!--   )                                                                               -->
-            <!-- use_custom_agg_time_dimension = False -->
             <!-- join_type = INNER -->
             <!-- offset_window = PydanticMetricTimeWindow(count=10, granularity='day') -->
             <!-- time_range_constraint =                             -->

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/DataflowPlan/test_join_to_time_spine_node_without_offset__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/DataflowPlan/test_join_to_time_spine_node_without_offset__plan0.xml
@@ -17,7 +17,6 @@ docstring:
             <!--       time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
             <!--     ),                                                                            -->
             <!--   )                                                                               -->
-            <!-- use_custom_agg_time_dimension = False -->
             <!-- join_type = INNER -->
             <!-- time_range_constraint =                             -->
             <!--   TimeRangeConstraint(                              -->

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
@@ -125,8 +125,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_5.metric_time__day AS metric_time__day
-            , subq_4.ds__day AS ds__day
+            subq_4.ds__day AS ds__day
             , subq_4.ds__week AS ds__week
             , subq_4.ds__month AS ds__month
             , subq_4.ds__quarter AS ds__quarter
@@ -202,6 +201,7 @@ FROM (
             , subq_4.metric_time__extract_day AS metric_time__extract_day
             , subq_4.metric_time__extract_dow AS metric_time__extract_dow
             , subq_4.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_5.metric_time__day AS metric_time__day
             , subq_4.listing AS listing
             , subq_4.guest AS guest
             , subq_4.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
@@ -24,8 +24,7 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_2.metric_time__month AS metric_time__month
-          , subq_1.ds__month AS ds__month
+          subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
           , subq_1.ds__year AS ds__year
           , subq_1.ds__extract_year AS ds__extract_year
@@ -42,6 +41,7 @@ FROM (
           , subq_1.metric_time__extract_year AS metric_time__extract_year
           , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
           , subq_1.metric_time__extract_month AS metric_time__extract_month
+          , subq_2.metric_time__month AS metric_time__month
           , subq_1.listing AS listing
           , subq_1.booking_monthly__listing AS booking_monthly__listing
           , subq_1.bookings_monthly AS bookings_monthly

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_to_grain__plan0.sql
@@ -245,8 +245,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_7.metric_time__day AS metric_time__day
-            , subq_6.ds__day AS ds__day
+            subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -322,6 +321,7 @@ FROM (
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_7.metric_time__day AS metric_time__day
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_to_grain_and_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_to_grain_and_granularity__plan0.sql
@@ -245,8 +245,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            DATETIME_TRUNC(subq_7.metric_time__day, isoweek) AS metric_time__week
-            , subq_6.ds__day AS ds__day
+            subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -312,7 +311,6 @@ FROM (
             , subq_6.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_6.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_6.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
-            , subq_6.metric_time__day AS metric_time__day
             , subq_6.metric_time__month AS metric_time__month
             , subq_6.metric_time__quarter AS metric_time__quarter
             , subq_6.metric_time__year AS metric_time__year
@@ -322,6 +320,8 @@ FROM (
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_7.metric_time__day AS metric_time__day
+            , subq_7.metric_time__week AS metric_time__week
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host
@@ -347,6 +347,7 @@ FROM (
             -- Time Spine
             SELECT
               subq_8.ds AS metric_time__day
+              , DATETIME_TRUNC(subq_8.ds, isoweek) AS metric_time__week
             FROM ***************************.mf_time_spine subq_8
           ) subq_7
           INNER JOIN (
@@ -546,7 +547,7 @@ FROM (
           ) subq_6
           ON
             DATETIME_TRUNC(subq_7.metric_time__day, month) = subq_6.metric_time__day
-          WHERE DATETIME_TRUNC(subq_7.metric_time__day, isoweek) = subq_7.metric_time__day
+          WHERE subq_7.metric_time__week = subq_7.metric_time__day
         ) subq_9
       ) subq_10
       GROUP BY

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_window__plan0.sql
@@ -245,8 +245,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_7.metric_time__day AS metric_time__day
-            , subq_6.ds__day AS ds__day
+            subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -322,6 +321,7 @@ FROM (
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_7.metric_time__day AS metric_time__day
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_window_and_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_window_and_granularity__plan0.sql
@@ -245,8 +245,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            DATETIME_TRUNC(subq_7.metric_time__day, quarter) AS metric_time__quarter
-            , subq_6.ds__day AS ds__day
+            subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -312,7 +311,6 @@ FROM (
             , subq_6.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_6.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_6.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
-            , subq_6.metric_time__day AS metric_time__day
             , subq_6.metric_time__week AS metric_time__week
             , subq_6.metric_time__month AS metric_time__month
             , subq_6.metric_time__year AS metric_time__year
@@ -322,6 +320,8 @@ FROM (
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_7.metric_time__day AS metric_time__day
+            , subq_7.metric_time__quarter AS metric_time__quarter
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host
@@ -347,6 +347,7 @@ FROM (
             -- Time Spine
             SELECT
               subq_8.ds AS metric_time__day
+              , DATETIME_TRUNC(subq_8.ds, quarter) AS metric_time__quarter
             FROM ***************************.mf_time_spine subq_8
           ) subq_7
           INNER JOIN (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
@@ -30,8 +30,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_2.metric_time__day AS metric_time__day
-            , subq_1.ds__day AS ds__day
+            subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -107,6 +106,7 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_2.metric_time__day AS metric_time__day
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host
@@ -355,8 +355,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_10.metric_time__day AS metric_time__day
-            , subq_9.ds__day AS ds__day
+            subq_9.ds__day AS ds__day
             , subq_9.ds__week AS ds__week
             , subq_9.ds__month AS ds__month
             , subq_9.ds__quarter AS ds__quarter
@@ -432,6 +431,7 @@ FROM (
             , subq_9.metric_time__extract_day AS metric_time__extract_day
             , subq_9.metric_time__extract_dow AS metric_time__extract_dow
             , subq_9.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_10.metric_time__day AS metric_time__day
             , subq_9.listing AS listing
             , subq_9.guest AS guest
             , subq_9.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0.sql
@@ -30,8 +30,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            DATETIME_TRUNC(subq_2.metric_time__day, year) AS metric_time__year
-            , subq_1.ds__day AS ds__day
+            subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -97,7 +96,6 @@ FROM (
             , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
-            , subq_1.metric_time__day AS metric_time__day
             , subq_1.metric_time__week AS metric_time__week
             , subq_1.metric_time__month AS metric_time__month
             , subq_1.metric_time__quarter AS metric_time__quarter
@@ -107,6 +105,8 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_2.metric_time__day AS metric_time__day
+            , subq_2.metric_time__year AS metric_time__year
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host
@@ -132,6 +132,7 @@ FROM (
             -- Time Spine
             SELECT
               subq_3.ds AS metric_time__day
+              , DATETIME_TRUNC(subq_3.ds, year) AS metric_time__year
             FROM ***************************.mf_time_spine subq_3
           ) subq_2
           INNER JOIN (
@@ -331,7 +332,7 @@ FROM (
           ) subq_1
           ON
             DATETIME_TRUNC(subq_2.metric_time__day, month) = subq_1.metric_time__day
-          WHERE DATETIME_TRUNC(subq_2.metric_time__day, year) = subq_2.metric_time__day
+          WHERE subq_2.metric_time__year = subq_2.metric_time__day
         ) subq_4
       ) subq_5
       GROUP BY
@@ -356,8 +357,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            DATETIME_TRUNC(subq_10.metric_time__day, year) AS metric_time__year
-            , subq_9.ds__day AS ds__day
+            subq_9.ds__day AS ds__day
             , subq_9.ds__week AS ds__week
             , subq_9.ds__month AS ds__month
             , subq_9.ds__quarter AS ds__quarter
@@ -423,7 +423,6 @@ FROM (
             , subq_9.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_9.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_9.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
-            , subq_9.metric_time__day AS metric_time__day
             , subq_9.metric_time__week AS metric_time__week
             , subq_9.metric_time__month AS metric_time__month
             , subq_9.metric_time__quarter AS metric_time__quarter
@@ -433,6 +432,8 @@ FROM (
             , subq_9.metric_time__extract_day AS metric_time__extract_day
             , subq_9.metric_time__extract_dow AS metric_time__extract_dow
             , subq_9.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_10.metric_time__day AS metric_time__day
+            , subq_10.metric_time__year AS metric_time__year
             , subq_9.listing AS listing
             , subq_9.guest AS guest
             , subq_9.host AS host
@@ -458,6 +459,7 @@ FROM (
             -- Time Spine
             SELECT
               subq_11.ds AS metric_time__day
+              , DATETIME_TRUNC(subq_11.ds, year) AS metric_time__year
             FROM ***************************.mf_time_spine subq_11
           ) subq_10
           INNER JOIN (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
@@ -449,8 +449,7 @@ FROM (
           FROM (
             -- Join to Time Spine Dataset
             SELECT
-              subq_8.metric_time__day AS metric_time__day
-              , subq_7.ds__day AS ds__day
+              subq_7.ds__day AS ds__day
               , subq_7.ds__week AS ds__week
               , subq_7.ds__month AS ds__month
               , subq_7.ds__quarter AS ds__quarter
@@ -526,6 +525,7 @@ FROM (
               , subq_7.metric_time__extract_day AS metric_time__extract_day
               , subq_7.metric_time__extract_dow AS metric_time__extract_dow
               , subq_7.metric_time__extract_doy AS metric_time__extract_doy
+              , subq_8.metric_time__day AS metric_time__day
               , subq_7.listing AS listing
               , subq_7.guest AS guest
               , subq_7.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_offset_cumulative_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_offset_cumulative_metric__plan0.sql
@@ -24,8 +24,7 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_5.metric_time__day AS metric_time__day
-          , subq_4.ds__day AS ds__day
+          subq_4.ds__day AS ds__day
           , subq_4.ds__week AS ds__week
           , subq_4.ds__month AS ds__month
           , subq_4.ds__quarter AS ds__quarter
@@ -101,6 +100,7 @@ FROM (
           , subq_4.metric_time__extract_day AS metric_time__extract_day
           , subq_4.metric_time__extract_dow AS metric_time__extract_dow
           , subq_4.metric_time__extract_doy AS metric_time__extract_doy
+          , subq_5.metric_time__day AS metric_time__day
           , subq_4.listing AS listing
           , subq_4.guest AS guest
           , subq_4.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_offset_metric_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_offset_metric_with_agg_time_dim__plan0.sql
@@ -30,8 +30,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_2.booking__ds__day AS booking__ds__day
-            , subq_1.ds__day AS ds__day
+            subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -107,6 +106,7 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_2.booking__ds__day AS booking__ds__day
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_offset_metric_with_one_input_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_offset_metric_with_one_input_metric__plan0.sql
@@ -24,8 +24,7 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_2.metric_time__day AS metric_time__day
-          , subq_1.ds__day AS ds__day
+          subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
@@ -101,6 +100,7 @@ FROM (
           , subq_1.metric_time__extract_day AS metric_time__extract_day
           , subq_1.metric_time__extract_dow AS metric_time__extract_dow
           , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+          , subq_2.metric_time__day AS metric_time__day
           , subq_1.listing AS listing
           , subq_1.guest AS guest
           , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0.sql
@@ -56,8 +56,7 @@ FROM (
               FROM (
                 -- Join to Time Spine Dataset
                 SELECT
-                  subq_2.metric_time__day AS metric_time__day
-                  , subq_1.ds__day AS ds__day
+                  subq_1.ds__day AS ds__day
                   , subq_1.ds__week AS ds__week
                   , subq_1.ds__month AS ds__month
                   , subq_1.ds__quarter AS ds__quarter
@@ -133,6 +132,7 @@ FROM (
                   , subq_1.metric_time__extract_day AS metric_time__extract_day
                   , subq_1.metric_time__extract_dow AS metric_time__extract_dow
                   , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+                  , subq_2.metric_time__day AS metric_time__day
                   , subq_1.listing AS listing
                   , subq_1.guest AS guest
                   , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_offsets__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_offsets__plan0.sql
@@ -40,8 +40,7 @@ FROM (
           FROM (
             -- Join to Time Spine Dataset
             SELECT
-              subq_2.metric_time__day AS metric_time__day
-              , subq_1.ds__day AS ds__day
+              subq_1.ds__day AS ds__day
               , subq_1.ds__week AS ds__week
               , subq_1.ds__month AS ds__month
               , subq_1.ds__quarter AS ds__quarter
@@ -117,6 +116,7 @@ FROM (
               , subq_1.metric_time__extract_day AS metric_time__extract_day
               , subq_1.metric_time__extract_dow AS metric_time__extract_dow
               , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+              , subq_2.metric_time__day AS metric_time__day
               , subq_1.listing AS listing
               , subq_1.guest AS guest
               , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_offsets_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_offsets_with_time_constraint__plan0.sql
@@ -41,8 +41,7 @@ FROM (
           FROM (
             -- Join to Time Spine Dataset
             SELECT
-              subq_2.metric_time__day AS metric_time__day
-              , subq_1.ds__day AS ds__day
+              subq_1.ds__day AS ds__day
               , subq_1.ds__week AS ds__week
               , subq_1.ds__month AS ds__month
               , subq_1.ds__quarter AS ds__quarter
@@ -118,6 +117,7 @@ FROM (
               , subq_1.metric_time__extract_day AS metric_time__extract_day
               , subq_1.metric_time__extract_dow AS metric_time__extract_dow
               , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+              , subq_2.metric_time__day AS metric_time__day
               , subq_1.listing AS listing
               , subq_1.guest AS guest
               , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_offsets_with_where_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_offsets_with_where_constraint__plan0.sql
@@ -45,8 +45,7 @@ FROM (
             FROM (
               -- Join to Time Spine Dataset
               SELECT
-                subq_2.metric_time__day AS metric_time__day
-                , subq_1.ds__day AS ds__day
+                subq_1.ds__day AS ds__day
                 , subq_1.ds__week AS ds__week
                 , subq_1.ds__month AS ds__month
                 , subq_1.ds__quarter AS ds__quarter
@@ -122,6 +121,7 @@ FROM (
                 , subq_1.metric_time__extract_day AS metric_time__extract_day
                 , subq_1.metric_time__extract_dow AS metric_time__extract_dow
                 , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+                , subq_2.metric_time__day AS metric_time__day
                 , subq_1.listing AS listing
                 , subq_1.guest AS guest
                 , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0.sql
@@ -26,7 +26,8 @@ FROM (
       FROM (
         -- Constrain Output with WHERE
         SELECT
-          subq_4.metric_time__month
+          subq_4.metric_time__day
+          , subq_4.metric_time__month
           , subq_4.ds__day
           , subq_4.ds__week
           , subq_4.ds__month
@@ -93,7 +94,6 @@ FROM (
           , subq_4.booking__paid_at__extract_day
           , subq_4.booking__paid_at__extract_dow
           , subq_4.booking__paid_at__extract_doy
-          , subq_4.metric_time__day
           , subq_4.metric_time__week
           , subq_4.metric_time__quarter
           , subq_4.metric_time__year
@@ -127,8 +127,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            DATETIME_TRUNC(subq_2.metric_time__day, month) AS metric_time__month
-            , subq_1.ds__day AS ds__day
+            subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -194,7 +193,6 @@ FROM (
             , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
-            , subq_1.metric_time__day AS metric_time__day
             , subq_1.metric_time__week AS metric_time__week
             , subq_1.metric_time__quarter AS metric_time__quarter
             , subq_1.metric_time__year AS metric_time__year
@@ -204,6 +202,8 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_2.metric_time__day AS metric_time__day
+            , subq_2.metric_time__month AS metric_time__month
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host
@@ -229,6 +229,7 @@ FROM (
             -- Time Spine
             SELECT
               subq_3.ds AS metric_time__day
+              , DATETIME_TRUNC(subq_3.ds, month) AS metric_time__month
             FROM ***************************.mf_time_spine subq_3
           ) subq_2
           INNER JOIN (
@@ -428,7 +429,7 @@ FROM (
           ) subq_1
           ON
             DATETIME_TRUNC(subq_2.metric_time__day, month) = subq_1.metric_time__day
-          WHERE DATETIME_TRUNC(subq_2.metric_time__day, month) = subq_2.metric_time__day
+          WHERE subq_2.metric_time__month = subq_2.metric_time__day
         ) subq_4
         WHERE metric_time__day = '2020-01-01'
       ) subq_5

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
@@ -19,8 +19,8 @@ FROM (
   FROM (
     -- Join to Time Spine Dataset
     SELECT
-      DATETIME_TRUNC(subq_12.ds, month) AS metric_time__month
-      , subq_10.metric_time__day AS metric_time__day
+      subq_12.ds AS metric_time__day
+      , DATETIME_TRUNC(subq_12.ds, month) AS metric_time__month
       , subq_10.bookings AS bookings
     FROM ***************************.mf_time_spine subq_12
     INNER JOIN (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_offset_to_grain_metric_multiple_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_offset_to_grain_metric_multiple_granularities__plan0.sql
@@ -34,10 +34,7 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_2.metric_time__day AS metric_time__day
-          , DATETIME_TRUNC(subq_2.metric_time__day, month) AS metric_time__month
-          , DATETIME_TRUNC(subq_2.metric_time__day, year) AS metric_time__year
-          , subq_1.ds__day AS ds__day
+          subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
@@ -111,6 +108,9 @@ FROM (
           , subq_1.metric_time__extract_day AS metric_time__extract_day
           , subq_1.metric_time__extract_dow AS metric_time__extract_dow
           , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+          , subq_2.metric_time__day AS metric_time__day
+          , subq_2.metric_time__month AS metric_time__month
+          , subq_2.metric_time__year AS metric_time__year
           , subq_1.listing AS listing
           , subq_1.guest AS guest
           , subq_1.host AS host
@@ -136,6 +136,8 @@ FROM (
           -- Time Spine
           SELECT
             subq_3.ds AS metric_time__day
+            , DATETIME_TRUNC(subq_3.ds, month) AS metric_time__month
+            , DATETIME_TRUNC(subq_3.ds, year) AS metric_time__year
           FROM ***************************.mf_time_spine subq_3
         ) subq_2
         INNER JOIN (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_offset_to_grain_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_offset_to_grain_with_agg_time_dim__plan0.sql
@@ -245,8 +245,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_7.booking__ds__day AS booking__ds__day
-            , subq_6.ds__day AS ds__day
+            subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -322,6 +321,7 @@ FROM (
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_7.booking__ds__day AS booking__ds__day
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_offset_window_metric_filter_and_query_have_different_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_offset_window_metric_filter_and_query_have_different_granularities__plan0.sql
@@ -32,7 +32,8 @@ FROM (
         FROM (
           -- Constrain Output with WHERE
           SELECT
-            subq_4.metric_time__month
+            subq_4.metric_time__day
+            , subq_4.metric_time__month
             , subq_4.ds__day
             , subq_4.ds__week
             , subq_4.ds__month
@@ -99,7 +100,6 @@ FROM (
             , subq_4.booking__paid_at__extract_day
             , subq_4.booking__paid_at__extract_dow
             , subq_4.booking__paid_at__extract_doy
-            , subq_4.metric_time__day
             , subq_4.metric_time__week
             , subq_4.metric_time__quarter
             , subq_4.metric_time__year
@@ -133,8 +133,7 @@ FROM (
           FROM (
             -- Join to Time Spine Dataset
             SELECT
-              DATETIME_TRUNC(subq_2.metric_time__day, month) AS metric_time__month
-              , subq_1.ds__day AS ds__day
+              subq_1.ds__day AS ds__day
               , subq_1.ds__week AS ds__week
               , subq_1.ds__month AS ds__month
               , subq_1.ds__quarter AS ds__quarter
@@ -200,7 +199,6 @@ FROM (
               , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
               , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
               , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
-              , subq_1.metric_time__day AS metric_time__day
               , subq_1.metric_time__week AS metric_time__week
               , subq_1.metric_time__quarter AS metric_time__quarter
               , subq_1.metric_time__year AS metric_time__year
@@ -210,6 +208,8 @@ FROM (
               , subq_1.metric_time__extract_day AS metric_time__extract_day
               , subq_1.metric_time__extract_dow AS metric_time__extract_dow
               , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+              , subq_2.metric_time__day AS metric_time__day
+              , subq_2.metric_time__month AS metric_time__month
               , subq_1.listing AS listing
               , subq_1.guest AS guest
               , subq_1.host AS host
@@ -235,6 +235,7 @@ FROM (
               -- Time Spine
               SELECT
                 subq_3.ds AS metric_time__day
+                , DATETIME_TRUNC(subq_3.ds, month) AS metric_time__month
               FROM ***************************.mf_time_spine subq_3
             ) subq_2
             INNER JOIN (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_offset_window_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_offset_window_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
@@ -25,8 +25,8 @@ FROM (
     FROM (
       -- Join to Time Spine Dataset
       SELECT
-        DATETIME_TRUNC(subq_19.ds, month) AS metric_time__month
-        , DATETIME_TRUNC(bookings_source_src_28000.ds, day) AS metric_time__day
+        subq_19.ds AS metric_time__day
+        , DATETIME_TRUNC(subq_19.ds, month) AS metric_time__month
         , bookings_source_src_28000.booking_value AS booking_value
       FROM ***************************.mf_time_spine subq_19
       INNER JOIN

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_offset_window_metric_multiple_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_offset_window_metric_multiple_granularities__plan0.sql
@@ -42,10 +42,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_2.metric_time__day AS metric_time__day
-            , DATETIME_TRUNC(subq_2.metric_time__day, month) AS metric_time__month
-            , DATETIME_TRUNC(subq_2.metric_time__day, year) AS metric_time__year
-            , subq_1.ds__day AS ds__day
+            subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -119,6 +116,9 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_2.metric_time__day AS metric_time__day
+            , subq_2.metric_time__month AS metric_time__month
+            , subq_2.metric_time__year AS metric_time__year
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host
@@ -144,6 +144,8 @@ FROM (
             -- Time Spine
             SELECT
               subq_3.ds AS metric_time__day
+              , DATETIME_TRUNC(subq_3.ds, month) AS metric_time__month
+              , DATETIME_TRUNC(subq_3.ds, year) AS metric_time__year
             FROM ***************************.mf_time_spine subq_3
           ) subq_2
           INNER JOIN (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_offset_window_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_offset_window_with_agg_time_dim__plan0.sql
@@ -245,8 +245,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_7.booking__ds__day AS booking__ds__day
-            , subq_6.ds__day AS ds__day
+            subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -322,6 +321,7 @@ FROM (
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_7.booking__ds__day AS booking__ds__day
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_time_offset_metric_with_time_constraint__plan0.sql
@@ -24,8 +24,7 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_2.metric_time__day AS metric_time__day
-          , subq_1.ds__day AS ds__day
+          subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
@@ -101,6 +100,7 @@ FROM (
           , subq_1.metric_time__extract_day AS metric_time__extract_day
           , subq_1.metric_time__extract_dow AS metric_time__extract_dow
           , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+          , subq_2.metric_time__day AS metric_time__day
           , subq_1.listing AS listing
           , subq_1.guest AS guest
           , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
@@ -125,8 +125,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_5.metric_time__day AS metric_time__day
-            , subq_4.ds__day AS ds__day
+            subq_4.ds__day AS ds__day
             , subq_4.ds__week AS ds__week
             , subq_4.ds__month AS ds__month
             , subq_4.ds__quarter AS ds__quarter
@@ -202,6 +201,7 @@ FROM (
             , subq_4.metric_time__extract_day AS metric_time__extract_day
             , subq_4.metric_time__extract_dow AS metric_time__extract_dow
             , subq_4.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_5.metric_time__day AS metric_time__day
             , subq_4.listing AS listing
             , subq_4.guest AS guest
             , subq_4.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
@@ -24,8 +24,7 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_2.metric_time__month AS metric_time__month
-          , subq_1.ds__month AS ds__month
+          subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
           , subq_1.ds__year AS ds__year
           , subq_1.ds__extract_year AS ds__extract_year
@@ -42,6 +41,7 @@ FROM (
           , subq_1.metric_time__extract_year AS metric_time__extract_year
           , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
           , subq_1.metric_time__extract_month AS metric_time__extract_month
+          , subq_2.metric_time__month AS metric_time__month
           , subq_1.listing AS listing
           , subq_1.booking_monthly__listing AS booking_monthly__listing
           , subq_1.bookings_monthly AS bookings_monthly

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_to_grain__plan0.sql
@@ -245,8 +245,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_7.metric_time__day AS metric_time__day
-            , subq_6.ds__day AS ds__day
+            subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -322,6 +321,7 @@ FROM (
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_7.metric_time__day AS metric_time__day
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_to_grain_and_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_to_grain_and_granularity__plan0.sql
@@ -245,8 +245,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            DATE_TRUNC('week', subq_7.metric_time__day) AS metric_time__week
-            , subq_6.ds__day AS ds__day
+            subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -312,7 +311,6 @@ FROM (
             , subq_6.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_6.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_6.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
-            , subq_6.metric_time__day AS metric_time__day
             , subq_6.metric_time__month AS metric_time__month
             , subq_6.metric_time__quarter AS metric_time__quarter
             , subq_6.metric_time__year AS metric_time__year
@@ -322,6 +320,8 @@ FROM (
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_7.metric_time__day AS metric_time__day
+            , subq_7.metric_time__week AS metric_time__week
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host
@@ -347,6 +347,7 @@ FROM (
             -- Time Spine
             SELECT
               subq_8.ds AS metric_time__day
+              , DATE_TRUNC('week', subq_8.ds) AS metric_time__week
             FROM ***************************.mf_time_spine subq_8
           ) subq_7
           INNER JOIN (
@@ -546,7 +547,7 @@ FROM (
           ) subq_6
           ON
             DATE_TRUNC('month', subq_7.metric_time__day) = subq_6.metric_time__day
-          WHERE DATE_TRUNC('week', subq_7.metric_time__day) = subq_7.metric_time__day
+          WHERE subq_7.metric_time__week = subq_7.metric_time__day
         ) subq_9
       ) subq_10
       GROUP BY

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_window__plan0.sql
@@ -245,8 +245,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_7.metric_time__day AS metric_time__day
-            , subq_6.ds__day AS ds__day
+            subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -322,6 +321,7 @@ FROM (
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_7.metric_time__day AS metric_time__day
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_window_and_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_window_and_granularity__plan0.sql
@@ -245,8 +245,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            DATE_TRUNC('quarter', subq_7.metric_time__day) AS metric_time__quarter
-            , subq_6.ds__day AS ds__day
+            subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -312,7 +311,6 @@ FROM (
             , subq_6.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_6.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_6.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
-            , subq_6.metric_time__day AS metric_time__day
             , subq_6.metric_time__week AS metric_time__week
             , subq_6.metric_time__month AS metric_time__month
             , subq_6.metric_time__year AS metric_time__year
@@ -322,6 +320,8 @@ FROM (
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_7.metric_time__day AS metric_time__day
+            , subq_7.metric_time__quarter AS metric_time__quarter
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host
@@ -347,6 +347,7 @@ FROM (
             -- Time Spine
             SELECT
               subq_8.ds AS metric_time__day
+              , DATE_TRUNC('quarter', subq_8.ds) AS metric_time__quarter
             FROM ***************************.mf_time_spine subq_8
           ) subq_7
           INNER JOIN (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
@@ -30,8 +30,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_2.metric_time__day AS metric_time__day
-            , subq_1.ds__day AS ds__day
+            subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -107,6 +106,7 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_2.metric_time__day AS metric_time__day
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host
@@ -355,8 +355,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_10.metric_time__day AS metric_time__day
-            , subq_9.ds__day AS ds__day
+            subq_9.ds__day AS ds__day
             , subq_9.ds__week AS ds__week
             , subq_9.ds__month AS ds__month
             , subq_9.ds__quarter AS ds__quarter
@@ -432,6 +431,7 @@ FROM (
             , subq_9.metric_time__extract_day AS metric_time__extract_day
             , subq_9.metric_time__extract_dow AS metric_time__extract_dow
             , subq_9.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_10.metric_time__day AS metric_time__day
             , subq_9.listing AS listing
             , subq_9.guest AS guest
             , subq_9.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0.sql
@@ -30,8 +30,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-            , subq_1.ds__day AS ds__day
+            subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -97,7 +96,6 @@ FROM (
             , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
-            , subq_1.metric_time__day AS metric_time__day
             , subq_1.metric_time__week AS metric_time__week
             , subq_1.metric_time__month AS metric_time__month
             , subq_1.metric_time__quarter AS metric_time__quarter
@@ -107,6 +105,8 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_2.metric_time__day AS metric_time__day
+            , subq_2.metric_time__year AS metric_time__year
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host
@@ -132,6 +132,7 @@ FROM (
             -- Time Spine
             SELECT
               subq_3.ds AS metric_time__day
+              , DATE_TRUNC('year', subq_3.ds) AS metric_time__year
             FROM ***************************.mf_time_spine subq_3
           ) subq_2
           INNER JOIN (
@@ -331,7 +332,7 @@ FROM (
           ) subq_1
           ON
             DATE_TRUNC('month', subq_2.metric_time__day) = subq_1.metric_time__day
-          WHERE DATE_TRUNC('year', subq_2.metric_time__day) = subq_2.metric_time__day
+          WHERE subq_2.metric_time__year = subq_2.metric_time__day
         ) subq_4
       ) subq_5
       GROUP BY
@@ -356,8 +357,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            DATE_TRUNC('year', subq_10.metric_time__day) AS metric_time__year
-            , subq_9.ds__day AS ds__day
+            subq_9.ds__day AS ds__day
             , subq_9.ds__week AS ds__week
             , subq_9.ds__month AS ds__month
             , subq_9.ds__quarter AS ds__quarter
@@ -423,7 +423,6 @@ FROM (
             , subq_9.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_9.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_9.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
-            , subq_9.metric_time__day AS metric_time__day
             , subq_9.metric_time__week AS metric_time__week
             , subq_9.metric_time__month AS metric_time__month
             , subq_9.metric_time__quarter AS metric_time__quarter
@@ -433,6 +432,8 @@ FROM (
             , subq_9.metric_time__extract_day AS metric_time__extract_day
             , subq_9.metric_time__extract_dow AS metric_time__extract_dow
             , subq_9.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_10.metric_time__day AS metric_time__day
+            , subq_10.metric_time__year AS metric_time__year
             , subq_9.listing AS listing
             , subq_9.guest AS guest
             , subq_9.host AS host
@@ -458,6 +459,7 @@ FROM (
             -- Time Spine
             SELECT
               subq_11.ds AS metric_time__day
+              , DATE_TRUNC('year', subq_11.ds) AS metric_time__year
             FROM ***************************.mf_time_spine subq_11
           ) subq_10
           INNER JOIN (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
@@ -449,8 +449,7 @@ FROM (
           FROM (
             -- Join to Time Spine Dataset
             SELECT
-              subq_8.metric_time__day AS metric_time__day
-              , subq_7.ds__day AS ds__day
+              subq_7.ds__day AS ds__day
               , subq_7.ds__week AS ds__week
               , subq_7.ds__month AS ds__month
               , subq_7.ds__quarter AS ds__quarter
@@ -526,6 +525,7 @@ FROM (
               , subq_7.metric_time__extract_day AS metric_time__extract_day
               , subq_7.metric_time__extract_dow AS metric_time__extract_dow
               , subq_7.metric_time__extract_doy AS metric_time__extract_doy
+              , subq_8.metric_time__day AS metric_time__day
               , subq_7.listing AS listing
               , subq_7.guest AS guest
               , subq_7.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_offset_cumulative_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_offset_cumulative_metric__plan0.sql
@@ -24,8 +24,7 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_5.metric_time__day AS metric_time__day
-          , subq_4.ds__day AS ds__day
+          subq_4.ds__day AS ds__day
           , subq_4.ds__week AS ds__week
           , subq_4.ds__month AS ds__month
           , subq_4.ds__quarter AS ds__quarter
@@ -101,6 +100,7 @@ FROM (
           , subq_4.metric_time__extract_day AS metric_time__extract_day
           , subq_4.metric_time__extract_dow AS metric_time__extract_dow
           , subq_4.metric_time__extract_doy AS metric_time__extract_doy
+          , subq_5.metric_time__day AS metric_time__day
           , subq_4.listing AS listing
           , subq_4.guest AS guest
           , subq_4.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_offset_metric_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_offset_metric_with_agg_time_dim__plan0.sql
@@ -30,8 +30,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_2.booking__ds__day AS booking__ds__day
-            , subq_1.ds__day AS ds__day
+            subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -107,6 +106,7 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_2.booking__ds__day AS booking__ds__day
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_offset_metric_with_one_input_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_offset_metric_with_one_input_metric__plan0.sql
@@ -24,8 +24,7 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_2.metric_time__day AS metric_time__day
-          , subq_1.ds__day AS ds__day
+          subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
@@ -101,6 +100,7 @@ FROM (
           , subq_1.metric_time__extract_day AS metric_time__extract_day
           , subq_1.metric_time__extract_dow AS metric_time__extract_dow
           , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+          , subq_2.metric_time__day AS metric_time__day
           , subq_1.listing AS listing
           , subq_1.guest AS guest
           , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0.sql
@@ -56,8 +56,7 @@ FROM (
               FROM (
                 -- Join to Time Spine Dataset
                 SELECT
-                  subq_2.metric_time__day AS metric_time__day
-                  , subq_1.ds__day AS ds__day
+                  subq_1.ds__day AS ds__day
                   , subq_1.ds__week AS ds__week
                   , subq_1.ds__month AS ds__month
                   , subq_1.ds__quarter AS ds__quarter
@@ -133,6 +132,7 @@ FROM (
                   , subq_1.metric_time__extract_day AS metric_time__extract_day
                   , subq_1.metric_time__extract_dow AS metric_time__extract_dow
                   , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+                  , subq_2.metric_time__day AS metric_time__day
                   , subq_1.listing AS listing
                   , subq_1.guest AS guest
                   , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_offsets__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_offsets__plan0.sql
@@ -40,8 +40,7 @@ FROM (
           FROM (
             -- Join to Time Spine Dataset
             SELECT
-              subq_2.metric_time__day AS metric_time__day
-              , subq_1.ds__day AS ds__day
+              subq_1.ds__day AS ds__day
               , subq_1.ds__week AS ds__week
               , subq_1.ds__month AS ds__month
               , subq_1.ds__quarter AS ds__quarter
@@ -117,6 +116,7 @@ FROM (
               , subq_1.metric_time__extract_day AS metric_time__extract_day
               , subq_1.metric_time__extract_dow AS metric_time__extract_dow
               , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+              , subq_2.metric_time__day AS metric_time__day
               , subq_1.listing AS listing
               , subq_1.guest AS guest
               , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_offsets_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_offsets_with_time_constraint__plan0.sql
@@ -41,8 +41,7 @@ FROM (
           FROM (
             -- Join to Time Spine Dataset
             SELECT
-              subq_2.metric_time__day AS metric_time__day
-              , subq_1.ds__day AS ds__day
+              subq_1.ds__day AS ds__day
               , subq_1.ds__week AS ds__week
               , subq_1.ds__month AS ds__month
               , subq_1.ds__quarter AS ds__quarter
@@ -118,6 +117,7 @@ FROM (
               , subq_1.metric_time__extract_day AS metric_time__extract_day
               , subq_1.metric_time__extract_dow AS metric_time__extract_dow
               , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+              , subq_2.metric_time__day AS metric_time__day
               , subq_1.listing AS listing
               , subq_1.guest AS guest
               , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_offsets_with_where_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_offsets_with_where_constraint__plan0.sql
@@ -45,8 +45,7 @@ FROM (
             FROM (
               -- Join to Time Spine Dataset
               SELECT
-                subq_2.metric_time__day AS metric_time__day
-                , subq_1.ds__day AS ds__day
+                subq_1.ds__day AS ds__day
                 , subq_1.ds__week AS ds__week
                 , subq_1.ds__month AS ds__month
                 , subq_1.ds__quarter AS ds__quarter
@@ -122,6 +121,7 @@ FROM (
                 , subq_1.metric_time__extract_day AS metric_time__extract_day
                 , subq_1.metric_time__extract_dow AS metric_time__extract_dow
                 , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+                , subq_2.metric_time__day AS metric_time__day
                 , subq_1.listing AS listing
                 , subq_1.guest AS guest
                 , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0.sql
@@ -26,7 +26,8 @@ FROM (
       FROM (
         -- Constrain Output with WHERE
         SELECT
-          subq_4.metric_time__month
+          subq_4.metric_time__day
+          , subq_4.metric_time__month
           , subq_4.ds__day
           , subq_4.ds__week
           , subq_4.ds__month
@@ -93,7 +94,6 @@ FROM (
           , subq_4.booking__paid_at__extract_day
           , subq_4.booking__paid_at__extract_dow
           , subq_4.booking__paid_at__extract_doy
-          , subq_4.metric_time__day
           , subq_4.metric_time__week
           , subq_4.metric_time__quarter
           , subq_4.metric_time__year
@@ -127,8 +127,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-            , subq_1.ds__day AS ds__day
+            subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -194,7 +193,6 @@ FROM (
             , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
-            , subq_1.metric_time__day AS metric_time__day
             , subq_1.metric_time__week AS metric_time__week
             , subq_1.metric_time__quarter AS metric_time__quarter
             , subq_1.metric_time__year AS metric_time__year
@@ -204,6 +202,8 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_2.metric_time__day AS metric_time__day
+            , subq_2.metric_time__month AS metric_time__month
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host
@@ -229,6 +229,7 @@ FROM (
             -- Time Spine
             SELECT
               subq_3.ds AS metric_time__day
+              , DATE_TRUNC('month', subq_3.ds) AS metric_time__month
             FROM ***************************.mf_time_spine subq_3
           ) subq_2
           INNER JOIN (
@@ -428,7 +429,7 @@ FROM (
           ) subq_1
           ON
             DATE_TRUNC('month', subq_2.metric_time__day) = subq_1.metric_time__day
-          WHERE DATE_TRUNC('month', subq_2.metric_time__day) = subq_2.metric_time__day
+          WHERE subq_2.metric_time__month = subq_2.metric_time__day
         ) subq_4
         WHERE metric_time__day = '2020-01-01'
       ) subq_5

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
@@ -19,8 +19,8 @@ FROM (
   FROM (
     -- Join to Time Spine Dataset
     SELECT
-      DATE_TRUNC('month', subq_12.ds) AS metric_time__month
-      , subq_10.metric_time__day AS metric_time__day
+      subq_12.ds AS metric_time__day
+      , DATE_TRUNC('month', subq_12.ds) AS metric_time__month
       , subq_10.bookings AS bookings
     FROM ***************************.mf_time_spine subq_12
     INNER JOIN (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_offset_to_grain_metric_multiple_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_offset_to_grain_metric_multiple_granularities__plan0.sql
@@ -34,10 +34,7 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_2.metric_time__day AS metric_time__day
-          , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-          , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-          , subq_1.ds__day AS ds__day
+          subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
@@ -111,6 +108,9 @@ FROM (
           , subq_1.metric_time__extract_day AS metric_time__extract_day
           , subq_1.metric_time__extract_dow AS metric_time__extract_dow
           , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+          , subq_2.metric_time__day AS metric_time__day
+          , subq_2.metric_time__month AS metric_time__month
+          , subq_2.metric_time__year AS metric_time__year
           , subq_1.listing AS listing
           , subq_1.guest AS guest
           , subq_1.host AS host
@@ -136,6 +136,8 @@ FROM (
           -- Time Spine
           SELECT
             subq_3.ds AS metric_time__day
+            , DATE_TRUNC('month', subq_3.ds) AS metric_time__month
+            , DATE_TRUNC('year', subq_3.ds) AS metric_time__year
           FROM ***************************.mf_time_spine subq_3
         ) subq_2
         INNER JOIN (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_offset_to_grain_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_offset_to_grain_with_agg_time_dim__plan0.sql
@@ -245,8 +245,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_7.booking__ds__day AS booking__ds__day
-            , subq_6.ds__day AS ds__day
+            subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -322,6 +321,7 @@ FROM (
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_7.booking__ds__day AS booking__ds__day
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_offset_window_metric_filter_and_query_have_different_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_offset_window_metric_filter_and_query_have_different_granularities__plan0.sql
@@ -32,7 +32,8 @@ FROM (
         FROM (
           -- Constrain Output with WHERE
           SELECT
-            subq_4.metric_time__month
+            subq_4.metric_time__day
+            , subq_4.metric_time__month
             , subq_4.ds__day
             , subq_4.ds__week
             , subq_4.ds__month
@@ -99,7 +100,6 @@ FROM (
             , subq_4.booking__paid_at__extract_day
             , subq_4.booking__paid_at__extract_dow
             , subq_4.booking__paid_at__extract_doy
-            , subq_4.metric_time__day
             , subq_4.metric_time__week
             , subq_4.metric_time__quarter
             , subq_4.metric_time__year
@@ -133,8 +133,7 @@ FROM (
           FROM (
             -- Join to Time Spine Dataset
             SELECT
-              DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-              , subq_1.ds__day AS ds__day
+              subq_1.ds__day AS ds__day
               , subq_1.ds__week AS ds__week
               , subq_1.ds__month AS ds__month
               , subq_1.ds__quarter AS ds__quarter
@@ -200,7 +199,6 @@ FROM (
               , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
               , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
               , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
-              , subq_1.metric_time__day AS metric_time__day
               , subq_1.metric_time__week AS metric_time__week
               , subq_1.metric_time__quarter AS metric_time__quarter
               , subq_1.metric_time__year AS metric_time__year
@@ -210,6 +208,8 @@ FROM (
               , subq_1.metric_time__extract_day AS metric_time__extract_day
               , subq_1.metric_time__extract_dow AS metric_time__extract_dow
               , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+              , subq_2.metric_time__day AS metric_time__day
+              , subq_2.metric_time__month AS metric_time__month
               , subq_1.listing AS listing
               , subq_1.guest AS guest
               , subq_1.host AS host
@@ -235,6 +235,7 @@ FROM (
               -- Time Spine
               SELECT
                 subq_3.ds AS metric_time__day
+                , DATE_TRUNC('month', subq_3.ds) AS metric_time__month
               FROM ***************************.mf_time_spine subq_3
             ) subq_2
             INNER JOIN (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_offset_window_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_offset_window_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
@@ -25,8 +25,8 @@ FROM (
     FROM (
       -- Join to Time Spine Dataset
       SELECT
-        DATE_TRUNC('month', subq_19.ds) AS metric_time__month
-        , DATE_TRUNC('day', bookings_source_src_28000.ds) AS metric_time__day
+        subq_19.ds AS metric_time__day
+        , DATE_TRUNC('month', subq_19.ds) AS metric_time__month
         , bookings_source_src_28000.booking_value AS booking_value
       FROM ***************************.mf_time_spine subq_19
       INNER JOIN

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_offset_window_metric_multiple_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_offset_window_metric_multiple_granularities__plan0.sql
@@ -42,10 +42,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_2.metric_time__day AS metric_time__day
-            , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-            , subq_1.ds__day AS ds__day
+            subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -119,6 +116,9 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_2.metric_time__day AS metric_time__day
+            , subq_2.metric_time__month AS metric_time__month
+            , subq_2.metric_time__year AS metric_time__year
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host
@@ -144,6 +144,8 @@ FROM (
             -- Time Spine
             SELECT
               subq_3.ds AS metric_time__day
+              , DATE_TRUNC('month', subq_3.ds) AS metric_time__month
+              , DATE_TRUNC('year', subq_3.ds) AS metric_time__year
             FROM ***************************.mf_time_spine subq_3
           ) subq_2
           INNER JOIN (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_offset_window_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_offset_window_with_agg_time_dim__plan0.sql
@@ -245,8 +245,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_7.booking__ds__day AS booking__ds__day
-            , subq_6.ds__day AS ds__day
+            subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -322,6 +321,7 @@ FROM (
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_7.booking__ds__day AS booking__ds__day
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_time_offset_metric_with_time_constraint__plan0.sql
@@ -24,8 +24,7 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_2.metric_time__day AS metric_time__day
-          , subq_1.ds__day AS ds__day
+          subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
@@ -101,6 +100,7 @@ FROM (
           , subq_1.metric_time__extract_day AS metric_time__extract_day
           , subq_1.metric_time__extract_dow AS metric_time__extract_dow
           , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+          , subq_2.metric_time__day AS metric_time__day
           , subq_1.listing AS listing
           , subq_1.guest AS guest
           , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
@@ -125,8 +125,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_5.metric_time__day AS metric_time__day
-            , subq_4.ds__day AS ds__day
+            subq_4.ds__day AS ds__day
             , subq_4.ds__week AS ds__week
             , subq_4.ds__month AS ds__month
             , subq_4.ds__quarter AS ds__quarter
@@ -202,6 +201,7 @@ FROM (
             , subq_4.metric_time__extract_day AS metric_time__extract_day
             , subq_4.metric_time__extract_dow AS metric_time__extract_dow
             , subq_4.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_5.metric_time__day AS metric_time__day
             , subq_4.listing AS listing
             , subq_4.guest AS guest
             , subq_4.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
@@ -24,8 +24,7 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_2.metric_time__month AS metric_time__month
-          , subq_1.ds__month AS ds__month
+          subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
           , subq_1.ds__year AS ds__year
           , subq_1.ds__extract_year AS ds__extract_year
@@ -42,6 +41,7 @@ FROM (
           , subq_1.metric_time__extract_year AS metric_time__extract_year
           , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
           , subq_1.metric_time__extract_month AS metric_time__extract_month
+          , subq_2.metric_time__month AS metric_time__month
           , subq_1.listing AS listing
           , subq_1.booking_monthly__listing AS booking_monthly__listing
           , subq_1.bookings_monthly AS bookings_monthly

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_to_grain__plan0.sql
@@ -245,8 +245,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_7.metric_time__day AS metric_time__day
-            , subq_6.ds__day AS ds__day
+            subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -322,6 +321,7 @@ FROM (
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_7.metric_time__day AS metric_time__day
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_to_grain_and_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_to_grain_and_granularity__plan0.sql
@@ -245,8 +245,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            DATE_TRUNC('week', subq_7.metric_time__day) AS metric_time__week
-            , subq_6.ds__day AS ds__day
+            subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -312,7 +311,6 @@ FROM (
             , subq_6.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_6.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_6.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
-            , subq_6.metric_time__day AS metric_time__day
             , subq_6.metric_time__month AS metric_time__month
             , subq_6.metric_time__quarter AS metric_time__quarter
             , subq_6.metric_time__year AS metric_time__year
@@ -322,6 +320,8 @@ FROM (
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_7.metric_time__day AS metric_time__day
+            , subq_7.metric_time__week AS metric_time__week
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host
@@ -347,6 +347,7 @@ FROM (
             -- Time Spine
             SELECT
               subq_8.ds AS metric_time__day
+              , DATE_TRUNC('week', subq_8.ds) AS metric_time__week
             FROM ***************************.mf_time_spine subq_8
           ) subq_7
           INNER JOIN (
@@ -546,7 +547,7 @@ FROM (
           ) subq_6
           ON
             DATE_TRUNC('month', subq_7.metric_time__day) = subq_6.metric_time__day
-          WHERE DATE_TRUNC('week', subq_7.metric_time__day) = subq_7.metric_time__day
+          WHERE subq_7.metric_time__week = subq_7.metric_time__day
         ) subq_9
       ) subq_10
       GROUP BY

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_window__plan0.sql
@@ -245,8 +245,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_7.metric_time__day AS metric_time__day
-            , subq_6.ds__day AS ds__day
+            subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -322,6 +321,7 @@ FROM (
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_7.metric_time__day AS metric_time__day
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_window_and_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_window_and_granularity__plan0.sql
@@ -245,8 +245,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            DATE_TRUNC('quarter', subq_7.metric_time__day) AS metric_time__quarter
-            , subq_6.ds__day AS ds__day
+            subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -312,7 +311,6 @@ FROM (
             , subq_6.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_6.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_6.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
-            , subq_6.metric_time__day AS metric_time__day
             , subq_6.metric_time__week AS metric_time__week
             , subq_6.metric_time__month AS metric_time__month
             , subq_6.metric_time__year AS metric_time__year
@@ -322,6 +320,8 @@ FROM (
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_7.metric_time__day AS metric_time__day
+            , subq_7.metric_time__quarter AS metric_time__quarter
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host
@@ -347,6 +347,7 @@ FROM (
             -- Time Spine
             SELECT
               subq_8.ds AS metric_time__day
+              , DATE_TRUNC('quarter', subq_8.ds) AS metric_time__quarter
             FROM ***************************.mf_time_spine subq_8
           ) subq_7
           INNER JOIN (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
@@ -30,8 +30,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_2.metric_time__day AS metric_time__day
-            , subq_1.ds__day AS ds__day
+            subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -107,6 +106,7 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_2.metric_time__day AS metric_time__day
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host
@@ -355,8 +355,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_10.metric_time__day AS metric_time__day
-            , subq_9.ds__day AS ds__day
+            subq_9.ds__day AS ds__day
             , subq_9.ds__week AS ds__week
             , subq_9.ds__month AS ds__month
             , subq_9.ds__quarter AS ds__quarter
@@ -432,6 +431,7 @@ FROM (
             , subq_9.metric_time__extract_day AS metric_time__extract_day
             , subq_9.metric_time__extract_dow AS metric_time__extract_dow
             , subq_9.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_10.metric_time__day AS metric_time__day
             , subq_9.listing AS listing
             , subq_9.guest AS guest
             , subq_9.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0.sql
@@ -30,8 +30,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-            , subq_1.ds__day AS ds__day
+            subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -97,7 +96,6 @@ FROM (
             , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
-            , subq_1.metric_time__day AS metric_time__day
             , subq_1.metric_time__week AS metric_time__week
             , subq_1.metric_time__month AS metric_time__month
             , subq_1.metric_time__quarter AS metric_time__quarter
@@ -107,6 +105,8 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_2.metric_time__day AS metric_time__day
+            , subq_2.metric_time__year AS metric_time__year
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host
@@ -132,6 +132,7 @@ FROM (
             -- Time Spine
             SELECT
               subq_3.ds AS metric_time__day
+              , DATE_TRUNC('year', subq_3.ds) AS metric_time__year
             FROM ***************************.mf_time_spine subq_3
           ) subq_2
           INNER JOIN (
@@ -331,7 +332,7 @@ FROM (
           ) subq_1
           ON
             DATE_TRUNC('month', subq_2.metric_time__day) = subq_1.metric_time__day
-          WHERE DATE_TRUNC('year', subq_2.metric_time__day) = subq_2.metric_time__day
+          WHERE subq_2.metric_time__year = subq_2.metric_time__day
         ) subq_4
       ) subq_5
       GROUP BY
@@ -356,8 +357,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            DATE_TRUNC('year', subq_10.metric_time__day) AS metric_time__year
-            , subq_9.ds__day AS ds__day
+            subq_9.ds__day AS ds__day
             , subq_9.ds__week AS ds__week
             , subq_9.ds__month AS ds__month
             , subq_9.ds__quarter AS ds__quarter
@@ -423,7 +423,6 @@ FROM (
             , subq_9.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_9.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_9.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
-            , subq_9.metric_time__day AS metric_time__day
             , subq_9.metric_time__week AS metric_time__week
             , subq_9.metric_time__month AS metric_time__month
             , subq_9.metric_time__quarter AS metric_time__quarter
@@ -433,6 +432,8 @@ FROM (
             , subq_9.metric_time__extract_day AS metric_time__extract_day
             , subq_9.metric_time__extract_dow AS metric_time__extract_dow
             , subq_9.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_10.metric_time__day AS metric_time__day
+            , subq_10.metric_time__year AS metric_time__year
             , subq_9.listing AS listing
             , subq_9.guest AS guest
             , subq_9.host AS host
@@ -458,6 +459,7 @@ FROM (
             -- Time Spine
             SELECT
               subq_11.ds AS metric_time__day
+              , DATE_TRUNC('year', subq_11.ds) AS metric_time__year
             FROM ***************************.mf_time_spine subq_11
           ) subq_10
           INNER JOIN (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
@@ -449,8 +449,7 @@ FROM (
           FROM (
             -- Join to Time Spine Dataset
             SELECT
-              subq_8.metric_time__day AS metric_time__day
-              , subq_7.ds__day AS ds__day
+              subq_7.ds__day AS ds__day
               , subq_7.ds__week AS ds__week
               , subq_7.ds__month AS ds__month
               , subq_7.ds__quarter AS ds__quarter
@@ -526,6 +525,7 @@ FROM (
               , subq_7.metric_time__extract_day AS metric_time__extract_day
               , subq_7.metric_time__extract_dow AS metric_time__extract_dow
               , subq_7.metric_time__extract_doy AS metric_time__extract_doy
+              , subq_8.metric_time__day AS metric_time__day
               , subq_7.listing AS listing
               , subq_7.guest AS guest
               , subq_7.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_offset_cumulative_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_offset_cumulative_metric__plan0.sql
@@ -24,8 +24,7 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_5.metric_time__day AS metric_time__day
-          , subq_4.ds__day AS ds__day
+          subq_4.ds__day AS ds__day
           , subq_4.ds__week AS ds__week
           , subq_4.ds__month AS ds__month
           , subq_4.ds__quarter AS ds__quarter
@@ -101,6 +100,7 @@ FROM (
           , subq_4.metric_time__extract_day AS metric_time__extract_day
           , subq_4.metric_time__extract_dow AS metric_time__extract_dow
           , subq_4.metric_time__extract_doy AS metric_time__extract_doy
+          , subq_5.metric_time__day AS metric_time__day
           , subq_4.listing AS listing
           , subq_4.guest AS guest
           , subq_4.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_offset_metric_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_offset_metric_with_agg_time_dim__plan0.sql
@@ -30,8 +30,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_2.booking__ds__day AS booking__ds__day
-            , subq_1.ds__day AS ds__day
+            subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -107,6 +106,7 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_2.booking__ds__day AS booking__ds__day
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_offset_metric_with_one_input_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_offset_metric_with_one_input_metric__plan0.sql
@@ -24,8 +24,7 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_2.metric_time__day AS metric_time__day
-          , subq_1.ds__day AS ds__day
+          subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
@@ -101,6 +100,7 @@ FROM (
           , subq_1.metric_time__extract_day AS metric_time__extract_day
           , subq_1.metric_time__extract_dow AS metric_time__extract_dow
           , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+          , subq_2.metric_time__day AS metric_time__day
           , subq_1.listing AS listing
           , subq_1.guest AS guest
           , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0.sql
@@ -56,8 +56,7 @@ FROM (
               FROM (
                 -- Join to Time Spine Dataset
                 SELECT
-                  subq_2.metric_time__day AS metric_time__day
-                  , subq_1.ds__day AS ds__day
+                  subq_1.ds__day AS ds__day
                   , subq_1.ds__week AS ds__week
                   , subq_1.ds__month AS ds__month
                   , subq_1.ds__quarter AS ds__quarter
@@ -133,6 +132,7 @@ FROM (
                   , subq_1.metric_time__extract_day AS metric_time__extract_day
                   , subq_1.metric_time__extract_dow AS metric_time__extract_dow
                   , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+                  , subq_2.metric_time__day AS metric_time__day
                   , subq_1.listing AS listing
                   , subq_1.guest AS guest
                   , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_offsets__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_offsets__plan0.sql
@@ -40,8 +40,7 @@ FROM (
           FROM (
             -- Join to Time Spine Dataset
             SELECT
-              subq_2.metric_time__day AS metric_time__day
-              , subq_1.ds__day AS ds__day
+              subq_1.ds__day AS ds__day
               , subq_1.ds__week AS ds__week
               , subq_1.ds__month AS ds__month
               , subq_1.ds__quarter AS ds__quarter
@@ -117,6 +116,7 @@ FROM (
               , subq_1.metric_time__extract_day AS metric_time__extract_day
               , subq_1.metric_time__extract_dow AS metric_time__extract_dow
               , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+              , subq_2.metric_time__day AS metric_time__day
               , subq_1.listing AS listing
               , subq_1.guest AS guest
               , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_offsets_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_offsets_with_time_constraint__plan0.sql
@@ -41,8 +41,7 @@ FROM (
           FROM (
             -- Join to Time Spine Dataset
             SELECT
-              subq_2.metric_time__day AS metric_time__day
-              , subq_1.ds__day AS ds__day
+              subq_1.ds__day AS ds__day
               , subq_1.ds__week AS ds__week
               , subq_1.ds__month AS ds__month
               , subq_1.ds__quarter AS ds__quarter
@@ -118,6 +117,7 @@ FROM (
               , subq_1.metric_time__extract_day AS metric_time__extract_day
               , subq_1.metric_time__extract_dow AS metric_time__extract_dow
               , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+              , subq_2.metric_time__day AS metric_time__day
               , subq_1.listing AS listing
               , subq_1.guest AS guest
               , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_offsets_with_where_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_offsets_with_where_constraint__plan0.sql
@@ -45,8 +45,7 @@ FROM (
             FROM (
               -- Join to Time Spine Dataset
               SELECT
-                subq_2.metric_time__day AS metric_time__day
-                , subq_1.ds__day AS ds__day
+                subq_1.ds__day AS ds__day
                 , subq_1.ds__week AS ds__week
                 , subq_1.ds__month AS ds__month
                 , subq_1.ds__quarter AS ds__quarter
@@ -122,6 +121,7 @@ FROM (
                 , subq_1.metric_time__extract_day AS metric_time__extract_day
                 , subq_1.metric_time__extract_dow AS metric_time__extract_dow
                 , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+                , subq_2.metric_time__day AS metric_time__day
                 , subq_1.listing AS listing
                 , subq_1.guest AS guest
                 , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0.sql
@@ -26,7 +26,8 @@ FROM (
       FROM (
         -- Constrain Output with WHERE
         SELECT
-          subq_4.metric_time__month
+          subq_4.metric_time__day
+          , subq_4.metric_time__month
           , subq_4.ds__day
           , subq_4.ds__week
           , subq_4.ds__month
@@ -93,7 +94,6 @@ FROM (
           , subq_4.booking__paid_at__extract_day
           , subq_4.booking__paid_at__extract_dow
           , subq_4.booking__paid_at__extract_doy
-          , subq_4.metric_time__day
           , subq_4.metric_time__week
           , subq_4.metric_time__quarter
           , subq_4.metric_time__year
@@ -127,8 +127,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-            , subq_1.ds__day AS ds__day
+            subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -194,7 +193,6 @@ FROM (
             , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
-            , subq_1.metric_time__day AS metric_time__day
             , subq_1.metric_time__week AS metric_time__week
             , subq_1.metric_time__quarter AS metric_time__quarter
             , subq_1.metric_time__year AS metric_time__year
@@ -204,6 +202,8 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_2.metric_time__day AS metric_time__day
+            , subq_2.metric_time__month AS metric_time__month
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host
@@ -229,6 +229,7 @@ FROM (
             -- Time Spine
             SELECT
               subq_3.ds AS metric_time__day
+              , DATE_TRUNC('month', subq_3.ds) AS metric_time__month
             FROM ***************************.mf_time_spine subq_3
           ) subq_2
           INNER JOIN (
@@ -428,7 +429,7 @@ FROM (
           ) subq_1
           ON
             DATE_TRUNC('month', subq_2.metric_time__day) = subq_1.metric_time__day
-          WHERE DATE_TRUNC('month', subq_2.metric_time__day) = subq_2.metric_time__day
+          WHERE subq_2.metric_time__month = subq_2.metric_time__day
         ) subq_4
         WHERE metric_time__day = '2020-01-01'
       ) subq_5

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
@@ -19,8 +19,8 @@ FROM (
   FROM (
     -- Join to Time Spine Dataset
     SELECT
-      DATE_TRUNC('month', subq_12.ds) AS metric_time__month
-      , subq_10.metric_time__day AS metric_time__day
+      subq_12.ds AS metric_time__day
+      , DATE_TRUNC('month', subq_12.ds) AS metric_time__month
       , subq_10.bookings AS bookings
     FROM ***************************.mf_time_spine subq_12
     INNER JOIN (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_offset_to_grain_metric_multiple_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_offset_to_grain_metric_multiple_granularities__plan0.sql
@@ -34,10 +34,7 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_2.metric_time__day AS metric_time__day
-          , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-          , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-          , subq_1.ds__day AS ds__day
+          subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
@@ -111,6 +108,9 @@ FROM (
           , subq_1.metric_time__extract_day AS metric_time__extract_day
           , subq_1.metric_time__extract_dow AS metric_time__extract_dow
           , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+          , subq_2.metric_time__day AS metric_time__day
+          , subq_2.metric_time__month AS metric_time__month
+          , subq_2.metric_time__year AS metric_time__year
           , subq_1.listing AS listing
           , subq_1.guest AS guest
           , subq_1.host AS host
@@ -136,6 +136,8 @@ FROM (
           -- Time Spine
           SELECT
             subq_3.ds AS metric_time__day
+            , DATE_TRUNC('month', subq_3.ds) AS metric_time__month
+            , DATE_TRUNC('year', subq_3.ds) AS metric_time__year
           FROM ***************************.mf_time_spine subq_3
         ) subq_2
         INNER JOIN (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_offset_to_grain_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_offset_to_grain_with_agg_time_dim__plan0.sql
@@ -245,8 +245,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_7.booking__ds__day AS booking__ds__day
-            , subq_6.ds__day AS ds__day
+            subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -322,6 +321,7 @@ FROM (
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_7.booking__ds__day AS booking__ds__day
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_offset_window_metric_filter_and_query_have_different_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_offset_window_metric_filter_and_query_have_different_granularities__plan0.sql
@@ -32,7 +32,8 @@ FROM (
         FROM (
           -- Constrain Output with WHERE
           SELECT
-            subq_4.metric_time__month
+            subq_4.metric_time__day
+            , subq_4.metric_time__month
             , subq_4.ds__day
             , subq_4.ds__week
             , subq_4.ds__month
@@ -99,7 +100,6 @@ FROM (
             , subq_4.booking__paid_at__extract_day
             , subq_4.booking__paid_at__extract_dow
             , subq_4.booking__paid_at__extract_doy
-            , subq_4.metric_time__day
             , subq_4.metric_time__week
             , subq_4.metric_time__quarter
             , subq_4.metric_time__year
@@ -133,8 +133,7 @@ FROM (
           FROM (
             -- Join to Time Spine Dataset
             SELECT
-              DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-              , subq_1.ds__day AS ds__day
+              subq_1.ds__day AS ds__day
               , subq_1.ds__week AS ds__week
               , subq_1.ds__month AS ds__month
               , subq_1.ds__quarter AS ds__quarter
@@ -200,7 +199,6 @@ FROM (
               , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
               , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
               , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
-              , subq_1.metric_time__day AS metric_time__day
               , subq_1.metric_time__week AS metric_time__week
               , subq_1.metric_time__quarter AS metric_time__quarter
               , subq_1.metric_time__year AS metric_time__year
@@ -210,6 +208,8 @@ FROM (
               , subq_1.metric_time__extract_day AS metric_time__extract_day
               , subq_1.metric_time__extract_dow AS metric_time__extract_dow
               , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+              , subq_2.metric_time__day AS metric_time__day
+              , subq_2.metric_time__month AS metric_time__month
               , subq_1.listing AS listing
               , subq_1.guest AS guest
               , subq_1.host AS host
@@ -235,6 +235,7 @@ FROM (
               -- Time Spine
               SELECT
                 subq_3.ds AS metric_time__day
+                , DATE_TRUNC('month', subq_3.ds) AS metric_time__month
               FROM ***************************.mf_time_spine subq_3
             ) subq_2
             INNER JOIN (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_offset_window_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_offset_window_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
@@ -25,8 +25,8 @@ FROM (
     FROM (
       -- Join to Time Spine Dataset
       SELECT
-        DATE_TRUNC('month', subq_19.ds) AS metric_time__month
-        , DATE_TRUNC('day', bookings_source_src_28000.ds) AS metric_time__day
+        subq_19.ds AS metric_time__day
+        , DATE_TRUNC('month', subq_19.ds) AS metric_time__month
         , bookings_source_src_28000.booking_value AS booking_value
       FROM ***************************.mf_time_spine subq_19
       INNER JOIN

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_offset_window_metric_multiple_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_offset_window_metric_multiple_granularities__plan0.sql
@@ -42,10 +42,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_2.metric_time__day AS metric_time__day
-            , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-            , subq_1.ds__day AS ds__day
+            subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -119,6 +116,9 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_2.metric_time__day AS metric_time__day
+            , subq_2.metric_time__month AS metric_time__month
+            , subq_2.metric_time__year AS metric_time__year
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host
@@ -144,6 +144,8 @@ FROM (
             -- Time Spine
             SELECT
               subq_3.ds AS metric_time__day
+              , DATE_TRUNC('month', subq_3.ds) AS metric_time__month
+              , DATE_TRUNC('year', subq_3.ds) AS metric_time__year
             FROM ***************************.mf_time_spine subq_3
           ) subq_2
           INNER JOIN (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_offset_window_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_offset_window_with_agg_time_dim__plan0.sql
@@ -245,8 +245,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_7.booking__ds__day AS booking__ds__day
-            , subq_6.ds__day AS ds__day
+            subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -322,6 +321,7 @@ FROM (
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_7.booking__ds__day AS booking__ds__day
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_time_offset_metric_with_time_constraint__plan0.sql
@@ -24,8 +24,7 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_2.metric_time__day AS metric_time__day
-          , subq_1.ds__day AS ds__day
+          subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
@@ -101,6 +100,7 @@ FROM (
           , subq_1.metric_time__extract_day AS metric_time__extract_day
           , subq_1.metric_time__extract_dow AS metric_time__extract_dow
           , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+          , subq_2.metric_time__day AS metric_time__day
           , subq_1.listing AS listing
           , subq_1.guest AS guest
           , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
@@ -125,8 +125,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_5.metric_time__day AS metric_time__day
-            , subq_4.ds__day AS ds__day
+            subq_4.ds__day AS ds__day
             , subq_4.ds__week AS ds__week
             , subq_4.ds__month AS ds__month
             , subq_4.ds__quarter AS ds__quarter
@@ -202,6 +201,7 @@ FROM (
             , subq_4.metric_time__extract_day AS metric_time__extract_day
             , subq_4.metric_time__extract_dow AS metric_time__extract_dow
             , subq_4.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_5.metric_time__day AS metric_time__day
             , subq_4.listing AS listing
             , subq_4.guest AS guest
             , subq_4.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
@@ -24,8 +24,7 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_2.metric_time__month AS metric_time__month
-          , subq_1.ds__month AS ds__month
+          subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
           , subq_1.ds__year AS ds__year
           , subq_1.ds__extract_year AS ds__extract_year
@@ -42,6 +41,7 @@ FROM (
           , subq_1.metric_time__extract_year AS metric_time__extract_year
           , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
           , subq_1.metric_time__extract_month AS metric_time__extract_month
+          , subq_2.metric_time__month AS metric_time__month
           , subq_1.listing AS listing
           , subq_1.booking_monthly__listing AS booking_monthly__listing
           , subq_1.bookings_monthly AS bookings_monthly

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_to_grain__plan0.sql
@@ -245,8 +245,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_7.metric_time__day AS metric_time__day
-            , subq_6.ds__day AS ds__day
+            subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -322,6 +321,7 @@ FROM (
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_7.metric_time__day AS metric_time__day
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_to_grain_and_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_to_grain_and_granularity__plan0.sql
@@ -245,8 +245,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            DATE_TRUNC('week', subq_7.metric_time__day) AS metric_time__week
-            , subq_6.ds__day AS ds__day
+            subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -312,7 +311,6 @@ FROM (
             , subq_6.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_6.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_6.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
-            , subq_6.metric_time__day AS metric_time__day
             , subq_6.metric_time__month AS metric_time__month
             , subq_6.metric_time__quarter AS metric_time__quarter
             , subq_6.metric_time__year AS metric_time__year
@@ -322,6 +320,8 @@ FROM (
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_7.metric_time__day AS metric_time__day
+            , subq_7.metric_time__week AS metric_time__week
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host
@@ -347,6 +347,7 @@ FROM (
             -- Time Spine
             SELECT
               subq_8.ds AS metric_time__day
+              , DATE_TRUNC('week', subq_8.ds) AS metric_time__week
             FROM ***************************.mf_time_spine subq_8
           ) subq_7
           INNER JOIN (
@@ -546,7 +547,7 @@ FROM (
           ) subq_6
           ON
             DATE_TRUNC('month', subq_7.metric_time__day) = subq_6.metric_time__day
-          WHERE DATE_TRUNC('week', subq_7.metric_time__day) = subq_7.metric_time__day
+          WHERE subq_7.metric_time__week = subq_7.metric_time__day
         ) subq_9
       ) subq_10
       GROUP BY

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_window__plan0.sql
@@ -245,8 +245,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_7.metric_time__day AS metric_time__day
-            , subq_6.ds__day AS ds__day
+            subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -322,6 +321,7 @@ FROM (
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_7.metric_time__day AS metric_time__day
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_window_and_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_window_and_granularity__plan0.sql
@@ -245,8 +245,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            DATE_TRUNC('quarter', subq_7.metric_time__day) AS metric_time__quarter
-            , subq_6.ds__day AS ds__day
+            subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -312,7 +311,6 @@ FROM (
             , subq_6.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_6.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_6.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
-            , subq_6.metric_time__day AS metric_time__day
             , subq_6.metric_time__week AS metric_time__week
             , subq_6.metric_time__month AS metric_time__month
             , subq_6.metric_time__year AS metric_time__year
@@ -322,6 +320,8 @@ FROM (
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_7.metric_time__day AS metric_time__day
+            , subq_7.metric_time__quarter AS metric_time__quarter
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host
@@ -347,6 +347,7 @@ FROM (
             -- Time Spine
             SELECT
               subq_8.ds AS metric_time__day
+              , DATE_TRUNC('quarter', subq_8.ds) AS metric_time__quarter
             FROM ***************************.mf_time_spine subq_8
           ) subq_7
           INNER JOIN (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
@@ -30,8 +30,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_2.metric_time__day AS metric_time__day
-            , subq_1.ds__day AS ds__day
+            subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -107,6 +106,7 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_2.metric_time__day AS metric_time__day
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host
@@ -355,8 +355,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_10.metric_time__day AS metric_time__day
-            , subq_9.ds__day AS ds__day
+            subq_9.ds__day AS ds__day
             , subq_9.ds__week AS ds__week
             , subq_9.ds__month AS ds__month
             , subq_9.ds__quarter AS ds__quarter
@@ -432,6 +431,7 @@ FROM (
             , subq_9.metric_time__extract_day AS metric_time__extract_day
             , subq_9.metric_time__extract_dow AS metric_time__extract_dow
             , subq_9.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_10.metric_time__day AS metric_time__day
             , subq_9.listing AS listing
             , subq_9.guest AS guest
             , subq_9.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0.sql
@@ -30,8 +30,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-            , subq_1.ds__day AS ds__day
+            subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -97,7 +96,6 @@ FROM (
             , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
-            , subq_1.metric_time__day AS metric_time__day
             , subq_1.metric_time__week AS metric_time__week
             , subq_1.metric_time__month AS metric_time__month
             , subq_1.metric_time__quarter AS metric_time__quarter
@@ -107,6 +105,8 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_2.metric_time__day AS metric_time__day
+            , subq_2.metric_time__year AS metric_time__year
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host
@@ -132,6 +132,7 @@ FROM (
             -- Time Spine
             SELECT
               subq_3.ds AS metric_time__day
+              , DATE_TRUNC('year', subq_3.ds) AS metric_time__year
             FROM ***************************.mf_time_spine subq_3
           ) subq_2
           INNER JOIN (
@@ -331,7 +332,7 @@ FROM (
           ) subq_1
           ON
             DATE_TRUNC('month', subq_2.metric_time__day) = subq_1.metric_time__day
-          WHERE DATE_TRUNC('year', subq_2.metric_time__day) = subq_2.metric_time__day
+          WHERE subq_2.metric_time__year = subq_2.metric_time__day
         ) subq_4
       ) subq_5
       GROUP BY
@@ -356,8 +357,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            DATE_TRUNC('year', subq_10.metric_time__day) AS metric_time__year
-            , subq_9.ds__day AS ds__day
+            subq_9.ds__day AS ds__day
             , subq_9.ds__week AS ds__week
             , subq_9.ds__month AS ds__month
             , subq_9.ds__quarter AS ds__quarter
@@ -423,7 +423,6 @@ FROM (
             , subq_9.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_9.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_9.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
-            , subq_9.metric_time__day AS metric_time__day
             , subq_9.metric_time__week AS metric_time__week
             , subq_9.metric_time__month AS metric_time__month
             , subq_9.metric_time__quarter AS metric_time__quarter
@@ -433,6 +432,8 @@ FROM (
             , subq_9.metric_time__extract_day AS metric_time__extract_day
             , subq_9.metric_time__extract_dow AS metric_time__extract_dow
             , subq_9.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_10.metric_time__day AS metric_time__day
+            , subq_10.metric_time__year AS metric_time__year
             , subq_9.listing AS listing
             , subq_9.guest AS guest
             , subq_9.host AS host
@@ -458,6 +459,7 @@ FROM (
             -- Time Spine
             SELECT
               subq_11.ds AS metric_time__day
+              , DATE_TRUNC('year', subq_11.ds) AS metric_time__year
             FROM ***************************.mf_time_spine subq_11
           ) subq_10
           INNER JOIN (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
@@ -449,8 +449,7 @@ FROM (
           FROM (
             -- Join to Time Spine Dataset
             SELECT
-              subq_8.metric_time__day AS metric_time__day
-              , subq_7.ds__day AS ds__day
+              subq_7.ds__day AS ds__day
               , subq_7.ds__week AS ds__week
               , subq_7.ds__month AS ds__month
               , subq_7.ds__quarter AS ds__quarter
@@ -526,6 +525,7 @@ FROM (
               , subq_7.metric_time__extract_day AS metric_time__extract_day
               , subq_7.metric_time__extract_dow AS metric_time__extract_dow
               , subq_7.metric_time__extract_doy AS metric_time__extract_doy
+              , subq_8.metric_time__day AS metric_time__day
               , subq_7.listing AS listing
               , subq_7.guest AS guest
               , subq_7.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_offset_cumulative_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_offset_cumulative_metric__plan0.sql
@@ -24,8 +24,7 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_5.metric_time__day AS metric_time__day
-          , subq_4.ds__day AS ds__day
+          subq_4.ds__day AS ds__day
           , subq_4.ds__week AS ds__week
           , subq_4.ds__month AS ds__month
           , subq_4.ds__quarter AS ds__quarter
@@ -101,6 +100,7 @@ FROM (
           , subq_4.metric_time__extract_day AS metric_time__extract_day
           , subq_4.metric_time__extract_dow AS metric_time__extract_dow
           , subq_4.metric_time__extract_doy AS metric_time__extract_doy
+          , subq_5.metric_time__day AS metric_time__day
           , subq_4.listing AS listing
           , subq_4.guest AS guest
           , subq_4.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_offset_metric_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_offset_metric_with_agg_time_dim__plan0.sql
@@ -30,8 +30,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_2.booking__ds__day AS booking__ds__day
-            , subq_1.ds__day AS ds__day
+            subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -107,6 +106,7 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_2.booking__ds__day AS booking__ds__day
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_offset_metric_with_one_input_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_offset_metric_with_one_input_metric__plan0.sql
@@ -24,8 +24,7 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_2.metric_time__day AS metric_time__day
-          , subq_1.ds__day AS ds__day
+          subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
@@ -101,6 +100,7 @@ FROM (
           , subq_1.metric_time__extract_day AS metric_time__extract_day
           , subq_1.metric_time__extract_dow AS metric_time__extract_dow
           , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+          , subq_2.metric_time__day AS metric_time__day
           , subq_1.listing AS listing
           , subq_1.guest AS guest
           , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0.sql
@@ -56,8 +56,7 @@ FROM (
               FROM (
                 -- Join to Time Spine Dataset
                 SELECT
-                  subq_2.metric_time__day AS metric_time__day
-                  , subq_1.ds__day AS ds__day
+                  subq_1.ds__day AS ds__day
                   , subq_1.ds__week AS ds__week
                   , subq_1.ds__month AS ds__month
                   , subq_1.ds__quarter AS ds__quarter
@@ -133,6 +132,7 @@ FROM (
                   , subq_1.metric_time__extract_day AS metric_time__extract_day
                   , subq_1.metric_time__extract_dow AS metric_time__extract_dow
                   , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+                  , subq_2.metric_time__day AS metric_time__day
                   , subq_1.listing AS listing
                   , subq_1.guest AS guest
                   , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_offsets__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_offsets__plan0.sql
@@ -40,8 +40,7 @@ FROM (
           FROM (
             -- Join to Time Spine Dataset
             SELECT
-              subq_2.metric_time__day AS metric_time__day
-              , subq_1.ds__day AS ds__day
+              subq_1.ds__day AS ds__day
               , subq_1.ds__week AS ds__week
               , subq_1.ds__month AS ds__month
               , subq_1.ds__quarter AS ds__quarter
@@ -117,6 +116,7 @@ FROM (
               , subq_1.metric_time__extract_day AS metric_time__extract_day
               , subq_1.metric_time__extract_dow AS metric_time__extract_dow
               , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+              , subq_2.metric_time__day AS metric_time__day
               , subq_1.listing AS listing
               , subq_1.guest AS guest
               , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_offsets_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_offsets_with_time_constraint__plan0.sql
@@ -41,8 +41,7 @@ FROM (
           FROM (
             -- Join to Time Spine Dataset
             SELECT
-              subq_2.metric_time__day AS metric_time__day
-              , subq_1.ds__day AS ds__day
+              subq_1.ds__day AS ds__day
               , subq_1.ds__week AS ds__week
               , subq_1.ds__month AS ds__month
               , subq_1.ds__quarter AS ds__quarter
@@ -118,6 +117,7 @@ FROM (
               , subq_1.metric_time__extract_day AS metric_time__extract_day
               , subq_1.metric_time__extract_dow AS metric_time__extract_dow
               , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+              , subq_2.metric_time__day AS metric_time__day
               , subq_1.listing AS listing
               , subq_1.guest AS guest
               , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_offsets_with_where_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_offsets_with_where_constraint__plan0.sql
@@ -45,8 +45,7 @@ FROM (
             FROM (
               -- Join to Time Spine Dataset
               SELECT
-                subq_2.metric_time__day AS metric_time__day
-                , subq_1.ds__day AS ds__day
+                subq_1.ds__day AS ds__day
                 , subq_1.ds__week AS ds__week
                 , subq_1.ds__month AS ds__month
                 , subq_1.ds__quarter AS ds__quarter
@@ -122,6 +121,7 @@ FROM (
                 , subq_1.metric_time__extract_day AS metric_time__extract_day
                 , subq_1.metric_time__extract_dow AS metric_time__extract_dow
                 , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+                , subq_2.metric_time__day AS metric_time__day
                 , subq_1.listing AS listing
                 , subq_1.guest AS guest
                 , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0.sql
@@ -26,7 +26,8 @@ FROM (
       FROM (
         -- Constrain Output with WHERE
         SELECT
-          subq_4.metric_time__month
+          subq_4.metric_time__day
+          , subq_4.metric_time__month
           , subq_4.ds__day
           , subq_4.ds__week
           , subq_4.ds__month
@@ -93,7 +94,6 @@ FROM (
           , subq_4.booking__paid_at__extract_day
           , subq_4.booking__paid_at__extract_dow
           , subq_4.booking__paid_at__extract_doy
-          , subq_4.metric_time__day
           , subq_4.metric_time__week
           , subq_4.metric_time__quarter
           , subq_4.metric_time__year
@@ -127,8 +127,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-            , subq_1.ds__day AS ds__day
+            subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -194,7 +193,6 @@ FROM (
             , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
-            , subq_1.metric_time__day AS metric_time__day
             , subq_1.metric_time__week AS metric_time__week
             , subq_1.metric_time__quarter AS metric_time__quarter
             , subq_1.metric_time__year AS metric_time__year
@@ -204,6 +202,8 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_2.metric_time__day AS metric_time__day
+            , subq_2.metric_time__month AS metric_time__month
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host
@@ -229,6 +229,7 @@ FROM (
             -- Time Spine
             SELECT
               subq_3.ds AS metric_time__day
+              , DATE_TRUNC('month', subq_3.ds) AS metric_time__month
             FROM ***************************.mf_time_spine subq_3
           ) subq_2
           INNER JOIN (
@@ -428,7 +429,7 @@ FROM (
           ) subq_1
           ON
             DATE_TRUNC('month', subq_2.metric_time__day) = subq_1.metric_time__day
-          WHERE DATE_TRUNC('month', subq_2.metric_time__day) = subq_2.metric_time__day
+          WHERE subq_2.metric_time__month = subq_2.metric_time__day
         ) subq_4
         WHERE metric_time__day = '2020-01-01'
       ) subq_5

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
@@ -19,8 +19,8 @@ FROM (
   FROM (
     -- Join to Time Spine Dataset
     SELECT
-      DATE_TRUNC('month', subq_12.ds) AS metric_time__month
-      , subq_10.metric_time__day AS metric_time__day
+      subq_12.ds AS metric_time__day
+      , DATE_TRUNC('month', subq_12.ds) AS metric_time__month
       , subq_10.bookings AS bookings
     FROM ***************************.mf_time_spine subq_12
     INNER JOIN (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_offset_to_grain_metric_multiple_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_offset_to_grain_metric_multiple_granularities__plan0.sql
@@ -34,10 +34,7 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_2.metric_time__day AS metric_time__day
-          , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-          , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-          , subq_1.ds__day AS ds__day
+          subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
@@ -111,6 +108,9 @@ FROM (
           , subq_1.metric_time__extract_day AS metric_time__extract_day
           , subq_1.metric_time__extract_dow AS metric_time__extract_dow
           , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+          , subq_2.metric_time__day AS metric_time__day
+          , subq_2.metric_time__month AS metric_time__month
+          , subq_2.metric_time__year AS metric_time__year
           , subq_1.listing AS listing
           , subq_1.guest AS guest
           , subq_1.host AS host
@@ -136,6 +136,8 @@ FROM (
           -- Time Spine
           SELECT
             subq_3.ds AS metric_time__day
+            , DATE_TRUNC('month', subq_3.ds) AS metric_time__month
+            , DATE_TRUNC('year', subq_3.ds) AS metric_time__year
           FROM ***************************.mf_time_spine subq_3
         ) subq_2
         INNER JOIN (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_offset_to_grain_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_offset_to_grain_with_agg_time_dim__plan0.sql
@@ -245,8 +245,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_7.booking__ds__day AS booking__ds__day
-            , subq_6.ds__day AS ds__day
+            subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -322,6 +321,7 @@ FROM (
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_7.booking__ds__day AS booking__ds__day
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_offset_window_metric_filter_and_query_have_different_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_offset_window_metric_filter_and_query_have_different_granularities__plan0.sql
@@ -32,7 +32,8 @@ FROM (
         FROM (
           -- Constrain Output with WHERE
           SELECT
-            subq_4.metric_time__month
+            subq_4.metric_time__day
+            , subq_4.metric_time__month
             , subq_4.ds__day
             , subq_4.ds__week
             , subq_4.ds__month
@@ -99,7 +100,6 @@ FROM (
             , subq_4.booking__paid_at__extract_day
             , subq_4.booking__paid_at__extract_dow
             , subq_4.booking__paid_at__extract_doy
-            , subq_4.metric_time__day
             , subq_4.metric_time__week
             , subq_4.metric_time__quarter
             , subq_4.metric_time__year
@@ -133,8 +133,7 @@ FROM (
           FROM (
             -- Join to Time Spine Dataset
             SELECT
-              DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-              , subq_1.ds__day AS ds__day
+              subq_1.ds__day AS ds__day
               , subq_1.ds__week AS ds__week
               , subq_1.ds__month AS ds__month
               , subq_1.ds__quarter AS ds__quarter
@@ -200,7 +199,6 @@ FROM (
               , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
               , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
               , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
-              , subq_1.metric_time__day AS metric_time__day
               , subq_1.metric_time__week AS metric_time__week
               , subq_1.metric_time__quarter AS metric_time__quarter
               , subq_1.metric_time__year AS metric_time__year
@@ -210,6 +208,8 @@ FROM (
               , subq_1.metric_time__extract_day AS metric_time__extract_day
               , subq_1.metric_time__extract_dow AS metric_time__extract_dow
               , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+              , subq_2.metric_time__day AS metric_time__day
+              , subq_2.metric_time__month AS metric_time__month
               , subq_1.listing AS listing
               , subq_1.guest AS guest
               , subq_1.host AS host
@@ -235,6 +235,7 @@ FROM (
               -- Time Spine
               SELECT
                 subq_3.ds AS metric_time__day
+                , DATE_TRUNC('month', subq_3.ds) AS metric_time__month
               FROM ***************************.mf_time_spine subq_3
             ) subq_2
             INNER JOIN (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_offset_window_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_offset_window_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
@@ -25,8 +25,8 @@ FROM (
     FROM (
       -- Join to Time Spine Dataset
       SELECT
-        DATE_TRUNC('month', subq_19.ds) AS metric_time__month
-        , DATE_TRUNC('day', bookings_source_src_28000.ds) AS metric_time__day
+        subq_19.ds AS metric_time__day
+        , DATE_TRUNC('month', subq_19.ds) AS metric_time__month
         , bookings_source_src_28000.booking_value AS booking_value
       FROM ***************************.mf_time_spine subq_19
       INNER JOIN

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_offset_window_metric_multiple_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_offset_window_metric_multiple_granularities__plan0.sql
@@ -42,10 +42,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_2.metric_time__day AS metric_time__day
-            , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-            , subq_1.ds__day AS ds__day
+            subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -119,6 +116,9 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_2.metric_time__day AS metric_time__day
+            , subq_2.metric_time__month AS metric_time__month
+            , subq_2.metric_time__year AS metric_time__year
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host
@@ -144,6 +144,8 @@ FROM (
             -- Time Spine
             SELECT
               subq_3.ds AS metric_time__day
+              , DATE_TRUNC('month', subq_3.ds) AS metric_time__month
+              , DATE_TRUNC('year', subq_3.ds) AS metric_time__year
             FROM ***************************.mf_time_spine subq_3
           ) subq_2
           INNER JOIN (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_offset_window_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_offset_window_with_agg_time_dim__plan0.sql
@@ -245,8 +245,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_7.booking__ds__day AS booking__ds__day
-            , subq_6.ds__day AS ds__day
+            subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -322,6 +321,7 @@ FROM (
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_7.booking__ds__day AS booking__ds__day
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_time_offset_metric_with_time_constraint__plan0.sql
@@ -24,8 +24,7 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_2.metric_time__day AS metric_time__day
-          , subq_1.ds__day AS ds__day
+          subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
@@ -101,6 +100,7 @@ FROM (
           , subq_1.metric_time__extract_day AS metric_time__extract_day
           , subq_1.metric_time__extract_dow AS metric_time__extract_dow
           , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+          , subq_2.metric_time__day AS metric_time__day
           , subq_1.listing AS listing
           , subq_1.guest AS guest
           , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
@@ -125,8 +125,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_5.metric_time__day AS metric_time__day
-            , subq_4.ds__day AS ds__day
+            subq_4.ds__day AS ds__day
             , subq_4.ds__week AS ds__week
             , subq_4.ds__month AS ds__month
             , subq_4.ds__quarter AS ds__quarter
@@ -202,6 +201,7 @@ FROM (
             , subq_4.metric_time__extract_day AS metric_time__extract_day
             , subq_4.metric_time__extract_dow AS metric_time__extract_dow
             , subq_4.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_5.metric_time__day AS metric_time__day
             , subq_4.listing AS listing
             , subq_4.guest AS guest
             , subq_4.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
@@ -24,8 +24,7 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_2.metric_time__month AS metric_time__month
-          , subq_1.ds__month AS ds__month
+          subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
           , subq_1.ds__year AS ds__year
           , subq_1.ds__extract_year AS ds__extract_year
@@ -42,6 +41,7 @@ FROM (
           , subq_1.metric_time__extract_year AS metric_time__extract_year
           , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
           , subq_1.metric_time__extract_month AS metric_time__extract_month
+          , subq_2.metric_time__month AS metric_time__month
           , subq_1.listing AS listing
           , subq_1.booking_monthly__listing AS booking_monthly__listing
           , subq_1.bookings_monthly AS bookings_monthly

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_to_grain__plan0.sql
@@ -245,8 +245,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_7.metric_time__day AS metric_time__day
-            , subq_6.ds__day AS ds__day
+            subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -322,6 +321,7 @@ FROM (
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_7.metric_time__day AS metric_time__day
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_to_grain_and_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_to_grain_and_granularity__plan0.sql
@@ -245,8 +245,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            DATE_TRUNC('week', subq_7.metric_time__day) AS metric_time__week
-            , subq_6.ds__day AS ds__day
+            subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -312,7 +311,6 @@ FROM (
             , subq_6.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_6.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_6.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
-            , subq_6.metric_time__day AS metric_time__day
             , subq_6.metric_time__month AS metric_time__month
             , subq_6.metric_time__quarter AS metric_time__quarter
             , subq_6.metric_time__year AS metric_time__year
@@ -322,6 +320,8 @@ FROM (
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_7.metric_time__day AS metric_time__day
+            , subq_7.metric_time__week AS metric_time__week
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host
@@ -347,6 +347,7 @@ FROM (
             -- Time Spine
             SELECT
               subq_8.ds AS metric_time__day
+              , DATE_TRUNC('week', subq_8.ds) AS metric_time__week
             FROM ***************************.mf_time_spine subq_8
           ) subq_7
           INNER JOIN (
@@ -546,7 +547,7 @@ FROM (
           ) subq_6
           ON
             DATE_TRUNC('month', subq_7.metric_time__day) = subq_6.metric_time__day
-          WHERE DATE_TRUNC('week', subq_7.metric_time__day) = subq_7.metric_time__day
+          WHERE subq_7.metric_time__week = subq_7.metric_time__day
         ) subq_9
       ) subq_10
       GROUP BY

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_window__plan0.sql
@@ -245,8 +245,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_7.metric_time__day AS metric_time__day
-            , subq_6.ds__day AS ds__day
+            subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -322,6 +321,7 @@ FROM (
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_7.metric_time__day AS metric_time__day
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_window_and_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_window_and_granularity__plan0.sql
@@ -245,8 +245,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            DATE_TRUNC('quarter', subq_7.metric_time__day) AS metric_time__quarter
-            , subq_6.ds__day AS ds__day
+            subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -312,7 +311,6 @@ FROM (
             , subq_6.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_6.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_6.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
-            , subq_6.metric_time__day AS metric_time__day
             , subq_6.metric_time__week AS metric_time__week
             , subq_6.metric_time__month AS metric_time__month
             , subq_6.metric_time__year AS metric_time__year
@@ -322,6 +320,8 @@ FROM (
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_7.metric_time__day AS metric_time__day
+            , subq_7.metric_time__quarter AS metric_time__quarter
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host
@@ -347,6 +347,7 @@ FROM (
             -- Time Spine
             SELECT
               subq_8.ds AS metric_time__day
+              , DATE_TRUNC('quarter', subq_8.ds) AS metric_time__quarter
             FROM ***************************.mf_time_spine subq_8
           ) subq_7
           INNER JOIN (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
@@ -30,8 +30,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_2.metric_time__day AS metric_time__day
-            , subq_1.ds__day AS ds__day
+            subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -107,6 +106,7 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_2.metric_time__day AS metric_time__day
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host
@@ -355,8 +355,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_10.metric_time__day AS metric_time__day
-            , subq_9.ds__day AS ds__day
+            subq_9.ds__day AS ds__day
             , subq_9.ds__week AS ds__week
             , subq_9.ds__month AS ds__month
             , subq_9.ds__quarter AS ds__quarter
@@ -432,6 +431,7 @@ FROM (
             , subq_9.metric_time__extract_day AS metric_time__extract_day
             , subq_9.metric_time__extract_dow AS metric_time__extract_dow
             , subq_9.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_10.metric_time__day AS metric_time__day
             , subq_9.listing AS listing
             , subq_9.guest AS guest
             , subq_9.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0.sql
@@ -30,8 +30,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-            , subq_1.ds__day AS ds__day
+            subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -97,7 +96,6 @@ FROM (
             , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
-            , subq_1.metric_time__day AS metric_time__day
             , subq_1.metric_time__week AS metric_time__week
             , subq_1.metric_time__month AS metric_time__month
             , subq_1.metric_time__quarter AS metric_time__quarter
@@ -107,6 +105,8 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_2.metric_time__day AS metric_time__day
+            , subq_2.metric_time__year AS metric_time__year
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host
@@ -132,6 +132,7 @@ FROM (
             -- Time Spine
             SELECT
               subq_3.ds AS metric_time__day
+              , DATE_TRUNC('year', subq_3.ds) AS metric_time__year
             FROM ***************************.mf_time_spine subq_3
           ) subq_2
           INNER JOIN (
@@ -331,7 +332,7 @@ FROM (
           ) subq_1
           ON
             DATE_TRUNC('month', subq_2.metric_time__day) = subq_1.metric_time__day
-          WHERE DATE_TRUNC('year', subq_2.metric_time__day) = subq_2.metric_time__day
+          WHERE subq_2.metric_time__year = subq_2.metric_time__day
         ) subq_4
       ) subq_5
       GROUP BY
@@ -356,8 +357,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            DATE_TRUNC('year', subq_10.metric_time__day) AS metric_time__year
-            , subq_9.ds__day AS ds__day
+            subq_9.ds__day AS ds__day
             , subq_9.ds__week AS ds__week
             , subq_9.ds__month AS ds__month
             , subq_9.ds__quarter AS ds__quarter
@@ -423,7 +423,6 @@ FROM (
             , subq_9.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_9.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_9.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
-            , subq_9.metric_time__day AS metric_time__day
             , subq_9.metric_time__week AS metric_time__week
             , subq_9.metric_time__month AS metric_time__month
             , subq_9.metric_time__quarter AS metric_time__quarter
@@ -433,6 +432,8 @@ FROM (
             , subq_9.metric_time__extract_day AS metric_time__extract_day
             , subq_9.metric_time__extract_dow AS metric_time__extract_dow
             , subq_9.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_10.metric_time__day AS metric_time__day
+            , subq_10.metric_time__year AS metric_time__year
             , subq_9.listing AS listing
             , subq_9.guest AS guest
             , subq_9.host AS host
@@ -458,6 +459,7 @@ FROM (
             -- Time Spine
             SELECT
               subq_11.ds AS metric_time__day
+              , DATE_TRUNC('year', subq_11.ds) AS metric_time__year
             FROM ***************************.mf_time_spine subq_11
           ) subq_10
           INNER JOIN (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
@@ -449,8 +449,7 @@ FROM (
           FROM (
             -- Join to Time Spine Dataset
             SELECT
-              subq_8.metric_time__day AS metric_time__day
-              , subq_7.ds__day AS ds__day
+              subq_7.ds__day AS ds__day
               , subq_7.ds__week AS ds__week
               , subq_7.ds__month AS ds__month
               , subq_7.ds__quarter AS ds__quarter
@@ -526,6 +525,7 @@ FROM (
               , subq_7.metric_time__extract_day AS metric_time__extract_day
               , subq_7.metric_time__extract_dow AS metric_time__extract_dow
               , subq_7.metric_time__extract_doy AS metric_time__extract_doy
+              , subq_8.metric_time__day AS metric_time__day
               , subq_7.listing AS listing
               , subq_7.guest AS guest
               , subq_7.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_offset_cumulative_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_offset_cumulative_metric__plan0.sql
@@ -24,8 +24,7 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_5.metric_time__day AS metric_time__day
-          , subq_4.ds__day AS ds__day
+          subq_4.ds__day AS ds__day
           , subq_4.ds__week AS ds__week
           , subq_4.ds__month AS ds__month
           , subq_4.ds__quarter AS ds__quarter
@@ -101,6 +100,7 @@ FROM (
           , subq_4.metric_time__extract_day AS metric_time__extract_day
           , subq_4.metric_time__extract_dow AS metric_time__extract_dow
           , subq_4.metric_time__extract_doy AS metric_time__extract_doy
+          , subq_5.metric_time__day AS metric_time__day
           , subq_4.listing AS listing
           , subq_4.guest AS guest
           , subq_4.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_offset_metric_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_offset_metric_with_agg_time_dim__plan0.sql
@@ -30,8 +30,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_2.booking__ds__day AS booking__ds__day
-            , subq_1.ds__day AS ds__day
+            subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -107,6 +106,7 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_2.booking__ds__day AS booking__ds__day
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_offset_metric_with_one_input_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_offset_metric_with_one_input_metric__plan0.sql
@@ -24,8 +24,7 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_2.metric_time__day AS metric_time__day
-          , subq_1.ds__day AS ds__day
+          subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
@@ -101,6 +100,7 @@ FROM (
           , subq_1.metric_time__extract_day AS metric_time__extract_day
           , subq_1.metric_time__extract_dow AS metric_time__extract_dow
           , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+          , subq_2.metric_time__day AS metric_time__day
           , subq_1.listing AS listing
           , subq_1.guest AS guest
           , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0.sql
@@ -56,8 +56,7 @@ FROM (
               FROM (
                 -- Join to Time Spine Dataset
                 SELECT
-                  subq_2.metric_time__day AS metric_time__day
-                  , subq_1.ds__day AS ds__day
+                  subq_1.ds__day AS ds__day
                   , subq_1.ds__week AS ds__week
                   , subq_1.ds__month AS ds__month
                   , subq_1.ds__quarter AS ds__quarter
@@ -133,6 +132,7 @@ FROM (
                   , subq_1.metric_time__extract_day AS metric_time__extract_day
                   , subq_1.metric_time__extract_dow AS metric_time__extract_dow
                   , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+                  , subq_2.metric_time__day AS metric_time__day
                   , subq_1.listing AS listing
                   , subq_1.guest AS guest
                   , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_nested_offsets__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_nested_offsets__plan0.sql
@@ -40,8 +40,7 @@ FROM (
           FROM (
             -- Join to Time Spine Dataset
             SELECT
-              subq_2.metric_time__day AS metric_time__day
-              , subq_1.ds__day AS ds__day
+              subq_1.ds__day AS ds__day
               , subq_1.ds__week AS ds__week
               , subq_1.ds__month AS ds__month
               , subq_1.ds__quarter AS ds__quarter
@@ -117,6 +116,7 @@ FROM (
               , subq_1.metric_time__extract_day AS metric_time__extract_day
               , subq_1.metric_time__extract_dow AS metric_time__extract_dow
               , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+              , subq_2.metric_time__day AS metric_time__day
               , subq_1.listing AS listing
               , subq_1.guest AS guest
               , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_nested_offsets_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_nested_offsets_with_time_constraint__plan0.sql
@@ -41,8 +41,7 @@ FROM (
           FROM (
             -- Join to Time Spine Dataset
             SELECT
-              subq_2.metric_time__day AS metric_time__day
-              , subq_1.ds__day AS ds__day
+              subq_1.ds__day AS ds__day
               , subq_1.ds__week AS ds__week
               , subq_1.ds__month AS ds__month
               , subq_1.ds__quarter AS ds__quarter
@@ -118,6 +117,7 @@ FROM (
               , subq_1.metric_time__extract_day AS metric_time__extract_day
               , subq_1.metric_time__extract_dow AS metric_time__extract_dow
               , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+              , subq_2.metric_time__day AS metric_time__day
               , subq_1.listing AS listing
               , subq_1.guest AS guest
               , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_nested_offsets_with_where_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_nested_offsets_with_where_constraint__plan0.sql
@@ -45,8 +45,7 @@ FROM (
             FROM (
               -- Join to Time Spine Dataset
               SELECT
-                subq_2.metric_time__day AS metric_time__day
-                , subq_1.ds__day AS ds__day
+                subq_1.ds__day AS ds__day
                 , subq_1.ds__week AS ds__week
                 , subq_1.ds__month AS ds__month
                 , subq_1.ds__quarter AS ds__quarter
@@ -122,6 +121,7 @@ FROM (
                 , subq_1.metric_time__extract_day AS metric_time__extract_day
                 , subq_1.metric_time__extract_dow AS metric_time__extract_dow
                 , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+                , subq_2.metric_time__day AS metric_time__day
                 , subq_1.listing AS listing
                 , subq_1.guest AS guest
                 , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0.sql
@@ -26,7 +26,8 @@ FROM (
       FROM (
         -- Constrain Output with WHERE
         SELECT
-          subq_4.metric_time__month
+          subq_4.metric_time__day
+          , subq_4.metric_time__month
           , subq_4.ds__day
           , subq_4.ds__week
           , subq_4.ds__month
@@ -93,7 +94,6 @@ FROM (
           , subq_4.booking__paid_at__extract_day
           , subq_4.booking__paid_at__extract_dow
           , subq_4.booking__paid_at__extract_doy
-          , subq_4.metric_time__day
           , subq_4.metric_time__week
           , subq_4.metric_time__quarter
           , subq_4.metric_time__year
@@ -127,8 +127,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-            , subq_1.ds__day AS ds__day
+            subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -194,7 +193,6 @@ FROM (
             , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
-            , subq_1.metric_time__day AS metric_time__day
             , subq_1.metric_time__week AS metric_time__week
             , subq_1.metric_time__quarter AS metric_time__quarter
             , subq_1.metric_time__year AS metric_time__year
@@ -204,6 +202,8 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_2.metric_time__day AS metric_time__day
+            , subq_2.metric_time__month AS metric_time__month
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host
@@ -229,6 +229,7 @@ FROM (
             -- Time Spine
             SELECT
               subq_3.ds AS metric_time__day
+              , DATE_TRUNC('month', subq_3.ds) AS metric_time__month
             FROM ***************************.mf_time_spine subq_3
           ) subq_2
           INNER JOIN (
@@ -428,7 +429,7 @@ FROM (
           ) subq_1
           ON
             DATE_TRUNC('month', subq_2.metric_time__day) = subq_1.metric_time__day
-          WHERE DATE_TRUNC('month', subq_2.metric_time__day) = subq_2.metric_time__day
+          WHERE subq_2.metric_time__month = subq_2.metric_time__day
         ) subq_4
         WHERE metric_time__day = '2020-01-01'
       ) subq_5

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
@@ -19,8 +19,8 @@ FROM (
   FROM (
     -- Join to Time Spine Dataset
     SELECT
-      DATE_TRUNC('month', subq_12.ds) AS metric_time__month
-      , subq_10.metric_time__day AS metric_time__day
+      subq_12.ds AS metric_time__day
+      , DATE_TRUNC('month', subq_12.ds) AS metric_time__month
       , subq_10.bookings AS bookings
     FROM ***************************.mf_time_spine subq_12
     INNER JOIN (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_offset_to_grain_metric_multiple_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_offset_to_grain_metric_multiple_granularities__plan0.sql
@@ -34,10 +34,7 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_2.metric_time__day AS metric_time__day
-          , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-          , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-          , subq_1.ds__day AS ds__day
+          subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
@@ -111,6 +108,9 @@ FROM (
           , subq_1.metric_time__extract_day AS metric_time__extract_day
           , subq_1.metric_time__extract_dow AS metric_time__extract_dow
           , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+          , subq_2.metric_time__day AS metric_time__day
+          , subq_2.metric_time__month AS metric_time__month
+          , subq_2.metric_time__year AS metric_time__year
           , subq_1.listing AS listing
           , subq_1.guest AS guest
           , subq_1.host AS host
@@ -136,6 +136,8 @@ FROM (
           -- Time Spine
           SELECT
             subq_3.ds AS metric_time__day
+            , DATE_TRUNC('month', subq_3.ds) AS metric_time__month
+            , DATE_TRUNC('year', subq_3.ds) AS metric_time__year
           FROM ***************************.mf_time_spine subq_3
         ) subq_2
         INNER JOIN (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_offset_to_grain_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_offset_to_grain_with_agg_time_dim__plan0.sql
@@ -245,8 +245,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_7.booking__ds__day AS booking__ds__day
-            , subq_6.ds__day AS ds__day
+            subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -322,6 +321,7 @@ FROM (
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_7.booking__ds__day AS booking__ds__day
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_offset_window_metric_filter_and_query_have_different_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_offset_window_metric_filter_and_query_have_different_granularities__plan0.sql
@@ -32,7 +32,8 @@ FROM (
         FROM (
           -- Constrain Output with WHERE
           SELECT
-            subq_4.metric_time__month
+            subq_4.metric_time__day
+            , subq_4.metric_time__month
             , subq_4.ds__day
             , subq_4.ds__week
             , subq_4.ds__month
@@ -99,7 +100,6 @@ FROM (
             , subq_4.booking__paid_at__extract_day
             , subq_4.booking__paid_at__extract_dow
             , subq_4.booking__paid_at__extract_doy
-            , subq_4.metric_time__day
             , subq_4.metric_time__week
             , subq_4.metric_time__quarter
             , subq_4.metric_time__year
@@ -133,8 +133,7 @@ FROM (
           FROM (
             -- Join to Time Spine Dataset
             SELECT
-              DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-              , subq_1.ds__day AS ds__day
+              subq_1.ds__day AS ds__day
               , subq_1.ds__week AS ds__week
               , subq_1.ds__month AS ds__month
               , subq_1.ds__quarter AS ds__quarter
@@ -200,7 +199,6 @@ FROM (
               , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
               , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
               , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
-              , subq_1.metric_time__day AS metric_time__day
               , subq_1.metric_time__week AS metric_time__week
               , subq_1.metric_time__quarter AS metric_time__quarter
               , subq_1.metric_time__year AS metric_time__year
@@ -210,6 +208,8 @@ FROM (
               , subq_1.metric_time__extract_day AS metric_time__extract_day
               , subq_1.metric_time__extract_dow AS metric_time__extract_dow
               , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+              , subq_2.metric_time__day AS metric_time__day
+              , subq_2.metric_time__month AS metric_time__month
               , subq_1.listing AS listing
               , subq_1.guest AS guest
               , subq_1.host AS host
@@ -235,6 +235,7 @@ FROM (
               -- Time Spine
               SELECT
                 subq_3.ds AS metric_time__day
+                , DATE_TRUNC('month', subq_3.ds) AS metric_time__month
               FROM ***************************.mf_time_spine subq_3
             ) subq_2
             INNER JOIN (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_offset_window_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_offset_window_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
@@ -25,8 +25,8 @@ FROM (
     FROM (
       -- Join to Time Spine Dataset
       SELECT
-        DATE_TRUNC('month', subq_19.ds) AS metric_time__month
-        , DATE_TRUNC('day', bookings_source_src_28000.ds) AS metric_time__day
+        subq_19.ds AS metric_time__day
+        , DATE_TRUNC('month', subq_19.ds) AS metric_time__month
         , bookings_source_src_28000.booking_value AS booking_value
       FROM ***************************.mf_time_spine subq_19
       INNER JOIN

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_offset_window_metric_multiple_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_offset_window_metric_multiple_granularities__plan0.sql
@@ -42,10 +42,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_2.metric_time__day AS metric_time__day
-            , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-            , subq_1.ds__day AS ds__day
+            subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -119,6 +116,9 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_2.metric_time__day AS metric_time__day
+            , subq_2.metric_time__month AS metric_time__month
+            , subq_2.metric_time__year AS metric_time__year
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host
@@ -144,6 +144,8 @@ FROM (
             -- Time Spine
             SELECT
               subq_3.ds AS metric_time__day
+              , DATE_TRUNC('month', subq_3.ds) AS metric_time__month
+              , DATE_TRUNC('year', subq_3.ds) AS metric_time__year
             FROM ***************************.mf_time_spine subq_3
           ) subq_2
           INNER JOIN (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_offset_window_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_offset_window_with_agg_time_dim__plan0.sql
@@ -245,8 +245,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_7.booking__ds__day AS booking__ds__day
-            , subq_6.ds__day AS ds__day
+            subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -322,6 +321,7 @@ FROM (
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_7.booking__ds__day AS booking__ds__day
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_time_offset_metric_with_time_constraint__plan0.sql
@@ -24,8 +24,7 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_2.metric_time__day AS metric_time__day
-          , subq_1.ds__day AS ds__day
+          subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
@@ -101,6 +100,7 @@ FROM (
           , subq_1.metric_time__extract_day AS metric_time__extract_day
           , subq_1.metric_time__extract_dow AS metric_time__extract_dow
           , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+          , subq_2.metric_time__day AS metric_time__day
           , subq_1.listing AS listing
           , subq_1.guest AS guest
           , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
@@ -125,8 +125,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_5.metric_time__day AS metric_time__day
-            , subq_4.ds__day AS ds__day
+            subq_4.ds__day AS ds__day
             , subq_4.ds__week AS ds__week
             , subq_4.ds__month AS ds__month
             , subq_4.ds__quarter AS ds__quarter
@@ -202,6 +201,7 @@ FROM (
             , subq_4.metric_time__extract_day AS metric_time__extract_day
             , subq_4.metric_time__extract_dow AS metric_time__extract_dow
             , subq_4.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_5.metric_time__day AS metric_time__day
             , subq_4.listing AS listing
             , subq_4.guest AS guest
             , subq_4.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
@@ -24,8 +24,7 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_2.metric_time__month AS metric_time__month
-          , subq_1.ds__month AS ds__month
+          subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
           , subq_1.ds__year AS ds__year
           , subq_1.ds__extract_year AS ds__extract_year
@@ -42,6 +41,7 @@ FROM (
           , subq_1.metric_time__extract_year AS metric_time__extract_year
           , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
           , subq_1.metric_time__extract_month AS metric_time__extract_month
+          , subq_2.metric_time__month AS metric_time__month
           , subq_1.listing AS listing
           , subq_1.booking_monthly__listing AS booking_monthly__listing
           , subq_1.bookings_monthly AS bookings_monthly

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_to_grain__plan0.sql
@@ -245,8 +245,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_7.metric_time__day AS metric_time__day
-            , subq_6.ds__day AS ds__day
+            subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -322,6 +321,7 @@ FROM (
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_7.metric_time__day AS metric_time__day
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_to_grain_and_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_to_grain_and_granularity__plan0.sql
@@ -245,8 +245,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            DATE_TRUNC('week', subq_7.metric_time__day) AS metric_time__week
-            , subq_6.ds__day AS ds__day
+            subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -312,7 +311,6 @@ FROM (
             , subq_6.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_6.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_6.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
-            , subq_6.metric_time__day AS metric_time__day
             , subq_6.metric_time__month AS metric_time__month
             , subq_6.metric_time__quarter AS metric_time__quarter
             , subq_6.metric_time__year AS metric_time__year
@@ -322,6 +320,8 @@ FROM (
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_7.metric_time__day AS metric_time__day
+            , subq_7.metric_time__week AS metric_time__week
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host
@@ -347,6 +347,7 @@ FROM (
             -- Time Spine
             SELECT
               subq_8.ds AS metric_time__day
+              , DATE_TRUNC('week', subq_8.ds) AS metric_time__week
             FROM ***************************.mf_time_spine subq_8
           ) subq_7
           INNER JOIN (
@@ -546,7 +547,7 @@ FROM (
           ) subq_6
           ON
             DATE_TRUNC('month', subq_7.metric_time__day) = subq_6.metric_time__day
-          WHERE DATE_TRUNC('week', subq_7.metric_time__day) = subq_7.metric_time__day
+          WHERE subq_7.metric_time__week = subq_7.metric_time__day
         ) subq_9
       ) subq_10
       GROUP BY

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_window__plan0.sql
@@ -245,8 +245,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_7.metric_time__day AS metric_time__day
-            , subq_6.ds__day AS ds__day
+            subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -322,6 +321,7 @@ FROM (
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_7.metric_time__day AS metric_time__day
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_window_and_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_window_and_granularity__plan0.sql
@@ -245,8 +245,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            DATE_TRUNC('quarter', subq_7.metric_time__day) AS metric_time__quarter
-            , subq_6.ds__day AS ds__day
+            subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -312,7 +311,6 @@ FROM (
             , subq_6.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_6.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_6.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
-            , subq_6.metric_time__day AS metric_time__day
             , subq_6.metric_time__week AS metric_time__week
             , subq_6.metric_time__month AS metric_time__month
             , subq_6.metric_time__year AS metric_time__year
@@ -322,6 +320,8 @@ FROM (
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_7.metric_time__day AS metric_time__day
+            , subq_7.metric_time__quarter AS metric_time__quarter
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host
@@ -347,6 +347,7 @@ FROM (
             -- Time Spine
             SELECT
               subq_8.ds AS metric_time__day
+              , DATE_TRUNC('quarter', subq_8.ds) AS metric_time__quarter
             FROM ***************************.mf_time_spine subq_8
           ) subq_7
           INNER JOIN (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
@@ -30,8 +30,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_2.metric_time__day AS metric_time__day
-            , subq_1.ds__day AS ds__day
+            subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -107,6 +106,7 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_2.metric_time__day AS metric_time__day
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host
@@ -355,8 +355,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_10.metric_time__day AS metric_time__day
-            , subq_9.ds__day AS ds__day
+            subq_9.ds__day AS ds__day
             , subq_9.ds__week AS ds__week
             , subq_9.ds__month AS ds__month
             , subq_9.ds__quarter AS ds__quarter
@@ -432,6 +431,7 @@ FROM (
             , subq_9.metric_time__extract_day AS metric_time__extract_day
             , subq_9.metric_time__extract_dow AS metric_time__extract_dow
             , subq_9.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_10.metric_time__day AS metric_time__day
             , subq_9.listing AS listing
             , subq_9.guest AS guest
             , subq_9.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0.sql
@@ -30,8 +30,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-            , subq_1.ds__day AS ds__day
+            subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -97,7 +96,6 @@ FROM (
             , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
-            , subq_1.metric_time__day AS metric_time__day
             , subq_1.metric_time__week AS metric_time__week
             , subq_1.metric_time__month AS metric_time__month
             , subq_1.metric_time__quarter AS metric_time__quarter
@@ -107,6 +105,8 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_2.metric_time__day AS metric_time__day
+            , subq_2.metric_time__year AS metric_time__year
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host
@@ -132,6 +132,7 @@ FROM (
             -- Time Spine
             SELECT
               subq_3.ds AS metric_time__day
+              , DATE_TRUNC('year', subq_3.ds) AS metric_time__year
             FROM ***************************.mf_time_spine subq_3
           ) subq_2
           INNER JOIN (
@@ -331,7 +332,7 @@ FROM (
           ) subq_1
           ON
             DATE_TRUNC('month', subq_2.metric_time__day) = subq_1.metric_time__day
-          WHERE DATE_TRUNC('year', subq_2.metric_time__day) = subq_2.metric_time__day
+          WHERE subq_2.metric_time__year = subq_2.metric_time__day
         ) subq_4
       ) subq_5
       GROUP BY
@@ -356,8 +357,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            DATE_TRUNC('year', subq_10.metric_time__day) AS metric_time__year
-            , subq_9.ds__day AS ds__day
+            subq_9.ds__day AS ds__day
             , subq_9.ds__week AS ds__week
             , subq_9.ds__month AS ds__month
             , subq_9.ds__quarter AS ds__quarter
@@ -423,7 +423,6 @@ FROM (
             , subq_9.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_9.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_9.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
-            , subq_9.metric_time__day AS metric_time__day
             , subq_9.metric_time__week AS metric_time__week
             , subq_9.metric_time__month AS metric_time__month
             , subq_9.metric_time__quarter AS metric_time__quarter
@@ -433,6 +432,8 @@ FROM (
             , subq_9.metric_time__extract_day AS metric_time__extract_day
             , subq_9.metric_time__extract_dow AS metric_time__extract_dow
             , subq_9.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_10.metric_time__day AS metric_time__day
+            , subq_10.metric_time__year AS metric_time__year
             , subq_9.listing AS listing
             , subq_9.guest AS guest
             , subq_9.host AS host
@@ -458,6 +459,7 @@ FROM (
             -- Time Spine
             SELECT
               subq_11.ds AS metric_time__day
+              , DATE_TRUNC('year', subq_11.ds) AS metric_time__year
             FROM ***************************.mf_time_spine subq_11
           ) subq_10
           INNER JOIN (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
@@ -449,8 +449,7 @@ FROM (
           FROM (
             -- Join to Time Spine Dataset
             SELECT
-              subq_8.metric_time__day AS metric_time__day
-              , subq_7.ds__day AS ds__day
+              subq_7.ds__day AS ds__day
               , subq_7.ds__week AS ds__week
               , subq_7.ds__month AS ds__month
               , subq_7.ds__quarter AS ds__quarter
@@ -526,6 +525,7 @@ FROM (
               , subq_7.metric_time__extract_day AS metric_time__extract_day
               , subq_7.metric_time__extract_dow AS metric_time__extract_dow
               , subq_7.metric_time__extract_doy AS metric_time__extract_doy
+              , subq_8.metric_time__day AS metric_time__day
               , subq_7.listing AS listing
               , subq_7.guest AS guest
               , subq_7.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_offset_cumulative_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_offset_cumulative_metric__plan0.sql
@@ -24,8 +24,7 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_5.metric_time__day AS metric_time__day
-          , subq_4.ds__day AS ds__day
+          subq_4.ds__day AS ds__day
           , subq_4.ds__week AS ds__week
           , subq_4.ds__month AS ds__month
           , subq_4.ds__quarter AS ds__quarter
@@ -101,6 +100,7 @@ FROM (
           , subq_4.metric_time__extract_day AS metric_time__extract_day
           , subq_4.metric_time__extract_dow AS metric_time__extract_dow
           , subq_4.metric_time__extract_doy AS metric_time__extract_doy
+          , subq_5.metric_time__day AS metric_time__day
           , subq_4.listing AS listing
           , subq_4.guest AS guest
           , subq_4.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_offset_metric_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_offset_metric_with_agg_time_dim__plan0.sql
@@ -30,8 +30,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_2.booking__ds__day AS booking__ds__day
-            , subq_1.ds__day AS ds__day
+            subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -107,6 +106,7 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_2.booking__ds__day AS booking__ds__day
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_offset_metric_with_one_input_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_offset_metric_with_one_input_metric__plan0.sql
@@ -24,8 +24,7 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_2.metric_time__day AS metric_time__day
-          , subq_1.ds__day AS ds__day
+          subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
@@ -101,6 +100,7 @@ FROM (
           , subq_1.metric_time__extract_day AS metric_time__extract_day
           , subq_1.metric_time__extract_dow AS metric_time__extract_dow
           , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+          , subq_2.metric_time__day AS metric_time__day
           , subq_1.listing AS listing
           , subq_1.guest AS guest
           , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0.sql
@@ -56,8 +56,7 @@ FROM (
               FROM (
                 -- Join to Time Spine Dataset
                 SELECT
-                  subq_2.metric_time__day AS metric_time__day
-                  , subq_1.ds__day AS ds__day
+                  subq_1.ds__day AS ds__day
                   , subq_1.ds__week AS ds__week
                   , subq_1.ds__month AS ds__month
                   , subq_1.ds__quarter AS ds__quarter
@@ -133,6 +132,7 @@ FROM (
                   , subq_1.metric_time__extract_day AS metric_time__extract_day
                   , subq_1.metric_time__extract_dow AS metric_time__extract_dow
                   , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+                  , subq_2.metric_time__day AS metric_time__day
                   , subq_1.listing AS listing
                   , subq_1.guest AS guest
                   , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_nested_offsets__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_nested_offsets__plan0.sql
@@ -40,8 +40,7 @@ FROM (
           FROM (
             -- Join to Time Spine Dataset
             SELECT
-              subq_2.metric_time__day AS metric_time__day
-              , subq_1.ds__day AS ds__day
+              subq_1.ds__day AS ds__day
               , subq_1.ds__week AS ds__week
               , subq_1.ds__month AS ds__month
               , subq_1.ds__quarter AS ds__quarter
@@ -117,6 +116,7 @@ FROM (
               , subq_1.metric_time__extract_day AS metric_time__extract_day
               , subq_1.metric_time__extract_dow AS metric_time__extract_dow
               , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+              , subq_2.metric_time__day AS metric_time__day
               , subq_1.listing AS listing
               , subq_1.guest AS guest
               , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_nested_offsets_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_nested_offsets_with_time_constraint__plan0.sql
@@ -41,8 +41,7 @@ FROM (
           FROM (
             -- Join to Time Spine Dataset
             SELECT
-              subq_2.metric_time__day AS metric_time__day
-              , subq_1.ds__day AS ds__day
+              subq_1.ds__day AS ds__day
               , subq_1.ds__week AS ds__week
               , subq_1.ds__month AS ds__month
               , subq_1.ds__quarter AS ds__quarter
@@ -118,6 +117,7 @@ FROM (
               , subq_1.metric_time__extract_day AS metric_time__extract_day
               , subq_1.metric_time__extract_dow AS metric_time__extract_dow
               , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+              , subq_2.metric_time__day AS metric_time__day
               , subq_1.listing AS listing
               , subq_1.guest AS guest
               , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_nested_offsets_with_where_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_nested_offsets_with_where_constraint__plan0.sql
@@ -45,8 +45,7 @@ FROM (
             FROM (
               -- Join to Time Spine Dataset
               SELECT
-                subq_2.metric_time__day AS metric_time__day
-                , subq_1.ds__day AS ds__day
+                subq_1.ds__day AS ds__day
                 , subq_1.ds__week AS ds__week
                 , subq_1.ds__month AS ds__month
                 , subq_1.ds__quarter AS ds__quarter
@@ -122,6 +121,7 @@ FROM (
                 , subq_1.metric_time__extract_day AS metric_time__extract_day
                 , subq_1.metric_time__extract_dow AS metric_time__extract_dow
                 , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+                , subq_2.metric_time__day AS metric_time__day
                 , subq_1.listing AS listing
                 , subq_1.guest AS guest
                 , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0.sql
@@ -26,7 +26,8 @@ FROM (
       FROM (
         -- Constrain Output with WHERE
         SELECT
-          subq_4.metric_time__month
+          subq_4.metric_time__day
+          , subq_4.metric_time__month
           , subq_4.ds__day
           , subq_4.ds__week
           , subq_4.ds__month
@@ -93,7 +94,6 @@ FROM (
           , subq_4.booking__paid_at__extract_day
           , subq_4.booking__paid_at__extract_dow
           , subq_4.booking__paid_at__extract_doy
-          , subq_4.metric_time__day
           , subq_4.metric_time__week
           , subq_4.metric_time__quarter
           , subq_4.metric_time__year
@@ -127,8 +127,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-            , subq_1.ds__day AS ds__day
+            subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -194,7 +193,6 @@ FROM (
             , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
-            , subq_1.metric_time__day AS metric_time__day
             , subq_1.metric_time__week AS metric_time__week
             , subq_1.metric_time__quarter AS metric_time__quarter
             , subq_1.metric_time__year AS metric_time__year
@@ -204,6 +202,8 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_2.metric_time__day AS metric_time__day
+            , subq_2.metric_time__month AS metric_time__month
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host
@@ -229,6 +229,7 @@ FROM (
             -- Time Spine
             SELECT
               subq_3.ds AS metric_time__day
+              , DATE_TRUNC('month', subq_3.ds) AS metric_time__month
             FROM ***************************.mf_time_spine subq_3
           ) subq_2
           INNER JOIN (
@@ -428,7 +429,7 @@ FROM (
           ) subq_1
           ON
             DATE_TRUNC('month', subq_2.metric_time__day) = subq_1.metric_time__day
-          WHERE DATE_TRUNC('month', subq_2.metric_time__day) = subq_2.metric_time__day
+          WHERE subq_2.metric_time__month = subq_2.metric_time__day
         ) subq_4
         WHERE metric_time__day = '2020-01-01'
       ) subq_5

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
@@ -19,8 +19,8 @@ FROM (
   FROM (
     -- Join to Time Spine Dataset
     SELECT
-      DATE_TRUNC('month', subq_12.ds) AS metric_time__month
-      , subq_10.metric_time__day AS metric_time__day
+      subq_12.ds AS metric_time__day
+      , DATE_TRUNC('month', subq_12.ds) AS metric_time__month
       , subq_10.bookings AS bookings
     FROM ***************************.mf_time_spine subq_12
     INNER JOIN (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_offset_to_grain_metric_multiple_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_offset_to_grain_metric_multiple_granularities__plan0.sql
@@ -34,10 +34,7 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_2.metric_time__day AS metric_time__day
-          , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-          , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-          , subq_1.ds__day AS ds__day
+          subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
@@ -111,6 +108,9 @@ FROM (
           , subq_1.metric_time__extract_day AS metric_time__extract_day
           , subq_1.metric_time__extract_dow AS metric_time__extract_dow
           , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+          , subq_2.metric_time__day AS metric_time__day
+          , subq_2.metric_time__month AS metric_time__month
+          , subq_2.metric_time__year AS metric_time__year
           , subq_1.listing AS listing
           , subq_1.guest AS guest
           , subq_1.host AS host
@@ -136,6 +136,8 @@ FROM (
           -- Time Spine
           SELECT
             subq_3.ds AS metric_time__day
+            , DATE_TRUNC('month', subq_3.ds) AS metric_time__month
+            , DATE_TRUNC('year', subq_3.ds) AS metric_time__year
           FROM ***************************.mf_time_spine subq_3
         ) subq_2
         INNER JOIN (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_offset_to_grain_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_offset_to_grain_with_agg_time_dim__plan0.sql
@@ -245,8 +245,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_7.booking__ds__day AS booking__ds__day
-            , subq_6.ds__day AS ds__day
+            subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -322,6 +321,7 @@ FROM (
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_7.booking__ds__day AS booking__ds__day
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_offset_window_metric_filter_and_query_have_different_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_offset_window_metric_filter_and_query_have_different_granularities__plan0.sql
@@ -32,7 +32,8 @@ FROM (
         FROM (
           -- Constrain Output with WHERE
           SELECT
-            subq_4.metric_time__month
+            subq_4.metric_time__day
+            , subq_4.metric_time__month
             , subq_4.ds__day
             , subq_4.ds__week
             , subq_4.ds__month
@@ -99,7 +100,6 @@ FROM (
             , subq_4.booking__paid_at__extract_day
             , subq_4.booking__paid_at__extract_dow
             , subq_4.booking__paid_at__extract_doy
-            , subq_4.metric_time__day
             , subq_4.metric_time__week
             , subq_4.metric_time__quarter
             , subq_4.metric_time__year
@@ -133,8 +133,7 @@ FROM (
           FROM (
             -- Join to Time Spine Dataset
             SELECT
-              DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-              , subq_1.ds__day AS ds__day
+              subq_1.ds__day AS ds__day
               , subq_1.ds__week AS ds__week
               , subq_1.ds__month AS ds__month
               , subq_1.ds__quarter AS ds__quarter
@@ -200,7 +199,6 @@ FROM (
               , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
               , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
               , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
-              , subq_1.metric_time__day AS metric_time__day
               , subq_1.metric_time__week AS metric_time__week
               , subq_1.metric_time__quarter AS metric_time__quarter
               , subq_1.metric_time__year AS metric_time__year
@@ -210,6 +208,8 @@ FROM (
               , subq_1.metric_time__extract_day AS metric_time__extract_day
               , subq_1.metric_time__extract_dow AS metric_time__extract_dow
               , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+              , subq_2.metric_time__day AS metric_time__day
+              , subq_2.metric_time__month AS metric_time__month
               , subq_1.listing AS listing
               , subq_1.guest AS guest
               , subq_1.host AS host
@@ -235,6 +235,7 @@ FROM (
               -- Time Spine
               SELECT
                 subq_3.ds AS metric_time__day
+                , DATE_TRUNC('month', subq_3.ds) AS metric_time__month
               FROM ***************************.mf_time_spine subq_3
             ) subq_2
             INNER JOIN (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_offset_window_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_offset_window_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
@@ -25,8 +25,8 @@ FROM (
     FROM (
       -- Join to Time Spine Dataset
       SELECT
-        DATE_TRUNC('month', subq_19.ds) AS metric_time__month
-        , DATE_TRUNC('day', bookings_source_src_28000.ds) AS metric_time__day
+        subq_19.ds AS metric_time__day
+        , DATE_TRUNC('month', subq_19.ds) AS metric_time__month
         , bookings_source_src_28000.booking_value AS booking_value
       FROM ***************************.mf_time_spine subq_19
       INNER JOIN

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_offset_window_metric_multiple_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_offset_window_metric_multiple_granularities__plan0.sql
@@ -42,10 +42,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_2.metric_time__day AS metric_time__day
-            , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-            , subq_1.ds__day AS ds__day
+            subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -119,6 +116,9 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_2.metric_time__day AS metric_time__day
+            , subq_2.metric_time__month AS metric_time__month
+            , subq_2.metric_time__year AS metric_time__year
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host
@@ -144,6 +144,8 @@ FROM (
             -- Time Spine
             SELECT
               subq_3.ds AS metric_time__day
+              , DATE_TRUNC('month', subq_3.ds) AS metric_time__month
+              , DATE_TRUNC('year', subq_3.ds) AS metric_time__year
             FROM ***************************.mf_time_spine subq_3
           ) subq_2
           INNER JOIN (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_offset_window_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_offset_window_with_agg_time_dim__plan0.sql
@@ -245,8 +245,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_7.booking__ds__day AS booking__ds__day
-            , subq_6.ds__day AS ds__day
+            subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -322,6 +321,7 @@ FROM (
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_7.booking__ds__day AS booking__ds__day
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_time_offset_metric_with_time_constraint__plan0.sql
@@ -24,8 +24,7 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_2.metric_time__day AS metric_time__day
-          , subq_1.ds__day AS ds__day
+          subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
@@ -101,6 +100,7 @@ FROM (
           , subq_1.metric_time__extract_day AS metric_time__extract_day
           , subq_1.metric_time__extract_dow AS metric_time__extract_dow
           , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+          , subq_2.metric_time__day AS metric_time__day
           , subq_1.listing AS listing
           , subq_1.guest AS guest
           , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
@@ -125,8 +125,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_5.metric_time__day AS metric_time__day
-            , subq_4.ds__day AS ds__day
+            subq_4.ds__day AS ds__day
             , subq_4.ds__week AS ds__week
             , subq_4.ds__month AS ds__month
             , subq_4.ds__quarter AS ds__quarter
@@ -202,6 +201,7 @@ FROM (
             , subq_4.metric_time__extract_day AS metric_time__extract_day
             , subq_4.metric_time__extract_dow AS metric_time__extract_dow
             , subq_4.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_5.metric_time__day AS metric_time__day
             , subq_4.listing AS listing
             , subq_4.guest AS guest
             , subq_4.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
@@ -24,8 +24,7 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_2.metric_time__month AS metric_time__month
-          , subq_1.ds__month AS ds__month
+          subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
           , subq_1.ds__year AS ds__year
           , subq_1.ds__extract_year AS ds__extract_year
@@ -42,6 +41,7 @@ FROM (
           , subq_1.metric_time__extract_year AS metric_time__extract_year
           , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
           , subq_1.metric_time__extract_month AS metric_time__extract_month
+          , subq_2.metric_time__month AS metric_time__month
           , subq_1.listing AS listing
           , subq_1.booking_monthly__listing AS booking_monthly__listing
           , subq_1.bookings_monthly AS bookings_monthly

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_metric_with_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_metric_with_offset_to_grain__plan0.sql
@@ -245,8 +245,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_7.metric_time__day AS metric_time__day
-            , subq_6.ds__day AS ds__day
+            subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -322,6 +321,7 @@ FROM (
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_7.metric_time__day AS metric_time__day
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_metric_with_offset_to_grain_and_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_metric_with_offset_to_grain_and_granularity__plan0.sql
@@ -245,8 +245,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            DATE_TRUNC('week', subq_7.metric_time__day) AS metric_time__week
-            , subq_6.ds__day AS ds__day
+            subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -312,7 +311,6 @@ FROM (
             , subq_6.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_6.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_6.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
-            , subq_6.metric_time__day AS metric_time__day
             , subq_6.metric_time__month AS metric_time__month
             , subq_6.metric_time__quarter AS metric_time__quarter
             , subq_6.metric_time__year AS metric_time__year
@@ -322,6 +320,8 @@ FROM (
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_7.metric_time__day AS metric_time__day
+            , subq_7.metric_time__week AS metric_time__week
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host
@@ -347,6 +347,7 @@ FROM (
             -- Time Spine
             SELECT
               subq_8.ds AS metric_time__day
+              , DATE_TRUNC('week', subq_8.ds) AS metric_time__week
             FROM ***************************.mf_time_spine subq_8
           ) subq_7
           INNER JOIN (
@@ -546,7 +547,7 @@ FROM (
           ) subq_6
           ON
             DATE_TRUNC('month', subq_7.metric_time__day) = subq_6.metric_time__day
-          WHERE DATE_TRUNC('week', subq_7.metric_time__day) = subq_7.metric_time__day
+          WHERE subq_7.metric_time__week = subq_7.metric_time__day
         ) subq_9
       ) subq_10
       GROUP BY

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_metric_with_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_metric_with_offset_window__plan0.sql
@@ -245,8 +245,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_7.metric_time__day AS metric_time__day
-            , subq_6.ds__day AS ds__day
+            subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -322,6 +321,7 @@ FROM (
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_7.metric_time__day AS metric_time__day
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_metric_with_offset_window_and_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_metric_with_offset_window_and_granularity__plan0.sql
@@ -245,8 +245,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            DATE_TRUNC('quarter', subq_7.metric_time__day) AS metric_time__quarter
-            , subq_6.ds__day AS ds__day
+            subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -312,7 +311,6 @@ FROM (
             , subq_6.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_6.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_6.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
-            , subq_6.metric_time__day AS metric_time__day
             , subq_6.metric_time__week AS metric_time__week
             , subq_6.metric_time__month AS metric_time__month
             , subq_6.metric_time__year AS metric_time__year
@@ -322,6 +320,8 @@ FROM (
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_7.metric_time__day AS metric_time__day
+            , subq_7.metric_time__quarter AS metric_time__quarter
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host
@@ -347,6 +347,7 @@ FROM (
             -- Time Spine
             SELECT
               subq_8.ds AS metric_time__day
+              , DATE_TRUNC('quarter', subq_8.ds) AS metric_time__quarter
             FROM ***************************.mf_time_spine subq_8
           ) subq_7
           INNER JOIN (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
@@ -30,8 +30,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_2.metric_time__day AS metric_time__day
-            , subq_1.ds__day AS ds__day
+            subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -107,6 +106,7 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_2.metric_time__day AS metric_time__day
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host
@@ -355,8 +355,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_10.metric_time__day AS metric_time__day
-            , subq_9.ds__day AS ds__day
+            subq_9.ds__day AS ds__day
             , subq_9.ds__week AS ds__week
             , subq_9.ds__month AS ds__month
             , subq_9.ds__quarter AS ds__quarter
@@ -432,6 +431,7 @@ FROM (
             , subq_9.metric_time__extract_day AS metric_time__extract_day
             , subq_9.metric_time__extract_dow AS metric_time__extract_dow
             , subq_9.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_10.metric_time__day AS metric_time__day
             , subq_9.listing AS listing
             , subq_9.guest AS guest
             , subq_9.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0.sql
@@ -30,8 +30,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-            , subq_1.ds__day AS ds__day
+            subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -97,7 +96,6 @@ FROM (
             , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
-            , subq_1.metric_time__day AS metric_time__day
             , subq_1.metric_time__week AS metric_time__week
             , subq_1.metric_time__month AS metric_time__month
             , subq_1.metric_time__quarter AS metric_time__quarter
@@ -107,6 +105,8 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_2.metric_time__day AS metric_time__day
+            , subq_2.metric_time__year AS metric_time__year
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host
@@ -132,6 +132,7 @@ FROM (
             -- Time Spine
             SELECT
               subq_3.ds AS metric_time__day
+              , DATE_TRUNC('year', subq_3.ds) AS metric_time__year
             FROM ***************************.mf_time_spine subq_3
           ) subq_2
           INNER JOIN (
@@ -331,7 +332,7 @@ FROM (
           ) subq_1
           ON
             DATE_TRUNC('month', subq_2.metric_time__day) = subq_1.metric_time__day
-          WHERE DATE_TRUNC('year', subq_2.metric_time__day) = subq_2.metric_time__day
+          WHERE subq_2.metric_time__year = subq_2.metric_time__day
         ) subq_4
       ) subq_5
       GROUP BY
@@ -356,8 +357,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            DATE_TRUNC('year', subq_10.metric_time__day) AS metric_time__year
-            , subq_9.ds__day AS ds__day
+            subq_9.ds__day AS ds__day
             , subq_9.ds__week AS ds__week
             , subq_9.ds__month AS ds__month
             , subq_9.ds__quarter AS ds__quarter
@@ -423,7 +423,6 @@ FROM (
             , subq_9.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_9.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_9.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
-            , subq_9.metric_time__day AS metric_time__day
             , subq_9.metric_time__week AS metric_time__week
             , subq_9.metric_time__month AS metric_time__month
             , subq_9.metric_time__quarter AS metric_time__quarter
@@ -433,6 +432,8 @@ FROM (
             , subq_9.metric_time__extract_day AS metric_time__extract_day
             , subq_9.metric_time__extract_dow AS metric_time__extract_dow
             , subq_9.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_10.metric_time__day AS metric_time__day
+            , subq_10.metric_time__year AS metric_time__year
             , subq_9.listing AS listing
             , subq_9.guest AS guest
             , subq_9.host AS host
@@ -458,6 +459,7 @@ FROM (
             -- Time Spine
             SELECT
               subq_11.ds AS metric_time__day
+              , DATE_TRUNC('year', subq_11.ds) AS metric_time__year
             FROM ***************************.mf_time_spine subq_11
           ) subq_10
           INNER JOIN (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
@@ -449,8 +449,7 @@ FROM (
           FROM (
             -- Join to Time Spine Dataset
             SELECT
-              subq_8.metric_time__day AS metric_time__day
-              , subq_7.ds__day AS ds__day
+              subq_7.ds__day AS ds__day
               , subq_7.ds__week AS ds__week
               , subq_7.ds__month AS ds__month
               , subq_7.ds__quarter AS ds__quarter
@@ -526,6 +525,7 @@ FROM (
               , subq_7.metric_time__extract_day AS metric_time__extract_day
               , subq_7.metric_time__extract_dow AS metric_time__extract_dow
               , subq_7.metric_time__extract_doy AS metric_time__extract_doy
+              , subq_8.metric_time__day AS metric_time__day
               , subq_7.listing AS listing
               , subq_7.guest AS guest
               , subq_7.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_offset_cumulative_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_offset_cumulative_metric__plan0.sql
@@ -24,8 +24,7 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_5.metric_time__day AS metric_time__day
-          , subq_4.ds__day AS ds__day
+          subq_4.ds__day AS ds__day
           , subq_4.ds__week AS ds__week
           , subq_4.ds__month AS ds__month
           , subq_4.ds__quarter AS ds__quarter
@@ -101,6 +100,7 @@ FROM (
           , subq_4.metric_time__extract_day AS metric_time__extract_day
           , subq_4.metric_time__extract_dow AS metric_time__extract_dow
           , subq_4.metric_time__extract_doy AS metric_time__extract_doy
+          , subq_5.metric_time__day AS metric_time__day
           , subq_4.listing AS listing
           , subq_4.guest AS guest
           , subq_4.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_offset_metric_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_offset_metric_with_agg_time_dim__plan0.sql
@@ -30,8 +30,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_2.booking__ds__day AS booking__ds__day
-            , subq_1.ds__day AS ds__day
+            subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -107,6 +106,7 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_2.booking__ds__day AS booking__ds__day
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_offset_metric_with_one_input_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_offset_metric_with_one_input_metric__plan0.sql
@@ -24,8 +24,7 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_2.metric_time__day AS metric_time__day
-          , subq_1.ds__day AS ds__day
+          subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
@@ -101,6 +100,7 @@ FROM (
           , subq_1.metric_time__extract_day AS metric_time__extract_day
           , subq_1.metric_time__extract_dow AS metric_time__extract_dow
           , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+          , subq_2.metric_time__day AS metric_time__day
           , subq_1.listing AS listing
           , subq_1.guest AS guest
           , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0.sql
@@ -56,8 +56,7 @@ FROM (
               FROM (
                 -- Join to Time Spine Dataset
                 SELECT
-                  subq_2.metric_time__day AS metric_time__day
-                  , subq_1.ds__day AS ds__day
+                  subq_1.ds__day AS ds__day
                   , subq_1.ds__week AS ds__week
                   , subq_1.ds__month AS ds__month
                   , subq_1.ds__quarter AS ds__quarter
@@ -133,6 +132,7 @@ FROM (
                   , subq_1.metric_time__extract_day AS metric_time__extract_day
                   , subq_1.metric_time__extract_dow AS metric_time__extract_dow
                   , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+                  , subq_2.metric_time__day AS metric_time__day
                   , subq_1.listing AS listing
                   , subq_1.guest AS guest
                   , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_nested_offsets__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_nested_offsets__plan0.sql
@@ -40,8 +40,7 @@ FROM (
           FROM (
             -- Join to Time Spine Dataset
             SELECT
-              subq_2.metric_time__day AS metric_time__day
-              , subq_1.ds__day AS ds__day
+              subq_1.ds__day AS ds__day
               , subq_1.ds__week AS ds__week
               , subq_1.ds__month AS ds__month
               , subq_1.ds__quarter AS ds__quarter
@@ -117,6 +116,7 @@ FROM (
               , subq_1.metric_time__extract_day AS metric_time__extract_day
               , subq_1.metric_time__extract_dow AS metric_time__extract_dow
               , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+              , subq_2.metric_time__day AS metric_time__day
               , subq_1.listing AS listing
               , subq_1.guest AS guest
               , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_nested_offsets_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_nested_offsets_with_time_constraint__plan0.sql
@@ -41,8 +41,7 @@ FROM (
           FROM (
             -- Join to Time Spine Dataset
             SELECT
-              subq_2.metric_time__day AS metric_time__day
-              , subq_1.ds__day AS ds__day
+              subq_1.ds__day AS ds__day
               , subq_1.ds__week AS ds__week
               , subq_1.ds__month AS ds__month
               , subq_1.ds__quarter AS ds__quarter
@@ -118,6 +117,7 @@ FROM (
               , subq_1.metric_time__extract_day AS metric_time__extract_day
               , subq_1.metric_time__extract_dow AS metric_time__extract_dow
               , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+              , subq_2.metric_time__day AS metric_time__day
               , subq_1.listing AS listing
               , subq_1.guest AS guest
               , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_nested_offsets_with_where_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_nested_offsets_with_where_constraint__plan0.sql
@@ -45,8 +45,7 @@ FROM (
             FROM (
               -- Join to Time Spine Dataset
               SELECT
-                subq_2.metric_time__day AS metric_time__day
-                , subq_1.ds__day AS ds__day
+                subq_1.ds__day AS ds__day
                 , subq_1.ds__week AS ds__week
                 , subq_1.ds__month AS ds__month
                 , subq_1.ds__quarter AS ds__quarter
@@ -122,6 +121,7 @@ FROM (
                 , subq_1.metric_time__extract_day AS metric_time__extract_day
                 , subq_1.metric_time__extract_dow AS metric_time__extract_dow
                 , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+                , subq_2.metric_time__day AS metric_time__day
                 , subq_1.listing AS listing
                 , subq_1.guest AS guest
                 , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0.sql
@@ -26,7 +26,8 @@ FROM (
       FROM (
         -- Constrain Output with WHERE
         SELECT
-          subq_4.metric_time__month
+          subq_4.metric_time__day
+          , subq_4.metric_time__month
           , subq_4.ds__day
           , subq_4.ds__week
           , subq_4.ds__month
@@ -93,7 +94,6 @@ FROM (
           , subq_4.booking__paid_at__extract_day
           , subq_4.booking__paid_at__extract_dow
           , subq_4.booking__paid_at__extract_doy
-          , subq_4.metric_time__day
           , subq_4.metric_time__week
           , subq_4.metric_time__quarter
           , subq_4.metric_time__year
@@ -127,8 +127,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-            , subq_1.ds__day AS ds__day
+            subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -194,7 +193,6 @@ FROM (
             , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
-            , subq_1.metric_time__day AS metric_time__day
             , subq_1.metric_time__week AS metric_time__week
             , subq_1.metric_time__quarter AS metric_time__quarter
             , subq_1.metric_time__year AS metric_time__year
@@ -204,6 +202,8 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_2.metric_time__day AS metric_time__day
+            , subq_2.metric_time__month AS metric_time__month
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host
@@ -229,6 +229,7 @@ FROM (
             -- Time Spine
             SELECT
               subq_3.ds AS metric_time__day
+              , DATE_TRUNC('month', subq_3.ds) AS metric_time__month
             FROM ***************************.mf_time_spine subq_3
           ) subq_2
           INNER JOIN (
@@ -428,7 +429,7 @@ FROM (
           ) subq_1
           ON
             DATE_TRUNC('month', subq_2.metric_time__day) = subq_1.metric_time__day
-          WHERE DATE_TRUNC('month', subq_2.metric_time__day) = subq_2.metric_time__day
+          WHERE subq_2.metric_time__month = subq_2.metric_time__day
         ) subq_4
         WHERE metric_time__day = '2020-01-01'
       ) subq_5

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
@@ -19,8 +19,8 @@ FROM (
   FROM (
     -- Join to Time Spine Dataset
     SELECT
-      DATE_TRUNC('month', subq_12.ds) AS metric_time__month
-      , subq_10.metric_time__day AS metric_time__day
+      subq_12.ds AS metric_time__day
+      , DATE_TRUNC('month', subq_12.ds) AS metric_time__month
       , subq_10.bookings AS bookings
     FROM ***************************.mf_time_spine subq_12
     INNER JOIN (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_offset_to_grain_metric_multiple_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_offset_to_grain_metric_multiple_granularities__plan0.sql
@@ -34,10 +34,7 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_2.metric_time__day AS metric_time__day
-          , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-          , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-          , subq_1.ds__day AS ds__day
+          subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
@@ -111,6 +108,9 @@ FROM (
           , subq_1.metric_time__extract_day AS metric_time__extract_day
           , subq_1.metric_time__extract_dow AS metric_time__extract_dow
           , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+          , subq_2.metric_time__day AS metric_time__day
+          , subq_2.metric_time__month AS metric_time__month
+          , subq_2.metric_time__year AS metric_time__year
           , subq_1.listing AS listing
           , subq_1.guest AS guest
           , subq_1.host AS host
@@ -136,6 +136,8 @@ FROM (
           -- Time Spine
           SELECT
             subq_3.ds AS metric_time__day
+            , DATE_TRUNC('month', subq_3.ds) AS metric_time__month
+            , DATE_TRUNC('year', subq_3.ds) AS metric_time__year
           FROM ***************************.mf_time_spine subq_3
         ) subq_2
         INNER JOIN (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_offset_to_grain_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_offset_to_grain_with_agg_time_dim__plan0.sql
@@ -245,8 +245,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_7.booking__ds__day AS booking__ds__day
-            , subq_6.ds__day AS ds__day
+            subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -322,6 +321,7 @@ FROM (
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_7.booking__ds__day AS booking__ds__day
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_offset_window_metric_filter_and_query_have_different_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_offset_window_metric_filter_and_query_have_different_granularities__plan0.sql
@@ -32,7 +32,8 @@ FROM (
         FROM (
           -- Constrain Output with WHERE
           SELECT
-            subq_4.metric_time__month
+            subq_4.metric_time__day
+            , subq_4.metric_time__month
             , subq_4.ds__day
             , subq_4.ds__week
             , subq_4.ds__month
@@ -99,7 +100,6 @@ FROM (
             , subq_4.booking__paid_at__extract_day
             , subq_4.booking__paid_at__extract_dow
             , subq_4.booking__paid_at__extract_doy
-            , subq_4.metric_time__day
             , subq_4.metric_time__week
             , subq_4.metric_time__quarter
             , subq_4.metric_time__year
@@ -133,8 +133,7 @@ FROM (
           FROM (
             -- Join to Time Spine Dataset
             SELECT
-              DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-              , subq_1.ds__day AS ds__day
+              subq_1.ds__day AS ds__day
               , subq_1.ds__week AS ds__week
               , subq_1.ds__month AS ds__month
               , subq_1.ds__quarter AS ds__quarter
@@ -200,7 +199,6 @@ FROM (
               , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
               , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
               , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
-              , subq_1.metric_time__day AS metric_time__day
               , subq_1.metric_time__week AS metric_time__week
               , subq_1.metric_time__quarter AS metric_time__quarter
               , subq_1.metric_time__year AS metric_time__year
@@ -210,6 +208,8 @@ FROM (
               , subq_1.metric_time__extract_day AS metric_time__extract_day
               , subq_1.metric_time__extract_dow AS metric_time__extract_dow
               , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+              , subq_2.metric_time__day AS metric_time__day
+              , subq_2.metric_time__month AS metric_time__month
               , subq_1.listing AS listing
               , subq_1.guest AS guest
               , subq_1.host AS host
@@ -235,6 +235,7 @@ FROM (
               -- Time Spine
               SELECT
                 subq_3.ds AS metric_time__day
+                , DATE_TRUNC('month', subq_3.ds) AS metric_time__month
               FROM ***************************.mf_time_spine subq_3
             ) subq_2
             INNER JOIN (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_offset_window_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_offset_window_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
@@ -25,8 +25,8 @@ FROM (
     FROM (
       -- Join to Time Spine Dataset
       SELECT
-        DATE_TRUNC('month', subq_19.ds) AS metric_time__month
-        , DATE_TRUNC('day', bookings_source_src_28000.ds) AS metric_time__day
+        subq_19.ds AS metric_time__day
+        , DATE_TRUNC('month', subq_19.ds) AS metric_time__month
         , bookings_source_src_28000.booking_value AS booking_value
       FROM ***************************.mf_time_spine subq_19
       INNER JOIN

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_offset_window_metric_multiple_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_offset_window_metric_multiple_granularities__plan0.sql
@@ -42,10 +42,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_2.metric_time__day AS metric_time__day
-            , DATE_TRUNC('month', subq_2.metric_time__day) AS metric_time__month
-            , DATE_TRUNC('year', subq_2.metric_time__day) AS metric_time__year
-            , subq_1.ds__day AS ds__day
+            subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -119,6 +116,9 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_2.metric_time__day AS metric_time__day
+            , subq_2.metric_time__month AS metric_time__month
+            , subq_2.metric_time__year AS metric_time__year
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host
@@ -144,6 +144,8 @@ FROM (
             -- Time Spine
             SELECT
               subq_3.ds AS metric_time__day
+              , DATE_TRUNC('month', subq_3.ds) AS metric_time__month
+              , DATE_TRUNC('year', subq_3.ds) AS metric_time__year
             FROM ***************************.mf_time_spine subq_3
           ) subq_2
           INNER JOIN (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_offset_window_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_offset_window_with_agg_time_dim__plan0.sql
@@ -245,8 +245,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_7.booking__ds__day AS booking__ds__day
-            , subq_6.ds__day AS ds__day
+            subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -322,6 +321,7 @@ FROM (
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_7.booking__ds__day AS booking__ds__day
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_time_offset_metric_with_time_constraint__plan0.sql
@@ -24,8 +24,7 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_2.metric_time__day AS metric_time__day
-          , subq_1.ds__day AS ds__day
+          subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
@@ -101,6 +100,7 @@ FROM (
           , subq_1.metric_time__extract_day AS metric_time__extract_day
           , subq_1.metric_time__extract_dow AS metric_time__extract_dow
           , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+          , subq_2.metric_time__day AS metric_time__day
           , subq_1.listing AS listing
           , subq_1.guest AS guest
           , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/BigQuery/test_derived_fill_nulls_for_one_input_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/BigQuery/test_derived_fill_nulls_for_one_input_metric__plan0.sql
@@ -259,8 +259,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_10.metric_time__day AS metric_time__day
-            , subq_9.ds__day AS ds__day
+            subq_9.ds__day AS ds__day
             , subq_9.ds__week AS ds__week
             , subq_9.ds__month AS ds__month
             , subq_9.ds__quarter AS ds__quarter
@@ -336,6 +335,7 @@ FROM (
             , subq_9.metric_time__extract_day AS metric_time__extract_day
             , subq_9.metric_time__extract_dow AS metric_time__extract_dow
             , subq_9.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_10.metric_time__day AS metric_time__day
             , subq_9.listing AS listing
             , subq_9.guest AS guest
             , subq_9.host AS host

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time__plan0.sql
@@ -19,8 +19,8 @@ FROM (
       -- Time Spine
       SELECT
         subq_6.ds AS booking__ds__day
-        , DATETIME_TRUNC(subq_6.ds, month) AS booking__ds__month
         , subq_6.ds AS metric_time__day
+        , DATETIME_TRUNC(subq_6.ds, month) AS booking__ds__month
       FROM ***************************.mf_time_spine subq_6
     ) subq_7
     WHERE (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time__plan0_optimized.sql
@@ -15,8 +15,8 @@ FROM (
     -- Time Spine
     SELECT
       ds AS booking__ds__day
-      , DATETIME_TRUNC(ds, month) AS booking__ds__month
       , ds AS metric_time__day
+      , DATETIME_TRUNC(ds, month) AS booking__ds__month
     FROM ***************************.mf_time_spine subq_15
   ) subq_16
   WHERE (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time_and_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time_and_metric_time__plan0.sql
@@ -18,8 +18,8 @@ FROM (
     FROM (
       -- Time Spine
       SELECT
-        DATETIME_TRUNC(subq_6.ds, month) AS booking__ds__month
-        , subq_6.ds AS metric_time__day
+        subq_6.ds AS metric_time__day
+        , DATETIME_TRUNC(subq_6.ds, month) AS booking__ds__month
       FROM ***************************.mf_time_spine subq_6
     ) subq_7
     WHERE (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time_and_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time_and_metric_time__plan0_optimized.sql
@@ -14,8 +14,8 @@ FROM (
   FROM (
     -- Time Spine
     SELECT
-      DATETIME_TRUNC(ds, month) AS booking__ds__month
-      , ds AS metric_time__day
+      ds AS metric_time__day
+      , DATETIME_TRUNC(ds, month) AS booking__ds__month
     FROM ***************************.mf_time_spine subq_15
   ) subq_16
   WHERE (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_with_filter_smaller_than_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_with_filter_smaller_than_group_by__plan0.sql
@@ -18,8 +18,8 @@ FROM (
     FROM (
       -- Time Spine
       SELECT
-        subq_6.ts AS metric_time__hour
-        , DATETIME_TRUNC(subq_6.ts, day) AS metric_time__day
+        DATETIME_TRUNC(subq_6.ts, day) AS metric_time__day
+        , subq_6.ts AS metric_time__hour
       FROM ***************************.mf_time_spine_hour subq_6
     ) subq_7
     WHERE (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_with_filter_smaller_than_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_with_filter_smaller_than_group_by__plan0_optimized.sql
@@ -14,8 +14,8 @@ FROM (
   FROM (
     -- Time Spine
     SELECT
-      ts AS metric_time__hour
-      , DATETIME_TRUNC(ts, day) AS metric_time__day
+      DATETIME_TRUNC(ts, day) AS metric_time__day
+      , ts AS metric_time__hour
     FROM ***************************.mf_time_spine_hour subq_15
   ) subq_16
   WHERE (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Databricks/test_derived_fill_nulls_for_one_input_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Databricks/test_derived_fill_nulls_for_one_input_metric__plan0.sql
@@ -259,8 +259,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_10.metric_time__day AS metric_time__day
-            , subq_9.ds__day AS ds__day
+            subq_9.ds__day AS ds__day
             , subq_9.ds__week AS ds__week
             , subq_9.ds__month AS ds__month
             , subq_9.ds__quarter AS ds__quarter
@@ -336,6 +335,7 @@ FROM (
             , subq_9.metric_time__extract_day AS metric_time__extract_day
             , subq_9.metric_time__extract_dow AS metric_time__extract_dow
             , subq_9.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_10.metric_time__day AS metric_time__day
             , subq_9.listing AS listing
             , subq_9.guest AS guest
             , subq_9.host AS host

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Databricks/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Databricks/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time__plan0.sql
@@ -19,8 +19,8 @@ FROM (
       -- Time Spine
       SELECT
         subq_6.ds AS booking__ds__day
-        , DATE_TRUNC('month', subq_6.ds) AS booking__ds__month
         , subq_6.ds AS metric_time__day
+        , DATE_TRUNC('month', subq_6.ds) AS booking__ds__month
       FROM ***************************.mf_time_spine subq_6
     ) subq_7
     WHERE (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Databricks/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Databricks/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time__plan0_optimized.sql
@@ -15,8 +15,8 @@ FROM (
     -- Time Spine
     SELECT
       ds AS booking__ds__day
-      , DATE_TRUNC('month', ds) AS booking__ds__month
       , ds AS metric_time__day
+      , DATE_TRUNC('month', ds) AS booking__ds__month
     FROM ***************************.mf_time_spine subq_15
   ) subq_16
   WHERE (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Databricks/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time_and_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Databricks/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time_and_metric_time__plan0.sql
@@ -18,8 +18,8 @@ FROM (
     FROM (
       -- Time Spine
       SELECT
-        DATE_TRUNC('month', subq_6.ds) AS booking__ds__month
-        , subq_6.ds AS metric_time__day
+        subq_6.ds AS metric_time__day
+        , DATE_TRUNC('month', subq_6.ds) AS booking__ds__month
       FROM ***************************.mf_time_spine subq_6
     ) subq_7
     WHERE (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Databricks/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time_and_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Databricks/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time_and_metric_time__plan0_optimized.sql
@@ -14,8 +14,8 @@ FROM (
   FROM (
     -- Time Spine
     SELECT
-      DATE_TRUNC('month', ds) AS booking__ds__month
-      , ds AS metric_time__day
+      ds AS metric_time__day
+      , DATE_TRUNC('month', ds) AS booking__ds__month
     FROM ***************************.mf_time_spine subq_15
   ) subq_16
   WHERE (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Databricks/test_join_to_time_spine_with_filter_smaller_than_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Databricks/test_join_to_time_spine_with_filter_smaller_than_group_by__plan0.sql
@@ -18,8 +18,8 @@ FROM (
     FROM (
       -- Time Spine
       SELECT
-        subq_6.ts AS metric_time__hour
-        , DATE_TRUNC('day', subq_6.ts) AS metric_time__day
+        DATE_TRUNC('day', subq_6.ts) AS metric_time__day
+        , subq_6.ts AS metric_time__hour
       FROM ***************************.mf_time_spine_hour subq_6
     ) subq_7
     WHERE (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Databricks/test_join_to_time_spine_with_filter_smaller_than_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Databricks/test_join_to_time_spine_with_filter_smaller_than_group_by__plan0_optimized.sql
@@ -14,8 +14,8 @@ FROM (
   FROM (
     -- Time Spine
     SELECT
-      ts AS metric_time__hour
-      , DATE_TRUNC('day', ts) AS metric_time__day
+      DATE_TRUNC('day', ts) AS metric_time__day
+      , ts AS metric_time__hour
     FROM ***************************.mf_time_spine_hour subq_15
   ) subq_16
   WHERE (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/DuckDB/test_derived_fill_nulls_for_one_input_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/DuckDB/test_derived_fill_nulls_for_one_input_metric__plan0.sql
@@ -259,8 +259,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_10.metric_time__day AS metric_time__day
-            , subq_9.ds__day AS ds__day
+            subq_9.ds__day AS ds__day
             , subq_9.ds__week AS ds__week
             , subq_9.ds__month AS ds__month
             , subq_9.ds__quarter AS ds__quarter
@@ -336,6 +335,7 @@ FROM (
             , subq_9.metric_time__extract_day AS metric_time__extract_day
             , subq_9.metric_time__extract_dow AS metric_time__extract_dow
             , subq_9.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_10.metric_time__day AS metric_time__day
             , subq_9.listing AS listing
             , subq_9.guest AS guest
             , subq_9.host AS host

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time__plan0.sql
@@ -19,8 +19,8 @@ FROM (
       -- Time Spine
       SELECT
         subq_6.ds AS booking__ds__day
-        , DATE_TRUNC('month', subq_6.ds) AS booking__ds__month
         , subq_6.ds AS metric_time__day
+        , DATE_TRUNC('month', subq_6.ds) AS booking__ds__month
       FROM ***************************.mf_time_spine subq_6
     ) subq_7
     WHERE (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time__plan0_optimized.sql
@@ -15,8 +15,8 @@ FROM (
     -- Time Spine
     SELECT
       ds AS booking__ds__day
-      , DATE_TRUNC('month', ds) AS booking__ds__month
       , ds AS metric_time__day
+      , DATE_TRUNC('month', ds) AS booking__ds__month
     FROM ***************************.mf_time_spine subq_15
   ) subq_16
   WHERE (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time_and_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time_and_metric_time__plan0.sql
@@ -18,8 +18,8 @@ FROM (
     FROM (
       -- Time Spine
       SELECT
-        DATE_TRUNC('month', subq_6.ds) AS booking__ds__month
-        , subq_6.ds AS metric_time__day
+        subq_6.ds AS metric_time__day
+        , DATE_TRUNC('month', subq_6.ds) AS booking__ds__month
       FROM ***************************.mf_time_spine subq_6
     ) subq_7
     WHERE (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time_and_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time_and_metric_time__plan0_optimized.sql
@@ -14,8 +14,8 @@ FROM (
   FROM (
     -- Time Spine
     SELECT
-      DATE_TRUNC('month', ds) AS booking__ds__month
-      , ds AS metric_time__day
+      ds AS metric_time__day
+      , DATE_TRUNC('month', ds) AS booking__ds__month
     FROM ***************************.mf_time_spine subq_15
   ) subq_16
   WHERE (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_with_filter_smaller_than_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_with_filter_smaller_than_group_by__plan0.sql
@@ -18,8 +18,8 @@ FROM (
     FROM (
       -- Time Spine
       SELECT
-        subq_6.ts AS metric_time__hour
-        , DATE_TRUNC('day', subq_6.ts) AS metric_time__day
+        DATE_TRUNC('day', subq_6.ts) AS metric_time__day
+        , subq_6.ts AS metric_time__hour
       FROM ***************************.mf_time_spine_hour subq_6
     ) subq_7
     WHERE (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_with_filter_smaller_than_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_with_filter_smaller_than_group_by__plan0_optimized.sql
@@ -14,8 +14,8 @@ FROM (
   FROM (
     -- Time Spine
     SELECT
-      ts AS metric_time__hour
-      , DATE_TRUNC('day', ts) AS metric_time__day
+      DATE_TRUNC('day', ts) AS metric_time__day
+      , ts AS metric_time__hour
     FROM ***************************.mf_time_spine_hour subq_15
   ) subq_16
   WHERE (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Postgres/test_derived_fill_nulls_for_one_input_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Postgres/test_derived_fill_nulls_for_one_input_metric__plan0.sql
@@ -259,8 +259,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_10.metric_time__day AS metric_time__day
-            , subq_9.ds__day AS ds__day
+            subq_9.ds__day AS ds__day
             , subq_9.ds__week AS ds__week
             , subq_9.ds__month AS ds__month
             , subq_9.ds__quarter AS ds__quarter
@@ -336,6 +335,7 @@ FROM (
             , subq_9.metric_time__extract_day AS metric_time__extract_day
             , subq_9.metric_time__extract_dow AS metric_time__extract_dow
             , subq_9.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_10.metric_time__day AS metric_time__day
             , subq_9.listing AS listing
             , subq_9.guest AS guest
             , subq_9.host AS host

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Postgres/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Postgres/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time__plan0.sql
@@ -19,8 +19,8 @@ FROM (
       -- Time Spine
       SELECT
         subq_6.ds AS booking__ds__day
-        , DATE_TRUNC('month', subq_6.ds) AS booking__ds__month
         , subq_6.ds AS metric_time__day
+        , DATE_TRUNC('month', subq_6.ds) AS booking__ds__month
       FROM ***************************.mf_time_spine subq_6
     ) subq_7
     WHERE (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Postgres/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Postgres/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time__plan0_optimized.sql
@@ -15,8 +15,8 @@ FROM (
     -- Time Spine
     SELECT
       ds AS booking__ds__day
-      , DATE_TRUNC('month', ds) AS booking__ds__month
       , ds AS metric_time__day
+      , DATE_TRUNC('month', ds) AS booking__ds__month
     FROM ***************************.mf_time_spine subq_15
   ) subq_16
   WHERE (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Postgres/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time_and_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Postgres/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time_and_metric_time__plan0.sql
@@ -18,8 +18,8 @@ FROM (
     FROM (
       -- Time Spine
       SELECT
-        DATE_TRUNC('month', subq_6.ds) AS booking__ds__month
-        , subq_6.ds AS metric_time__day
+        subq_6.ds AS metric_time__day
+        , DATE_TRUNC('month', subq_6.ds) AS booking__ds__month
       FROM ***************************.mf_time_spine subq_6
     ) subq_7
     WHERE (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Postgres/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time_and_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Postgres/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time_and_metric_time__plan0_optimized.sql
@@ -14,8 +14,8 @@ FROM (
   FROM (
     -- Time Spine
     SELECT
-      DATE_TRUNC('month', ds) AS booking__ds__month
-      , ds AS metric_time__day
+      ds AS metric_time__day
+      , DATE_TRUNC('month', ds) AS booking__ds__month
     FROM ***************************.mf_time_spine subq_15
   ) subq_16
   WHERE (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Postgres/test_join_to_time_spine_with_filter_smaller_than_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Postgres/test_join_to_time_spine_with_filter_smaller_than_group_by__plan0.sql
@@ -18,8 +18,8 @@ FROM (
     FROM (
       -- Time Spine
       SELECT
-        subq_6.ts AS metric_time__hour
-        , DATE_TRUNC('day', subq_6.ts) AS metric_time__day
+        DATE_TRUNC('day', subq_6.ts) AS metric_time__day
+        , subq_6.ts AS metric_time__hour
       FROM ***************************.mf_time_spine_hour subq_6
     ) subq_7
     WHERE (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Postgres/test_join_to_time_spine_with_filter_smaller_than_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Postgres/test_join_to_time_spine_with_filter_smaller_than_group_by__plan0_optimized.sql
@@ -14,8 +14,8 @@ FROM (
   FROM (
     -- Time Spine
     SELECT
-      ts AS metric_time__hour
-      , DATE_TRUNC('day', ts) AS metric_time__day
+      DATE_TRUNC('day', ts) AS metric_time__day
+      , ts AS metric_time__hour
     FROM ***************************.mf_time_spine_hour subq_15
   ) subq_16
   WHERE (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Redshift/test_derived_fill_nulls_for_one_input_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Redshift/test_derived_fill_nulls_for_one_input_metric__plan0.sql
@@ -259,8 +259,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_10.metric_time__day AS metric_time__day
-            , subq_9.ds__day AS ds__day
+            subq_9.ds__day AS ds__day
             , subq_9.ds__week AS ds__week
             , subq_9.ds__month AS ds__month
             , subq_9.ds__quarter AS ds__quarter
@@ -336,6 +335,7 @@ FROM (
             , subq_9.metric_time__extract_day AS metric_time__extract_day
             , subq_9.metric_time__extract_dow AS metric_time__extract_dow
             , subq_9.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_10.metric_time__day AS metric_time__day
             , subq_9.listing AS listing
             , subq_9.guest AS guest
             , subq_9.host AS host

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Redshift/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Redshift/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time__plan0.sql
@@ -19,8 +19,8 @@ FROM (
       -- Time Spine
       SELECT
         subq_6.ds AS booking__ds__day
-        , DATE_TRUNC('month', subq_6.ds) AS booking__ds__month
         , subq_6.ds AS metric_time__day
+        , DATE_TRUNC('month', subq_6.ds) AS booking__ds__month
       FROM ***************************.mf_time_spine subq_6
     ) subq_7
     WHERE (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Redshift/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Redshift/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time__plan0_optimized.sql
@@ -15,8 +15,8 @@ FROM (
     -- Time Spine
     SELECT
       ds AS booking__ds__day
-      , DATE_TRUNC('month', ds) AS booking__ds__month
       , ds AS metric_time__day
+      , DATE_TRUNC('month', ds) AS booking__ds__month
     FROM ***************************.mf_time_spine subq_15
   ) subq_16
   WHERE (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Redshift/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time_and_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Redshift/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time_and_metric_time__plan0.sql
@@ -18,8 +18,8 @@ FROM (
     FROM (
       -- Time Spine
       SELECT
-        DATE_TRUNC('month', subq_6.ds) AS booking__ds__month
-        , subq_6.ds AS metric_time__day
+        subq_6.ds AS metric_time__day
+        , DATE_TRUNC('month', subq_6.ds) AS booking__ds__month
       FROM ***************************.mf_time_spine subq_6
     ) subq_7
     WHERE (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Redshift/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time_and_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Redshift/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time_and_metric_time__plan0_optimized.sql
@@ -14,8 +14,8 @@ FROM (
   FROM (
     -- Time Spine
     SELECT
-      DATE_TRUNC('month', ds) AS booking__ds__month
-      , ds AS metric_time__day
+      ds AS metric_time__day
+      , DATE_TRUNC('month', ds) AS booking__ds__month
     FROM ***************************.mf_time_spine subq_15
   ) subq_16
   WHERE (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Redshift/test_join_to_time_spine_with_filter_smaller_than_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Redshift/test_join_to_time_spine_with_filter_smaller_than_group_by__plan0.sql
@@ -18,8 +18,8 @@ FROM (
     FROM (
       -- Time Spine
       SELECT
-        subq_6.ts AS metric_time__hour
-        , DATE_TRUNC('day', subq_6.ts) AS metric_time__day
+        DATE_TRUNC('day', subq_6.ts) AS metric_time__day
+        , subq_6.ts AS metric_time__hour
       FROM ***************************.mf_time_spine_hour subq_6
     ) subq_7
     WHERE (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Redshift/test_join_to_time_spine_with_filter_smaller_than_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Redshift/test_join_to_time_spine_with_filter_smaller_than_group_by__plan0_optimized.sql
@@ -14,8 +14,8 @@ FROM (
   FROM (
     -- Time Spine
     SELECT
-      ts AS metric_time__hour
-      , DATE_TRUNC('day', ts) AS metric_time__day
+      DATE_TRUNC('day', ts) AS metric_time__day
+      , ts AS metric_time__hour
     FROM ***************************.mf_time_spine_hour subq_15
   ) subq_16
   WHERE (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Snowflake/test_derived_fill_nulls_for_one_input_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Snowflake/test_derived_fill_nulls_for_one_input_metric__plan0.sql
@@ -259,8 +259,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_10.metric_time__day AS metric_time__day
-            , subq_9.ds__day AS ds__day
+            subq_9.ds__day AS ds__day
             , subq_9.ds__week AS ds__week
             , subq_9.ds__month AS ds__month
             , subq_9.ds__quarter AS ds__quarter
@@ -336,6 +335,7 @@ FROM (
             , subq_9.metric_time__extract_day AS metric_time__extract_day
             , subq_9.metric_time__extract_dow AS metric_time__extract_dow
             , subq_9.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_10.metric_time__day AS metric_time__day
             , subq_9.listing AS listing
             , subq_9.guest AS guest
             , subq_9.host AS host

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time__plan0.sql
@@ -19,8 +19,8 @@ FROM (
       -- Time Spine
       SELECT
         subq_6.ds AS booking__ds__day
-        , DATE_TRUNC('month', subq_6.ds) AS booking__ds__month
         , subq_6.ds AS metric_time__day
+        , DATE_TRUNC('month', subq_6.ds) AS booking__ds__month
       FROM ***************************.mf_time_spine subq_6
     ) subq_7
     WHERE (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time__plan0_optimized.sql
@@ -15,8 +15,8 @@ FROM (
     -- Time Spine
     SELECT
       ds AS booking__ds__day
-      , DATE_TRUNC('month', ds) AS booking__ds__month
       , ds AS metric_time__day
+      , DATE_TRUNC('month', ds) AS booking__ds__month
     FROM ***************************.mf_time_spine subq_15
   ) subq_16
   WHERE (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time_and_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time_and_metric_time__plan0.sql
@@ -18,8 +18,8 @@ FROM (
     FROM (
       -- Time Spine
       SELECT
-        DATE_TRUNC('month', subq_6.ds) AS booking__ds__month
-        , subq_6.ds AS metric_time__day
+        subq_6.ds AS metric_time__day
+        , DATE_TRUNC('month', subq_6.ds) AS booking__ds__month
       FROM ***************************.mf_time_spine subq_6
     ) subq_7
     WHERE (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time_and_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time_and_metric_time__plan0_optimized.sql
@@ -14,8 +14,8 @@ FROM (
   FROM (
     -- Time Spine
     SELECT
-      DATE_TRUNC('month', ds) AS booking__ds__month
-      , ds AS metric_time__day
+      ds AS metric_time__day
+      , DATE_TRUNC('month', ds) AS booking__ds__month
     FROM ***************************.mf_time_spine subq_15
   ) subq_16
   WHERE (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_with_filter_smaller_than_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_with_filter_smaller_than_group_by__plan0.sql
@@ -18,8 +18,8 @@ FROM (
     FROM (
       -- Time Spine
       SELECT
-        subq_6.ts AS metric_time__hour
-        , DATE_TRUNC('day', subq_6.ts) AS metric_time__day
+        DATE_TRUNC('day', subq_6.ts) AS metric_time__day
+        , subq_6.ts AS metric_time__hour
       FROM ***************************.mf_time_spine_hour subq_6
     ) subq_7
     WHERE (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_with_filter_smaller_than_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_with_filter_smaller_than_group_by__plan0_optimized.sql
@@ -14,8 +14,8 @@ FROM (
   FROM (
     -- Time Spine
     SELECT
-      ts AS metric_time__hour
-      , DATE_TRUNC('day', ts) AS metric_time__day
+      DATE_TRUNC('day', ts) AS metric_time__day
+      , ts AS metric_time__hour
     FROM ***************************.mf_time_spine_hour subq_15
   ) subq_16
   WHERE (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Trino/test_derived_fill_nulls_for_one_input_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Trino/test_derived_fill_nulls_for_one_input_metric__plan0.sql
@@ -259,8 +259,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_10.metric_time__day AS metric_time__day
-            , subq_9.ds__day AS ds__day
+            subq_9.ds__day AS ds__day
             , subq_9.ds__week AS ds__week
             , subq_9.ds__month AS ds__month
             , subq_9.ds__quarter AS ds__quarter
@@ -336,6 +335,7 @@ FROM (
             , subq_9.metric_time__extract_day AS metric_time__extract_day
             , subq_9.metric_time__extract_dow AS metric_time__extract_dow
             , subq_9.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_10.metric_time__day AS metric_time__day
             , subq_9.listing AS listing
             , subq_9.guest AS guest
             , subq_9.host AS host

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Trino/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Trino/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time__plan0.sql
@@ -19,8 +19,8 @@ FROM (
       -- Time Spine
       SELECT
         subq_6.ds AS booking__ds__day
-        , DATE_TRUNC('month', subq_6.ds) AS booking__ds__month
         , subq_6.ds AS metric_time__day
+        , DATE_TRUNC('month', subq_6.ds) AS booking__ds__month
       FROM ***************************.mf_time_spine subq_6
     ) subq_7
     WHERE (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Trino/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Trino/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time__plan0_optimized.sql
@@ -15,8 +15,8 @@ FROM (
     -- Time Spine
     SELECT
       ds AS booking__ds__day
-      , DATE_TRUNC('month', ds) AS booking__ds__month
       , ds AS metric_time__day
+      , DATE_TRUNC('month', ds) AS booking__ds__month
     FROM ***************************.mf_time_spine subq_15
   ) subq_16
   WHERE (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Trino/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time_and_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Trino/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time_and_metric_time__plan0.sql
@@ -18,8 +18,8 @@ FROM (
     FROM (
       -- Time Spine
       SELECT
-        DATE_TRUNC('month', subq_6.ds) AS booking__ds__month
-        , subq_6.ds AS metric_time__day
+        subq_6.ds AS metric_time__day
+        , DATE_TRUNC('month', subq_6.ds) AS booking__ds__month
       FROM ***************************.mf_time_spine subq_6
     ) subq_7
     WHERE (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Trino/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time_and_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Trino/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time_and_metric_time__plan0_optimized.sql
@@ -14,8 +14,8 @@ FROM (
   FROM (
     -- Time Spine
     SELECT
-      DATE_TRUNC('month', ds) AS booking__ds__month
-      , ds AS metric_time__day
+      ds AS metric_time__day
+      , DATE_TRUNC('month', ds) AS booking__ds__month
     FROM ***************************.mf_time_spine subq_15
   ) subq_16
   WHERE (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Trino/test_join_to_time_spine_with_filter_smaller_than_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Trino/test_join_to_time_spine_with_filter_smaller_than_group_by__plan0.sql
@@ -18,8 +18,8 @@ FROM (
     FROM (
       -- Time Spine
       SELECT
-        subq_6.ts AS metric_time__hour
-        , DATE_TRUNC('day', subq_6.ts) AS metric_time__day
+        DATE_TRUNC('day', subq_6.ts) AS metric_time__day
+        , subq_6.ts AS metric_time__hour
       FROM ***************************.mf_time_spine_hour subq_6
     ) subq_7
     WHERE (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Trino/test_join_to_time_spine_with_filter_smaller_than_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Trino/test_join_to_time_spine_with_filter_smaller_than_group_by__plan0_optimized.sql
@@ -14,8 +14,8 @@ FROM (
   FROM (
     -- Time Spine
     SELECT
-      ts AS metric_time__hour
-      , DATE_TRUNC('day', ts) AS metric_time__day
+      DATE_TRUNC('day', ts) AS metric_time__day
+      , ts AS metric_time__hour
     FROM ***************************.mf_time_spine_hour subq_15
   ) subq_16
   WHERE (

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/BigQuery/test_offset_window_with_date_part__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/BigQuery/test_offset_window_with_date_part__plan0.sql
@@ -245,8 +245,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            IF(EXTRACT(dayofweek FROM subq_7.metric_time__day) = 1, 7, EXTRACT(dayofweek FROM subq_7.metric_time__day) - 1) AS metric_time__extract_dow
-            , subq_6.ds__day AS ds__day
+            subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -312,7 +311,6 @@ FROM (
             , subq_6.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_6.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_6.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
-            , subq_6.metric_time__day AS metric_time__day
             , subq_6.metric_time__week AS metric_time__week
             , subq_6.metric_time__month AS metric_time__month
             , subq_6.metric_time__quarter AS metric_time__quarter
@@ -322,6 +320,8 @@ FROM (
             , subq_6.metric_time__extract_month AS metric_time__extract_month
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_7.metric_time__day AS metric_time__day
+            , subq_7.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host
@@ -347,6 +347,7 @@ FROM (
             -- Time Spine
             SELECT
               subq_8.ds AS metric_time__day
+              , IF(EXTRACT(dayofweek FROM subq_8.ds) = 1, 7, EXTRACT(dayofweek FROM subq_8.ds) - 1) AS metric_time__extract_dow
             FROM ***************************.mf_time_spine subq_8
           ) subq_7
           INNER JOIN (

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/BigQuery/test_subdaily_offset_to_grain_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/BigQuery/test_subdaily_offset_to_grain_metric__plan0.sql
@@ -24,8 +24,7 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_2.metric_time__hour AS metric_time__hour
-          , subq_1.ds__day AS ds__day
+          subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
@@ -210,6 +209,7 @@ FROM (
           , subq_1.metric_time__extract_day AS metric_time__extract_day
           , subq_1.metric_time__extract_dow AS metric_time__extract_dow
           , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+          , subq_2.metric_time__hour AS metric_time__hour
           , subq_1.user AS user
           , subq_1.home_state AS home_state
           , subq_1.user__home_state AS user__home_state

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/BigQuery/test_subdaily_offset_window_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/BigQuery/test_subdaily_offset_window_metric__plan0.sql
@@ -24,8 +24,7 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_2.metric_time__hour AS metric_time__hour
-          , subq_1.ds__day AS ds__day
+          subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
@@ -210,6 +209,7 @@ FROM (
           , subq_1.metric_time__extract_day AS metric_time__extract_day
           , subq_1.metric_time__extract_dow AS metric_time__extract_dow
           , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+          , subq_2.metric_time__hour AS metric_time__hour
           , subq_1.user AS user
           , subq_1.home_state AS home_state
           , subq_1.user__home_state AS user__home_state

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Databricks/test_offset_window_with_date_part__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Databricks/test_offset_window_with_date_part__plan0.sql
@@ -245,8 +245,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            EXTRACT(DAYOFWEEK_ISO FROM subq_7.metric_time__day) AS metric_time__extract_dow
-            , subq_6.ds__day AS ds__day
+            subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -312,7 +311,6 @@ FROM (
             , subq_6.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_6.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_6.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
-            , subq_6.metric_time__day AS metric_time__day
             , subq_6.metric_time__week AS metric_time__week
             , subq_6.metric_time__month AS metric_time__month
             , subq_6.metric_time__quarter AS metric_time__quarter
@@ -322,6 +320,8 @@ FROM (
             , subq_6.metric_time__extract_month AS metric_time__extract_month
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_7.metric_time__day AS metric_time__day
+            , subq_7.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host
@@ -347,6 +347,7 @@ FROM (
             -- Time Spine
             SELECT
               subq_8.ds AS metric_time__day
+              , EXTRACT(DAYOFWEEK_ISO FROM subq_8.ds) AS metric_time__extract_dow
             FROM ***************************.mf_time_spine subq_8
           ) subq_7
           INNER JOIN (

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Databricks/test_subdaily_offset_to_grain_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Databricks/test_subdaily_offset_to_grain_metric__plan0.sql
@@ -24,8 +24,7 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_2.metric_time__hour AS metric_time__hour
-          , subq_1.ds__day AS ds__day
+          subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
@@ -210,6 +209,7 @@ FROM (
           , subq_1.metric_time__extract_day AS metric_time__extract_day
           , subq_1.metric_time__extract_dow AS metric_time__extract_dow
           , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+          , subq_2.metric_time__hour AS metric_time__hour
           , subq_1.user AS user
           , subq_1.home_state AS home_state
           , subq_1.user__home_state AS user__home_state

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Databricks/test_subdaily_offset_window_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Databricks/test_subdaily_offset_window_metric__plan0.sql
@@ -24,8 +24,7 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_2.metric_time__hour AS metric_time__hour
-          , subq_1.ds__day AS ds__day
+          subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
@@ -210,6 +209,7 @@ FROM (
           , subq_1.metric_time__extract_day AS metric_time__extract_day
           , subq_1.metric_time__extract_dow AS metric_time__extract_dow
           , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+          , subq_2.metric_time__hour AS metric_time__hour
           , subq_1.user AS user
           , subq_1.home_state AS home_state
           , subq_1.user__home_state AS user__home_state

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/DuckDB/test_offset_window_with_date_part__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/DuckDB/test_offset_window_with_date_part__plan0.sql
@@ -245,8 +245,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            EXTRACT(isodow FROM subq_7.metric_time__day) AS metric_time__extract_dow
-            , subq_6.ds__day AS ds__day
+            subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -312,7 +311,6 @@ FROM (
             , subq_6.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_6.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_6.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
-            , subq_6.metric_time__day AS metric_time__day
             , subq_6.metric_time__week AS metric_time__week
             , subq_6.metric_time__month AS metric_time__month
             , subq_6.metric_time__quarter AS metric_time__quarter
@@ -322,6 +320,8 @@ FROM (
             , subq_6.metric_time__extract_month AS metric_time__extract_month
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_7.metric_time__day AS metric_time__day
+            , subq_7.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host
@@ -347,6 +347,7 @@ FROM (
             -- Time Spine
             SELECT
               subq_8.ds AS metric_time__day
+              , EXTRACT(isodow FROM subq_8.ds) AS metric_time__extract_dow
             FROM ***************************.mf_time_spine subq_8
           ) subq_7
           INNER JOIN (

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/DuckDB/test_subdaily_offset_to_grain_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/DuckDB/test_subdaily_offset_to_grain_metric__plan0.sql
@@ -24,8 +24,7 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_2.metric_time__hour AS metric_time__hour
-          , subq_1.ds__day AS ds__day
+          subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
@@ -210,6 +209,7 @@ FROM (
           , subq_1.metric_time__extract_day AS metric_time__extract_day
           , subq_1.metric_time__extract_dow AS metric_time__extract_dow
           , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+          , subq_2.metric_time__hour AS metric_time__hour
           , subq_1.user AS user
           , subq_1.home_state AS home_state
           , subq_1.user__home_state AS user__home_state

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/DuckDB/test_subdaily_offset_window_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/DuckDB/test_subdaily_offset_window_metric__plan0.sql
@@ -24,8 +24,7 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_2.metric_time__hour AS metric_time__hour
-          , subq_1.ds__day AS ds__day
+          subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
@@ -210,6 +209,7 @@ FROM (
           , subq_1.metric_time__extract_day AS metric_time__extract_day
           , subq_1.metric_time__extract_dow AS metric_time__extract_dow
           , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+          , subq_2.metric_time__hour AS metric_time__hour
           , subq_1.user AS user
           , subq_1.home_state AS home_state
           , subq_1.user__home_state AS user__home_state

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Postgres/test_offset_window_with_date_part__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Postgres/test_offset_window_with_date_part__plan0.sql
@@ -245,8 +245,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            EXTRACT(isodow FROM subq_7.metric_time__day) AS metric_time__extract_dow
-            , subq_6.ds__day AS ds__day
+            subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -312,7 +311,6 @@ FROM (
             , subq_6.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_6.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_6.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
-            , subq_6.metric_time__day AS metric_time__day
             , subq_6.metric_time__week AS metric_time__week
             , subq_6.metric_time__month AS metric_time__month
             , subq_6.metric_time__quarter AS metric_time__quarter
@@ -322,6 +320,8 @@ FROM (
             , subq_6.metric_time__extract_month AS metric_time__extract_month
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_7.metric_time__day AS metric_time__day
+            , subq_7.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host
@@ -347,6 +347,7 @@ FROM (
             -- Time Spine
             SELECT
               subq_8.ds AS metric_time__day
+              , EXTRACT(isodow FROM subq_8.ds) AS metric_time__extract_dow
             FROM ***************************.mf_time_spine subq_8
           ) subq_7
           INNER JOIN (

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Postgres/test_subdaily_offset_to_grain_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Postgres/test_subdaily_offset_to_grain_metric__plan0.sql
@@ -24,8 +24,7 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_2.metric_time__hour AS metric_time__hour
-          , subq_1.ds__day AS ds__day
+          subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
@@ -210,6 +209,7 @@ FROM (
           , subq_1.metric_time__extract_day AS metric_time__extract_day
           , subq_1.metric_time__extract_dow AS metric_time__extract_dow
           , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+          , subq_2.metric_time__hour AS metric_time__hour
           , subq_1.user AS user
           , subq_1.home_state AS home_state
           , subq_1.user__home_state AS user__home_state

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Postgres/test_subdaily_offset_window_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Postgres/test_subdaily_offset_window_metric__plan0.sql
@@ -24,8 +24,7 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_2.metric_time__hour AS metric_time__hour
-          , subq_1.ds__day AS ds__day
+          subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
@@ -210,6 +209,7 @@ FROM (
           , subq_1.metric_time__extract_day AS metric_time__extract_day
           , subq_1.metric_time__extract_dow AS metric_time__extract_dow
           , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+          , subq_2.metric_time__hour AS metric_time__hour
           , subq_1.user AS user
           , subq_1.home_state AS home_state
           , subq_1.user__home_state AS user__home_state

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Redshift/test_offset_window_with_date_part__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Redshift/test_offset_window_with_date_part__plan0.sql
@@ -245,8 +245,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            CASE WHEN EXTRACT(dow FROM subq_7.metric_time__day) = 0 THEN EXTRACT(dow FROM subq_7.metric_time__day) + 7 ELSE EXTRACT(dow FROM subq_7.metric_time__day) END AS metric_time__extract_dow
-            , subq_6.ds__day AS ds__day
+            subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -312,7 +311,6 @@ FROM (
             , subq_6.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_6.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_6.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
-            , subq_6.metric_time__day AS metric_time__day
             , subq_6.metric_time__week AS metric_time__week
             , subq_6.metric_time__month AS metric_time__month
             , subq_6.metric_time__quarter AS metric_time__quarter
@@ -322,6 +320,8 @@ FROM (
             , subq_6.metric_time__extract_month AS metric_time__extract_month
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_7.metric_time__day AS metric_time__day
+            , subq_7.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host
@@ -347,6 +347,7 @@ FROM (
             -- Time Spine
             SELECT
               subq_8.ds AS metric_time__day
+              , CASE WHEN EXTRACT(dow FROM subq_8.ds) = 0 THEN EXTRACT(dow FROM subq_8.ds) + 7 ELSE EXTRACT(dow FROM subq_8.ds) END AS metric_time__extract_dow
             FROM ***************************.mf_time_spine subq_8
           ) subq_7
           INNER JOIN (

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Redshift/test_subdaily_offset_to_grain_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Redshift/test_subdaily_offset_to_grain_metric__plan0.sql
@@ -24,8 +24,7 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_2.metric_time__hour AS metric_time__hour
-          , subq_1.ds__day AS ds__day
+          subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
@@ -210,6 +209,7 @@ FROM (
           , subq_1.metric_time__extract_day AS metric_time__extract_day
           , subq_1.metric_time__extract_dow AS metric_time__extract_dow
           , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+          , subq_2.metric_time__hour AS metric_time__hour
           , subq_1.user AS user
           , subq_1.home_state AS home_state
           , subq_1.user__home_state AS user__home_state

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Redshift/test_subdaily_offset_window_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Redshift/test_subdaily_offset_window_metric__plan0.sql
@@ -24,8 +24,7 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_2.metric_time__hour AS metric_time__hour
-          , subq_1.ds__day AS ds__day
+          subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
@@ -210,6 +209,7 @@ FROM (
           , subq_1.metric_time__extract_day AS metric_time__extract_day
           , subq_1.metric_time__extract_dow AS metric_time__extract_dow
           , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+          , subq_2.metric_time__hour AS metric_time__hour
           , subq_1.user AS user
           , subq_1.home_state AS home_state
           , subq_1.user__home_state AS user__home_state

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Snowflake/test_offset_window_with_date_part__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Snowflake/test_offset_window_with_date_part__plan0.sql
@@ -245,8 +245,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            EXTRACT(dayofweekiso FROM subq_7.metric_time__day) AS metric_time__extract_dow
-            , subq_6.ds__day AS ds__day
+            subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -312,7 +311,6 @@ FROM (
             , subq_6.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_6.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_6.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
-            , subq_6.metric_time__day AS metric_time__day
             , subq_6.metric_time__week AS metric_time__week
             , subq_6.metric_time__month AS metric_time__month
             , subq_6.metric_time__quarter AS metric_time__quarter
@@ -322,6 +320,8 @@ FROM (
             , subq_6.metric_time__extract_month AS metric_time__extract_month
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_7.metric_time__day AS metric_time__day
+            , subq_7.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host
@@ -347,6 +347,7 @@ FROM (
             -- Time Spine
             SELECT
               subq_8.ds AS metric_time__day
+              , EXTRACT(dayofweekiso FROM subq_8.ds) AS metric_time__extract_dow
             FROM ***************************.mf_time_spine subq_8
           ) subq_7
           INNER JOIN (

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Snowflake/test_subdaily_offset_to_grain_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Snowflake/test_subdaily_offset_to_grain_metric__plan0.sql
@@ -24,8 +24,7 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_2.metric_time__hour AS metric_time__hour
-          , subq_1.ds__day AS ds__day
+          subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
@@ -210,6 +209,7 @@ FROM (
           , subq_1.metric_time__extract_day AS metric_time__extract_day
           , subq_1.metric_time__extract_dow AS metric_time__extract_dow
           , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+          , subq_2.metric_time__hour AS metric_time__hour
           , subq_1.user AS user
           , subq_1.home_state AS home_state
           , subq_1.user__home_state AS user__home_state

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Snowflake/test_subdaily_offset_window_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Snowflake/test_subdaily_offset_window_metric__plan0.sql
@@ -24,8 +24,7 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_2.metric_time__hour AS metric_time__hour
-          , subq_1.ds__day AS ds__day
+          subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
@@ -210,6 +209,7 @@ FROM (
           , subq_1.metric_time__extract_day AS metric_time__extract_day
           , subq_1.metric_time__extract_dow AS metric_time__extract_dow
           , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+          , subq_2.metric_time__hour AS metric_time__hour
           , subq_1.user AS user
           , subq_1.home_state AS home_state
           , subq_1.user__home_state AS user__home_state

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Trino/test_offset_window_with_date_part__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Trino/test_offset_window_with_date_part__plan0.sql
@@ -245,8 +245,7 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            EXTRACT(DAY_OF_WEEK FROM subq_7.metric_time__day) AS metric_time__extract_dow
-            , subq_6.ds__day AS ds__day
+            subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -312,7 +311,6 @@ FROM (
             , subq_6.booking__paid_at__extract_day AS booking__paid_at__extract_day
             , subq_6.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
             , subq_6.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
-            , subq_6.metric_time__day AS metric_time__day
             , subq_6.metric_time__week AS metric_time__week
             , subq_6.metric_time__month AS metric_time__month
             , subq_6.metric_time__quarter AS metric_time__quarter
@@ -322,6 +320,8 @@ FROM (
             , subq_6.metric_time__extract_month AS metric_time__extract_month
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_7.metric_time__day AS metric_time__day
+            , subq_7.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host
@@ -347,6 +347,7 @@ FROM (
             -- Time Spine
             SELECT
               subq_8.ds AS metric_time__day
+              , EXTRACT(DAY_OF_WEEK FROM subq_8.ds) AS metric_time__extract_dow
             FROM ***************************.mf_time_spine subq_8
           ) subq_7
           INNER JOIN (

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Trino/test_subdaily_offset_to_grain_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Trino/test_subdaily_offset_to_grain_metric__plan0.sql
@@ -24,8 +24,7 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_2.metric_time__hour AS metric_time__hour
-          , subq_1.ds__day AS ds__day
+          subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
@@ -210,6 +209,7 @@ FROM (
           , subq_1.metric_time__extract_day AS metric_time__extract_day
           , subq_1.metric_time__extract_dow AS metric_time__extract_dow
           , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+          , subq_2.metric_time__hour AS metric_time__hour
           , subq_1.user AS user
           , subq_1.home_state AS home_state
           , subq_1.user__home_state AS user__home_state

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Trino/test_subdaily_offset_window_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Trino/test_subdaily_offset_window_metric__plan0.sql
@@ -24,8 +24,7 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_2.metric_time__hour AS metric_time__hour
-          , subq_1.ds__day AS ds__day
+          subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
@@ -210,6 +209,7 @@ FROM (
           , subq_1.metric_time__extract_day AS metric_time__extract_day
           , subq_1.metric_time__extract_dow AS metric_time__extract_dow
           , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+          , subq_2.metric_time__hour AS metric_time__hour
           , subq_1.user AS user
           , subq_1.home_state AS home_state
           , subq_1.user__home_state AS user__home_state

--- a/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_fill_nulls_time_spine_metric_predicate_pushdown__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_fill_nulls_time_spine_metric_predicate_pushdown__dfp_0.xml
@@ -128,7 +128,6 @@ docstring:
                         <!--       time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
                         <!--     ),                                                                            -->
                         <!--   )                                                                               -->
-                        <!-- use_custom_agg_time_dimension = False -->
                         <!-- join_type = LEFT_OUTER -->
                         <AggregateMeasuresNode>
                             <!-- description = 'Aggregate Measures' -->
@@ -297,7 +296,6 @@ docstring:
                         <!--       time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
                         <!--     ),                                                                            -->
                         <!--   )                                                                               -->
-                        <!-- use_custom_agg_time_dimension = False -->
                         <!-- join_type = LEFT_OUTER -->
                         <AggregateMeasuresNode>
                             <!-- description = 'Aggregate Measures' -->
@@ -382,7 +380,6 @@ docstring:
                                             <!--       ),                                        -->
                                             <!--     ),                                          -->
                                             <!--   )                                             -->
-                                            <!-- use_custom_agg_time_dimension = False -->
                                             <!-- join_type = INNER -->
                                             <!-- offset_window = PydanticMetricTimeWindow(count=14, granularity='day') -->
                                             <MetricTimeDimensionTransformNode>

--- a/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_fill_nulls_time_spine_metric_predicate_pushdown__dfpo_0.xml
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_fill_nulls_time_spine_metric_predicate_pushdown__dfpo_0.xml
@@ -128,7 +128,6 @@ docstring:
                         <!--       time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
                         <!--     ),                                                                            -->
                         <!--   )                                                                               -->
-                        <!-- use_custom_agg_time_dimension = False -->
                         <!-- join_type = LEFT_OUTER -->
                         <AggregateMeasuresNode>
                             <!-- description = 'Aggregate Measures' -->
@@ -296,7 +295,6 @@ docstring:
                         <!--       time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
                         <!--     ),                                                                            -->
                         <!--   )                                                                               -->
-                        <!-- use_custom_agg_time_dimension = False -->
                         <!-- join_type = LEFT_OUTER -->
                         <AggregateMeasuresNode>
                             <!-- description = 'Aggregate Measures' -->
@@ -381,7 +379,6 @@ docstring:
                                             <!--       ),                                        -->
                                             <!--     ),                                          -->
                                             <!--   )                                             -->
-                                            <!-- use_custom_agg_time_dimension = False -->
                                             <!-- join_type = INNER -->
                                             <!-- offset_window = PydanticMetricTimeWindow(count=14, granularity='day') -->
                                             <MetricTimeDimensionTransformNode>

--- a/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_fill_nulls_time_spine_metric_with_post_agg_join_predicate_pushdown__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_fill_nulls_time_spine_metric_with_post_agg_join_predicate_pushdown__dfp_0.xml
@@ -177,7 +177,6 @@ docstring:
                             <!--       time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
                             <!--     ),                                                                            -->
                             <!--   )                                                                               -->
-                            <!-- use_custom_agg_time_dimension = False -->
                             <!-- join_type = LEFT_OUTER -->
                             <AggregateMeasuresNode>
                                 <!-- description = 'Aggregate Measures' -->
@@ -397,7 +396,6 @@ docstring:
                             <!--       time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
                             <!--     ),                                                                            -->
                             <!--   )                                                                               -->
-                            <!-- use_custom_agg_time_dimension = False -->
                             <!-- join_type = LEFT_OUTER -->
                             <AggregateMeasuresNode>
                                 <!-- description = 'Aggregate Measures' -->
@@ -488,7 +486,6 @@ docstring:
                                                 <!--       ),                                        -->
                                                 <!--     ),                                          -->
                                                 <!--   )                                             -->
-                                                <!-- use_custom_agg_time_dimension = False -->
                                                 <!-- join_type = INNER -->
                                                 <!-- offset_window =                                         -->
                                                 <!--   PydanticMetricTimeWindow(count=14, granularity='day') -->

--- a/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_fill_nulls_time_spine_metric_with_post_agg_join_predicate_pushdown__dfpo_0.xml
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_fill_nulls_time_spine_metric_with_post_agg_join_predicate_pushdown__dfpo_0.xml
@@ -177,7 +177,6 @@ docstring:
                             <!--       time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
                             <!--     ),                                                                            -->
                             <!--   )                                                                               -->
-                            <!-- use_custom_agg_time_dimension = False -->
                             <!-- join_type = LEFT_OUTER -->
                             <AggregateMeasuresNode>
                                 <!-- description = 'Aggregate Measures' -->
@@ -397,7 +396,6 @@ docstring:
                             <!--       time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
                             <!--     ),                                                                            -->
                             <!--   )                                                                               -->
-                            <!-- use_custom_agg_time_dimension = False -->
                             <!-- join_type = LEFT_OUTER -->
                             <AggregateMeasuresNode>
                                 <!-- description = 'Aggregate Measures' -->
@@ -488,7 +486,6 @@ docstring:
                                                 <!--       ),                                        -->
                                                 <!--     ),                                          -->
                                                 <!--   )                                             -->
-                                                <!-- use_custom_agg_time_dimension = False -->
                                                 <!-- join_type = INNER -->
                                                 <!-- offset_window =                                         -->
                                                 <!--   PydanticMetricTimeWindow(count=14, granularity='day') -->

--- a/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_offset_metric_predicate_pushdown__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_offset_metric_predicate_pushdown__dfp_0.xml
@@ -357,7 +357,6 @@ docstring:
                                         <!--       ),                                        -->
                                         <!--     ),                                          -->
                                         <!--   )                                             -->
-                                        <!-- use_custom_agg_time_dimension = False -->
                                         <!-- join_type = INNER -->
                                         <!-- offset_window = PydanticMetricTimeWindow(count=14, granularity='day') -->
                                         <MetricTimeDimensionTransformNode>

--- a/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_offset_metric_predicate_pushdown__dfpo_0.xml
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_offset_metric_predicate_pushdown__dfpo_0.xml
@@ -357,7 +357,6 @@ docstring:
                                         <!--       ),                                        -->
                                         <!--     ),                                          -->
                                         <!--   )                                             -->
-                                        <!-- use_custom_agg_time_dimension = False -->
                                         <!-- join_type = INNER -->
                                         <!-- offset_window = PydanticMetricTimeWindow(count=14, granularity='day') -->
                                         <MetricTimeDimensionTransformNode>

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
@@ -836,8 +836,7 @@ FROM (
               FROM (
                 -- Join to Time Spine Dataset
                 SELECT
-                  subq_15.metric_time__day AS metric_time__day
-                  , subq_14.ds__day AS ds__day
+                  subq_14.ds__day AS ds__day
                   , subq_14.ds__week AS ds__week
                   , subq_14.ds__month AS ds__month
                   , subq_14.ds__quarter AS ds__quarter
@@ -913,6 +912,7 @@ FROM (
                   , subq_14.metric_time__extract_day AS metric_time__extract_day
                   , subq_14.metric_time__extract_dow AS metric_time__extract_dow
                   , subq_14.metric_time__extract_doy AS metric_time__extract_doy
+                  , subq_15.metric_time__day AS metric_time__day
                   , subq_14.listing AS listing
                   , subq_14.guest AS guest
                   , subq_14.host AS host

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_offset_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_offset_metric_with_query_time_filters__plan0.sql
@@ -809,8 +809,7 @@ FROM (
             FROM (
               -- Join to Time Spine Dataset
               SELECT
-                subq_12.metric_time__day AS metric_time__day
-                , subq_11.ds__day AS ds__day
+                subq_11.ds__day AS ds__day
                 , subq_11.ds__week AS ds__week
                 , subq_11.ds__month AS ds__month
                 , subq_11.ds__quarter AS ds__quarter
@@ -886,6 +885,7 @@ FROM (
                 , subq_11.metric_time__extract_day AS metric_time__extract_day
                 , subq_11.metric_time__extract_dow AS metric_time__extract_dow
                 , subq_11.metric_time__extract_doy AS metric_time__extract_doy
+                , subq_12.metric_time__day AS metric_time__day
                 , subq_11.listing AS listing
                 , subq_11.guest AS guest
                 , subq_11.host AS host

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
@@ -836,8 +836,7 @@ FROM (
               FROM (
                 -- Join to Time Spine Dataset
                 SELECT
-                  subq_15.metric_time__day AS metric_time__day
-                  , subq_14.ds__day AS ds__day
+                  subq_14.ds__day AS ds__day
                   , subq_14.ds__week AS ds__week
                   , subq_14.ds__month AS ds__month
                   , subq_14.ds__quarter AS ds__quarter
@@ -913,6 +912,7 @@ FROM (
                   , subq_14.metric_time__extract_day AS metric_time__extract_day
                   , subq_14.metric_time__extract_dow AS metric_time__extract_dow
                   , subq_14.metric_time__extract_doy AS metric_time__extract_doy
+                  , subq_15.metric_time__day AS metric_time__day
                   , subq_14.listing AS listing
                   , subq_14.guest AS guest
                   , subq_14.host AS host

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_offset_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_offset_metric_with_query_time_filters__plan0.sql
@@ -809,8 +809,7 @@ FROM (
             FROM (
               -- Join to Time Spine Dataset
               SELECT
-                subq_12.metric_time__day AS metric_time__day
-                , subq_11.ds__day AS ds__day
+                subq_11.ds__day AS ds__day
                 , subq_11.ds__week AS ds__week
                 , subq_11.ds__month AS ds__month
                 , subq_11.ds__quarter AS ds__quarter
@@ -886,6 +885,7 @@ FROM (
                 , subq_11.metric_time__extract_day AS metric_time__extract_day
                 , subq_11.metric_time__extract_dow AS metric_time__extract_dow
                 , subq_11.metric_time__extract_doy AS metric_time__extract_doy
+                , subq_12.metric_time__day AS metric_time__day
                 , subq_11.listing AS listing
                 , subq_11.guest AS guest
                 , subq_11.host AS host

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
@@ -836,8 +836,7 @@ FROM (
               FROM (
                 -- Join to Time Spine Dataset
                 SELECT
-                  subq_15.metric_time__day AS metric_time__day
-                  , subq_14.ds__day AS ds__day
+                  subq_14.ds__day AS ds__day
                   , subq_14.ds__week AS ds__week
                   , subq_14.ds__month AS ds__month
                   , subq_14.ds__quarter AS ds__quarter
@@ -913,6 +912,7 @@ FROM (
                   , subq_14.metric_time__extract_day AS metric_time__extract_day
                   , subq_14.metric_time__extract_dow AS metric_time__extract_dow
                   , subq_14.metric_time__extract_doy AS metric_time__extract_doy
+                  , subq_15.metric_time__day AS metric_time__day
                   , subq_14.listing AS listing
                   , subq_14.guest AS guest
                   , subq_14.host AS host

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_offset_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_offset_metric_with_query_time_filters__plan0.sql
@@ -809,8 +809,7 @@ FROM (
             FROM (
               -- Join to Time Spine Dataset
               SELECT
-                subq_12.metric_time__day AS metric_time__day
-                , subq_11.ds__day AS ds__day
+                subq_11.ds__day AS ds__day
                 , subq_11.ds__week AS ds__week
                 , subq_11.ds__month AS ds__month
                 , subq_11.ds__quarter AS ds__quarter
@@ -886,6 +885,7 @@ FROM (
                 , subq_11.metric_time__extract_day AS metric_time__extract_day
                 , subq_11.metric_time__extract_dow AS metric_time__extract_dow
                 , subq_11.metric_time__extract_doy AS metric_time__extract_doy
+                , subq_12.metric_time__day AS metric_time__day
                 , subq_11.listing AS listing
                 , subq_11.guest AS guest
                 , subq_11.host AS host

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
@@ -836,8 +836,7 @@ FROM (
               FROM (
                 -- Join to Time Spine Dataset
                 SELECT
-                  subq_15.metric_time__day AS metric_time__day
-                  , subq_14.ds__day AS ds__day
+                  subq_14.ds__day AS ds__day
                   , subq_14.ds__week AS ds__week
                   , subq_14.ds__month AS ds__month
                   , subq_14.ds__quarter AS ds__quarter
@@ -913,6 +912,7 @@ FROM (
                   , subq_14.metric_time__extract_day AS metric_time__extract_day
                   , subq_14.metric_time__extract_dow AS metric_time__extract_dow
                   , subq_14.metric_time__extract_doy AS metric_time__extract_doy
+                  , subq_15.metric_time__day AS metric_time__day
                   , subq_14.listing AS listing
                   , subq_14.guest AS guest
                   , subq_14.host AS host

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_offset_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_offset_metric_with_query_time_filters__plan0.sql
@@ -809,8 +809,7 @@ FROM (
             FROM (
               -- Join to Time Spine Dataset
               SELECT
-                subq_12.metric_time__day AS metric_time__day
-                , subq_11.ds__day AS ds__day
+                subq_11.ds__day AS ds__day
                 , subq_11.ds__week AS ds__week
                 , subq_11.ds__month AS ds__month
                 , subq_11.ds__quarter AS ds__quarter
@@ -886,6 +885,7 @@ FROM (
                 , subq_11.metric_time__extract_day AS metric_time__extract_day
                 , subq_11.metric_time__extract_dow AS metric_time__extract_dow
                 , subq_11.metric_time__extract_doy AS metric_time__extract_doy
+                , subq_12.metric_time__day AS metric_time__day
                 , subq_11.listing AS listing
                 , subq_11.guest AS guest
                 , subq_11.host AS host

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
@@ -836,8 +836,7 @@ FROM (
               FROM (
                 -- Join to Time Spine Dataset
                 SELECT
-                  subq_15.metric_time__day AS metric_time__day
-                  , subq_14.ds__day AS ds__day
+                  subq_14.ds__day AS ds__day
                   , subq_14.ds__week AS ds__week
                   , subq_14.ds__month AS ds__month
                   , subq_14.ds__quarter AS ds__quarter
@@ -913,6 +912,7 @@ FROM (
                   , subq_14.metric_time__extract_day AS metric_time__extract_day
                   , subq_14.metric_time__extract_dow AS metric_time__extract_dow
                   , subq_14.metric_time__extract_doy AS metric_time__extract_doy
+                  , subq_15.metric_time__day AS metric_time__day
                   , subq_14.listing AS listing
                   , subq_14.guest AS guest
                   , subq_14.host AS host

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_offset_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_offset_metric_with_query_time_filters__plan0.sql
@@ -809,8 +809,7 @@ FROM (
             FROM (
               -- Join to Time Spine Dataset
               SELECT
-                subq_12.metric_time__day AS metric_time__day
-                , subq_11.ds__day AS ds__day
+                subq_11.ds__day AS ds__day
                 , subq_11.ds__week AS ds__week
                 , subq_11.ds__month AS ds__month
                 , subq_11.ds__quarter AS ds__quarter
@@ -886,6 +885,7 @@ FROM (
                 , subq_11.metric_time__extract_day AS metric_time__extract_day
                 , subq_11.metric_time__extract_dow AS metric_time__extract_dow
                 , subq_11.metric_time__extract_doy AS metric_time__extract_doy
+                , subq_12.metric_time__day AS metric_time__day
                 , subq_11.listing AS listing
                 , subq_11.guest AS guest
                 , subq_11.host AS host

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
@@ -836,8 +836,7 @@ FROM (
               FROM (
                 -- Join to Time Spine Dataset
                 SELECT
-                  subq_15.metric_time__day AS metric_time__day
-                  , subq_14.ds__day AS ds__day
+                  subq_14.ds__day AS ds__day
                   , subq_14.ds__week AS ds__week
                   , subq_14.ds__month AS ds__month
                   , subq_14.ds__quarter AS ds__quarter
@@ -913,6 +912,7 @@ FROM (
                   , subq_14.metric_time__extract_day AS metric_time__extract_day
                   , subq_14.metric_time__extract_dow AS metric_time__extract_dow
                   , subq_14.metric_time__extract_doy AS metric_time__extract_doy
+                  , subq_15.metric_time__day AS metric_time__day
                   , subq_14.listing AS listing
                   , subq_14.guest AS guest
                   , subq_14.host AS host

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_offset_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_offset_metric_with_query_time_filters__plan0.sql
@@ -809,8 +809,7 @@ FROM (
             FROM (
               -- Join to Time Spine Dataset
               SELECT
-                subq_12.metric_time__day AS metric_time__day
-                , subq_11.ds__day AS ds__day
+                subq_11.ds__day AS ds__day
                 , subq_11.ds__week AS ds__week
                 , subq_11.ds__month AS ds__month
                 , subq_11.ds__quarter AS ds__quarter
@@ -886,6 +885,7 @@ FROM (
                 , subq_11.metric_time__extract_day AS metric_time__extract_day
                 , subq_11.metric_time__extract_dow AS metric_time__extract_dow
                 , subq_11.metric_time__extract_doy AS metric_time__extract_doy
+                , subq_12.metric_time__day AS metric_time__day
                 , subq_11.listing AS listing
                 , subq_11.guest AS guest
                 , subq_11.host AS host

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
@@ -836,8 +836,7 @@ FROM (
               FROM (
                 -- Join to Time Spine Dataset
                 SELECT
-                  subq_15.metric_time__day AS metric_time__day
-                  , subq_14.ds__day AS ds__day
+                  subq_14.ds__day AS ds__day
                   , subq_14.ds__week AS ds__week
                   , subq_14.ds__month AS ds__month
                   , subq_14.ds__quarter AS ds__quarter
@@ -913,6 +912,7 @@ FROM (
                   , subq_14.metric_time__extract_day AS metric_time__extract_day
                   , subq_14.metric_time__extract_dow AS metric_time__extract_dow
                   , subq_14.metric_time__extract_doy AS metric_time__extract_doy
+                  , subq_15.metric_time__day AS metric_time__day
                   , subq_14.listing AS listing
                   , subq_14.guest AS guest
                   , subq_14.host AS host

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_offset_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_offset_metric_with_query_time_filters__plan0.sql
@@ -809,8 +809,7 @@ FROM (
             FROM (
               -- Join to Time Spine Dataset
               SELECT
-                subq_12.metric_time__day AS metric_time__day
-                , subq_11.ds__day AS ds__day
+                subq_11.ds__day AS ds__day
                 , subq_11.ds__week AS ds__week
                 , subq_11.ds__month AS ds__month
                 , subq_11.ds__quarter AS ds__quarter
@@ -886,6 +885,7 @@ FROM (
                 , subq_11.metric_time__extract_day AS metric_time__extract_day
                 , subq_11.metric_time__extract_dow AS metric_time__extract_dow
                 , subq_11.metric_time__extract_doy AS metric_time__extract_doy
+                , subq_12.metric_time__day AS metric_time__day
                 , subq_11.listing AS listing
                 , subq_11.guest AS guest
                 , subq_11.host AS host


### PR DESCRIPTION
A bunch of cleanup in the dataflow to SQL logic for the `JoinToTimeSpineNode`. There was a lot of duplication and hard to read code here.

Notes:
- Please review by commit. The more complex commits have extended commit descriptions to help explain the changes.
- There are many SQL changes here but none of them functional changes. The changes to optimized snapshots might be best to focus on.