### PR TITLE
Bug fix: apply time constraints after time offsets

### DIFF
--- a/.changes/unreleased/Fixes-20241121-140607.yaml
+++ b/.changes/unreleased/Fixes-20241121-140607.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Apply time constraints after time offsets to avoid filtering out values that
+  will change later in the query.
+time: 2024-11-21T14:06:07.618628-08:00
+custom:
+  Author: courtneyholcomb
+  Issue: "1544"

--- a/tests_metricflow/integration/test_cases/itest_metrics.yaml
+++ b/tests_metricflow/integration/test_cases/itest_metrics.yaml
@@ -1705,7 +1705,6 @@ integration_test:
         SELECT
           ds AS metric_time__day
         FROM {{ source_schema }}.mf_time_spine
-        WHERE {{ render_time_constraint('ds', '2019-12-19', '2020-01-02') }}
       ) subq_3
       INNER JOIN (
         SELECT
@@ -1716,6 +1715,7 @@ integration_test:
       ON {{ render_date_sub("subq_3", "metric_time__day", 5, TimeGranularity.DAY) }} = subq_2.metric_time__day
       GROUP BY subq_3.metric_time__day
     ) outer_subq
+    WHERE {{ render_time_constraint('metric_time__day', '2019-12-19', '2020-01-02') }}
 ---
 integration_test:
   name: cumulative_time_offset_metric_with_time_constraint

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
@@ -228,7 +228,6 @@ FROM (
             SELECT
               subq_6.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_6
-            WHERE subq_6.ds BETWEEN '2019-12-19' AND '2020-01-02'
           ) subq_5
           INNER JOIN (
             -- Join Self Over Time Range

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_time_offset_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_time_offset_metric_with_time_constraint__plan0_optimized.sql
@@ -13,15 +13,9 @@ FROM (
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT
-    subq_17.metric_time__day AS metric_time__day
+    subq_18.ds AS metric_time__day
     , COUNT(DISTINCT subq_16.bookers) AS every_2_days_bookers_2_days_ago
-  FROM (
-    -- Time Spine
-    SELECT
-      ds AS metric_time__day
-    FROM ***************************.mf_time_spine subq_18
-    WHERE ds BETWEEN '2019-12-19' AND '2020-01-02'
-  ) subq_17
+  FROM ***************************.mf_time_spine subq_18
   INNER JOIN (
     -- Join Self Over Time Range
     SELECT
@@ -38,8 +32,8 @@ FROM (
       )
   ) subq_16
   ON
-    DATE_SUB(CAST(subq_17.metric_time__day AS DATETIME), INTERVAL 2 day) = subq_16.metric_time__day
-  WHERE subq_17.metric_time__day BETWEEN '2019-12-19' AND '2020-01-02'
+    DATE_SUB(CAST(subq_18.ds AS DATETIME), INTERVAL 2 day) = subq_16.metric_time__day
+  WHERE subq_18.ds BETWEEN '2019-12-19' AND '2020-01-02'
   GROUP BY
     metric_time__day
 ) subq_23

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_offsets_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_offsets_with_time_constraint__plan0.sql
@@ -4,351 +4,357 @@ sql_engine: BigQuery
 ---
 -- Compute Metrics via Expressions
 SELECT
-  subq_11.metric_time__day
+  subq_12.metric_time__day
   , 2 * bookings_offset_once AS bookings_offset_twice
 FROM (
-  -- Join to Time Spine Dataset
+  -- Constrain Time Range to [2020-01-12T00:00:00, 2020-01-13T00:00:00]
   SELECT
-    subq_9.metric_time__day AS metric_time__day
-    , subq_8.bookings_offset_once AS bookings_offset_once
+    subq_11.metric_time__day
+    , subq_11.bookings_offset_once
   FROM (
-    -- Time Spine
+    -- Join to Time Spine Dataset
     SELECT
-      subq_10.ds AS metric_time__day
-    FROM ***************************.mf_time_spine subq_10
-    WHERE subq_10.ds BETWEEN '2020-01-12' AND '2020-01-13'
-  ) subq_9
-  INNER JOIN (
-    -- Compute Metrics via Expressions
-    SELECT
-      subq_7.metric_time__day
-      , 2 * bookings AS bookings_offset_once
+      subq_9.metric_time__day AS metric_time__day
+      , subq_8.bookings_offset_once AS bookings_offset_once
     FROM (
+      -- Time Spine
+      SELECT
+        subq_10.ds AS metric_time__day
+      FROM ***************************.mf_time_spine subq_10
+    ) subq_9
+    INNER JOIN (
       -- Compute Metrics via Expressions
       SELECT
-        subq_6.metric_time__day
-        , subq_6.bookings
+        subq_7.metric_time__day
+        , 2 * bookings AS bookings_offset_once
       FROM (
-        -- Aggregate Measures
+        -- Compute Metrics via Expressions
         SELECT
-          subq_5.metric_time__day
-          , SUM(subq_5.bookings) AS bookings
+          subq_6.metric_time__day
+          , subq_6.bookings
         FROM (
-          -- Pass Only Elements: ['bookings', 'metric_time__day']
+          -- Aggregate Measures
           SELECT
-            subq_4.metric_time__day
-            , subq_4.bookings
+            subq_5.metric_time__day
+            , SUM(subq_5.bookings) AS bookings
           FROM (
-            -- Join to Time Spine Dataset
+            -- Pass Only Elements: ['bookings', 'metric_time__day']
             SELECT
-              subq_1.ds__day AS ds__day
-              , subq_1.ds__week AS ds__week
-              , subq_1.ds__month AS ds__month
-              , subq_1.ds__quarter AS ds__quarter
-              , subq_1.ds__year AS ds__year
-              , subq_1.ds__extract_year AS ds__extract_year
-              , subq_1.ds__extract_quarter AS ds__extract_quarter
-              , subq_1.ds__extract_month AS ds__extract_month
-              , subq_1.ds__extract_day AS ds__extract_day
-              , subq_1.ds__extract_dow AS ds__extract_dow
-              , subq_1.ds__extract_doy AS ds__extract_doy
-              , subq_1.ds_partitioned__day AS ds_partitioned__day
-              , subq_1.ds_partitioned__week AS ds_partitioned__week
-              , subq_1.ds_partitioned__month AS ds_partitioned__month
-              , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
-              , subq_1.ds_partitioned__year AS ds_partitioned__year
-              , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
-              , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
-              , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
-              , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
-              , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
-              , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
-              , subq_1.paid_at__day AS paid_at__day
-              , subq_1.paid_at__week AS paid_at__week
-              , subq_1.paid_at__month AS paid_at__month
-              , subq_1.paid_at__quarter AS paid_at__quarter
-              , subq_1.paid_at__year AS paid_at__year
-              , subq_1.paid_at__extract_year AS paid_at__extract_year
-              , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
-              , subq_1.paid_at__extract_month AS paid_at__extract_month
-              , subq_1.paid_at__extract_day AS paid_at__extract_day
-              , subq_1.paid_at__extract_dow AS paid_at__extract_dow
-              , subq_1.paid_at__extract_doy AS paid_at__extract_doy
-              , subq_1.booking__ds__day AS booking__ds__day
-              , subq_1.booking__ds__week AS booking__ds__week
-              , subq_1.booking__ds__month AS booking__ds__month
-              , subq_1.booking__ds__quarter AS booking__ds__quarter
-              , subq_1.booking__ds__year AS booking__ds__year
-              , subq_1.booking__ds__extract_year AS booking__ds__extract_year
-              , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
-              , subq_1.booking__ds__extract_month AS booking__ds__extract_month
-              , subq_1.booking__ds__extract_day AS booking__ds__extract_day
-              , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
-              , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
-              , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
-              , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
-              , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
-              , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
-              , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
-              , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
-              , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
-              , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
-              , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
-              , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
-              , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
-              , subq_1.booking__paid_at__day AS booking__paid_at__day
-              , subq_1.booking__paid_at__week AS booking__paid_at__week
-              , subq_1.booking__paid_at__month AS booking__paid_at__month
-              , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
-              , subq_1.booking__paid_at__year AS booking__paid_at__year
-              , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
-              , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
-              , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
-              , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
-              , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
-              , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
-              , subq_1.metric_time__week AS metric_time__week
-              , subq_1.metric_time__month AS metric_time__month
-              , subq_1.metric_time__quarter AS metric_time__quarter
-              , subq_1.metric_time__year AS metric_time__year
-              , subq_1.metric_time__extract_year AS metric_time__extract_year
-              , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
-              , subq_1.metric_time__extract_month AS metric_time__extract_month
-              , subq_1.metric_time__extract_day AS metric_time__extract_day
-              , subq_1.metric_time__extract_dow AS metric_time__extract_dow
-              , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-              , subq_2.metric_time__day AS metric_time__day
-              , subq_1.listing AS listing
-              , subq_1.guest AS guest
-              , subq_1.host AS host
-              , subq_1.booking__listing AS booking__listing
-              , subq_1.booking__guest AS booking__guest
-              , subq_1.booking__host AS booking__host
-              , subq_1.is_instant AS is_instant
-              , subq_1.booking__is_instant AS booking__is_instant
-              , subq_1.bookings AS bookings
-              , subq_1.instant_bookings AS instant_bookings
-              , subq_1.booking_value AS booking_value
-              , subq_1.max_booking_value AS max_booking_value
-              , subq_1.min_booking_value AS min_booking_value
-              , subq_1.bookers AS bookers
-              , subq_1.average_booking_value AS average_booking_value
-              , subq_1.referred_bookings AS referred_bookings
-              , subq_1.median_booking_value AS median_booking_value
-              , subq_1.booking_value_p99 AS booking_value_p99
-              , subq_1.discrete_booking_value_p99 AS discrete_booking_value_p99
-              , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
-              , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+              subq_4.metric_time__day
+              , subq_4.bookings
             FROM (
-              -- Time Spine
+              -- Join to Time Spine Dataset
               SELECT
-                subq_3.ds AS metric_time__day
-              FROM ***************************.mf_time_spine subq_3
-            ) subq_2
-            INNER JOIN (
-              -- Metric Time Dimension 'ds'
-              SELECT
-                subq_0.ds__day
-                , subq_0.ds__week
-                , subq_0.ds__month
-                , subq_0.ds__quarter
-                , subq_0.ds__year
-                , subq_0.ds__extract_year
-                , subq_0.ds__extract_quarter
-                , subq_0.ds__extract_month
-                , subq_0.ds__extract_day
-                , subq_0.ds__extract_dow
-                , subq_0.ds__extract_doy
-                , subq_0.ds_partitioned__day
-                , subq_0.ds_partitioned__week
-                , subq_0.ds_partitioned__month
-                , subq_0.ds_partitioned__quarter
-                , subq_0.ds_partitioned__year
-                , subq_0.ds_partitioned__extract_year
-                , subq_0.ds_partitioned__extract_quarter
-                , subq_0.ds_partitioned__extract_month
-                , subq_0.ds_partitioned__extract_day
-                , subq_0.ds_partitioned__extract_dow
-                , subq_0.ds_partitioned__extract_doy
-                , subq_0.paid_at__day
-                , subq_0.paid_at__week
-                , subq_0.paid_at__month
-                , subq_0.paid_at__quarter
-                , subq_0.paid_at__year
-                , subq_0.paid_at__extract_year
-                , subq_0.paid_at__extract_quarter
-                , subq_0.paid_at__extract_month
-                , subq_0.paid_at__extract_day
-                , subq_0.paid_at__extract_dow
-                , subq_0.paid_at__extract_doy
-                , subq_0.booking__ds__day
-                , subq_0.booking__ds__week
-                , subq_0.booking__ds__month
-                , subq_0.booking__ds__quarter
-                , subq_0.booking__ds__year
-                , subq_0.booking__ds__extract_year
-                , subq_0.booking__ds__extract_quarter
-                , subq_0.booking__ds__extract_month
-                , subq_0.booking__ds__extract_day
-                , subq_0.booking__ds__extract_dow
-                , subq_0.booking__ds__extract_doy
-                , subq_0.booking__ds_partitioned__day
-                , subq_0.booking__ds_partitioned__week
-                , subq_0.booking__ds_partitioned__month
-                , subq_0.booking__ds_partitioned__quarter
-                , subq_0.booking__ds_partitioned__year
-                , subq_0.booking__ds_partitioned__extract_year
-                , subq_0.booking__ds_partitioned__extract_quarter
-                , subq_0.booking__ds_partitioned__extract_month
-                , subq_0.booking__ds_partitioned__extract_day
-                , subq_0.booking__ds_partitioned__extract_dow
-                , subq_0.booking__ds_partitioned__extract_doy
-                , subq_0.booking__paid_at__day
-                , subq_0.booking__paid_at__week
-                , subq_0.booking__paid_at__month
-                , subq_0.booking__paid_at__quarter
-                , subq_0.booking__paid_at__year
-                , subq_0.booking__paid_at__extract_year
-                , subq_0.booking__paid_at__extract_quarter
-                , subq_0.booking__paid_at__extract_month
-                , subq_0.booking__paid_at__extract_day
-                , subq_0.booking__paid_at__extract_dow
-                , subq_0.booking__paid_at__extract_doy
-                , subq_0.ds__day AS metric_time__day
-                , subq_0.ds__week AS metric_time__week
-                , subq_0.ds__month AS metric_time__month
-                , subq_0.ds__quarter AS metric_time__quarter
-                , subq_0.ds__year AS metric_time__year
-                , subq_0.ds__extract_year AS metric_time__extract_year
-                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_0.ds__extract_month AS metric_time__extract_month
-                , subq_0.ds__extract_day AS metric_time__extract_day
-                , subq_0.ds__extract_dow AS metric_time__extract_dow
-                , subq_0.ds__extract_doy AS metric_time__extract_doy
-                , subq_0.listing
-                , subq_0.guest
-                , subq_0.host
-                , subq_0.booking__listing
-                , subq_0.booking__guest
-                , subq_0.booking__host
-                , subq_0.is_instant
-                , subq_0.booking__is_instant
-                , subq_0.bookings
-                , subq_0.instant_bookings
-                , subq_0.booking_value
-                , subq_0.max_booking_value
-                , subq_0.min_booking_value
-                , subq_0.bookers
-                , subq_0.average_booking_value
-                , subq_0.referred_bookings
-                , subq_0.median_booking_value
-                , subq_0.booking_value_p99
-                , subq_0.discrete_booking_value_p99
-                , subq_0.approximate_continuous_booking_value_p99
-                , subq_0.approximate_discrete_booking_value_p99
+                subq_1.ds__day AS ds__day
+                , subq_1.ds__week AS ds__week
+                , subq_1.ds__month AS ds__month
+                , subq_1.ds__quarter AS ds__quarter
+                , subq_1.ds__year AS ds__year
+                , subq_1.ds__extract_year AS ds__extract_year
+                , subq_1.ds__extract_quarter AS ds__extract_quarter
+                , subq_1.ds__extract_month AS ds__extract_month
+                , subq_1.ds__extract_day AS ds__extract_day
+                , subq_1.ds__extract_dow AS ds__extract_dow
+                , subq_1.ds__extract_doy AS ds__extract_doy
+                , subq_1.ds_partitioned__day AS ds_partitioned__day
+                , subq_1.ds_partitioned__week AS ds_partitioned__week
+                , subq_1.ds_partitioned__month AS ds_partitioned__month
+                , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
+                , subq_1.ds_partitioned__year AS ds_partitioned__year
+                , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
+                , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+                , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
+                , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
+                , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+                , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+                , subq_1.paid_at__day AS paid_at__day
+                , subq_1.paid_at__week AS paid_at__week
+                , subq_1.paid_at__month AS paid_at__month
+                , subq_1.paid_at__quarter AS paid_at__quarter
+                , subq_1.paid_at__year AS paid_at__year
+                , subq_1.paid_at__extract_year AS paid_at__extract_year
+                , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
+                , subq_1.paid_at__extract_month AS paid_at__extract_month
+                , subq_1.paid_at__extract_day AS paid_at__extract_day
+                , subq_1.paid_at__extract_dow AS paid_at__extract_dow
+                , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+                , subq_1.booking__ds__day AS booking__ds__day
+                , subq_1.booking__ds__week AS booking__ds__week
+                , subq_1.booking__ds__month AS booking__ds__month
+                , subq_1.booking__ds__quarter AS booking__ds__quarter
+                , subq_1.booking__ds__year AS booking__ds__year
+                , subq_1.booking__ds__extract_year AS booking__ds__extract_year
+                , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
+                , subq_1.booking__ds__extract_month AS booking__ds__extract_month
+                , subq_1.booking__ds__extract_day AS booking__ds__extract_day
+                , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
+                , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
+                , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
+                , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
+                , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
+                , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+                , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
+                , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+                , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+                , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+                , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+                , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+                , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+                , subq_1.booking__paid_at__day AS booking__paid_at__day
+                , subq_1.booking__paid_at__week AS booking__paid_at__week
+                , subq_1.booking__paid_at__month AS booking__paid_at__month
+                , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
+                , subq_1.booking__paid_at__year AS booking__paid_at__year
+                , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
+                , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+                , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
+                , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
+                , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+                , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                , subq_1.metric_time__week AS metric_time__week
+                , subq_1.metric_time__month AS metric_time__month
+                , subq_1.metric_time__quarter AS metric_time__quarter
+                , subq_1.metric_time__year AS metric_time__year
+                , subq_1.metric_time__extract_year AS metric_time__extract_year
+                , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+                , subq_1.metric_time__extract_month AS metric_time__extract_month
+                , subq_1.metric_time__extract_day AS metric_time__extract_day
+                , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+                , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+                , subq_2.metric_time__day AS metric_time__day
+                , subq_1.listing AS listing
+                , subq_1.guest AS guest
+                , subq_1.host AS host
+                , subq_1.booking__listing AS booking__listing
+                , subq_1.booking__guest AS booking__guest
+                , subq_1.booking__host AS booking__host
+                , subq_1.is_instant AS is_instant
+                , subq_1.booking__is_instant AS booking__is_instant
+                , subq_1.bookings AS bookings
+                , subq_1.instant_bookings AS instant_bookings
+                , subq_1.booking_value AS booking_value
+                , subq_1.max_booking_value AS max_booking_value
+                , subq_1.min_booking_value AS min_booking_value
+                , subq_1.bookers AS bookers
+                , subq_1.average_booking_value AS average_booking_value
+                , subq_1.referred_bookings AS referred_bookings
+                , subq_1.median_booking_value AS median_booking_value
+                , subq_1.booking_value_p99 AS booking_value_p99
+                , subq_1.discrete_booking_value_p99 AS discrete_booking_value_p99
+                , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+                , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
               FROM (
-                -- Read Elements From Semantic Model 'bookings_source'
+                -- Time Spine
                 SELECT
-                  1 AS bookings
-                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                  , bookings_source_src_28000.booking_value
-                  , bookings_source_src_28000.booking_value AS max_booking_value
-                  , bookings_source_src_28000.booking_value AS min_booking_value
-                  , bookings_source_src_28000.guest_id AS bookers
-                  , bookings_source_src_28000.booking_value AS average_booking_value
-                  , bookings_source_src_28000.booking_value AS booking_payments
-                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-                  , bookings_source_src_28000.booking_value AS median_booking_value
-                  , bookings_source_src_28000.booking_value AS booking_value_p99
-                  , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
-                  , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
-                  , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
-                  , bookings_source_src_28000.is_instant
-                  , DATETIME_TRUNC(bookings_source_src_28000.ds, day) AS ds__day
-                  , DATETIME_TRUNC(bookings_source_src_28000.ds, isoweek) AS ds__week
-                  , DATETIME_TRUNC(bookings_source_src_28000.ds, month) AS ds__month
-                  , DATETIME_TRUNC(bookings_source_src_28000.ds, quarter) AS ds__quarter
-                  , DATETIME_TRUNC(bookings_source_src_28000.ds, year) AS ds__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                  , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS ds__extract_dow
-                  , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS ds_partitioned__day
-                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS ds_partitioned__week
-                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS ds_partitioned__month
-                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS ds_partitioned__quarter
-                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS ds_partitioned__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                  , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS ds_partitioned__extract_dow
-                  , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, day) AS paid_at__day
-                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS paid_at__week
-                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, month) AS paid_at__month
-                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, quarter) AS paid_at__quarter
-                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, year) AS paid_at__year
-                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                  , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS paid_at__extract_dow
-                  , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                  , bookings_source_src_28000.is_instant AS booking__is_instant
-                  , DATETIME_TRUNC(bookings_source_src_28000.ds, day) AS booking__ds__day
-                  , DATETIME_TRUNC(bookings_source_src_28000.ds, isoweek) AS booking__ds__week
-                  , DATETIME_TRUNC(bookings_source_src_28000.ds, month) AS booking__ds__month
-                  , DATETIME_TRUNC(bookings_source_src_28000.ds, quarter) AS booking__ds__quarter
-                  , DATETIME_TRUNC(bookings_source_src_28000.ds, year) AS booking__ds__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                  , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS booking__ds__extract_dow
-                  , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS booking__ds_partitioned__day
-                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS booking__ds_partitioned__week
-                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS booking__ds_partitioned__month
-                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
-                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS booking__ds_partitioned__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                  , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS booking__ds_partitioned__extract_dow
-                  , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, day) AS booking__paid_at__day
-                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS booking__paid_at__week
-                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, month) AS booking__paid_at__month
-                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, quarter) AS booking__paid_at__quarter
-                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, year) AS booking__paid_at__year
-                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                  , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS booking__paid_at__extract_dow
-                  , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                  , bookings_source_src_28000.listing_id AS listing
-                  , bookings_source_src_28000.guest_id AS guest
-                  , bookings_source_src_28000.host_id AS host
-                  , bookings_source_src_28000.listing_id AS booking__listing
-                  , bookings_source_src_28000.guest_id AS booking__guest
-                  , bookings_source_src_28000.host_id AS booking__host
-                FROM ***************************.fct_bookings bookings_source_src_28000
-              ) subq_0
-            ) subq_1
-            ON
-              DATE_SUB(CAST(subq_2.metric_time__day AS DATETIME), INTERVAL 5 day) = subq_1.metric_time__day
-          ) subq_4
-        ) subq_5
-        GROUP BY
-          metric_time__day
-      ) subq_6
-    ) subq_7
-  ) subq_8
-  ON
-    DATE_SUB(CAST(subq_9.metric_time__day AS DATETIME), INTERVAL 2 day) = subq_8.metric_time__day
-) subq_11
+                  subq_3.ds AS metric_time__day
+                FROM ***************************.mf_time_spine subq_3
+              ) subq_2
+              INNER JOIN (
+                -- Metric Time Dimension 'ds'
+                SELECT
+                  subq_0.ds__day
+                  , subq_0.ds__week
+                  , subq_0.ds__month
+                  , subq_0.ds__quarter
+                  , subq_0.ds__year
+                  , subq_0.ds__extract_year
+                  , subq_0.ds__extract_quarter
+                  , subq_0.ds__extract_month
+                  , subq_0.ds__extract_day
+                  , subq_0.ds__extract_dow
+                  , subq_0.ds__extract_doy
+                  , subq_0.ds_partitioned__day
+                  , subq_0.ds_partitioned__week
+                  , subq_0.ds_partitioned__month
+                  , subq_0.ds_partitioned__quarter
+                  , subq_0.ds_partitioned__year
+                  , subq_0.ds_partitioned__extract_year
+                  , subq_0.ds_partitioned__extract_quarter
+                  , subq_0.ds_partitioned__extract_month
+                  , subq_0.ds_partitioned__extract_day
+                  , subq_0.ds_partitioned__extract_dow
+                  , subq_0.ds_partitioned__extract_doy
+                  , subq_0.paid_at__day
+                  , subq_0.paid_at__week
+                  , subq_0.paid_at__month
+                  , subq_0.paid_at__quarter
+                  , subq_0.paid_at__year
+                  , subq_0.paid_at__extract_year
+                  , subq_0.paid_at__extract_quarter
+                  , subq_0.paid_at__extract_month
+                  , subq_0.paid_at__extract_day
+                  , subq_0.paid_at__extract_dow
+                  , subq_0.paid_at__extract_doy
+                  , subq_0.booking__ds__day
+                  , subq_0.booking__ds__week
+                  , subq_0.booking__ds__month
+                  , subq_0.booking__ds__quarter
+                  , subq_0.booking__ds__year
+                  , subq_0.booking__ds__extract_year
+                  , subq_0.booking__ds__extract_quarter
+                  , subq_0.booking__ds__extract_month
+                  , subq_0.booking__ds__extract_day
+                  , subq_0.booking__ds__extract_dow
+                  , subq_0.booking__ds__extract_doy
+                  , subq_0.booking__ds_partitioned__day
+                  , subq_0.booking__ds_partitioned__week
+                  , subq_0.booking__ds_partitioned__month
+                  , subq_0.booking__ds_partitioned__quarter
+                  , subq_0.booking__ds_partitioned__year
+                  , subq_0.booking__ds_partitioned__extract_year
+                  , subq_0.booking__ds_partitioned__extract_quarter
+                  , subq_0.booking__ds_partitioned__extract_month
+                  , subq_0.booking__ds_partitioned__extract_day
+                  , subq_0.booking__ds_partitioned__extract_dow
+                  , subq_0.booking__ds_partitioned__extract_doy
+                  , subq_0.booking__paid_at__day
+                  , subq_0.booking__paid_at__week
+                  , subq_0.booking__paid_at__month
+                  , subq_0.booking__paid_at__quarter
+                  , subq_0.booking__paid_at__year
+                  , subq_0.booking__paid_at__extract_year
+                  , subq_0.booking__paid_at__extract_quarter
+                  , subq_0.booking__paid_at__extract_month
+                  , subq_0.booking__paid_at__extract_day
+                  , subq_0.booking__paid_at__extract_dow
+                  , subq_0.booking__paid_at__extract_doy
+                  , subq_0.ds__day AS metric_time__day
+                  , subq_0.ds__week AS metric_time__week
+                  , subq_0.ds__month AS metric_time__month
+                  , subq_0.ds__quarter AS metric_time__quarter
+                  , subq_0.ds__year AS metric_time__year
+                  , subq_0.ds__extract_year AS metric_time__extract_year
+                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_0.ds__extract_month AS metric_time__extract_month
+                  , subq_0.ds__extract_day AS metric_time__extract_day
+                  , subq_0.ds__extract_dow AS metric_time__extract_dow
+                  , subq_0.ds__extract_doy AS metric_time__extract_doy
+                  , subq_0.listing
+                  , subq_0.guest
+                  , subq_0.host
+                  , subq_0.booking__listing
+                  , subq_0.booking__guest
+                  , subq_0.booking__host
+                  , subq_0.is_instant
+                  , subq_0.booking__is_instant
+                  , subq_0.bookings
+                  , subq_0.instant_bookings
+                  , subq_0.booking_value
+                  , subq_0.max_booking_value
+                  , subq_0.min_booking_value
+                  , subq_0.bookers
+                  , subq_0.average_booking_value
+                  , subq_0.referred_bookings
+                  , subq_0.median_booking_value
+                  , subq_0.booking_value_p99
+                  , subq_0.discrete_booking_value_p99
+                  , subq_0.approximate_continuous_booking_value_p99
+                  , subq_0.approximate_discrete_booking_value_p99
+                FROM (
+                  -- Read Elements From Semantic Model 'bookings_source'
+                  SELECT
+                    1 AS bookings
+                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                    , bookings_source_src_28000.booking_value
+                    , bookings_source_src_28000.booking_value AS max_booking_value
+                    , bookings_source_src_28000.booking_value AS min_booking_value
+                    , bookings_source_src_28000.guest_id AS bookers
+                    , bookings_source_src_28000.booking_value AS average_booking_value
+                    , bookings_source_src_28000.booking_value AS booking_payments
+                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                    , bookings_source_src_28000.booking_value AS median_booking_value
+                    , bookings_source_src_28000.booking_value AS booking_value_p99
+                    , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                    , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                    , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                    , bookings_source_src_28000.is_instant
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds, day) AS ds__day
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds, isoweek) AS ds__week
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds, month) AS ds__month
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds, quarter) AS ds__quarter
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds, year) AS ds__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                    , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS ds__extract_dow
+                    , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS ds_partitioned__day
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS ds_partitioned__week
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS ds_partitioned__month
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS ds_partitioned__quarter
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                    , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS ds_partitioned__extract_dow
+                    , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, day) AS paid_at__day
+                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS paid_at__week
+                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, month) AS paid_at__month
+                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, quarter) AS paid_at__quarter
+                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, year) AS paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                    , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS paid_at__extract_dow
+                    , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                    , bookings_source_src_28000.is_instant AS booking__is_instant
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds, day) AS booking__ds__day
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds, isoweek) AS booking__ds__week
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds, month) AS booking__ds__month
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds, quarter) AS booking__ds__quarter
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds, year) AS booking__ds__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                    , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS booking__ds__extract_dow
+                    , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS booking__ds_partitioned__day
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS booking__ds_partitioned__week
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS booking__ds_partitioned__month
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS booking__ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                    , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS booking__ds_partitioned__extract_dow
+                    , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, day) AS booking__paid_at__day
+                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS booking__paid_at__week
+                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, month) AS booking__paid_at__month
+                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, quarter) AS booking__paid_at__quarter
+                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, year) AS booking__paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                    , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS booking__paid_at__extract_dow
+                    , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                    , bookings_source_src_28000.listing_id AS listing
+                    , bookings_source_src_28000.guest_id AS guest
+                    , bookings_source_src_28000.host_id AS host
+                    , bookings_source_src_28000.listing_id AS booking__listing
+                    , bookings_source_src_28000.guest_id AS booking__guest
+                    , bookings_source_src_28000.host_id AS booking__host
+                  FROM ***************************.fct_bookings bookings_source_src_28000
+                ) subq_0
+              ) subq_1
+              ON
+                DATE_SUB(CAST(subq_2.metric_time__day AS DATETIME), INTERVAL 5 day) = subq_1.metric_time__day
+            ) subq_4
+          ) subq_5
+          GROUP BY
+            metric_time__day
+        ) subq_6
+      ) subq_7
+    ) subq_8
+    ON
+      DATE_SUB(CAST(subq_9.metric_time__day AS DATETIME), INTERVAL 2 day) = subq_8.metric_time__day
+  ) subq_11
+  WHERE subq_11.metric_time__day BETWEEN '2020-01-12' AND '2020-01-13'
+) subq_12

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_offsets_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_offsets_with_time_constraint__plan0_optimized.sql
@@ -8,16 +8,11 @@ SELECT
   , 2 * bookings_offset_once AS bookings_offset_twice
 FROM (
   -- Join to Time Spine Dataset
+  -- Constrain Time Range to [2020-01-12T00:00:00, 2020-01-13T00:00:00]
   SELECT
-    subq_21.metric_time__day AS metric_time__day
-    , subq_20.bookings_offset_once AS bookings_offset_once
-  FROM (
-    -- Time Spine
-    SELECT
-      ds AS metric_time__day
-    FROM ***************************.mf_time_spine subq_22
-    WHERE ds BETWEEN '2020-01-12' AND '2020-01-13'
-  ) subq_21
+    subq_23.ds AS metric_time__day
+    , subq_21.bookings_offset_once AS bookings_offset_once
+  FROM ***************************.mf_time_spine subq_23
   INNER JOIN (
     -- Compute Metrics via Expressions
     SELECT
@@ -29,9 +24,9 @@ FROM (
       -- Aggregate Measures
       -- Compute Metrics via Expressions
       SELECT
-        subq_15.ds AS metric_time__day
-        , SUM(subq_13.bookings) AS bookings
-      FROM ***************************.mf_time_spine subq_15
+        subq_16.ds AS metric_time__day
+        , SUM(subq_14.bookings) AS bookings
+      FROM ***************************.mf_time_spine subq_16
       INNER JOIN (
         -- Read Elements From Semantic Model 'bookings_source'
         -- Metric Time Dimension 'ds'
@@ -39,13 +34,14 @@ FROM (
           DATETIME_TRUNC(ds, day) AS metric_time__day
           , 1 AS bookings
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_13
+      ) subq_14
       ON
-        DATE_SUB(CAST(subq_15.ds AS DATETIME), INTERVAL 5 day) = subq_13.metric_time__day
+        DATE_SUB(CAST(subq_16.ds AS DATETIME), INTERVAL 5 day) = subq_14.metric_time__day
       GROUP BY
         metric_time__day
-    ) subq_19
-  ) subq_20
+    ) subq_20
+  ) subq_21
   ON
-    DATE_SUB(CAST(subq_21.metric_time__day AS DATETIME), INTERVAL 2 day) = subq_20.metric_time__day
-) subq_23
+    DATE_SUB(CAST(subq_23.ds AS DATETIME), INTERVAL 2 day) = subq_21.metric_time__day
+  WHERE subq_23.ds BETWEEN '2020-01-12' AND '2020-01-13'
+) subq_25

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_time_offset_metric_with_time_constraint__plan0.sql
@@ -4,331 +4,433 @@ sql_engine: BigQuery
 ---
 -- Compute Metrics via Expressions
 SELECT
-  subq_7.metric_time__day
+  subq_8.metric_time__day
   , bookings_5_days_ago AS bookings_5_day_lag
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_6.metric_time__day
-    , subq_6.bookings AS bookings_5_days_ago
+    subq_7.metric_time__day
+    , subq_7.bookings AS bookings_5_days_ago
   FROM (
     -- Aggregate Measures
     SELECT
-      subq_5.metric_time__day
-      , SUM(subq_5.bookings) AS bookings
+      subq_6.metric_time__day
+      , SUM(subq_6.bookings) AS bookings
     FROM (
       -- Pass Only Elements: ['bookings', 'metric_time__day']
       SELECT
-        subq_4.metric_time__day
-        , subq_4.bookings
+        subq_5.metric_time__day
+        , subq_5.bookings
       FROM (
-        -- Join to Time Spine Dataset
+        -- Constrain Time Range to [2019-12-19T00:00:00, 2020-01-02T00:00:00]
         SELECT
-          subq_1.ds__day AS ds__day
-          , subq_1.ds__week AS ds__week
-          , subq_1.ds__month AS ds__month
-          , subq_1.ds__quarter AS ds__quarter
-          , subq_1.ds__year AS ds__year
-          , subq_1.ds__extract_year AS ds__extract_year
-          , subq_1.ds__extract_quarter AS ds__extract_quarter
-          , subq_1.ds__extract_month AS ds__extract_month
-          , subq_1.ds__extract_day AS ds__extract_day
-          , subq_1.ds__extract_dow AS ds__extract_dow
-          , subq_1.ds__extract_doy AS ds__extract_doy
-          , subq_1.ds_partitioned__day AS ds_partitioned__day
-          , subq_1.ds_partitioned__week AS ds_partitioned__week
-          , subq_1.ds_partitioned__month AS ds_partitioned__month
-          , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
-          , subq_1.ds_partitioned__year AS ds_partitioned__year
-          , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
-          , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
-          , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
-          , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
-          , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
-          , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
-          , subq_1.paid_at__day AS paid_at__day
-          , subq_1.paid_at__week AS paid_at__week
-          , subq_1.paid_at__month AS paid_at__month
-          , subq_1.paid_at__quarter AS paid_at__quarter
-          , subq_1.paid_at__year AS paid_at__year
-          , subq_1.paid_at__extract_year AS paid_at__extract_year
-          , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
-          , subq_1.paid_at__extract_month AS paid_at__extract_month
-          , subq_1.paid_at__extract_day AS paid_at__extract_day
-          , subq_1.paid_at__extract_dow AS paid_at__extract_dow
-          , subq_1.paid_at__extract_doy AS paid_at__extract_doy
-          , subq_1.booking__ds__day AS booking__ds__day
-          , subq_1.booking__ds__week AS booking__ds__week
-          , subq_1.booking__ds__month AS booking__ds__month
-          , subq_1.booking__ds__quarter AS booking__ds__quarter
-          , subq_1.booking__ds__year AS booking__ds__year
-          , subq_1.booking__ds__extract_year AS booking__ds__extract_year
-          , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
-          , subq_1.booking__ds__extract_month AS booking__ds__extract_month
-          , subq_1.booking__ds__extract_day AS booking__ds__extract_day
-          , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
-          , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
-          , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
-          , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
-          , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
-          , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
-          , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
-          , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
-          , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
-          , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
-          , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
-          , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
-          , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
-          , subq_1.booking__paid_at__day AS booking__paid_at__day
-          , subq_1.booking__paid_at__week AS booking__paid_at__week
-          , subq_1.booking__paid_at__month AS booking__paid_at__month
-          , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
-          , subq_1.booking__paid_at__year AS booking__paid_at__year
-          , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
-          , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
-          , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
-          , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
-          , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
-          , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
-          , subq_1.metric_time__week AS metric_time__week
-          , subq_1.metric_time__month AS metric_time__month
-          , subq_1.metric_time__quarter AS metric_time__quarter
-          , subq_1.metric_time__year AS metric_time__year
-          , subq_1.metric_time__extract_year AS metric_time__extract_year
-          , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
-          , subq_1.metric_time__extract_month AS metric_time__extract_month
-          , subq_1.metric_time__extract_day AS metric_time__extract_day
-          , subq_1.metric_time__extract_dow AS metric_time__extract_dow
-          , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-          , subq_2.metric_time__day AS metric_time__day
-          , subq_1.listing AS listing
-          , subq_1.guest AS guest
-          , subq_1.host AS host
-          , subq_1.booking__listing AS booking__listing
-          , subq_1.booking__guest AS booking__guest
-          , subq_1.booking__host AS booking__host
-          , subq_1.is_instant AS is_instant
-          , subq_1.booking__is_instant AS booking__is_instant
-          , subq_1.bookings AS bookings
-          , subq_1.instant_bookings AS instant_bookings
-          , subq_1.booking_value AS booking_value
-          , subq_1.max_booking_value AS max_booking_value
-          , subq_1.min_booking_value AS min_booking_value
-          , subq_1.bookers AS bookers
-          , subq_1.average_booking_value AS average_booking_value
-          , subq_1.referred_bookings AS referred_bookings
-          , subq_1.median_booking_value AS median_booking_value
-          , subq_1.booking_value_p99 AS booking_value_p99
-          , subq_1.discrete_booking_value_p99 AS discrete_booking_value_p99
-          , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
-          , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+          subq_4.metric_time__day
+          , subq_4.ds__day
+          , subq_4.ds__week
+          , subq_4.ds__month
+          , subq_4.ds__quarter
+          , subq_4.ds__year
+          , subq_4.ds__extract_year
+          , subq_4.ds__extract_quarter
+          , subq_4.ds__extract_month
+          , subq_4.ds__extract_day
+          , subq_4.ds__extract_dow
+          , subq_4.ds__extract_doy
+          , subq_4.ds_partitioned__day
+          , subq_4.ds_partitioned__week
+          , subq_4.ds_partitioned__month
+          , subq_4.ds_partitioned__quarter
+          , subq_4.ds_partitioned__year
+          , subq_4.ds_partitioned__extract_year
+          , subq_4.ds_partitioned__extract_quarter
+          , subq_4.ds_partitioned__extract_month
+          , subq_4.ds_partitioned__extract_day
+          , subq_4.ds_partitioned__extract_dow
+          , subq_4.ds_partitioned__extract_doy
+          , subq_4.paid_at__day
+          , subq_4.paid_at__week
+          , subq_4.paid_at__month
+          , subq_4.paid_at__quarter
+          , subq_4.paid_at__year
+          , subq_4.paid_at__extract_year
+          , subq_4.paid_at__extract_quarter
+          , subq_4.paid_at__extract_month
+          , subq_4.paid_at__extract_day
+          , subq_4.paid_at__extract_dow
+          , subq_4.paid_at__extract_doy
+          , subq_4.booking__ds__day
+          , subq_4.booking__ds__week
+          , subq_4.booking__ds__month
+          , subq_4.booking__ds__quarter
+          , subq_4.booking__ds__year
+          , subq_4.booking__ds__extract_year
+          , subq_4.booking__ds__extract_quarter
+          , subq_4.booking__ds__extract_month
+          , subq_4.booking__ds__extract_day
+          , subq_4.booking__ds__extract_dow
+          , subq_4.booking__ds__extract_doy
+          , subq_4.booking__ds_partitioned__day
+          , subq_4.booking__ds_partitioned__week
+          , subq_4.booking__ds_partitioned__month
+          , subq_4.booking__ds_partitioned__quarter
+          , subq_4.booking__ds_partitioned__year
+          , subq_4.booking__ds_partitioned__extract_year
+          , subq_4.booking__ds_partitioned__extract_quarter
+          , subq_4.booking__ds_partitioned__extract_month
+          , subq_4.booking__ds_partitioned__extract_day
+          , subq_4.booking__ds_partitioned__extract_dow
+          , subq_4.booking__ds_partitioned__extract_doy
+          , subq_4.booking__paid_at__day
+          , subq_4.booking__paid_at__week
+          , subq_4.booking__paid_at__month
+          , subq_4.booking__paid_at__quarter
+          , subq_4.booking__paid_at__year
+          , subq_4.booking__paid_at__extract_year
+          , subq_4.booking__paid_at__extract_quarter
+          , subq_4.booking__paid_at__extract_month
+          , subq_4.booking__paid_at__extract_day
+          , subq_4.booking__paid_at__extract_dow
+          , subq_4.booking__paid_at__extract_doy
+          , subq_4.metric_time__week
+          , subq_4.metric_time__month
+          , subq_4.metric_time__quarter
+          , subq_4.metric_time__year
+          , subq_4.metric_time__extract_year
+          , subq_4.metric_time__extract_quarter
+          , subq_4.metric_time__extract_month
+          , subq_4.metric_time__extract_day
+          , subq_4.metric_time__extract_dow
+          , subq_4.metric_time__extract_doy
+          , subq_4.listing
+          , subq_4.guest
+          , subq_4.host
+          , subq_4.booking__listing
+          , subq_4.booking__guest
+          , subq_4.booking__host
+          , subq_4.is_instant
+          , subq_4.booking__is_instant
+          , subq_4.bookings
+          , subq_4.instant_bookings
+          , subq_4.booking_value
+          , subq_4.max_booking_value
+          , subq_4.min_booking_value
+          , subq_4.bookers
+          , subq_4.average_booking_value
+          , subq_4.referred_bookings
+          , subq_4.median_booking_value
+          , subq_4.booking_value_p99
+          , subq_4.discrete_booking_value_p99
+          , subq_4.approximate_continuous_booking_value_p99
+          , subq_4.approximate_discrete_booking_value_p99
         FROM (
-          -- Time Spine
+          -- Join to Time Spine Dataset
           SELECT
-            subq_3.ds AS metric_time__day
-          FROM ***************************.mf_time_spine subq_3
-          WHERE subq_3.ds BETWEEN '2019-12-19' AND '2020-01-02'
-        ) subq_2
-        INNER JOIN (
-          -- Metric Time Dimension 'ds'
-          SELECT
-            subq_0.ds__day
-            , subq_0.ds__week
-            , subq_0.ds__month
-            , subq_0.ds__quarter
-            , subq_0.ds__year
-            , subq_0.ds__extract_year
-            , subq_0.ds__extract_quarter
-            , subq_0.ds__extract_month
-            , subq_0.ds__extract_day
-            , subq_0.ds__extract_dow
-            , subq_0.ds__extract_doy
-            , subq_0.ds_partitioned__day
-            , subq_0.ds_partitioned__week
-            , subq_0.ds_partitioned__month
-            , subq_0.ds_partitioned__quarter
-            , subq_0.ds_partitioned__year
-            , subq_0.ds_partitioned__extract_year
-            , subq_0.ds_partitioned__extract_quarter
-            , subq_0.ds_partitioned__extract_month
-            , subq_0.ds_partitioned__extract_day
-            , subq_0.ds_partitioned__extract_dow
-            , subq_0.ds_partitioned__extract_doy
-            , subq_0.paid_at__day
-            , subq_0.paid_at__week
-            , subq_0.paid_at__month
-            , subq_0.paid_at__quarter
-            , subq_0.paid_at__year
-            , subq_0.paid_at__extract_year
-            , subq_0.paid_at__extract_quarter
-            , subq_0.paid_at__extract_month
-            , subq_0.paid_at__extract_day
-            , subq_0.paid_at__extract_dow
-            , subq_0.paid_at__extract_doy
-            , subq_0.booking__ds__day
-            , subq_0.booking__ds__week
-            , subq_0.booking__ds__month
-            , subq_0.booking__ds__quarter
-            , subq_0.booking__ds__year
-            , subq_0.booking__ds__extract_year
-            , subq_0.booking__ds__extract_quarter
-            , subq_0.booking__ds__extract_month
-            , subq_0.booking__ds__extract_day
-            , subq_0.booking__ds__extract_dow
-            , subq_0.booking__ds__extract_doy
-            , subq_0.booking__ds_partitioned__day
-            , subq_0.booking__ds_partitioned__week
-            , subq_0.booking__ds_partitioned__month
-            , subq_0.booking__ds_partitioned__quarter
-            , subq_0.booking__ds_partitioned__year
-            , subq_0.booking__ds_partitioned__extract_year
-            , subq_0.booking__ds_partitioned__extract_quarter
-            , subq_0.booking__ds_partitioned__extract_month
-            , subq_0.booking__ds_partitioned__extract_day
-            , subq_0.booking__ds_partitioned__extract_dow
-            , subq_0.booking__ds_partitioned__extract_doy
-            , subq_0.booking__paid_at__day
-            , subq_0.booking__paid_at__week
-            , subq_0.booking__paid_at__month
-            , subq_0.booking__paid_at__quarter
-            , subq_0.booking__paid_at__year
-            , subq_0.booking__paid_at__extract_year
-            , subq_0.booking__paid_at__extract_quarter
-            , subq_0.booking__paid_at__extract_month
-            , subq_0.booking__paid_at__extract_day
-            , subq_0.booking__paid_at__extract_dow
-            , subq_0.booking__paid_at__extract_doy
-            , subq_0.ds__day AS metric_time__day
-            , subq_0.ds__week AS metric_time__week
-            , subq_0.ds__month AS metric_time__month
-            , subq_0.ds__quarter AS metric_time__quarter
-            , subq_0.ds__year AS metric_time__year
-            , subq_0.ds__extract_year AS metric_time__extract_year
-            , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-            , subq_0.ds__extract_month AS metric_time__extract_month
-            , subq_0.ds__extract_day AS metric_time__extract_day
-            , subq_0.ds__extract_dow AS metric_time__extract_dow
-            , subq_0.ds__extract_doy AS metric_time__extract_doy
-            , subq_0.listing
-            , subq_0.guest
-            , subq_0.host
-            , subq_0.booking__listing
-            , subq_0.booking__guest
-            , subq_0.booking__host
-            , subq_0.is_instant
-            , subq_0.booking__is_instant
-            , subq_0.bookings
-            , subq_0.instant_bookings
-            , subq_0.booking_value
-            , subq_0.max_booking_value
-            , subq_0.min_booking_value
-            , subq_0.bookers
-            , subq_0.average_booking_value
-            , subq_0.referred_bookings
-            , subq_0.median_booking_value
-            , subq_0.booking_value_p99
-            , subq_0.discrete_booking_value_p99
-            , subq_0.approximate_continuous_booking_value_p99
-            , subq_0.approximate_discrete_booking_value_p99
+            subq_1.ds__day AS ds__day
+            , subq_1.ds__week AS ds__week
+            , subq_1.ds__month AS ds__month
+            , subq_1.ds__quarter AS ds__quarter
+            , subq_1.ds__year AS ds__year
+            , subq_1.ds__extract_year AS ds__extract_year
+            , subq_1.ds__extract_quarter AS ds__extract_quarter
+            , subq_1.ds__extract_month AS ds__extract_month
+            , subq_1.ds__extract_day AS ds__extract_day
+            , subq_1.ds__extract_dow AS ds__extract_dow
+            , subq_1.ds__extract_doy AS ds__extract_doy
+            , subq_1.ds_partitioned__day AS ds_partitioned__day
+            , subq_1.ds_partitioned__week AS ds_partitioned__week
+            , subq_1.ds_partitioned__month AS ds_partitioned__month
+            , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
+            , subq_1.ds_partitioned__year AS ds_partitioned__year
+            , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
+            , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+            , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
+            , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
+            , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+            , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+            , subq_1.paid_at__day AS paid_at__day
+            , subq_1.paid_at__week AS paid_at__week
+            , subq_1.paid_at__month AS paid_at__month
+            , subq_1.paid_at__quarter AS paid_at__quarter
+            , subq_1.paid_at__year AS paid_at__year
+            , subq_1.paid_at__extract_year AS paid_at__extract_year
+            , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
+            , subq_1.paid_at__extract_month AS paid_at__extract_month
+            , subq_1.paid_at__extract_day AS paid_at__extract_day
+            , subq_1.paid_at__extract_dow AS paid_at__extract_dow
+            , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+            , subq_1.booking__ds__day AS booking__ds__day
+            , subq_1.booking__ds__week AS booking__ds__week
+            , subq_1.booking__ds__month AS booking__ds__month
+            , subq_1.booking__ds__quarter AS booking__ds__quarter
+            , subq_1.booking__ds__year AS booking__ds__year
+            , subq_1.booking__ds__extract_year AS booking__ds__extract_year
+            , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
+            , subq_1.booking__ds__extract_month AS booking__ds__extract_month
+            , subq_1.booking__ds__extract_day AS booking__ds__extract_day
+            , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
+            , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
+            , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
+            , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
+            , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
+            , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+            , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
+            , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+            , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+            , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+            , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+            , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+            , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+            , subq_1.booking__paid_at__day AS booking__paid_at__day
+            , subq_1.booking__paid_at__week AS booking__paid_at__week
+            , subq_1.booking__paid_at__month AS booking__paid_at__month
+            , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
+            , subq_1.booking__paid_at__year AS booking__paid_at__year
+            , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
+            , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+            , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
+            , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
+            , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+            , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_1.metric_time__week AS metric_time__week
+            , subq_1.metric_time__month AS metric_time__month
+            , subq_1.metric_time__quarter AS metric_time__quarter
+            , subq_1.metric_time__year AS metric_time__year
+            , subq_1.metric_time__extract_year AS metric_time__extract_year
+            , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_1.metric_time__extract_month AS metric_time__extract_month
+            , subq_1.metric_time__extract_day AS metric_time__extract_day
+            , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_2.metric_time__day AS metric_time__day
+            , subq_1.listing AS listing
+            , subq_1.guest AS guest
+            , subq_1.host AS host
+            , subq_1.booking__listing AS booking__listing
+            , subq_1.booking__guest AS booking__guest
+            , subq_1.booking__host AS booking__host
+            , subq_1.is_instant AS is_instant
+            , subq_1.booking__is_instant AS booking__is_instant
+            , subq_1.bookings AS bookings
+            , subq_1.instant_bookings AS instant_bookings
+            , subq_1.booking_value AS booking_value
+            , subq_1.max_booking_value AS max_booking_value
+            , subq_1.min_booking_value AS min_booking_value
+            , subq_1.bookers AS bookers
+            , subq_1.average_booking_value AS average_booking_value
+            , subq_1.referred_bookings AS referred_bookings
+            , subq_1.median_booking_value AS median_booking_value
+            , subq_1.booking_value_p99 AS booking_value_p99
+            , subq_1.discrete_booking_value_p99 AS discrete_booking_value_p99
+            , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+            , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Read Elements From Semantic Model 'bookings_source'
+            -- Time Spine
             SELECT
-              1 AS bookings
-              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-              , bookings_source_src_28000.booking_value
-              , bookings_source_src_28000.booking_value AS max_booking_value
-              , bookings_source_src_28000.booking_value AS min_booking_value
-              , bookings_source_src_28000.guest_id AS bookers
-              , bookings_source_src_28000.booking_value AS average_booking_value
-              , bookings_source_src_28000.booking_value AS booking_payments
-              , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-              , bookings_source_src_28000.booking_value AS median_booking_value
-              , bookings_source_src_28000.booking_value AS booking_value_p99
-              , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
-              , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
-              , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
-              , bookings_source_src_28000.is_instant
-              , DATETIME_TRUNC(bookings_source_src_28000.ds, day) AS ds__day
-              , DATETIME_TRUNC(bookings_source_src_28000.ds, isoweek) AS ds__week
-              , DATETIME_TRUNC(bookings_source_src_28000.ds, month) AS ds__month
-              , DATETIME_TRUNC(bookings_source_src_28000.ds, quarter) AS ds__quarter
-              , DATETIME_TRUNC(bookings_source_src_28000.ds, year) AS ds__year
-              , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-              , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-              , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-              , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-              , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS ds__extract_dow
-              , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS ds__extract_doy
-              , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS ds_partitioned__day
-              , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS ds_partitioned__week
-              , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS ds_partitioned__month
-              , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS ds_partitioned__quarter
-              , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS ds_partitioned__year
-              , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-              , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-              , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-              , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-              , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS ds_partitioned__extract_dow
-              , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-              , DATETIME_TRUNC(bookings_source_src_28000.paid_at, day) AS paid_at__day
-              , DATETIME_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS paid_at__week
-              , DATETIME_TRUNC(bookings_source_src_28000.paid_at, month) AS paid_at__month
-              , DATETIME_TRUNC(bookings_source_src_28000.paid_at, quarter) AS paid_at__quarter
-              , DATETIME_TRUNC(bookings_source_src_28000.paid_at, year) AS paid_at__year
-              , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-              , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-              , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-              , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-              , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS paid_at__extract_dow
-              , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-              , bookings_source_src_28000.is_instant AS booking__is_instant
-              , DATETIME_TRUNC(bookings_source_src_28000.ds, day) AS booking__ds__day
-              , DATETIME_TRUNC(bookings_source_src_28000.ds, isoweek) AS booking__ds__week
-              , DATETIME_TRUNC(bookings_source_src_28000.ds, month) AS booking__ds__month
-              , DATETIME_TRUNC(bookings_source_src_28000.ds, quarter) AS booking__ds__quarter
-              , DATETIME_TRUNC(bookings_source_src_28000.ds, year) AS booking__ds__year
-              , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-              , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-              , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-              , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-              , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS booking__ds__extract_dow
-              , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-              , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS booking__ds_partitioned__day
-              , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS booking__ds_partitioned__week
-              , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS booking__ds_partitioned__month
-              , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
-              , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS booking__ds_partitioned__year
-              , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-              , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-              , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-              , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-              , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS booking__ds_partitioned__extract_dow
-              , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , DATETIME_TRUNC(bookings_source_src_28000.paid_at, day) AS booking__paid_at__day
-              , DATETIME_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS booking__paid_at__week
-              , DATETIME_TRUNC(bookings_source_src_28000.paid_at, month) AS booking__paid_at__month
-              , DATETIME_TRUNC(bookings_source_src_28000.paid_at, quarter) AS booking__paid_at__quarter
-              , DATETIME_TRUNC(bookings_source_src_28000.paid_at, year) AS booking__paid_at__year
-              , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-              , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-              , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-              , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-              , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS booking__paid_at__extract_dow
-              , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-              , bookings_source_src_28000.listing_id AS listing
-              , bookings_source_src_28000.guest_id AS guest
-              , bookings_source_src_28000.host_id AS host
-              , bookings_source_src_28000.listing_id AS booking__listing
-              , bookings_source_src_28000.guest_id AS booking__guest
-              , bookings_source_src_28000.host_id AS booking__host
-            FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_0
-        ) subq_1
-        ON
-          DATE_SUB(CAST(subq_2.metric_time__day AS DATETIME), INTERVAL 5 day) = subq_1.metric_time__day
-      ) subq_4
-    ) subq_5
+              subq_3.ds AS metric_time__day
+            FROM ***************************.mf_time_spine subq_3
+          ) subq_2
+          INNER JOIN (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.ds_partitioned__day
+              , subq_0.ds_partitioned__week
+              , subq_0.ds_partitioned__month
+              , subq_0.ds_partitioned__quarter
+              , subq_0.ds_partitioned__year
+              , subq_0.ds_partitioned__extract_year
+              , subq_0.ds_partitioned__extract_quarter
+              , subq_0.ds_partitioned__extract_month
+              , subq_0.ds_partitioned__extract_day
+              , subq_0.ds_partitioned__extract_dow
+              , subq_0.ds_partitioned__extract_doy
+              , subq_0.paid_at__day
+              , subq_0.paid_at__week
+              , subq_0.paid_at__month
+              , subq_0.paid_at__quarter
+              , subq_0.paid_at__year
+              , subq_0.paid_at__extract_year
+              , subq_0.paid_at__extract_quarter
+              , subq_0.paid_at__extract_month
+              , subq_0.paid_at__extract_day
+              , subq_0.paid_at__extract_dow
+              , subq_0.paid_at__extract_doy
+              , subq_0.booking__ds__day
+              , subq_0.booking__ds__week
+              , subq_0.booking__ds__month
+              , subq_0.booking__ds__quarter
+              , subq_0.booking__ds__year
+              , subq_0.booking__ds__extract_year
+              , subq_0.booking__ds__extract_quarter
+              , subq_0.booking__ds__extract_month
+              , subq_0.booking__ds__extract_day
+              , subq_0.booking__ds__extract_dow
+              , subq_0.booking__ds__extract_doy
+              , subq_0.booking__ds_partitioned__day
+              , subq_0.booking__ds_partitioned__week
+              , subq_0.booking__ds_partitioned__month
+              , subq_0.booking__ds_partitioned__quarter
+              , subq_0.booking__ds_partitioned__year
+              , subq_0.booking__ds_partitioned__extract_year
+              , subq_0.booking__ds_partitioned__extract_quarter
+              , subq_0.booking__ds_partitioned__extract_month
+              , subq_0.booking__ds_partitioned__extract_day
+              , subq_0.booking__ds_partitioned__extract_dow
+              , subq_0.booking__ds_partitioned__extract_doy
+              , subq_0.booking__paid_at__day
+              , subq_0.booking__paid_at__week
+              , subq_0.booking__paid_at__month
+              , subq_0.booking__paid_at__quarter
+              , subq_0.booking__paid_at__year
+              , subq_0.booking__paid_at__extract_year
+              , subq_0.booking__paid_at__extract_quarter
+              , subq_0.booking__paid_at__extract_month
+              , subq_0.booking__paid_at__extract_day
+              , subq_0.booking__paid_at__extract_dow
+              , subq_0.booking__paid_at__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.listing
+              , subq_0.guest
+              , subq_0.host
+              , subq_0.booking__listing
+              , subq_0.booking__guest
+              , subq_0.booking__host
+              , subq_0.is_instant
+              , subq_0.booking__is_instant
+              , subq_0.bookings
+              , subq_0.instant_bookings
+              , subq_0.booking_value
+              , subq_0.max_booking_value
+              , subq_0.min_booking_value
+              , subq_0.bookers
+              , subq_0.average_booking_value
+              , subq_0.referred_bookings
+              , subq_0.median_booking_value
+              , subq_0.booking_value_p99
+              , subq_0.discrete_booking_value_p99
+              , subq_0.approximate_continuous_booking_value_p99
+              , subq_0.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Semantic Model 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_28000.booking_value
+                , bookings_source_src_28000.booking_value AS max_booking_value
+                , bookings_source_src_28000.booking_value AS min_booking_value
+                , bookings_source_src_28000.guest_id AS bookers
+                , bookings_source_src_28000.booking_value AS average_booking_value
+                , bookings_source_src_28000.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_28000.booking_value AS median_booking_value
+                , bookings_source_src_28000.booking_value AS booking_value_p99
+                , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_28000.is_instant
+                , DATETIME_TRUNC(bookings_source_src_28000.ds, day) AS ds__day
+                , DATETIME_TRUNC(bookings_source_src_28000.ds, isoweek) AS ds__week
+                , DATETIME_TRUNC(bookings_source_src_28000.ds, month) AS ds__month
+                , DATETIME_TRUNC(bookings_source_src_28000.ds, quarter) AS ds__quarter
+                , DATETIME_TRUNC(bookings_source_src_28000.ds, year) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS ds__extract_dow
+                , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS ds_partitioned__day
+                , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS ds_partitioned__week
+                , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS ds_partitioned__month
+                , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS ds_partitioned__quarter
+                , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS ds_partitioned__extract_dow
+                , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATETIME_TRUNC(bookings_source_src_28000.paid_at, day) AS paid_at__day
+                , DATETIME_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS paid_at__week
+                , DATETIME_TRUNC(bookings_source_src_28000.paid_at, month) AS paid_at__month
+                , DATETIME_TRUNC(bookings_source_src_28000.paid_at, quarter) AS paid_at__quarter
+                , DATETIME_TRUNC(bookings_source_src_28000.paid_at, year) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS paid_at__extract_dow
+                , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_28000.is_instant AS booking__is_instant
+                , DATETIME_TRUNC(bookings_source_src_28000.ds, day) AS booking__ds__day
+                , DATETIME_TRUNC(bookings_source_src_28000.ds, isoweek) AS booking__ds__week
+                , DATETIME_TRUNC(bookings_source_src_28000.ds, month) AS booking__ds__month
+                , DATETIME_TRUNC(bookings_source_src_28000.ds, quarter) AS booking__ds__quarter
+                , DATETIME_TRUNC(bookings_source_src_28000.ds, year) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS booking__ds__extract_dow
+                , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS booking__ds_partitioned__day
+                , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS booking__ds_partitioned__week
+                , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS booking__ds_partitioned__month
+                , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
+                , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS booking__ds_partitioned__extract_dow
+                , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATETIME_TRUNC(bookings_source_src_28000.paid_at, day) AS booking__paid_at__day
+                , DATETIME_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS booking__paid_at__week
+                , DATETIME_TRUNC(bookings_source_src_28000.paid_at, month) AS booking__paid_at__month
+                , DATETIME_TRUNC(bookings_source_src_28000.paid_at, quarter) AS booking__paid_at__quarter
+                , DATETIME_TRUNC(bookings_source_src_28000.paid_at, year) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS booking__paid_at__extract_dow
+                , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_28000.listing_id AS listing
+                , bookings_source_src_28000.guest_id AS guest
+                , bookings_source_src_28000.host_id AS host
+                , bookings_source_src_28000.listing_id AS booking__listing
+                , bookings_source_src_28000.guest_id AS booking__guest
+                , bookings_source_src_28000.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_28000
+            ) subq_0
+          ) subq_1
+          ON
+            DATE_SUB(CAST(subq_2.metric_time__day AS DATETIME), INTERVAL 5 day) = subq_1.metric_time__day
+        ) subq_4
+        WHERE subq_4.metric_time__day BETWEEN '2019-12-19' AND '2020-01-02'
+      ) subq_5
+    ) subq_6
     GROUP BY
       metric_time__day
-  ) subq_6
-) subq_7
+  ) subq_7
+) subq_8

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_time_offset_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_time_offset_metric_with_time_constraint__plan0_optimized.sql
@@ -8,19 +8,14 @@ SELECT
   , bookings_5_days_ago AS bookings_5_day_lag
 FROM (
   -- Join to Time Spine Dataset
+  -- Constrain Time Range to [2019-12-19T00:00:00, 2020-01-02T00:00:00]
   -- Pass Only Elements: ['bookings', 'metric_time__day']
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT
-    subq_10.metric_time__day AS metric_time__day
-    , SUM(subq_9.bookings) AS bookings_5_days_ago
-  FROM (
-    -- Time Spine
-    SELECT
-      ds AS metric_time__day
-    FROM ***************************.mf_time_spine subq_11
-    WHERE ds BETWEEN '2019-12-19' AND '2020-01-02'
-  ) subq_10
+    subq_12.ds AS metric_time__day
+    , SUM(subq_10.bookings) AS bookings_5_days_ago
+  FROM ***************************.mf_time_spine subq_12
   INNER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -28,9 +23,10 @@ FROM (
       DATETIME_TRUNC(ds, day) AS metric_time__day
       , 1 AS bookings
     FROM ***************************.fct_bookings bookings_source_src_28000
-  ) subq_9
+  ) subq_10
   ON
-    DATE_SUB(CAST(subq_10.metric_time__day AS DATETIME), INTERVAL 5 day) = subq_9.metric_time__day
+    DATE_SUB(CAST(subq_12.ds AS DATETIME), INTERVAL 5 day) = subq_10.metric_time__day
+  WHERE subq_12.ds BETWEEN '2019-12-19' AND '2020-01-02'
   GROUP BY
     metric_time__day
-) subq_15
+) subq_17

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
@@ -228,7 +228,6 @@ FROM (
             SELECT
               subq_6.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_6
-            WHERE subq_6.ds BETWEEN '2019-12-19' AND '2020-01-02'
           ) subq_5
           INNER JOIN (
             -- Join Self Over Time Range

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_time_offset_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_time_offset_metric_with_time_constraint__plan0_optimized.sql
@@ -13,15 +13,9 @@ FROM (
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT
-    subq_17.metric_time__day AS metric_time__day
+    subq_18.ds AS metric_time__day
     , COUNT(DISTINCT subq_16.bookers) AS every_2_days_bookers_2_days_ago
-  FROM (
-    -- Time Spine
-    SELECT
-      ds AS metric_time__day
-    FROM ***************************.mf_time_spine subq_18
-    WHERE ds BETWEEN '2019-12-19' AND '2020-01-02'
-  ) subq_17
+  FROM ***************************.mf_time_spine subq_18
   INNER JOIN (
     -- Join Self Over Time Range
     SELECT
@@ -38,8 +32,8 @@ FROM (
       )
   ) subq_16
   ON
-    DATEADD(day, -2, subq_17.metric_time__day) = subq_16.metric_time__day
-  WHERE subq_17.metric_time__day BETWEEN '2019-12-19' AND '2020-01-02'
+    DATEADD(day, -2, subq_18.ds) = subq_16.metric_time__day
+  WHERE subq_18.ds BETWEEN '2019-12-19' AND '2020-01-02'
   GROUP BY
-    subq_17.metric_time__day
+    subq_18.ds
 ) subq_23

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_offsets_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_offsets_with_time_constraint__plan0.sql
@@ -4,351 +4,357 @@ sql_engine: Databricks
 ---
 -- Compute Metrics via Expressions
 SELECT
-  subq_11.metric_time__day
+  subq_12.metric_time__day
   , 2 * bookings_offset_once AS bookings_offset_twice
 FROM (
-  -- Join to Time Spine Dataset
+  -- Constrain Time Range to [2020-01-12T00:00:00, 2020-01-13T00:00:00]
   SELECT
-    subq_9.metric_time__day AS metric_time__day
-    , subq_8.bookings_offset_once AS bookings_offset_once
+    subq_11.metric_time__day
+    , subq_11.bookings_offset_once
   FROM (
-    -- Time Spine
+    -- Join to Time Spine Dataset
     SELECT
-      subq_10.ds AS metric_time__day
-    FROM ***************************.mf_time_spine subq_10
-    WHERE subq_10.ds BETWEEN '2020-01-12' AND '2020-01-13'
-  ) subq_9
-  INNER JOIN (
-    -- Compute Metrics via Expressions
-    SELECT
-      subq_7.metric_time__day
-      , 2 * bookings AS bookings_offset_once
+      subq_9.metric_time__day AS metric_time__day
+      , subq_8.bookings_offset_once AS bookings_offset_once
     FROM (
+      -- Time Spine
+      SELECT
+        subq_10.ds AS metric_time__day
+      FROM ***************************.mf_time_spine subq_10
+    ) subq_9
+    INNER JOIN (
       -- Compute Metrics via Expressions
       SELECT
-        subq_6.metric_time__day
-        , subq_6.bookings
+        subq_7.metric_time__day
+        , 2 * bookings AS bookings_offset_once
       FROM (
-        -- Aggregate Measures
+        -- Compute Metrics via Expressions
         SELECT
-          subq_5.metric_time__day
-          , SUM(subq_5.bookings) AS bookings
+          subq_6.metric_time__day
+          , subq_6.bookings
         FROM (
-          -- Pass Only Elements: ['bookings', 'metric_time__day']
+          -- Aggregate Measures
           SELECT
-            subq_4.metric_time__day
-            , subq_4.bookings
+            subq_5.metric_time__day
+            , SUM(subq_5.bookings) AS bookings
           FROM (
-            -- Join to Time Spine Dataset
+            -- Pass Only Elements: ['bookings', 'metric_time__day']
             SELECT
-              subq_1.ds__day AS ds__day
-              , subq_1.ds__week AS ds__week
-              , subq_1.ds__month AS ds__month
-              , subq_1.ds__quarter AS ds__quarter
-              , subq_1.ds__year AS ds__year
-              , subq_1.ds__extract_year AS ds__extract_year
-              , subq_1.ds__extract_quarter AS ds__extract_quarter
-              , subq_1.ds__extract_month AS ds__extract_month
-              , subq_1.ds__extract_day AS ds__extract_day
-              , subq_1.ds__extract_dow AS ds__extract_dow
-              , subq_1.ds__extract_doy AS ds__extract_doy
-              , subq_1.ds_partitioned__day AS ds_partitioned__day
-              , subq_1.ds_partitioned__week AS ds_partitioned__week
-              , subq_1.ds_partitioned__month AS ds_partitioned__month
-              , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
-              , subq_1.ds_partitioned__year AS ds_partitioned__year
-              , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
-              , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
-              , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
-              , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
-              , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
-              , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
-              , subq_1.paid_at__day AS paid_at__day
-              , subq_1.paid_at__week AS paid_at__week
-              , subq_1.paid_at__month AS paid_at__month
-              , subq_1.paid_at__quarter AS paid_at__quarter
-              , subq_1.paid_at__year AS paid_at__year
-              , subq_1.paid_at__extract_year AS paid_at__extract_year
-              , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
-              , subq_1.paid_at__extract_month AS paid_at__extract_month
-              , subq_1.paid_at__extract_day AS paid_at__extract_day
-              , subq_1.paid_at__extract_dow AS paid_at__extract_dow
-              , subq_1.paid_at__extract_doy AS paid_at__extract_doy
-              , subq_1.booking__ds__day AS booking__ds__day
-              , subq_1.booking__ds__week AS booking__ds__week
-              , subq_1.booking__ds__month AS booking__ds__month
-              , subq_1.booking__ds__quarter AS booking__ds__quarter
-              , subq_1.booking__ds__year AS booking__ds__year
-              , subq_1.booking__ds__extract_year AS booking__ds__extract_year
-              , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
-              , subq_1.booking__ds__extract_month AS booking__ds__extract_month
-              , subq_1.booking__ds__extract_day AS booking__ds__extract_day
-              , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
-              , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
-              , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
-              , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
-              , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
-              , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
-              , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
-              , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
-              , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
-              , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
-              , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
-              , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
-              , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
-              , subq_1.booking__paid_at__day AS booking__paid_at__day
-              , subq_1.booking__paid_at__week AS booking__paid_at__week
-              , subq_1.booking__paid_at__month AS booking__paid_at__month
-              , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
-              , subq_1.booking__paid_at__year AS booking__paid_at__year
-              , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
-              , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
-              , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
-              , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
-              , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
-              , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
-              , subq_1.metric_time__week AS metric_time__week
-              , subq_1.metric_time__month AS metric_time__month
-              , subq_1.metric_time__quarter AS metric_time__quarter
-              , subq_1.metric_time__year AS metric_time__year
-              , subq_1.metric_time__extract_year AS metric_time__extract_year
-              , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
-              , subq_1.metric_time__extract_month AS metric_time__extract_month
-              , subq_1.metric_time__extract_day AS metric_time__extract_day
-              , subq_1.metric_time__extract_dow AS metric_time__extract_dow
-              , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-              , subq_2.metric_time__day AS metric_time__day
-              , subq_1.listing AS listing
-              , subq_1.guest AS guest
-              , subq_1.host AS host
-              , subq_1.booking__listing AS booking__listing
-              , subq_1.booking__guest AS booking__guest
-              , subq_1.booking__host AS booking__host
-              , subq_1.is_instant AS is_instant
-              , subq_1.booking__is_instant AS booking__is_instant
-              , subq_1.bookings AS bookings
-              , subq_1.instant_bookings AS instant_bookings
-              , subq_1.booking_value AS booking_value
-              , subq_1.max_booking_value AS max_booking_value
-              , subq_1.min_booking_value AS min_booking_value
-              , subq_1.bookers AS bookers
-              , subq_1.average_booking_value AS average_booking_value
-              , subq_1.referred_bookings AS referred_bookings
-              , subq_1.median_booking_value AS median_booking_value
-              , subq_1.booking_value_p99 AS booking_value_p99
-              , subq_1.discrete_booking_value_p99 AS discrete_booking_value_p99
-              , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
-              , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+              subq_4.metric_time__day
+              , subq_4.bookings
             FROM (
-              -- Time Spine
+              -- Join to Time Spine Dataset
               SELECT
-                subq_3.ds AS metric_time__day
-              FROM ***************************.mf_time_spine subq_3
-            ) subq_2
-            INNER JOIN (
-              -- Metric Time Dimension 'ds'
-              SELECT
-                subq_0.ds__day
-                , subq_0.ds__week
-                , subq_0.ds__month
-                , subq_0.ds__quarter
-                , subq_0.ds__year
-                , subq_0.ds__extract_year
-                , subq_0.ds__extract_quarter
-                , subq_0.ds__extract_month
-                , subq_0.ds__extract_day
-                , subq_0.ds__extract_dow
-                , subq_0.ds__extract_doy
-                , subq_0.ds_partitioned__day
-                , subq_0.ds_partitioned__week
-                , subq_0.ds_partitioned__month
-                , subq_0.ds_partitioned__quarter
-                , subq_0.ds_partitioned__year
-                , subq_0.ds_partitioned__extract_year
-                , subq_0.ds_partitioned__extract_quarter
-                , subq_0.ds_partitioned__extract_month
-                , subq_0.ds_partitioned__extract_day
-                , subq_0.ds_partitioned__extract_dow
-                , subq_0.ds_partitioned__extract_doy
-                , subq_0.paid_at__day
-                , subq_0.paid_at__week
-                , subq_0.paid_at__month
-                , subq_0.paid_at__quarter
-                , subq_0.paid_at__year
-                , subq_0.paid_at__extract_year
-                , subq_0.paid_at__extract_quarter
-                , subq_0.paid_at__extract_month
-                , subq_0.paid_at__extract_day
-                , subq_0.paid_at__extract_dow
-                , subq_0.paid_at__extract_doy
-                , subq_0.booking__ds__day
-                , subq_0.booking__ds__week
-                , subq_0.booking__ds__month
-                , subq_0.booking__ds__quarter
-                , subq_0.booking__ds__year
-                , subq_0.booking__ds__extract_year
-                , subq_0.booking__ds__extract_quarter
-                , subq_0.booking__ds__extract_month
-                , subq_0.booking__ds__extract_day
-                , subq_0.booking__ds__extract_dow
-                , subq_0.booking__ds__extract_doy
-                , subq_0.booking__ds_partitioned__day
-                , subq_0.booking__ds_partitioned__week
-                , subq_0.booking__ds_partitioned__month
-                , subq_0.booking__ds_partitioned__quarter
-                , subq_0.booking__ds_partitioned__year
-                , subq_0.booking__ds_partitioned__extract_year
-                , subq_0.booking__ds_partitioned__extract_quarter
-                , subq_0.booking__ds_partitioned__extract_month
-                , subq_0.booking__ds_partitioned__extract_day
-                , subq_0.booking__ds_partitioned__extract_dow
-                , subq_0.booking__ds_partitioned__extract_doy
-                , subq_0.booking__paid_at__day
-                , subq_0.booking__paid_at__week
-                , subq_0.booking__paid_at__month
-                , subq_0.booking__paid_at__quarter
-                , subq_0.booking__paid_at__year
-                , subq_0.booking__paid_at__extract_year
-                , subq_0.booking__paid_at__extract_quarter
-                , subq_0.booking__paid_at__extract_month
-                , subq_0.booking__paid_at__extract_day
-                , subq_0.booking__paid_at__extract_dow
-                , subq_0.booking__paid_at__extract_doy
-                , subq_0.ds__day AS metric_time__day
-                , subq_0.ds__week AS metric_time__week
-                , subq_0.ds__month AS metric_time__month
-                , subq_0.ds__quarter AS metric_time__quarter
-                , subq_0.ds__year AS metric_time__year
-                , subq_0.ds__extract_year AS metric_time__extract_year
-                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_0.ds__extract_month AS metric_time__extract_month
-                , subq_0.ds__extract_day AS metric_time__extract_day
-                , subq_0.ds__extract_dow AS metric_time__extract_dow
-                , subq_0.ds__extract_doy AS metric_time__extract_doy
-                , subq_0.listing
-                , subq_0.guest
-                , subq_0.host
-                , subq_0.booking__listing
-                , subq_0.booking__guest
-                , subq_0.booking__host
-                , subq_0.is_instant
-                , subq_0.booking__is_instant
-                , subq_0.bookings
-                , subq_0.instant_bookings
-                , subq_0.booking_value
-                , subq_0.max_booking_value
-                , subq_0.min_booking_value
-                , subq_0.bookers
-                , subq_0.average_booking_value
-                , subq_0.referred_bookings
-                , subq_0.median_booking_value
-                , subq_0.booking_value_p99
-                , subq_0.discrete_booking_value_p99
-                , subq_0.approximate_continuous_booking_value_p99
-                , subq_0.approximate_discrete_booking_value_p99
+                subq_1.ds__day AS ds__day
+                , subq_1.ds__week AS ds__week
+                , subq_1.ds__month AS ds__month
+                , subq_1.ds__quarter AS ds__quarter
+                , subq_1.ds__year AS ds__year
+                , subq_1.ds__extract_year AS ds__extract_year
+                , subq_1.ds__extract_quarter AS ds__extract_quarter
+                , subq_1.ds__extract_month AS ds__extract_month
+                , subq_1.ds__extract_day AS ds__extract_day
+                , subq_1.ds__extract_dow AS ds__extract_dow
+                , subq_1.ds__extract_doy AS ds__extract_doy
+                , subq_1.ds_partitioned__day AS ds_partitioned__day
+                , subq_1.ds_partitioned__week AS ds_partitioned__week
+                , subq_1.ds_partitioned__month AS ds_partitioned__month
+                , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
+                , subq_1.ds_partitioned__year AS ds_partitioned__year
+                , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
+                , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+                , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
+                , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
+                , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+                , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+                , subq_1.paid_at__day AS paid_at__day
+                , subq_1.paid_at__week AS paid_at__week
+                , subq_1.paid_at__month AS paid_at__month
+                , subq_1.paid_at__quarter AS paid_at__quarter
+                , subq_1.paid_at__year AS paid_at__year
+                , subq_1.paid_at__extract_year AS paid_at__extract_year
+                , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
+                , subq_1.paid_at__extract_month AS paid_at__extract_month
+                , subq_1.paid_at__extract_day AS paid_at__extract_day
+                , subq_1.paid_at__extract_dow AS paid_at__extract_dow
+                , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+                , subq_1.booking__ds__day AS booking__ds__day
+                , subq_1.booking__ds__week AS booking__ds__week
+                , subq_1.booking__ds__month AS booking__ds__month
+                , subq_1.booking__ds__quarter AS booking__ds__quarter
+                , subq_1.booking__ds__year AS booking__ds__year
+                , subq_1.booking__ds__extract_year AS booking__ds__extract_year
+                , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
+                , subq_1.booking__ds__extract_month AS booking__ds__extract_month
+                , subq_1.booking__ds__extract_day AS booking__ds__extract_day
+                , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
+                , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
+                , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
+                , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
+                , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
+                , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+                , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
+                , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+                , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+                , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+                , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+                , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+                , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+                , subq_1.booking__paid_at__day AS booking__paid_at__day
+                , subq_1.booking__paid_at__week AS booking__paid_at__week
+                , subq_1.booking__paid_at__month AS booking__paid_at__month
+                , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
+                , subq_1.booking__paid_at__year AS booking__paid_at__year
+                , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
+                , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+                , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
+                , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
+                , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+                , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                , subq_1.metric_time__week AS metric_time__week
+                , subq_1.metric_time__month AS metric_time__month
+                , subq_1.metric_time__quarter AS metric_time__quarter
+                , subq_1.metric_time__year AS metric_time__year
+                , subq_1.metric_time__extract_year AS metric_time__extract_year
+                , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+                , subq_1.metric_time__extract_month AS metric_time__extract_month
+                , subq_1.metric_time__extract_day AS metric_time__extract_day
+                , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+                , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+                , subq_2.metric_time__day AS metric_time__day
+                , subq_1.listing AS listing
+                , subq_1.guest AS guest
+                , subq_1.host AS host
+                , subq_1.booking__listing AS booking__listing
+                , subq_1.booking__guest AS booking__guest
+                , subq_1.booking__host AS booking__host
+                , subq_1.is_instant AS is_instant
+                , subq_1.booking__is_instant AS booking__is_instant
+                , subq_1.bookings AS bookings
+                , subq_1.instant_bookings AS instant_bookings
+                , subq_1.booking_value AS booking_value
+                , subq_1.max_booking_value AS max_booking_value
+                , subq_1.min_booking_value AS min_booking_value
+                , subq_1.bookers AS bookers
+                , subq_1.average_booking_value AS average_booking_value
+                , subq_1.referred_bookings AS referred_bookings
+                , subq_1.median_booking_value AS median_booking_value
+                , subq_1.booking_value_p99 AS booking_value_p99
+                , subq_1.discrete_booking_value_p99 AS discrete_booking_value_p99
+                , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+                , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
               FROM (
-                -- Read Elements From Semantic Model 'bookings_source'
+                -- Time Spine
                 SELECT
-                  1 AS bookings
-                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                  , bookings_source_src_28000.booking_value
-                  , bookings_source_src_28000.booking_value AS max_booking_value
-                  , bookings_source_src_28000.booking_value AS min_booking_value
-                  , bookings_source_src_28000.guest_id AS bookers
-                  , bookings_source_src_28000.booking_value AS average_booking_value
-                  , bookings_source_src_28000.booking_value AS booking_payments
-                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-                  , bookings_source_src_28000.booking_value AS median_booking_value
-                  , bookings_source_src_28000.booking_value AS booking_value_p99
-                  , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
-                  , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
-                  , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
-                  , bookings_source_src_28000.is_instant
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS ds__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                  , bookings_source_src_28000.is_instant AS booking__is_instant
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                  , bookings_source_src_28000.listing_id AS listing
-                  , bookings_source_src_28000.guest_id AS guest
-                  , bookings_source_src_28000.host_id AS host
-                  , bookings_source_src_28000.listing_id AS booking__listing
-                  , bookings_source_src_28000.guest_id AS booking__guest
-                  , bookings_source_src_28000.host_id AS booking__host
-                FROM ***************************.fct_bookings bookings_source_src_28000
-              ) subq_0
-            ) subq_1
-            ON
-              DATEADD(day, -5, subq_2.metric_time__day) = subq_1.metric_time__day
-          ) subq_4
-        ) subq_5
-        GROUP BY
-          subq_5.metric_time__day
-      ) subq_6
-    ) subq_7
-  ) subq_8
-  ON
-    DATEADD(day, -2, subq_9.metric_time__day) = subq_8.metric_time__day
-) subq_11
+                  subq_3.ds AS metric_time__day
+                FROM ***************************.mf_time_spine subq_3
+              ) subq_2
+              INNER JOIN (
+                -- Metric Time Dimension 'ds'
+                SELECT
+                  subq_0.ds__day
+                  , subq_0.ds__week
+                  , subq_0.ds__month
+                  , subq_0.ds__quarter
+                  , subq_0.ds__year
+                  , subq_0.ds__extract_year
+                  , subq_0.ds__extract_quarter
+                  , subq_0.ds__extract_month
+                  , subq_0.ds__extract_day
+                  , subq_0.ds__extract_dow
+                  , subq_0.ds__extract_doy
+                  , subq_0.ds_partitioned__day
+                  , subq_0.ds_partitioned__week
+                  , subq_0.ds_partitioned__month
+                  , subq_0.ds_partitioned__quarter
+                  , subq_0.ds_partitioned__year
+                  , subq_0.ds_partitioned__extract_year
+                  , subq_0.ds_partitioned__extract_quarter
+                  , subq_0.ds_partitioned__extract_month
+                  , subq_0.ds_partitioned__extract_day
+                  , subq_0.ds_partitioned__extract_dow
+                  , subq_0.ds_partitioned__extract_doy
+                  , subq_0.paid_at__day
+                  , subq_0.paid_at__week
+                  , subq_0.paid_at__month
+                  , subq_0.paid_at__quarter
+                  , subq_0.paid_at__year
+                  , subq_0.paid_at__extract_year
+                  , subq_0.paid_at__extract_quarter
+                  , subq_0.paid_at__extract_month
+                  , subq_0.paid_at__extract_day
+                  , subq_0.paid_at__extract_dow
+                  , subq_0.paid_at__extract_doy
+                  , subq_0.booking__ds__day
+                  , subq_0.booking__ds__week
+                  , subq_0.booking__ds__month
+                  , subq_0.booking__ds__quarter
+                  , subq_0.booking__ds__year
+                  , subq_0.booking__ds__extract_year
+                  , subq_0.booking__ds__extract_quarter
+                  , subq_0.booking__ds__extract_month
+                  , subq_0.booking__ds__extract_day
+                  , subq_0.booking__ds__extract_dow
+                  , subq_0.booking__ds__extract_doy
+                  , subq_0.booking__ds_partitioned__day
+                  , subq_0.booking__ds_partitioned__week
+                  , subq_0.booking__ds_partitioned__month
+                  , subq_0.booking__ds_partitioned__quarter
+                  , subq_0.booking__ds_partitioned__year
+                  , subq_0.booking__ds_partitioned__extract_year
+                  , subq_0.booking__ds_partitioned__extract_quarter
+                  , subq_0.booking__ds_partitioned__extract_month
+                  , subq_0.booking__ds_partitioned__extract_day
+                  , subq_0.booking__ds_partitioned__extract_dow
+                  , subq_0.booking__ds_partitioned__extract_doy
+                  , subq_0.booking__paid_at__day
+                  , subq_0.booking__paid_at__week
+                  , subq_0.booking__paid_at__month
+                  , subq_0.booking__paid_at__quarter
+                  , subq_0.booking__paid_at__year
+                  , subq_0.booking__paid_at__extract_year
+                  , subq_0.booking__paid_at__extract_quarter
+                  , subq_0.booking__paid_at__extract_month
+                  , subq_0.booking__paid_at__extract_day
+                  , subq_0.booking__paid_at__extract_dow
+                  , subq_0.booking__paid_at__extract_doy
+                  , subq_0.ds__day AS metric_time__day
+                  , subq_0.ds__week AS metric_time__week
+                  , subq_0.ds__month AS metric_time__month
+                  , subq_0.ds__quarter AS metric_time__quarter
+                  , subq_0.ds__year AS metric_time__year
+                  , subq_0.ds__extract_year AS metric_time__extract_year
+                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_0.ds__extract_month AS metric_time__extract_month
+                  , subq_0.ds__extract_day AS metric_time__extract_day
+                  , subq_0.ds__extract_dow AS metric_time__extract_dow
+                  , subq_0.ds__extract_doy AS metric_time__extract_doy
+                  , subq_0.listing
+                  , subq_0.guest
+                  , subq_0.host
+                  , subq_0.booking__listing
+                  , subq_0.booking__guest
+                  , subq_0.booking__host
+                  , subq_0.is_instant
+                  , subq_0.booking__is_instant
+                  , subq_0.bookings
+                  , subq_0.instant_bookings
+                  , subq_0.booking_value
+                  , subq_0.max_booking_value
+                  , subq_0.min_booking_value
+                  , subq_0.bookers
+                  , subq_0.average_booking_value
+                  , subq_0.referred_bookings
+                  , subq_0.median_booking_value
+                  , subq_0.booking_value_p99
+                  , subq_0.discrete_booking_value_p99
+                  , subq_0.approximate_continuous_booking_value_p99
+                  , subq_0.approximate_discrete_booking_value_p99
+                FROM (
+                  -- Read Elements From Semantic Model 'bookings_source'
+                  SELECT
+                    1 AS bookings
+                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                    , bookings_source_src_28000.booking_value
+                    , bookings_source_src_28000.booking_value AS max_booking_value
+                    , bookings_source_src_28000.booking_value AS min_booking_value
+                    , bookings_source_src_28000.guest_id AS bookers
+                    , bookings_source_src_28000.booking_value AS average_booking_value
+                    , bookings_source_src_28000.booking_value AS booking_payments
+                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                    , bookings_source_src_28000.booking_value AS median_booking_value
+                    , bookings_source_src_28000.booking_value AS booking_value_p99
+                    , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                    , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                    , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                    , bookings_source_src_28000.is_instant
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                    , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                    , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                    , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                    , bookings_source_src_28000.is_instant AS booking__is_instant
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                    , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                    , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                    , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                    , bookings_source_src_28000.listing_id AS listing
+                    , bookings_source_src_28000.guest_id AS guest
+                    , bookings_source_src_28000.host_id AS host
+                    , bookings_source_src_28000.listing_id AS booking__listing
+                    , bookings_source_src_28000.guest_id AS booking__guest
+                    , bookings_source_src_28000.host_id AS booking__host
+                  FROM ***************************.fct_bookings bookings_source_src_28000
+                ) subq_0
+              ) subq_1
+              ON
+                DATEADD(day, -5, subq_2.metric_time__day) = subq_1.metric_time__day
+            ) subq_4
+          ) subq_5
+          GROUP BY
+            subq_5.metric_time__day
+        ) subq_6
+      ) subq_7
+    ) subq_8
+    ON
+      DATEADD(day, -2, subq_9.metric_time__day) = subq_8.metric_time__day
+  ) subq_11
+  WHERE subq_11.metric_time__day BETWEEN '2020-01-12' AND '2020-01-13'
+) subq_12

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_offsets_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_offsets_with_time_constraint__plan0_optimized.sql
@@ -8,16 +8,11 @@ SELECT
   , 2 * bookings_offset_once AS bookings_offset_twice
 FROM (
   -- Join to Time Spine Dataset
+  -- Constrain Time Range to [2020-01-12T00:00:00, 2020-01-13T00:00:00]
   SELECT
-    subq_21.metric_time__day AS metric_time__day
-    , subq_20.bookings_offset_once AS bookings_offset_once
-  FROM (
-    -- Time Spine
-    SELECT
-      ds AS metric_time__day
-    FROM ***************************.mf_time_spine subq_22
-    WHERE ds BETWEEN '2020-01-12' AND '2020-01-13'
-  ) subq_21
+    subq_23.ds AS metric_time__day
+    , subq_21.bookings_offset_once AS bookings_offset_once
+  FROM ***************************.mf_time_spine subq_23
   INNER JOIN (
     -- Compute Metrics via Expressions
     SELECT
@@ -29,9 +24,9 @@ FROM (
       -- Aggregate Measures
       -- Compute Metrics via Expressions
       SELECT
-        subq_15.ds AS metric_time__day
-        , SUM(subq_13.bookings) AS bookings
-      FROM ***************************.mf_time_spine subq_15
+        subq_16.ds AS metric_time__day
+        , SUM(subq_14.bookings) AS bookings
+      FROM ***************************.mf_time_spine subq_16
       INNER JOIN (
         -- Read Elements From Semantic Model 'bookings_source'
         -- Metric Time Dimension 'ds'
@@ -39,13 +34,14 @@ FROM (
           DATE_TRUNC('day', ds) AS metric_time__day
           , 1 AS bookings
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_13
+      ) subq_14
       ON
-        DATEADD(day, -5, subq_15.ds) = subq_13.metric_time__day
+        DATEADD(day, -5, subq_16.ds) = subq_14.metric_time__day
       GROUP BY
-        subq_15.ds
-    ) subq_19
-  ) subq_20
+        subq_16.ds
+    ) subq_20
+  ) subq_21
   ON
-    DATEADD(day, -2, subq_21.metric_time__day) = subq_20.metric_time__day
-) subq_23
+    DATEADD(day, -2, subq_23.ds) = subq_21.metric_time__day
+  WHERE subq_23.ds BETWEEN '2020-01-12' AND '2020-01-13'
+) subq_25

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_time_offset_metric_with_time_constraint__plan0.sql
@@ -4,331 +4,433 @@ sql_engine: Databricks
 ---
 -- Compute Metrics via Expressions
 SELECT
-  subq_7.metric_time__day
+  subq_8.metric_time__day
   , bookings_5_days_ago AS bookings_5_day_lag
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_6.metric_time__day
-    , subq_6.bookings AS bookings_5_days_ago
+    subq_7.metric_time__day
+    , subq_7.bookings AS bookings_5_days_ago
   FROM (
     -- Aggregate Measures
     SELECT
-      subq_5.metric_time__day
-      , SUM(subq_5.bookings) AS bookings
+      subq_6.metric_time__day
+      , SUM(subq_6.bookings) AS bookings
     FROM (
       -- Pass Only Elements: ['bookings', 'metric_time__day']
       SELECT
-        subq_4.metric_time__day
-        , subq_4.bookings
+        subq_5.metric_time__day
+        , subq_5.bookings
       FROM (
-        -- Join to Time Spine Dataset
+        -- Constrain Time Range to [2019-12-19T00:00:00, 2020-01-02T00:00:00]
         SELECT
-          subq_1.ds__day AS ds__day
-          , subq_1.ds__week AS ds__week
-          , subq_1.ds__month AS ds__month
-          , subq_1.ds__quarter AS ds__quarter
-          , subq_1.ds__year AS ds__year
-          , subq_1.ds__extract_year AS ds__extract_year
-          , subq_1.ds__extract_quarter AS ds__extract_quarter
-          , subq_1.ds__extract_month AS ds__extract_month
-          , subq_1.ds__extract_day AS ds__extract_day
-          , subq_1.ds__extract_dow AS ds__extract_dow
-          , subq_1.ds__extract_doy AS ds__extract_doy
-          , subq_1.ds_partitioned__day AS ds_partitioned__day
-          , subq_1.ds_partitioned__week AS ds_partitioned__week
-          , subq_1.ds_partitioned__month AS ds_partitioned__month
-          , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
-          , subq_1.ds_partitioned__year AS ds_partitioned__year
-          , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
-          , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
-          , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
-          , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
-          , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
-          , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
-          , subq_1.paid_at__day AS paid_at__day
-          , subq_1.paid_at__week AS paid_at__week
-          , subq_1.paid_at__month AS paid_at__month
-          , subq_1.paid_at__quarter AS paid_at__quarter
-          , subq_1.paid_at__year AS paid_at__year
-          , subq_1.paid_at__extract_year AS paid_at__extract_year
-          , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
-          , subq_1.paid_at__extract_month AS paid_at__extract_month
-          , subq_1.paid_at__extract_day AS paid_at__extract_day
-          , subq_1.paid_at__extract_dow AS paid_at__extract_dow
-          , subq_1.paid_at__extract_doy AS paid_at__extract_doy
-          , subq_1.booking__ds__day AS booking__ds__day
-          , subq_1.booking__ds__week AS booking__ds__week
-          , subq_1.booking__ds__month AS booking__ds__month
-          , subq_1.booking__ds__quarter AS booking__ds__quarter
-          , subq_1.booking__ds__year AS booking__ds__year
-          , subq_1.booking__ds__extract_year AS booking__ds__extract_year
-          , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
-          , subq_1.booking__ds__extract_month AS booking__ds__extract_month
-          , subq_1.booking__ds__extract_day AS booking__ds__extract_day
-          , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
-          , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
-          , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
-          , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
-          , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
-          , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
-          , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
-          , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
-          , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
-          , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
-          , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
-          , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
-          , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
-          , subq_1.booking__paid_at__day AS booking__paid_at__day
-          , subq_1.booking__paid_at__week AS booking__paid_at__week
-          , subq_1.booking__paid_at__month AS booking__paid_at__month
-          , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
-          , subq_1.booking__paid_at__year AS booking__paid_at__year
-          , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
-          , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
-          , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
-          , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
-          , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
-          , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
-          , subq_1.metric_time__week AS metric_time__week
-          , subq_1.metric_time__month AS metric_time__month
-          , subq_1.metric_time__quarter AS metric_time__quarter
-          , subq_1.metric_time__year AS metric_time__year
-          , subq_1.metric_time__extract_year AS metric_time__extract_year
-          , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
-          , subq_1.metric_time__extract_month AS metric_time__extract_month
-          , subq_1.metric_time__extract_day AS metric_time__extract_day
-          , subq_1.metric_time__extract_dow AS metric_time__extract_dow
-          , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-          , subq_2.metric_time__day AS metric_time__day
-          , subq_1.listing AS listing
-          , subq_1.guest AS guest
-          , subq_1.host AS host
-          , subq_1.booking__listing AS booking__listing
-          , subq_1.booking__guest AS booking__guest
-          , subq_1.booking__host AS booking__host
-          , subq_1.is_instant AS is_instant
-          , subq_1.booking__is_instant AS booking__is_instant
-          , subq_1.bookings AS bookings
-          , subq_1.instant_bookings AS instant_bookings
-          , subq_1.booking_value AS booking_value
-          , subq_1.max_booking_value AS max_booking_value
-          , subq_1.min_booking_value AS min_booking_value
-          , subq_1.bookers AS bookers
-          , subq_1.average_booking_value AS average_booking_value
-          , subq_1.referred_bookings AS referred_bookings
-          , subq_1.median_booking_value AS median_booking_value
-          , subq_1.booking_value_p99 AS booking_value_p99
-          , subq_1.discrete_booking_value_p99 AS discrete_booking_value_p99
-          , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
-          , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+          subq_4.metric_time__day
+          , subq_4.ds__day
+          , subq_4.ds__week
+          , subq_4.ds__month
+          , subq_4.ds__quarter
+          , subq_4.ds__year
+          , subq_4.ds__extract_year
+          , subq_4.ds__extract_quarter
+          , subq_4.ds__extract_month
+          , subq_4.ds__extract_day
+          , subq_4.ds__extract_dow
+          , subq_4.ds__extract_doy
+          , subq_4.ds_partitioned__day
+          , subq_4.ds_partitioned__week
+          , subq_4.ds_partitioned__month
+          , subq_4.ds_partitioned__quarter
+          , subq_4.ds_partitioned__year
+          , subq_4.ds_partitioned__extract_year
+          , subq_4.ds_partitioned__extract_quarter
+          , subq_4.ds_partitioned__extract_month
+          , subq_4.ds_partitioned__extract_day
+          , subq_4.ds_partitioned__extract_dow
+          , subq_4.ds_partitioned__extract_doy
+          , subq_4.paid_at__day
+          , subq_4.paid_at__week
+          , subq_4.paid_at__month
+          , subq_4.paid_at__quarter
+          , subq_4.paid_at__year
+          , subq_4.paid_at__extract_year
+          , subq_4.paid_at__extract_quarter
+          , subq_4.paid_at__extract_month
+          , subq_4.paid_at__extract_day
+          , subq_4.paid_at__extract_dow
+          , subq_4.paid_at__extract_doy
+          , subq_4.booking__ds__day
+          , subq_4.booking__ds__week
+          , subq_4.booking__ds__month
+          , subq_4.booking__ds__quarter
+          , subq_4.booking__ds__year
+          , subq_4.booking__ds__extract_year
+          , subq_4.booking__ds__extract_quarter
+          , subq_4.booking__ds__extract_month
+          , subq_4.booking__ds__extract_day
+          , subq_4.booking__ds__extract_dow
+          , subq_4.booking__ds__extract_doy
+          , subq_4.booking__ds_partitioned__day
+          , subq_4.booking__ds_partitioned__week
+          , subq_4.booking__ds_partitioned__month
+          , subq_4.booking__ds_partitioned__quarter
+          , subq_4.booking__ds_partitioned__year
+          , subq_4.booking__ds_partitioned__extract_year
+          , subq_4.booking__ds_partitioned__extract_quarter
+          , subq_4.booking__ds_partitioned__extract_month
+          , subq_4.booking__ds_partitioned__extract_day
+          , subq_4.booking__ds_partitioned__extract_dow
+          , subq_4.booking__ds_partitioned__extract_doy
+          , subq_4.booking__paid_at__day
+          , subq_4.booking__paid_at__week
+          , subq_4.booking__paid_at__month
+          , subq_4.booking__paid_at__quarter
+          , subq_4.booking__paid_at__year
+          , subq_4.booking__paid_at__extract_year
+          , subq_4.booking__paid_at__extract_quarter
+          , subq_4.booking__paid_at__extract_month
+          , subq_4.booking__paid_at__extract_day
+          , subq_4.booking__paid_at__extract_dow
+          , subq_4.booking__paid_at__extract_doy
+          , subq_4.metric_time__week
+          , subq_4.metric_time__month
+          , subq_4.metric_time__quarter
+          , subq_4.metric_time__year
+          , subq_4.metric_time__extract_year
+          , subq_4.metric_time__extract_quarter
+          , subq_4.metric_time__extract_month
+          , subq_4.metric_time__extract_day
+          , subq_4.metric_time__extract_dow
+          , subq_4.metric_time__extract_doy
+          , subq_4.listing
+          , subq_4.guest
+          , subq_4.host
+          , subq_4.booking__listing
+          , subq_4.booking__guest
+          , subq_4.booking__host
+          , subq_4.is_instant
+          , subq_4.booking__is_instant
+          , subq_4.bookings
+          , subq_4.instant_bookings
+          , subq_4.booking_value
+          , subq_4.max_booking_value
+          , subq_4.min_booking_value
+          , subq_4.bookers
+          , subq_4.average_booking_value
+          , subq_4.referred_bookings
+          , subq_4.median_booking_value
+          , subq_4.booking_value_p99
+          , subq_4.discrete_booking_value_p99
+          , subq_4.approximate_continuous_booking_value_p99
+          , subq_4.approximate_discrete_booking_value_p99
         FROM (
-          -- Time Spine
+          -- Join to Time Spine Dataset
           SELECT
-            subq_3.ds AS metric_time__day
-          FROM ***************************.mf_time_spine subq_3
-          WHERE subq_3.ds BETWEEN '2019-12-19' AND '2020-01-02'
-        ) subq_2
-        INNER JOIN (
-          -- Metric Time Dimension 'ds'
-          SELECT
-            subq_0.ds__day
-            , subq_0.ds__week
-            , subq_0.ds__month
-            , subq_0.ds__quarter
-            , subq_0.ds__year
-            , subq_0.ds__extract_year
-            , subq_0.ds__extract_quarter
-            , subq_0.ds__extract_month
-            , subq_0.ds__extract_day
-            , subq_0.ds__extract_dow
-            , subq_0.ds__extract_doy
-            , subq_0.ds_partitioned__day
-            , subq_0.ds_partitioned__week
-            , subq_0.ds_partitioned__month
-            , subq_0.ds_partitioned__quarter
-            , subq_0.ds_partitioned__year
-            , subq_0.ds_partitioned__extract_year
-            , subq_0.ds_partitioned__extract_quarter
-            , subq_0.ds_partitioned__extract_month
-            , subq_0.ds_partitioned__extract_day
-            , subq_0.ds_partitioned__extract_dow
-            , subq_0.ds_partitioned__extract_doy
-            , subq_0.paid_at__day
-            , subq_0.paid_at__week
-            , subq_0.paid_at__month
-            , subq_0.paid_at__quarter
-            , subq_0.paid_at__year
-            , subq_0.paid_at__extract_year
-            , subq_0.paid_at__extract_quarter
-            , subq_0.paid_at__extract_month
-            , subq_0.paid_at__extract_day
-            , subq_0.paid_at__extract_dow
-            , subq_0.paid_at__extract_doy
-            , subq_0.booking__ds__day
-            , subq_0.booking__ds__week
-            , subq_0.booking__ds__month
-            , subq_0.booking__ds__quarter
-            , subq_0.booking__ds__year
-            , subq_0.booking__ds__extract_year
-            , subq_0.booking__ds__extract_quarter
-            , subq_0.booking__ds__extract_month
-            , subq_0.booking__ds__extract_day
-            , subq_0.booking__ds__extract_dow
-            , subq_0.booking__ds__extract_doy
-            , subq_0.booking__ds_partitioned__day
-            , subq_0.booking__ds_partitioned__week
-            , subq_0.booking__ds_partitioned__month
-            , subq_0.booking__ds_partitioned__quarter
-            , subq_0.booking__ds_partitioned__year
-            , subq_0.booking__ds_partitioned__extract_year
-            , subq_0.booking__ds_partitioned__extract_quarter
-            , subq_0.booking__ds_partitioned__extract_month
-            , subq_0.booking__ds_partitioned__extract_day
-            , subq_0.booking__ds_partitioned__extract_dow
-            , subq_0.booking__ds_partitioned__extract_doy
-            , subq_0.booking__paid_at__day
-            , subq_0.booking__paid_at__week
-            , subq_0.booking__paid_at__month
-            , subq_0.booking__paid_at__quarter
-            , subq_0.booking__paid_at__year
-            , subq_0.booking__paid_at__extract_year
-            , subq_0.booking__paid_at__extract_quarter
-            , subq_0.booking__paid_at__extract_month
-            , subq_0.booking__paid_at__extract_day
-            , subq_0.booking__paid_at__extract_dow
-            , subq_0.booking__paid_at__extract_doy
-            , subq_0.ds__day AS metric_time__day
-            , subq_0.ds__week AS metric_time__week
-            , subq_0.ds__month AS metric_time__month
-            , subq_0.ds__quarter AS metric_time__quarter
-            , subq_0.ds__year AS metric_time__year
-            , subq_0.ds__extract_year AS metric_time__extract_year
-            , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-            , subq_0.ds__extract_month AS metric_time__extract_month
-            , subq_0.ds__extract_day AS metric_time__extract_day
-            , subq_0.ds__extract_dow AS metric_time__extract_dow
-            , subq_0.ds__extract_doy AS metric_time__extract_doy
-            , subq_0.listing
-            , subq_0.guest
-            , subq_0.host
-            , subq_0.booking__listing
-            , subq_0.booking__guest
-            , subq_0.booking__host
-            , subq_0.is_instant
-            , subq_0.booking__is_instant
-            , subq_0.bookings
-            , subq_0.instant_bookings
-            , subq_0.booking_value
-            , subq_0.max_booking_value
-            , subq_0.min_booking_value
-            , subq_0.bookers
-            , subq_0.average_booking_value
-            , subq_0.referred_bookings
-            , subq_0.median_booking_value
-            , subq_0.booking_value_p99
-            , subq_0.discrete_booking_value_p99
-            , subq_0.approximate_continuous_booking_value_p99
-            , subq_0.approximate_discrete_booking_value_p99
+            subq_1.ds__day AS ds__day
+            , subq_1.ds__week AS ds__week
+            , subq_1.ds__month AS ds__month
+            , subq_1.ds__quarter AS ds__quarter
+            , subq_1.ds__year AS ds__year
+            , subq_1.ds__extract_year AS ds__extract_year
+            , subq_1.ds__extract_quarter AS ds__extract_quarter
+            , subq_1.ds__extract_month AS ds__extract_month
+            , subq_1.ds__extract_day AS ds__extract_day
+            , subq_1.ds__extract_dow AS ds__extract_dow
+            , subq_1.ds__extract_doy AS ds__extract_doy
+            , subq_1.ds_partitioned__day AS ds_partitioned__day
+            , subq_1.ds_partitioned__week AS ds_partitioned__week
+            , subq_1.ds_partitioned__month AS ds_partitioned__month
+            , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
+            , subq_1.ds_partitioned__year AS ds_partitioned__year
+            , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
+            , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+            , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
+            , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
+            , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+            , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+            , subq_1.paid_at__day AS paid_at__day
+            , subq_1.paid_at__week AS paid_at__week
+            , subq_1.paid_at__month AS paid_at__month
+            , subq_1.paid_at__quarter AS paid_at__quarter
+            , subq_1.paid_at__year AS paid_at__year
+            , subq_1.paid_at__extract_year AS paid_at__extract_year
+            , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
+            , subq_1.paid_at__extract_month AS paid_at__extract_month
+            , subq_1.paid_at__extract_day AS paid_at__extract_day
+            , subq_1.paid_at__extract_dow AS paid_at__extract_dow
+            , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+            , subq_1.booking__ds__day AS booking__ds__day
+            , subq_1.booking__ds__week AS booking__ds__week
+            , subq_1.booking__ds__month AS booking__ds__month
+            , subq_1.booking__ds__quarter AS booking__ds__quarter
+            , subq_1.booking__ds__year AS booking__ds__year
+            , subq_1.booking__ds__extract_year AS booking__ds__extract_year
+            , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
+            , subq_1.booking__ds__extract_month AS booking__ds__extract_month
+            , subq_1.booking__ds__extract_day AS booking__ds__extract_day
+            , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
+            , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
+            , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
+            , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
+            , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
+            , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+            , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
+            , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+            , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+            , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+            , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+            , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+            , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+            , subq_1.booking__paid_at__day AS booking__paid_at__day
+            , subq_1.booking__paid_at__week AS booking__paid_at__week
+            , subq_1.booking__paid_at__month AS booking__paid_at__month
+            , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
+            , subq_1.booking__paid_at__year AS booking__paid_at__year
+            , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
+            , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+            , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
+            , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
+            , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+            , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_1.metric_time__week AS metric_time__week
+            , subq_1.metric_time__month AS metric_time__month
+            , subq_1.metric_time__quarter AS metric_time__quarter
+            , subq_1.metric_time__year AS metric_time__year
+            , subq_1.metric_time__extract_year AS metric_time__extract_year
+            , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_1.metric_time__extract_month AS metric_time__extract_month
+            , subq_1.metric_time__extract_day AS metric_time__extract_day
+            , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_2.metric_time__day AS metric_time__day
+            , subq_1.listing AS listing
+            , subq_1.guest AS guest
+            , subq_1.host AS host
+            , subq_1.booking__listing AS booking__listing
+            , subq_1.booking__guest AS booking__guest
+            , subq_1.booking__host AS booking__host
+            , subq_1.is_instant AS is_instant
+            , subq_1.booking__is_instant AS booking__is_instant
+            , subq_1.bookings AS bookings
+            , subq_1.instant_bookings AS instant_bookings
+            , subq_1.booking_value AS booking_value
+            , subq_1.max_booking_value AS max_booking_value
+            , subq_1.min_booking_value AS min_booking_value
+            , subq_1.bookers AS bookers
+            , subq_1.average_booking_value AS average_booking_value
+            , subq_1.referred_bookings AS referred_bookings
+            , subq_1.median_booking_value AS median_booking_value
+            , subq_1.booking_value_p99 AS booking_value_p99
+            , subq_1.discrete_booking_value_p99 AS discrete_booking_value_p99
+            , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+            , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Read Elements From Semantic Model 'bookings_source'
+            -- Time Spine
             SELECT
-              1 AS bookings
-              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-              , bookings_source_src_28000.booking_value
-              , bookings_source_src_28000.booking_value AS max_booking_value
-              , bookings_source_src_28000.booking_value AS min_booking_value
-              , bookings_source_src_28000.guest_id AS bookers
-              , bookings_source_src_28000.booking_value AS average_booking_value
-              , bookings_source_src_28000.booking_value AS booking_payments
-              , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-              , bookings_source_src_28000.booking_value AS median_booking_value
-              , bookings_source_src_28000.booking_value AS booking_value_p99
-              , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
-              , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
-              , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
-              , bookings_source_src_28000.is_instant
-              , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-              , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-              , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-              , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-              , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-              , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-              , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-              , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS ds__extract_dow
-              , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-              , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-              , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-              , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-              , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-              , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-              , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-              , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
-              , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-              , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-              , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-              , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-              , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-              , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-              , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-              , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
-              , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-              , bookings_source_src_28000.is_instant AS booking__is_instant
-              , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-              , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-              , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-              , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-              , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-              , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-              , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-              , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
-              , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-              , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-              , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-              , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-              , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-              , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-              , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-              , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
-              , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-              , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-              , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-              , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-              , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-              , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-              , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
-              , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-              , bookings_source_src_28000.listing_id AS listing
-              , bookings_source_src_28000.guest_id AS guest
-              , bookings_source_src_28000.host_id AS host
-              , bookings_source_src_28000.listing_id AS booking__listing
-              , bookings_source_src_28000.guest_id AS booking__guest
-              , bookings_source_src_28000.host_id AS booking__host
-            FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_0
-        ) subq_1
-        ON
-          DATEADD(day, -5, subq_2.metric_time__day) = subq_1.metric_time__day
-      ) subq_4
-    ) subq_5
+              subq_3.ds AS metric_time__day
+            FROM ***************************.mf_time_spine subq_3
+          ) subq_2
+          INNER JOIN (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.ds_partitioned__day
+              , subq_0.ds_partitioned__week
+              , subq_0.ds_partitioned__month
+              , subq_0.ds_partitioned__quarter
+              , subq_0.ds_partitioned__year
+              , subq_0.ds_partitioned__extract_year
+              , subq_0.ds_partitioned__extract_quarter
+              , subq_0.ds_partitioned__extract_month
+              , subq_0.ds_partitioned__extract_day
+              , subq_0.ds_partitioned__extract_dow
+              , subq_0.ds_partitioned__extract_doy
+              , subq_0.paid_at__day
+              , subq_0.paid_at__week
+              , subq_0.paid_at__month
+              , subq_0.paid_at__quarter
+              , subq_0.paid_at__year
+              , subq_0.paid_at__extract_year
+              , subq_0.paid_at__extract_quarter
+              , subq_0.paid_at__extract_month
+              , subq_0.paid_at__extract_day
+              , subq_0.paid_at__extract_dow
+              , subq_0.paid_at__extract_doy
+              , subq_0.booking__ds__day
+              , subq_0.booking__ds__week
+              , subq_0.booking__ds__month
+              , subq_0.booking__ds__quarter
+              , subq_0.booking__ds__year
+              , subq_0.booking__ds__extract_year
+              , subq_0.booking__ds__extract_quarter
+              , subq_0.booking__ds__extract_month
+              , subq_0.booking__ds__extract_day
+              , subq_0.booking__ds__extract_dow
+              , subq_0.booking__ds__extract_doy
+              , subq_0.booking__ds_partitioned__day
+              , subq_0.booking__ds_partitioned__week
+              , subq_0.booking__ds_partitioned__month
+              , subq_0.booking__ds_partitioned__quarter
+              , subq_0.booking__ds_partitioned__year
+              , subq_0.booking__ds_partitioned__extract_year
+              , subq_0.booking__ds_partitioned__extract_quarter
+              , subq_0.booking__ds_partitioned__extract_month
+              , subq_0.booking__ds_partitioned__extract_day
+              , subq_0.booking__ds_partitioned__extract_dow
+              , subq_0.booking__ds_partitioned__extract_doy
+              , subq_0.booking__paid_at__day
+              , subq_0.booking__paid_at__week
+              , subq_0.booking__paid_at__month
+              , subq_0.booking__paid_at__quarter
+              , subq_0.booking__paid_at__year
+              , subq_0.booking__paid_at__extract_year
+              , subq_0.booking__paid_at__extract_quarter
+              , subq_0.booking__paid_at__extract_month
+              , subq_0.booking__paid_at__extract_day
+              , subq_0.booking__paid_at__extract_dow
+              , subq_0.booking__paid_at__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.listing
+              , subq_0.guest
+              , subq_0.host
+              , subq_0.booking__listing
+              , subq_0.booking__guest
+              , subq_0.booking__host
+              , subq_0.is_instant
+              , subq_0.booking__is_instant
+              , subq_0.bookings
+              , subq_0.instant_bookings
+              , subq_0.booking_value
+              , subq_0.max_booking_value
+              , subq_0.min_booking_value
+              , subq_0.bookers
+              , subq_0.average_booking_value
+              , subq_0.referred_bookings
+              , subq_0.median_booking_value
+              , subq_0.booking_value_p99
+              , subq_0.discrete_booking_value_p99
+              , subq_0.approximate_continuous_booking_value_p99
+              , subq_0.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Semantic Model 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_28000.booking_value
+                , bookings_source_src_28000.booking_value AS max_booking_value
+                , bookings_source_src_28000.booking_value AS min_booking_value
+                , bookings_source_src_28000.guest_id AS bookers
+                , bookings_source_src_28000.booking_value AS average_booking_value
+                , bookings_source_src_28000.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_28000.booking_value AS median_booking_value
+                , bookings_source_src_28000.booking_value AS booking_value_p99
+                , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_28000.is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_28000.is_instant AS booking__is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_28000.listing_id AS listing
+                , bookings_source_src_28000.guest_id AS guest
+                , bookings_source_src_28000.host_id AS host
+                , bookings_source_src_28000.listing_id AS booking__listing
+                , bookings_source_src_28000.guest_id AS booking__guest
+                , bookings_source_src_28000.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_28000
+            ) subq_0
+          ) subq_1
+          ON
+            DATEADD(day, -5, subq_2.metric_time__day) = subq_1.metric_time__day
+        ) subq_4
+        WHERE subq_4.metric_time__day BETWEEN '2019-12-19' AND '2020-01-02'
+      ) subq_5
+    ) subq_6
     GROUP BY
-      subq_5.metric_time__day
-  ) subq_6
-) subq_7
+      subq_6.metric_time__day
+  ) subq_7
+) subq_8

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_time_offset_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_time_offset_metric_with_time_constraint__plan0_optimized.sql
@@ -8,19 +8,14 @@ SELECT
   , bookings_5_days_ago AS bookings_5_day_lag
 FROM (
   -- Join to Time Spine Dataset
+  -- Constrain Time Range to [2019-12-19T00:00:00, 2020-01-02T00:00:00]
   -- Pass Only Elements: ['bookings', 'metric_time__day']
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT
-    subq_10.metric_time__day AS metric_time__day
-    , SUM(subq_9.bookings) AS bookings_5_days_ago
-  FROM (
-    -- Time Spine
-    SELECT
-      ds AS metric_time__day
-    FROM ***************************.mf_time_spine subq_11
-    WHERE ds BETWEEN '2019-12-19' AND '2020-01-02'
-  ) subq_10
+    subq_12.ds AS metric_time__day
+    , SUM(subq_10.bookings) AS bookings_5_days_ago
+  FROM ***************************.mf_time_spine subq_12
   INNER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -28,9 +23,10 @@ FROM (
       DATE_TRUNC('day', ds) AS metric_time__day
       , 1 AS bookings
     FROM ***************************.fct_bookings bookings_source_src_28000
-  ) subq_9
+  ) subq_10
   ON
-    DATEADD(day, -5, subq_10.metric_time__day) = subq_9.metric_time__day
+    DATEADD(day, -5, subq_12.ds) = subq_10.metric_time__day
+  WHERE subq_12.ds BETWEEN '2019-12-19' AND '2020-01-02'
   GROUP BY
-    subq_10.metric_time__day
-) subq_15
+    subq_12.ds
+) subq_17

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
@@ -228,7 +228,6 @@ FROM (
             SELECT
               subq_6.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_6
-            WHERE subq_6.ds BETWEEN '2019-12-19' AND '2020-01-02'
           ) subq_5
           INNER JOIN (
             -- Join Self Over Time Range

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_time_offset_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_time_offset_metric_with_time_constraint__plan0_optimized.sql
@@ -13,15 +13,9 @@ FROM (
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT
-    subq_17.metric_time__day AS metric_time__day
+    subq_18.ds AS metric_time__day
     , COUNT(DISTINCT subq_16.bookers) AS every_2_days_bookers_2_days_ago
-  FROM (
-    -- Time Spine
-    SELECT
-      ds AS metric_time__day
-    FROM ***************************.mf_time_spine subq_18
-    WHERE ds BETWEEN '2019-12-19' AND '2020-01-02'
-  ) subq_17
+  FROM ***************************.mf_time_spine subq_18
   INNER JOIN (
     -- Join Self Over Time Range
     SELECT
@@ -38,8 +32,8 @@ FROM (
       )
   ) subq_16
   ON
-    subq_17.metric_time__day - INTERVAL 2 day = subq_16.metric_time__day
-  WHERE subq_17.metric_time__day BETWEEN '2019-12-19' AND '2020-01-02'
+    subq_18.ds - INTERVAL 2 day = subq_16.metric_time__day
+  WHERE subq_18.ds BETWEEN '2019-12-19' AND '2020-01-02'
   GROUP BY
-    subq_17.metric_time__day
+    subq_18.ds
 ) subq_23

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_offsets_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_offsets_with_time_constraint__plan0.sql
@@ -4,351 +4,357 @@ sql_engine: DuckDB
 ---
 -- Compute Metrics via Expressions
 SELECT
-  subq_11.metric_time__day
+  subq_12.metric_time__day
   , 2 * bookings_offset_once AS bookings_offset_twice
 FROM (
-  -- Join to Time Spine Dataset
+  -- Constrain Time Range to [2020-01-12T00:00:00, 2020-01-13T00:00:00]
   SELECT
-    subq_9.metric_time__day AS metric_time__day
-    , subq_8.bookings_offset_once AS bookings_offset_once
+    subq_11.metric_time__day
+    , subq_11.bookings_offset_once
   FROM (
-    -- Time Spine
+    -- Join to Time Spine Dataset
     SELECT
-      subq_10.ds AS metric_time__day
-    FROM ***************************.mf_time_spine subq_10
-    WHERE subq_10.ds BETWEEN '2020-01-12' AND '2020-01-13'
-  ) subq_9
-  INNER JOIN (
-    -- Compute Metrics via Expressions
-    SELECT
-      subq_7.metric_time__day
-      , 2 * bookings AS bookings_offset_once
+      subq_9.metric_time__day AS metric_time__day
+      , subq_8.bookings_offset_once AS bookings_offset_once
     FROM (
+      -- Time Spine
+      SELECT
+        subq_10.ds AS metric_time__day
+      FROM ***************************.mf_time_spine subq_10
+    ) subq_9
+    INNER JOIN (
       -- Compute Metrics via Expressions
       SELECT
-        subq_6.metric_time__day
-        , subq_6.bookings
+        subq_7.metric_time__day
+        , 2 * bookings AS bookings_offset_once
       FROM (
-        -- Aggregate Measures
+        -- Compute Metrics via Expressions
         SELECT
-          subq_5.metric_time__day
-          , SUM(subq_5.bookings) AS bookings
+          subq_6.metric_time__day
+          , subq_6.bookings
         FROM (
-          -- Pass Only Elements: ['bookings', 'metric_time__day']
+          -- Aggregate Measures
           SELECT
-            subq_4.metric_time__day
-            , subq_4.bookings
+            subq_5.metric_time__day
+            , SUM(subq_5.bookings) AS bookings
           FROM (
-            -- Join to Time Spine Dataset
+            -- Pass Only Elements: ['bookings', 'metric_time__day']
             SELECT
-              subq_1.ds__day AS ds__day
-              , subq_1.ds__week AS ds__week
-              , subq_1.ds__month AS ds__month
-              , subq_1.ds__quarter AS ds__quarter
-              , subq_1.ds__year AS ds__year
-              , subq_1.ds__extract_year AS ds__extract_year
-              , subq_1.ds__extract_quarter AS ds__extract_quarter
-              , subq_1.ds__extract_month AS ds__extract_month
-              , subq_1.ds__extract_day AS ds__extract_day
-              , subq_1.ds__extract_dow AS ds__extract_dow
-              , subq_1.ds__extract_doy AS ds__extract_doy
-              , subq_1.ds_partitioned__day AS ds_partitioned__day
-              , subq_1.ds_partitioned__week AS ds_partitioned__week
-              , subq_1.ds_partitioned__month AS ds_partitioned__month
-              , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
-              , subq_1.ds_partitioned__year AS ds_partitioned__year
-              , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
-              , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
-              , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
-              , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
-              , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
-              , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
-              , subq_1.paid_at__day AS paid_at__day
-              , subq_1.paid_at__week AS paid_at__week
-              , subq_1.paid_at__month AS paid_at__month
-              , subq_1.paid_at__quarter AS paid_at__quarter
-              , subq_1.paid_at__year AS paid_at__year
-              , subq_1.paid_at__extract_year AS paid_at__extract_year
-              , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
-              , subq_1.paid_at__extract_month AS paid_at__extract_month
-              , subq_1.paid_at__extract_day AS paid_at__extract_day
-              , subq_1.paid_at__extract_dow AS paid_at__extract_dow
-              , subq_1.paid_at__extract_doy AS paid_at__extract_doy
-              , subq_1.booking__ds__day AS booking__ds__day
-              , subq_1.booking__ds__week AS booking__ds__week
-              , subq_1.booking__ds__month AS booking__ds__month
-              , subq_1.booking__ds__quarter AS booking__ds__quarter
-              , subq_1.booking__ds__year AS booking__ds__year
-              , subq_1.booking__ds__extract_year AS booking__ds__extract_year
-              , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
-              , subq_1.booking__ds__extract_month AS booking__ds__extract_month
-              , subq_1.booking__ds__extract_day AS booking__ds__extract_day
-              , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
-              , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
-              , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
-              , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
-              , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
-              , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
-              , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
-              , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
-              , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
-              , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
-              , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
-              , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
-              , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
-              , subq_1.booking__paid_at__day AS booking__paid_at__day
-              , subq_1.booking__paid_at__week AS booking__paid_at__week
-              , subq_1.booking__paid_at__month AS booking__paid_at__month
-              , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
-              , subq_1.booking__paid_at__year AS booking__paid_at__year
-              , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
-              , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
-              , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
-              , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
-              , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
-              , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
-              , subq_1.metric_time__week AS metric_time__week
-              , subq_1.metric_time__month AS metric_time__month
-              , subq_1.metric_time__quarter AS metric_time__quarter
-              , subq_1.metric_time__year AS metric_time__year
-              , subq_1.metric_time__extract_year AS metric_time__extract_year
-              , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
-              , subq_1.metric_time__extract_month AS metric_time__extract_month
-              , subq_1.metric_time__extract_day AS metric_time__extract_day
-              , subq_1.metric_time__extract_dow AS metric_time__extract_dow
-              , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-              , subq_2.metric_time__day AS metric_time__day
-              , subq_1.listing AS listing
-              , subq_1.guest AS guest
-              , subq_1.host AS host
-              , subq_1.booking__listing AS booking__listing
-              , subq_1.booking__guest AS booking__guest
-              , subq_1.booking__host AS booking__host
-              , subq_1.is_instant AS is_instant
-              , subq_1.booking__is_instant AS booking__is_instant
-              , subq_1.bookings AS bookings
-              , subq_1.instant_bookings AS instant_bookings
-              , subq_1.booking_value AS booking_value
-              , subq_1.max_booking_value AS max_booking_value
-              , subq_1.min_booking_value AS min_booking_value
-              , subq_1.bookers AS bookers
-              , subq_1.average_booking_value AS average_booking_value
-              , subq_1.referred_bookings AS referred_bookings
-              , subq_1.median_booking_value AS median_booking_value
-              , subq_1.booking_value_p99 AS booking_value_p99
-              , subq_1.discrete_booking_value_p99 AS discrete_booking_value_p99
-              , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
-              , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+              subq_4.metric_time__day
+              , subq_4.bookings
             FROM (
-              -- Time Spine
+              -- Join to Time Spine Dataset
               SELECT
-                subq_3.ds AS metric_time__day
-              FROM ***************************.mf_time_spine subq_3
-            ) subq_2
-            INNER JOIN (
-              -- Metric Time Dimension 'ds'
-              SELECT
-                subq_0.ds__day
-                , subq_0.ds__week
-                , subq_0.ds__month
-                , subq_0.ds__quarter
-                , subq_0.ds__year
-                , subq_0.ds__extract_year
-                , subq_0.ds__extract_quarter
-                , subq_0.ds__extract_month
-                , subq_0.ds__extract_day
-                , subq_0.ds__extract_dow
-                , subq_0.ds__extract_doy
-                , subq_0.ds_partitioned__day
-                , subq_0.ds_partitioned__week
-                , subq_0.ds_partitioned__month
-                , subq_0.ds_partitioned__quarter
-                , subq_0.ds_partitioned__year
-                , subq_0.ds_partitioned__extract_year
-                , subq_0.ds_partitioned__extract_quarter
-                , subq_0.ds_partitioned__extract_month
-                , subq_0.ds_partitioned__extract_day
-                , subq_0.ds_partitioned__extract_dow
-                , subq_0.ds_partitioned__extract_doy
-                , subq_0.paid_at__day
-                , subq_0.paid_at__week
-                , subq_0.paid_at__month
-                , subq_0.paid_at__quarter
-                , subq_0.paid_at__year
-                , subq_0.paid_at__extract_year
-                , subq_0.paid_at__extract_quarter
-                , subq_0.paid_at__extract_month
-                , subq_0.paid_at__extract_day
-                , subq_0.paid_at__extract_dow
-                , subq_0.paid_at__extract_doy
-                , subq_0.booking__ds__day
-                , subq_0.booking__ds__week
-                , subq_0.booking__ds__month
-                , subq_0.booking__ds__quarter
-                , subq_0.booking__ds__year
-                , subq_0.booking__ds__extract_year
-                , subq_0.booking__ds__extract_quarter
-                , subq_0.booking__ds__extract_month
-                , subq_0.booking__ds__extract_day
-                , subq_0.booking__ds__extract_dow
-                , subq_0.booking__ds__extract_doy
-                , subq_0.booking__ds_partitioned__day
-                , subq_0.booking__ds_partitioned__week
-                , subq_0.booking__ds_partitioned__month
-                , subq_0.booking__ds_partitioned__quarter
-                , subq_0.booking__ds_partitioned__year
-                , subq_0.booking__ds_partitioned__extract_year
-                , subq_0.booking__ds_partitioned__extract_quarter
-                , subq_0.booking__ds_partitioned__extract_month
-                , subq_0.booking__ds_partitioned__extract_day
-                , subq_0.booking__ds_partitioned__extract_dow
-                , subq_0.booking__ds_partitioned__extract_doy
-                , subq_0.booking__paid_at__day
-                , subq_0.booking__paid_at__week
-                , subq_0.booking__paid_at__month
-                , subq_0.booking__paid_at__quarter
-                , subq_0.booking__paid_at__year
-                , subq_0.booking__paid_at__extract_year
-                , subq_0.booking__paid_at__extract_quarter
-                , subq_0.booking__paid_at__extract_month
-                , subq_0.booking__paid_at__extract_day
-                , subq_0.booking__paid_at__extract_dow
-                , subq_0.booking__paid_at__extract_doy
-                , subq_0.ds__day AS metric_time__day
-                , subq_0.ds__week AS metric_time__week
-                , subq_0.ds__month AS metric_time__month
-                , subq_0.ds__quarter AS metric_time__quarter
-                , subq_0.ds__year AS metric_time__year
-                , subq_0.ds__extract_year AS metric_time__extract_year
-                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_0.ds__extract_month AS metric_time__extract_month
-                , subq_0.ds__extract_day AS metric_time__extract_day
-                , subq_0.ds__extract_dow AS metric_time__extract_dow
-                , subq_0.ds__extract_doy AS metric_time__extract_doy
-                , subq_0.listing
-                , subq_0.guest
-                , subq_0.host
-                , subq_0.booking__listing
-                , subq_0.booking__guest
-                , subq_0.booking__host
-                , subq_0.is_instant
-                , subq_0.booking__is_instant
-                , subq_0.bookings
-                , subq_0.instant_bookings
-                , subq_0.booking_value
-                , subq_0.max_booking_value
-                , subq_0.min_booking_value
-                , subq_0.bookers
-                , subq_0.average_booking_value
-                , subq_0.referred_bookings
-                , subq_0.median_booking_value
-                , subq_0.booking_value_p99
-                , subq_0.discrete_booking_value_p99
-                , subq_0.approximate_continuous_booking_value_p99
-                , subq_0.approximate_discrete_booking_value_p99
+                subq_1.ds__day AS ds__day
+                , subq_1.ds__week AS ds__week
+                , subq_1.ds__month AS ds__month
+                , subq_1.ds__quarter AS ds__quarter
+                , subq_1.ds__year AS ds__year
+                , subq_1.ds__extract_year AS ds__extract_year
+                , subq_1.ds__extract_quarter AS ds__extract_quarter
+                , subq_1.ds__extract_month AS ds__extract_month
+                , subq_1.ds__extract_day AS ds__extract_day
+                , subq_1.ds__extract_dow AS ds__extract_dow
+                , subq_1.ds__extract_doy AS ds__extract_doy
+                , subq_1.ds_partitioned__day AS ds_partitioned__day
+                , subq_1.ds_partitioned__week AS ds_partitioned__week
+                , subq_1.ds_partitioned__month AS ds_partitioned__month
+                , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
+                , subq_1.ds_partitioned__year AS ds_partitioned__year
+                , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
+                , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+                , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
+                , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
+                , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+                , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+                , subq_1.paid_at__day AS paid_at__day
+                , subq_1.paid_at__week AS paid_at__week
+                , subq_1.paid_at__month AS paid_at__month
+                , subq_1.paid_at__quarter AS paid_at__quarter
+                , subq_1.paid_at__year AS paid_at__year
+                , subq_1.paid_at__extract_year AS paid_at__extract_year
+                , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
+                , subq_1.paid_at__extract_month AS paid_at__extract_month
+                , subq_1.paid_at__extract_day AS paid_at__extract_day
+                , subq_1.paid_at__extract_dow AS paid_at__extract_dow
+                , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+                , subq_1.booking__ds__day AS booking__ds__day
+                , subq_1.booking__ds__week AS booking__ds__week
+                , subq_1.booking__ds__month AS booking__ds__month
+                , subq_1.booking__ds__quarter AS booking__ds__quarter
+                , subq_1.booking__ds__year AS booking__ds__year
+                , subq_1.booking__ds__extract_year AS booking__ds__extract_year
+                , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
+                , subq_1.booking__ds__extract_month AS booking__ds__extract_month
+                , subq_1.booking__ds__extract_day AS booking__ds__extract_day
+                , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
+                , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
+                , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
+                , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
+                , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
+                , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+                , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
+                , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+                , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+                , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+                , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+                , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+                , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+                , subq_1.booking__paid_at__day AS booking__paid_at__day
+                , subq_1.booking__paid_at__week AS booking__paid_at__week
+                , subq_1.booking__paid_at__month AS booking__paid_at__month
+                , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
+                , subq_1.booking__paid_at__year AS booking__paid_at__year
+                , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
+                , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+                , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
+                , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
+                , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+                , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                , subq_1.metric_time__week AS metric_time__week
+                , subq_1.metric_time__month AS metric_time__month
+                , subq_1.metric_time__quarter AS metric_time__quarter
+                , subq_1.metric_time__year AS metric_time__year
+                , subq_1.metric_time__extract_year AS metric_time__extract_year
+                , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+                , subq_1.metric_time__extract_month AS metric_time__extract_month
+                , subq_1.metric_time__extract_day AS metric_time__extract_day
+                , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+                , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+                , subq_2.metric_time__day AS metric_time__day
+                , subq_1.listing AS listing
+                , subq_1.guest AS guest
+                , subq_1.host AS host
+                , subq_1.booking__listing AS booking__listing
+                , subq_1.booking__guest AS booking__guest
+                , subq_1.booking__host AS booking__host
+                , subq_1.is_instant AS is_instant
+                , subq_1.booking__is_instant AS booking__is_instant
+                , subq_1.bookings AS bookings
+                , subq_1.instant_bookings AS instant_bookings
+                , subq_1.booking_value AS booking_value
+                , subq_1.max_booking_value AS max_booking_value
+                , subq_1.min_booking_value AS min_booking_value
+                , subq_1.bookers AS bookers
+                , subq_1.average_booking_value AS average_booking_value
+                , subq_1.referred_bookings AS referred_bookings
+                , subq_1.median_booking_value AS median_booking_value
+                , subq_1.booking_value_p99 AS booking_value_p99
+                , subq_1.discrete_booking_value_p99 AS discrete_booking_value_p99
+                , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+                , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
               FROM (
-                -- Read Elements From Semantic Model 'bookings_source'
+                -- Time Spine
                 SELECT
-                  1 AS bookings
-                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                  , bookings_source_src_28000.booking_value
-                  , bookings_source_src_28000.booking_value AS max_booking_value
-                  , bookings_source_src_28000.booking_value AS min_booking_value
-                  , bookings_source_src_28000.guest_id AS bookers
-                  , bookings_source_src_28000.booking_value AS average_booking_value
-                  , bookings_source_src_28000.booking_value AS booking_payments
-                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-                  , bookings_source_src_28000.booking_value AS median_booking_value
-                  , bookings_source_src_28000.booking_value AS booking_value_p99
-                  , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
-                  , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
-                  , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
-                  , bookings_source_src_28000.is_instant
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                  , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                  , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                  , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                  , bookings_source_src_28000.is_instant AS booking__is_instant
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                  , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                  , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                  , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                  , bookings_source_src_28000.listing_id AS listing
-                  , bookings_source_src_28000.guest_id AS guest
-                  , bookings_source_src_28000.host_id AS host
-                  , bookings_source_src_28000.listing_id AS booking__listing
-                  , bookings_source_src_28000.guest_id AS booking__guest
-                  , bookings_source_src_28000.host_id AS booking__host
-                FROM ***************************.fct_bookings bookings_source_src_28000
-              ) subq_0
-            ) subq_1
-            ON
-              subq_2.metric_time__day - INTERVAL 5 day = subq_1.metric_time__day
-          ) subq_4
-        ) subq_5
-        GROUP BY
-          subq_5.metric_time__day
-      ) subq_6
-    ) subq_7
-  ) subq_8
-  ON
-    subq_9.metric_time__day - INTERVAL 2 day = subq_8.metric_time__day
-) subq_11
+                  subq_3.ds AS metric_time__day
+                FROM ***************************.mf_time_spine subq_3
+              ) subq_2
+              INNER JOIN (
+                -- Metric Time Dimension 'ds'
+                SELECT
+                  subq_0.ds__day
+                  , subq_0.ds__week
+                  , subq_0.ds__month
+                  , subq_0.ds__quarter
+                  , subq_0.ds__year
+                  , subq_0.ds__extract_year
+                  , subq_0.ds__extract_quarter
+                  , subq_0.ds__extract_month
+                  , subq_0.ds__extract_day
+                  , subq_0.ds__extract_dow
+                  , subq_0.ds__extract_doy
+                  , subq_0.ds_partitioned__day
+                  , subq_0.ds_partitioned__week
+                  , subq_0.ds_partitioned__month
+                  , subq_0.ds_partitioned__quarter
+                  , subq_0.ds_partitioned__year
+                  , subq_0.ds_partitioned__extract_year
+                  , subq_0.ds_partitioned__extract_quarter
+                  , subq_0.ds_partitioned__extract_month
+                  , subq_0.ds_partitioned__extract_day
+                  , subq_0.ds_partitioned__extract_dow
+                  , subq_0.ds_partitioned__extract_doy
+                  , subq_0.paid_at__day
+                  , subq_0.paid_at__week
+                  , subq_0.paid_at__month
+                  , subq_0.paid_at__quarter
+                  , subq_0.paid_at__year
+                  , subq_0.paid_at__extract_year
+                  , subq_0.paid_at__extract_quarter
+                  , subq_0.paid_at__extract_month
+                  , subq_0.paid_at__extract_day
+                  , subq_0.paid_at__extract_dow
+                  , subq_0.paid_at__extract_doy
+                  , subq_0.booking__ds__day
+                  , subq_0.booking__ds__week
+                  , subq_0.booking__ds__month
+                  , subq_0.booking__ds__quarter
+                  , subq_0.booking__ds__year
+                  , subq_0.booking__ds__extract_year
+                  , subq_0.booking__ds__extract_quarter
+                  , subq_0.booking__ds__extract_month
+                  , subq_0.booking__ds__extract_day
+                  , subq_0.booking__ds__extract_dow
+                  , subq_0.booking__ds__extract_doy
+                  , subq_0.booking__ds_partitioned__day
+                  , subq_0.booking__ds_partitioned__week
+                  , subq_0.booking__ds_partitioned__month
+                  , subq_0.booking__ds_partitioned__quarter
+                  , subq_0.booking__ds_partitioned__year
+                  , subq_0.booking__ds_partitioned__extract_year
+                  , subq_0.booking__ds_partitioned__extract_quarter
+                  , subq_0.booking__ds_partitioned__extract_month
+                  , subq_0.booking__ds_partitioned__extract_day
+                  , subq_0.booking__ds_partitioned__extract_dow
+                  , subq_0.booking__ds_partitioned__extract_doy
+                  , subq_0.booking__paid_at__day
+                  , subq_0.booking__paid_at__week
+                  , subq_0.booking__paid_at__month
+                  , subq_0.booking__paid_at__quarter
+                  , subq_0.booking__paid_at__year
+                  , subq_0.booking__paid_at__extract_year
+                  , subq_0.booking__paid_at__extract_quarter
+                  , subq_0.booking__paid_at__extract_month
+                  , subq_0.booking__paid_at__extract_day
+                  , subq_0.booking__paid_at__extract_dow
+                  , subq_0.booking__paid_at__extract_doy
+                  , subq_0.ds__day AS metric_time__day
+                  , subq_0.ds__week AS metric_time__week
+                  , subq_0.ds__month AS metric_time__month
+                  , subq_0.ds__quarter AS metric_time__quarter
+                  , subq_0.ds__year AS metric_time__year
+                  , subq_0.ds__extract_year AS metric_time__extract_year
+                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_0.ds__extract_month AS metric_time__extract_month
+                  , subq_0.ds__extract_day AS metric_time__extract_day
+                  , subq_0.ds__extract_dow AS metric_time__extract_dow
+                  , subq_0.ds__extract_doy AS metric_time__extract_doy
+                  , subq_0.listing
+                  , subq_0.guest
+                  , subq_0.host
+                  , subq_0.booking__listing
+                  , subq_0.booking__guest
+                  , subq_0.booking__host
+                  , subq_0.is_instant
+                  , subq_0.booking__is_instant
+                  , subq_0.bookings
+                  , subq_0.instant_bookings
+                  , subq_0.booking_value
+                  , subq_0.max_booking_value
+                  , subq_0.min_booking_value
+                  , subq_0.bookers
+                  , subq_0.average_booking_value
+                  , subq_0.referred_bookings
+                  , subq_0.median_booking_value
+                  , subq_0.booking_value_p99
+                  , subq_0.discrete_booking_value_p99
+                  , subq_0.approximate_continuous_booking_value_p99
+                  , subq_0.approximate_discrete_booking_value_p99
+                FROM (
+                  -- Read Elements From Semantic Model 'bookings_source'
+                  SELECT
+                    1 AS bookings
+                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                    , bookings_source_src_28000.booking_value
+                    , bookings_source_src_28000.booking_value AS max_booking_value
+                    , bookings_source_src_28000.booking_value AS min_booking_value
+                    , bookings_source_src_28000.guest_id AS bookers
+                    , bookings_source_src_28000.booking_value AS average_booking_value
+                    , bookings_source_src_28000.booking_value AS booking_payments
+                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                    , bookings_source_src_28000.booking_value AS median_booking_value
+                    , bookings_source_src_28000.booking_value AS booking_value_p99
+                    , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                    , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                    , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                    , bookings_source_src_28000.is_instant
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                    , bookings_source_src_28000.is_instant AS booking__is_instant
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                    , bookings_source_src_28000.listing_id AS listing
+                    , bookings_source_src_28000.guest_id AS guest
+                    , bookings_source_src_28000.host_id AS host
+                    , bookings_source_src_28000.listing_id AS booking__listing
+                    , bookings_source_src_28000.guest_id AS booking__guest
+                    , bookings_source_src_28000.host_id AS booking__host
+                  FROM ***************************.fct_bookings bookings_source_src_28000
+                ) subq_0
+              ) subq_1
+              ON
+                subq_2.metric_time__day - INTERVAL 5 day = subq_1.metric_time__day
+            ) subq_4
+          ) subq_5
+          GROUP BY
+            subq_5.metric_time__day
+        ) subq_6
+      ) subq_7
+    ) subq_8
+    ON
+      subq_9.metric_time__day - INTERVAL 2 day = subq_8.metric_time__day
+  ) subq_11
+  WHERE subq_11.metric_time__day BETWEEN '2020-01-12' AND '2020-01-13'
+) subq_12

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_offsets_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_offsets_with_time_constraint__plan0_optimized.sql
@@ -8,16 +8,11 @@ SELECT
   , 2 * bookings_offset_once AS bookings_offset_twice
 FROM (
   -- Join to Time Spine Dataset
+  -- Constrain Time Range to [2020-01-12T00:00:00, 2020-01-13T00:00:00]
   SELECT
-    subq_21.metric_time__day AS metric_time__day
-    , subq_20.bookings_offset_once AS bookings_offset_once
-  FROM (
-    -- Time Spine
-    SELECT
-      ds AS metric_time__day
-    FROM ***************************.mf_time_spine subq_22
-    WHERE ds BETWEEN '2020-01-12' AND '2020-01-13'
-  ) subq_21
+    subq_23.ds AS metric_time__day
+    , subq_21.bookings_offset_once AS bookings_offset_once
+  FROM ***************************.mf_time_spine subq_23
   INNER JOIN (
     -- Compute Metrics via Expressions
     SELECT
@@ -29,9 +24,9 @@ FROM (
       -- Aggregate Measures
       -- Compute Metrics via Expressions
       SELECT
-        subq_15.ds AS metric_time__day
-        , SUM(subq_13.bookings) AS bookings
-      FROM ***************************.mf_time_spine subq_15
+        subq_16.ds AS metric_time__day
+        , SUM(subq_14.bookings) AS bookings
+      FROM ***************************.mf_time_spine subq_16
       INNER JOIN (
         -- Read Elements From Semantic Model 'bookings_source'
         -- Metric Time Dimension 'ds'
@@ -39,13 +34,14 @@ FROM (
           DATE_TRUNC('day', ds) AS metric_time__day
           , 1 AS bookings
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_13
+      ) subq_14
       ON
-        subq_15.ds - INTERVAL 5 day = subq_13.metric_time__day
+        subq_16.ds - INTERVAL 5 day = subq_14.metric_time__day
       GROUP BY
-        subq_15.ds
-    ) subq_19
-  ) subq_20
+        subq_16.ds
+    ) subq_20
+  ) subq_21
   ON
-    subq_21.metric_time__day - INTERVAL 2 day = subq_20.metric_time__day
-) subq_23
+    subq_23.ds - INTERVAL 2 day = subq_21.metric_time__day
+  WHERE subq_23.ds BETWEEN '2020-01-12' AND '2020-01-13'
+) subq_25

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_time_offset_metric_with_time_constraint__plan0.sql
@@ -4,331 +4,433 @@ sql_engine: DuckDB
 ---
 -- Compute Metrics via Expressions
 SELECT
-  subq_7.metric_time__day
+  subq_8.metric_time__day
   , bookings_5_days_ago AS bookings_5_day_lag
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_6.metric_time__day
-    , subq_6.bookings AS bookings_5_days_ago
+    subq_7.metric_time__day
+    , subq_7.bookings AS bookings_5_days_ago
   FROM (
     -- Aggregate Measures
     SELECT
-      subq_5.metric_time__day
-      , SUM(subq_5.bookings) AS bookings
+      subq_6.metric_time__day
+      , SUM(subq_6.bookings) AS bookings
     FROM (
       -- Pass Only Elements: ['bookings', 'metric_time__day']
       SELECT
-        subq_4.metric_time__day
-        , subq_4.bookings
+        subq_5.metric_time__day
+        , subq_5.bookings
       FROM (
-        -- Join to Time Spine Dataset
+        -- Constrain Time Range to [2019-12-19T00:00:00, 2020-01-02T00:00:00]
         SELECT
-          subq_1.ds__day AS ds__day
-          , subq_1.ds__week AS ds__week
-          , subq_1.ds__month AS ds__month
-          , subq_1.ds__quarter AS ds__quarter
-          , subq_1.ds__year AS ds__year
-          , subq_1.ds__extract_year AS ds__extract_year
-          , subq_1.ds__extract_quarter AS ds__extract_quarter
-          , subq_1.ds__extract_month AS ds__extract_month
-          , subq_1.ds__extract_day AS ds__extract_day
-          , subq_1.ds__extract_dow AS ds__extract_dow
-          , subq_1.ds__extract_doy AS ds__extract_doy
-          , subq_1.ds_partitioned__day AS ds_partitioned__day
-          , subq_1.ds_partitioned__week AS ds_partitioned__week
-          , subq_1.ds_partitioned__month AS ds_partitioned__month
-          , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
-          , subq_1.ds_partitioned__year AS ds_partitioned__year
-          , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
-          , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
-          , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
-          , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
-          , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
-          , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
-          , subq_1.paid_at__day AS paid_at__day
-          , subq_1.paid_at__week AS paid_at__week
-          , subq_1.paid_at__month AS paid_at__month
-          , subq_1.paid_at__quarter AS paid_at__quarter
-          , subq_1.paid_at__year AS paid_at__year
-          , subq_1.paid_at__extract_year AS paid_at__extract_year
-          , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
-          , subq_1.paid_at__extract_month AS paid_at__extract_month
-          , subq_1.paid_at__extract_day AS paid_at__extract_day
-          , subq_1.paid_at__extract_dow AS paid_at__extract_dow
-          , subq_1.paid_at__extract_doy AS paid_at__extract_doy
-          , subq_1.booking__ds__day AS booking__ds__day
-          , subq_1.booking__ds__week AS booking__ds__week
-          , subq_1.booking__ds__month AS booking__ds__month
-          , subq_1.booking__ds__quarter AS booking__ds__quarter
-          , subq_1.booking__ds__year AS booking__ds__year
-          , subq_1.booking__ds__extract_year AS booking__ds__extract_year
-          , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
-          , subq_1.booking__ds__extract_month AS booking__ds__extract_month
-          , subq_1.booking__ds__extract_day AS booking__ds__extract_day
-          , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
-          , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
-          , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
-          , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
-          , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
-          , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
-          , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
-          , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
-          , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
-          , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
-          , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
-          , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
-          , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
-          , subq_1.booking__paid_at__day AS booking__paid_at__day
-          , subq_1.booking__paid_at__week AS booking__paid_at__week
-          , subq_1.booking__paid_at__month AS booking__paid_at__month
-          , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
-          , subq_1.booking__paid_at__year AS booking__paid_at__year
-          , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
-          , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
-          , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
-          , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
-          , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
-          , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
-          , subq_1.metric_time__week AS metric_time__week
-          , subq_1.metric_time__month AS metric_time__month
-          , subq_1.metric_time__quarter AS metric_time__quarter
-          , subq_1.metric_time__year AS metric_time__year
-          , subq_1.metric_time__extract_year AS metric_time__extract_year
-          , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
-          , subq_1.metric_time__extract_month AS metric_time__extract_month
-          , subq_1.metric_time__extract_day AS metric_time__extract_day
-          , subq_1.metric_time__extract_dow AS metric_time__extract_dow
-          , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-          , subq_2.metric_time__day AS metric_time__day
-          , subq_1.listing AS listing
-          , subq_1.guest AS guest
-          , subq_1.host AS host
-          , subq_1.booking__listing AS booking__listing
-          , subq_1.booking__guest AS booking__guest
-          , subq_1.booking__host AS booking__host
-          , subq_1.is_instant AS is_instant
-          , subq_1.booking__is_instant AS booking__is_instant
-          , subq_1.bookings AS bookings
-          , subq_1.instant_bookings AS instant_bookings
-          , subq_1.booking_value AS booking_value
-          , subq_1.max_booking_value AS max_booking_value
-          , subq_1.min_booking_value AS min_booking_value
-          , subq_1.bookers AS bookers
-          , subq_1.average_booking_value AS average_booking_value
-          , subq_1.referred_bookings AS referred_bookings
-          , subq_1.median_booking_value AS median_booking_value
-          , subq_1.booking_value_p99 AS booking_value_p99
-          , subq_1.discrete_booking_value_p99 AS discrete_booking_value_p99
-          , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
-          , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+          subq_4.metric_time__day
+          , subq_4.ds__day
+          , subq_4.ds__week
+          , subq_4.ds__month
+          , subq_4.ds__quarter
+          , subq_4.ds__year
+          , subq_4.ds__extract_year
+          , subq_4.ds__extract_quarter
+          , subq_4.ds__extract_month
+          , subq_4.ds__extract_day
+          , subq_4.ds__extract_dow
+          , subq_4.ds__extract_doy
+          , subq_4.ds_partitioned__day
+          , subq_4.ds_partitioned__week
+          , subq_4.ds_partitioned__month
+          , subq_4.ds_partitioned__quarter
+          , subq_4.ds_partitioned__year
+          , subq_4.ds_partitioned__extract_year
+          , subq_4.ds_partitioned__extract_quarter
+          , subq_4.ds_partitioned__extract_month
+          , subq_4.ds_partitioned__extract_day
+          , subq_4.ds_partitioned__extract_dow
+          , subq_4.ds_partitioned__extract_doy
+          , subq_4.paid_at__day
+          , subq_4.paid_at__week
+          , subq_4.paid_at__month
+          , subq_4.paid_at__quarter
+          , subq_4.paid_at__year
+          , subq_4.paid_at__extract_year
+          , subq_4.paid_at__extract_quarter
+          , subq_4.paid_at__extract_month
+          , subq_4.paid_at__extract_day
+          , subq_4.paid_at__extract_dow
+          , subq_4.paid_at__extract_doy
+          , subq_4.booking__ds__day
+          , subq_4.booking__ds__week
+          , subq_4.booking__ds__month
+          , subq_4.booking__ds__quarter
+          , subq_4.booking__ds__year
+          , subq_4.booking__ds__extract_year
+          , subq_4.booking__ds__extract_quarter
+          , subq_4.booking__ds__extract_month
+          , subq_4.booking__ds__extract_day
+          , subq_4.booking__ds__extract_dow
+          , subq_4.booking__ds__extract_doy
+          , subq_4.booking__ds_partitioned__day
+          , subq_4.booking__ds_partitioned__week
+          , subq_4.booking__ds_partitioned__month
+          , subq_4.booking__ds_partitioned__quarter
+          , subq_4.booking__ds_partitioned__year
+          , subq_4.booking__ds_partitioned__extract_year
+          , subq_4.booking__ds_partitioned__extract_quarter
+          , subq_4.booking__ds_partitioned__extract_month
+          , subq_4.booking__ds_partitioned__extract_day
+          , subq_4.booking__ds_partitioned__extract_dow
+          , subq_4.booking__ds_partitioned__extract_doy
+          , subq_4.booking__paid_at__day
+          , subq_4.booking__paid_at__week
+          , subq_4.booking__paid_at__month
+          , subq_4.booking__paid_at__quarter
+          , subq_4.booking__paid_at__year
+          , subq_4.booking__paid_at__extract_year
+          , subq_4.booking__paid_at__extract_quarter
+          , subq_4.booking__paid_at__extract_month
+          , subq_4.booking__paid_at__extract_day
+          , subq_4.booking__paid_at__extract_dow
+          , subq_4.booking__paid_at__extract_doy
+          , subq_4.metric_time__week
+          , subq_4.metric_time__month
+          , subq_4.metric_time__quarter
+          , subq_4.metric_time__year
+          , subq_4.metric_time__extract_year
+          , subq_4.metric_time__extract_quarter
+          , subq_4.metric_time__extract_month
+          , subq_4.metric_time__extract_day
+          , subq_4.metric_time__extract_dow
+          , subq_4.metric_time__extract_doy
+          , subq_4.listing
+          , subq_4.guest
+          , subq_4.host
+          , subq_4.booking__listing
+          , subq_4.booking__guest
+          , subq_4.booking__host
+          , subq_4.is_instant
+          , subq_4.booking__is_instant
+          , subq_4.bookings
+          , subq_4.instant_bookings
+          , subq_4.booking_value
+          , subq_4.max_booking_value
+          , subq_4.min_booking_value
+          , subq_4.bookers
+          , subq_4.average_booking_value
+          , subq_4.referred_bookings
+          , subq_4.median_booking_value
+          , subq_4.booking_value_p99
+          , subq_4.discrete_booking_value_p99
+          , subq_4.approximate_continuous_booking_value_p99
+          , subq_4.approximate_discrete_booking_value_p99
         FROM (
-          -- Time Spine
+          -- Join to Time Spine Dataset
           SELECT
-            subq_3.ds AS metric_time__day
-          FROM ***************************.mf_time_spine subq_3
-          WHERE subq_3.ds BETWEEN '2019-12-19' AND '2020-01-02'
-        ) subq_2
-        INNER JOIN (
-          -- Metric Time Dimension 'ds'
-          SELECT
-            subq_0.ds__day
-            , subq_0.ds__week
-            , subq_0.ds__month
-            , subq_0.ds__quarter
-            , subq_0.ds__year
-            , subq_0.ds__extract_year
-            , subq_0.ds__extract_quarter
-            , subq_0.ds__extract_month
-            , subq_0.ds__extract_day
-            , subq_0.ds__extract_dow
-            , subq_0.ds__extract_doy
-            , subq_0.ds_partitioned__day
-            , subq_0.ds_partitioned__week
-            , subq_0.ds_partitioned__month
-            , subq_0.ds_partitioned__quarter
-            , subq_0.ds_partitioned__year
-            , subq_0.ds_partitioned__extract_year
-            , subq_0.ds_partitioned__extract_quarter
-            , subq_0.ds_partitioned__extract_month
-            , subq_0.ds_partitioned__extract_day
-            , subq_0.ds_partitioned__extract_dow
-            , subq_0.ds_partitioned__extract_doy
-            , subq_0.paid_at__day
-            , subq_0.paid_at__week
-            , subq_0.paid_at__month
-            , subq_0.paid_at__quarter
-            , subq_0.paid_at__year
-            , subq_0.paid_at__extract_year
-            , subq_0.paid_at__extract_quarter
-            , subq_0.paid_at__extract_month
-            , subq_0.paid_at__extract_day
-            , subq_0.paid_at__extract_dow
-            , subq_0.paid_at__extract_doy
-            , subq_0.booking__ds__day
-            , subq_0.booking__ds__week
-            , subq_0.booking__ds__month
-            , subq_0.booking__ds__quarter
-            , subq_0.booking__ds__year
-            , subq_0.booking__ds__extract_year
-            , subq_0.booking__ds__extract_quarter
-            , subq_0.booking__ds__extract_month
-            , subq_0.booking__ds__extract_day
-            , subq_0.booking__ds__extract_dow
-            , subq_0.booking__ds__extract_doy
-            , subq_0.booking__ds_partitioned__day
-            , subq_0.booking__ds_partitioned__week
-            , subq_0.booking__ds_partitioned__month
-            , subq_0.booking__ds_partitioned__quarter
-            , subq_0.booking__ds_partitioned__year
-            , subq_0.booking__ds_partitioned__extract_year
-            , subq_0.booking__ds_partitioned__extract_quarter
-            , subq_0.booking__ds_partitioned__extract_month
-            , subq_0.booking__ds_partitioned__extract_day
-            , subq_0.booking__ds_partitioned__extract_dow
-            , subq_0.booking__ds_partitioned__extract_doy
-            , subq_0.booking__paid_at__day
-            , subq_0.booking__paid_at__week
-            , subq_0.booking__paid_at__month
-            , subq_0.booking__paid_at__quarter
-            , subq_0.booking__paid_at__year
-            , subq_0.booking__paid_at__extract_year
-            , subq_0.booking__paid_at__extract_quarter
-            , subq_0.booking__paid_at__extract_month
-            , subq_0.booking__paid_at__extract_day
-            , subq_0.booking__paid_at__extract_dow
-            , subq_0.booking__paid_at__extract_doy
-            , subq_0.ds__day AS metric_time__day
-            , subq_0.ds__week AS metric_time__week
-            , subq_0.ds__month AS metric_time__month
-            , subq_0.ds__quarter AS metric_time__quarter
-            , subq_0.ds__year AS metric_time__year
-            , subq_0.ds__extract_year AS metric_time__extract_year
-            , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-            , subq_0.ds__extract_month AS metric_time__extract_month
-            , subq_0.ds__extract_day AS metric_time__extract_day
-            , subq_0.ds__extract_dow AS metric_time__extract_dow
-            , subq_0.ds__extract_doy AS metric_time__extract_doy
-            , subq_0.listing
-            , subq_0.guest
-            , subq_0.host
-            , subq_0.booking__listing
-            , subq_0.booking__guest
-            , subq_0.booking__host
-            , subq_0.is_instant
-            , subq_0.booking__is_instant
-            , subq_0.bookings
-            , subq_0.instant_bookings
-            , subq_0.booking_value
-            , subq_0.max_booking_value
-            , subq_0.min_booking_value
-            , subq_0.bookers
-            , subq_0.average_booking_value
-            , subq_0.referred_bookings
-            , subq_0.median_booking_value
-            , subq_0.booking_value_p99
-            , subq_0.discrete_booking_value_p99
-            , subq_0.approximate_continuous_booking_value_p99
-            , subq_0.approximate_discrete_booking_value_p99
+            subq_1.ds__day AS ds__day
+            , subq_1.ds__week AS ds__week
+            , subq_1.ds__month AS ds__month
+            , subq_1.ds__quarter AS ds__quarter
+            , subq_1.ds__year AS ds__year
+            , subq_1.ds__extract_year AS ds__extract_year
+            , subq_1.ds__extract_quarter AS ds__extract_quarter
+            , subq_1.ds__extract_month AS ds__extract_month
+            , subq_1.ds__extract_day AS ds__extract_day
+            , subq_1.ds__extract_dow AS ds__extract_dow
+            , subq_1.ds__extract_doy AS ds__extract_doy
+            , subq_1.ds_partitioned__day AS ds_partitioned__day
+            , subq_1.ds_partitioned__week AS ds_partitioned__week
+            , subq_1.ds_partitioned__month AS ds_partitioned__month
+            , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
+            , subq_1.ds_partitioned__year AS ds_partitioned__year
+            , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
+            , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+            , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
+            , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
+            , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+            , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+            , subq_1.paid_at__day AS paid_at__day
+            , subq_1.paid_at__week AS paid_at__week
+            , subq_1.paid_at__month AS paid_at__month
+            , subq_1.paid_at__quarter AS paid_at__quarter
+            , subq_1.paid_at__year AS paid_at__year
+            , subq_1.paid_at__extract_year AS paid_at__extract_year
+            , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
+            , subq_1.paid_at__extract_month AS paid_at__extract_month
+            , subq_1.paid_at__extract_day AS paid_at__extract_day
+            , subq_1.paid_at__extract_dow AS paid_at__extract_dow
+            , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+            , subq_1.booking__ds__day AS booking__ds__day
+            , subq_1.booking__ds__week AS booking__ds__week
+            , subq_1.booking__ds__month AS booking__ds__month
+            , subq_1.booking__ds__quarter AS booking__ds__quarter
+            , subq_1.booking__ds__year AS booking__ds__year
+            , subq_1.booking__ds__extract_year AS booking__ds__extract_year
+            , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
+            , subq_1.booking__ds__extract_month AS booking__ds__extract_month
+            , subq_1.booking__ds__extract_day AS booking__ds__extract_day
+            , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
+            , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
+            , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
+            , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
+            , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
+            , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+            , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
+            , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+            , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+            , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+            , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+            , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+            , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+            , subq_1.booking__paid_at__day AS booking__paid_at__day
+            , subq_1.booking__paid_at__week AS booking__paid_at__week
+            , subq_1.booking__paid_at__month AS booking__paid_at__month
+            , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
+            , subq_1.booking__paid_at__year AS booking__paid_at__year
+            , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
+            , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+            , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
+            , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
+            , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+            , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_1.metric_time__week AS metric_time__week
+            , subq_1.metric_time__month AS metric_time__month
+            , subq_1.metric_time__quarter AS metric_time__quarter
+            , subq_1.metric_time__year AS metric_time__year
+            , subq_1.metric_time__extract_year AS metric_time__extract_year
+            , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_1.metric_time__extract_month AS metric_time__extract_month
+            , subq_1.metric_time__extract_day AS metric_time__extract_day
+            , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_2.metric_time__day AS metric_time__day
+            , subq_1.listing AS listing
+            , subq_1.guest AS guest
+            , subq_1.host AS host
+            , subq_1.booking__listing AS booking__listing
+            , subq_1.booking__guest AS booking__guest
+            , subq_1.booking__host AS booking__host
+            , subq_1.is_instant AS is_instant
+            , subq_1.booking__is_instant AS booking__is_instant
+            , subq_1.bookings AS bookings
+            , subq_1.instant_bookings AS instant_bookings
+            , subq_1.booking_value AS booking_value
+            , subq_1.max_booking_value AS max_booking_value
+            , subq_1.min_booking_value AS min_booking_value
+            , subq_1.bookers AS bookers
+            , subq_1.average_booking_value AS average_booking_value
+            , subq_1.referred_bookings AS referred_bookings
+            , subq_1.median_booking_value AS median_booking_value
+            , subq_1.booking_value_p99 AS booking_value_p99
+            , subq_1.discrete_booking_value_p99 AS discrete_booking_value_p99
+            , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+            , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Read Elements From Semantic Model 'bookings_source'
+            -- Time Spine
             SELECT
-              1 AS bookings
-              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-              , bookings_source_src_28000.booking_value
-              , bookings_source_src_28000.booking_value AS max_booking_value
-              , bookings_source_src_28000.booking_value AS min_booking_value
-              , bookings_source_src_28000.guest_id AS bookers
-              , bookings_source_src_28000.booking_value AS average_booking_value
-              , bookings_source_src_28000.booking_value AS booking_payments
-              , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-              , bookings_source_src_28000.booking_value AS median_booking_value
-              , bookings_source_src_28000.booking_value AS booking_value_p99
-              , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
-              , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
-              , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
-              , bookings_source_src_28000.is_instant
-              , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-              , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-              , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-              , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-              , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-              , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-              , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-              , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
-              , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-              , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-              , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-              , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-              , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-              , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-              , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-              , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
-              , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-              , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-              , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-              , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-              , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-              , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-              , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-              , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
-              , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-              , bookings_source_src_28000.is_instant AS booking__is_instant
-              , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-              , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-              , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-              , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-              , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-              , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-              , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-              , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
-              , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-              , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-              , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-              , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-              , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-              , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-              , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-              , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
-              , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-              , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-              , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-              , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-              , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-              , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-              , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
-              , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-              , bookings_source_src_28000.listing_id AS listing
-              , bookings_source_src_28000.guest_id AS guest
-              , bookings_source_src_28000.host_id AS host
-              , bookings_source_src_28000.listing_id AS booking__listing
-              , bookings_source_src_28000.guest_id AS booking__guest
-              , bookings_source_src_28000.host_id AS booking__host
-            FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_0
-        ) subq_1
-        ON
-          subq_2.metric_time__day - INTERVAL 5 day = subq_1.metric_time__day
-      ) subq_4
-    ) subq_5
+              subq_3.ds AS metric_time__day
+            FROM ***************************.mf_time_spine subq_3
+          ) subq_2
+          INNER JOIN (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.ds_partitioned__day
+              , subq_0.ds_partitioned__week
+              , subq_0.ds_partitioned__month
+              , subq_0.ds_partitioned__quarter
+              , subq_0.ds_partitioned__year
+              , subq_0.ds_partitioned__extract_year
+              , subq_0.ds_partitioned__extract_quarter
+              , subq_0.ds_partitioned__extract_month
+              , subq_0.ds_partitioned__extract_day
+              , subq_0.ds_partitioned__extract_dow
+              , subq_0.ds_partitioned__extract_doy
+              , subq_0.paid_at__day
+              , subq_0.paid_at__week
+              , subq_0.paid_at__month
+              , subq_0.paid_at__quarter
+              , subq_0.paid_at__year
+              , subq_0.paid_at__extract_year
+              , subq_0.paid_at__extract_quarter
+              , subq_0.paid_at__extract_month
+              , subq_0.paid_at__extract_day
+              , subq_0.paid_at__extract_dow
+              , subq_0.paid_at__extract_doy
+              , subq_0.booking__ds__day
+              , subq_0.booking__ds__week
+              , subq_0.booking__ds__month
+              , subq_0.booking__ds__quarter
+              , subq_0.booking__ds__year
+              , subq_0.booking__ds__extract_year
+              , subq_0.booking__ds__extract_quarter
+              , subq_0.booking__ds__extract_month
+              , subq_0.booking__ds__extract_day
+              , subq_0.booking__ds__extract_dow
+              , subq_0.booking__ds__extract_doy
+              , subq_0.booking__ds_partitioned__day
+              , subq_0.booking__ds_partitioned__week
+              , subq_0.booking__ds_partitioned__month
+              , subq_0.booking__ds_partitioned__quarter
+              , subq_0.booking__ds_partitioned__year
+              , subq_0.booking__ds_partitioned__extract_year
+              , subq_0.booking__ds_partitioned__extract_quarter
+              , subq_0.booking__ds_partitioned__extract_month
+              , subq_0.booking__ds_partitioned__extract_day
+              , subq_0.booking__ds_partitioned__extract_dow
+              , subq_0.booking__ds_partitioned__extract_doy
+              , subq_0.booking__paid_at__day
+              , subq_0.booking__paid_at__week
+              , subq_0.booking__paid_at__month
+              , subq_0.booking__paid_at__quarter
+              , subq_0.booking__paid_at__year
+              , subq_0.booking__paid_at__extract_year
+              , subq_0.booking__paid_at__extract_quarter
+              , subq_0.booking__paid_at__extract_month
+              , subq_0.booking__paid_at__extract_day
+              , subq_0.booking__paid_at__extract_dow
+              , subq_0.booking__paid_at__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.listing
+              , subq_0.guest
+              , subq_0.host
+              , subq_0.booking__listing
+              , subq_0.booking__guest
+              , subq_0.booking__host
+              , subq_0.is_instant
+              , subq_0.booking__is_instant
+              , subq_0.bookings
+              , subq_0.instant_bookings
+              , subq_0.booking_value
+              , subq_0.max_booking_value
+              , subq_0.min_booking_value
+              , subq_0.bookers
+              , subq_0.average_booking_value
+              , subq_0.referred_bookings
+              , subq_0.median_booking_value
+              , subq_0.booking_value_p99
+              , subq_0.discrete_booking_value_p99
+              , subq_0.approximate_continuous_booking_value_p99
+              , subq_0.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Semantic Model 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_28000.booking_value
+                , bookings_source_src_28000.booking_value AS max_booking_value
+                , bookings_source_src_28000.booking_value AS min_booking_value
+                , bookings_source_src_28000.guest_id AS bookers
+                , bookings_source_src_28000.booking_value AS average_booking_value
+                , bookings_source_src_28000.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_28000.booking_value AS median_booking_value
+                , bookings_source_src_28000.booking_value AS booking_value_p99
+                , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_28000.is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_28000.is_instant AS booking__is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_28000.listing_id AS listing
+                , bookings_source_src_28000.guest_id AS guest
+                , bookings_source_src_28000.host_id AS host
+                , bookings_source_src_28000.listing_id AS booking__listing
+                , bookings_source_src_28000.guest_id AS booking__guest
+                , bookings_source_src_28000.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_28000
+            ) subq_0
+          ) subq_1
+          ON
+            subq_2.metric_time__day - INTERVAL 5 day = subq_1.metric_time__day
+        ) subq_4
+        WHERE subq_4.metric_time__day BETWEEN '2019-12-19' AND '2020-01-02'
+      ) subq_5
+    ) subq_6
     GROUP BY
-      subq_5.metric_time__day
-  ) subq_6
-) subq_7
+      subq_6.metric_time__day
+  ) subq_7
+) subq_8

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_time_offset_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_time_offset_metric_with_time_constraint__plan0_optimized.sql
@@ -8,19 +8,14 @@ SELECT
   , bookings_5_days_ago AS bookings_5_day_lag
 FROM (
   -- Join to Time Spine Dataset
+  -- Constrain Time Range to [2019-12-19T00:00:00, 2020-01-02T00:00:00]
   -- Pass Only Elements: ['bookings', 'metric_time__day']
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT
-    subq_10.metric_time__day AS metric_time__day
-    , SUM(subq_9.bookings) AS bookings_5_days_ago
-  FROM (
-    -- Time Spine
-    SELECT
-      ds AS metric_time__day
-    FROM ***************************.mf_time_spine subq_11
-    WHERE ds BETWEEN '2019-12-19' AND '2020-01-02'
-  ) subq_10
+    subq_12.ds AS metric_time__day
+    , SUM(subq_10.bookings) AS bookings_5_days_ago
+  FROM ***************************.mf_time_spine subq_12
   INNER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -28,9 +23,10 @@ FROM (
       DATE_TRUNC('day', ds) AS metric_time__day
       , 1 AS bookings
     FROM ***************************.fct_bookings bookings_source_src_28000
-  ) subq_9
+  ) subq_10
   ON
-    subq_10.metric_time__day - INTERVAL 5 day = subq_9.metric_time__day
+    subq_12.ds - INTERVAL 5 day = subq_10.metric_time__day
+  WHERE subq_12.ds BETWEEN '2019-12-19' AND '2020-01-02'
   GROUP BY
-    subq_10.metric_time__day
-) subq_15
+    subq_12.ds
+) subq_17

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
@@ -228,7 +228,6 @@ FROM (
             SELECT
               subq_6.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_6
-            WHERE subq_6.ds BETWEEN '2019-12-19' AND '2020-01-02'
           ) subq_5
           INNER JOIN (
             -- Join Self Over Time Range

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_time_offset_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_time_offset_metric_with_time_constraint__plan0_optimized.sql
@@ -13,15 +13,9 @@ FROM (
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT
-    subq_17.metric_time__day AS metric_time__day
+    subq_18.ds AS metric_time__day
     , COUNT(DISTINCT subq_16.bookers) AS every_2_days_bookers_2_days_ago
-  FROM (
-    -- Time Spine
-    SELECT
-      ds AS metric_time__day
-    FROM ***************************.mf_time_spine subq_18
-    WHERE ds BETWEEN '2019-12-19' AND '2020-01-02'
-  ) subq_17
+  FROM ***************************.mf_time_spine subq_18
   INNER JOIN (
     -- Join Self Over Time Range
     SELECT
@@ -38,8 +32,8 @@ FROM (
       )
   ) subq_16
   ON
-    subq_17.metric_time__day - MAKE_INTERVAL(days => 2) = subq_16.metric_time__day
-  WHERE subq_17.metric_time__day BETWEEN '2019-12-19' AND '2020-01-02'
+    subq_18.ds - MAKE_INTERVAL(days => 2) = subq_16.metric_time__day
+  WHERE subq_18.ds BETWEEN '2019-12-19' AND '2020-01-02'
   GROUP BY
-    subq_17.metric_time__day
+    subq_18.ds
 ) subq_23

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_offsets_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_offsets_with_time_constraint__plan0.sql
@@ -4,351 +4,357 @@ sql_engine: Postgres
 ---
 -- Compute Metrics via Expressions
 SELECT
-  subq_11.metric_time__day
+  subq_12.metric_time__day
   , 2 * bookings_offset_once AS bookings_offset_twice
 FROM (
-  -- Join to Time Spine Dataset
+  -- Constrain Time Range to [2020-01-12T00:00:00, 2020-01-13T00:00:00]
   SELECT
-    subq_9.metric_time__day AS metric_time__day
-    , subq_8.bookings_offset_once AS bookings_offset_once
+    subq_11.metric_time__day
+    , subq_11.bookings_offset_once
   FROM (
-    -- Time Spine
+    -- Join to Time Spine Dataset
     SELECT
-      subq_10.ds AS metric_time__day
-    FROM ***************************.mf_time_spine subq_10
-    WHERE subq_10.ds BETWEEN '2020-01-12' AND '2020-01-13'
-  ) subq_9
-  INNER JOIN (
-    -- Compute Metrics via Expressions
-    SELECT
-      subq_7.metric_time__day
-      , 2 * bookings AS bookings_offset_once
+      subq_9.metric_time__day AS metric_time__day
+      , subq_8.bookings_offset_once AS bookings_offset_once
     FROM (
+      -- Time Spine
+      SELECT
+        subq_10.ds AS metric_time__day
+      FROM ***************************.mf_time_spine subq_10
+    ) subq_9
+    INNER JOIN (
       -- Compute Metrics via Expressions
       SELECT
-        subq_6.metric_time__day
-        , subq_6.bookings
+        subq_7.metric_time__day
+        , 2 * bookings AS bookings_offset_once
       FROM (
-        -- Aggregate Measures
+        -- Compute Metrics via Expressions
         SELECT
-          subq_5.metric_time__day
-          , SUM(subq_5.bookings) AS bookings
+          subq_6.metric_time__day
+          , subq_6.bookings
         FROM (
-          -- Pass Only Elements: ['bookings', 'metric_time__day']
+          -- Aggregate Measures
           SELECT
-            subq_4.metric_time__day
-            , subq_4.bookings
+            subq_5.metric_time__day
+            , SUM(subq_5.bookings) AS bookings
           FROM (
-            -- Join to Time Spine Dataset
+            -- Pass Only Elements: ['bookings', 'metric_time__day']
             SELECT
-              subq_1.ds__day AS ds__day
-              , subq_1.ds__week AS ds__week
-              , subq_1.ds__month AS ds__month
-              , subq_1.ds__quarter AS ds__quarter
-              , subq_1.ds__year AS ds__year
-              , subq_1.ds__extract_year AS ds__extract_year
-              , subq_1.ds__extract_quarter AS ds__extract_quarter
-              , subq_1.ds__extract_month AS ds__extract_month
-              , subq_1.ds__extract_day AS ds__extract_day
-              , subq_1.ds__extract_dow AS ds__extract_dow
-              , subq_1.ds__extract_doy AS ds__extract_doy
-              , subq_1.ds_partitioned__day AS ds_partitioned__day
-              , subq_1.ds_partitioned__week AS ds_partitioned__week
-              , subq_1.ds_partitioned__month AS ds_partitioned__month
-              , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
-              , subq_1.ds_partitioned__year AS ds_partitioned__year
-              , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
-              , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
-              , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
-              , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
-              , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
-              , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
-              , subq_1.paid_at__day AS paid_at__day
-              , subq_1.paid_at__week AS paid_at__week
-              , subq_1.paid_at__month AS paid_at__month
-              , subq_1.paid_at__quarter AS paid_at__quarter
-              , subq_1.paid_at__year AS paid_at__year
-              , subq_1.paid_at__extract_year AS paid_at__extract_year
-              , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
-              , subq_1.paid_at__extract_month AS paid_at__extract_month
-              , subq_1.paid_at__extract_day AS paid_at__extract_day
-              , subq_1.paid_at__extract_dow AS paid_at__extract_dow
-              , subq_1.paid_at__extract_doy AS paid_at__extract_doy
-              , subq_1.booking__ds__day AS booking__ds__day
-              , subq_1.booking__ds__week AS booking__ds__week
-              , subq_1.booking__ds__month AS booking__ds__month
-              , subq_1.booking__ds__quarter AS booking__ds__quarter
-              , subq_1.booking__ds__year AS booking__ds__year
-              , subq_1.booking__ds__extract_year AS booking__ds__extract_year
-              , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
-              , subq_1.booking__ds__extract_month AS booking__ds__extract_month
-              , subq_1.booking__ds__extract_day AS booking__ds__extract_day
-              , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
-              , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
-              , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
-              , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
-              , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
-              , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
-              , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
-              , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
-              , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
-              , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
-              , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
-              , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
-              , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
-              , subq_1.booking__paid_at__day AS booking__paid_at__day
-              , subq_1.booking__paid_at__week AS booking__paid_at__week
-              , subq_1.booking__paid_at__month AS booking__paid_at__month
-              , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
-              , subq_1.booking__paid_at__year AS booking__paid_at__year
-              , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
-              , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
-              , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
-              , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
-              , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
-              , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
-              , subq_1.metric_time__week AS metric_time__week
-              , subq_1.metric_time__month AS metric_time__month
-              , subq_1.metric_time__quarter AS metric_time__quarter
-              , subq_1.metric_time__year AS metric_time__year
-              , subq_1.metric_time__extract_year AS metric_time__extract_year
-              , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
-              , subq_1.metric_time__extract_month AS metric_time__extract_month
-              , subq_1.metric_time__extract_day AS metric_time__extract_day
-              , subq_1.metric_time__extract_dow AS metric_time__extract_dow
-              , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-              , subq_2.metric_time__day AS metric_time__day
-              , subq_1.listing AS listing
-              , subq_1.guest AS guest
-              , subq_1.host AS host
-              , subq_1.booking__listing AS booking__listing
-              , subq_1.booking__guest AS booking__guest
-              , subq_1.booking__host AS booking__host
-              , subq_1.is_instant AS is_instant
-              , subq_1.booking__is_instant AS booking__is_instant
-              , subq_1.bookings AS bookings
-              , subq_1.instant_bookings AS instant_bookings
-              , subq_1.booking_value AS booking_value
-              , subq_1.max_booking_value AS max_booking_value
-              , subq_1.min_booking_value AS min_booking_value
-              , subq_1.bookers AS bookers
-              , subq_1.average_booking_value AS average_booking_value
-              , subq_1.referred_bookings AS referred_bookings
-              , subq_1.median_booking_value AS median_booking_value
-              , subq_1.booking_value_p99 AS booking_value_p99
-              , subq_1.discrete_booking_value_p99 AS discrete_booking_value_p99
-              , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
-              , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+              subq_4.metric_time__day
+              , subq_4.bookings
             FROM (
-              -- Time Spine
+              -- Join to Time Spine Dataset
               SELECT
-                subq_3.ds AS metric_time__day
-              FROM ***************************.mf_time_spine subq_3
-            ) subq_2
-            INNER JOIN (
-              -- Metric Time Dimension 'ds'
-              SELECT
-                subq_0.ds__day
-                , subq_0.ds__week
-                , subq_0.ds__month
-                , subq_0.ds__quarter
-                , subq_0.ds__year
-                , subq_0.ds__extract_year
-                , subq_0.ds__extract_quarter
-                , subq_0.ds__extract_month
-                , subq_0.ds__extract_day
-                , subq_0.ds__extract_dow
-                , subq_0.ds__extract_doy
-                , subq_0.ds_partitioned__day
-                , subq_0.ds_partitioned__week
-                , subq_0.ds_partitioned__month
-                , subq_0.ds_partitioned__quarter
-                , subq_0.ds_partitioned__year
-                , subq_0.ds_partitioned__extract_year
-                , subq_0.ds_partitioned__extract_quarter
-                , subq_0.ds_partitioned__extract_month
-                , subq_0.ds_partitioned__extract_day
-                , subq_0.ds_partitioned__extract_dow
-                , subq_0.ds_partitioned__extract_doy
-                , subq_0.paid_at__day
-                , subq_0.paid_at__week
-                , subq_0.paid_at__month
-                , subq_0.paid_at__quarter
-                , subq_0.paid_at__year
-                , subq_0.paid_at__extract_year
-                , subq_0.paid_at__extract_quarter
-                , subq_0.paid_at__extract_month
-                , subq_0.paid_at__extract_day
-                , subq_0.paid_at__extract_dow
-                , subq_0.paid_at__extract_doy
-                , subq_0.booking__ds__day
-                , subq_0.booking__ds__week
-                , subq_0.booking__ds__month
-                , subq_0.booking__ds__quarter
-                , subq_0.booking__ds__year
-                , subq_0.booking__ds__extract_year
-                , subq_0.booking__ds__extract_quarter
-                , subq_0.booking__ds__extract_month
-                , subq_0.booking__ds__extract_day
-                , subq_0.booking__ds__extract_dow
-                , subq_0.booking__ds__extract_doy
-                , subq_0.booking__ds_partitioned__day
-                , subq_0.booking__ds_partitioned__week
-                , subq_0.booking__ds_partitioned__month
-                , subq_0.booking__ds_partitioned__quarter
-                , subq_0.booking__ds_partitioned__year
-                , subq_0.booking__ds_partitioned__extract_year
-                , subq_0.booking__ds_partitioned__extract_quarter
-                , subq_0.booking__ds_partitioned__extract_month
-                , subq_0.booking__ds_partitioned__extract_day
-                , subq_0.booking__ds_partitioned__extract_dow
-                , subq_0.booking__ds_partitioned__extract_doy
-                , subq_0.booking__paid_at__day
-                , subq_0.booking__paid_at__week
-                , subq_0.booking__paid_at__month
-                , subq_0.booking__paid_at__quarter
-                , subq_0.booking__paid_at__year
-                , subq_0.booking__paid_at__extract_year
-                , subq_0.booking__paid_at__extract_quarter
-                , subq_0.booking__paid_at__extract_month
-                , subq_0.booking__paid_at__extract_day
-                , subq_0.booking__paid_at__extract_dow
-                , subq_0.booking__paid_at__extract_doy
-                , subq_0.ds__day AS metric_time__day
-                , subq_0.ds__week AS metric_time__week
-                , subq_0.ds__month AS metric_time__month
-                , subq_0.ds__quarter AS metric_time__quarter
-                , subq_0.ds__year AS metric_time__year
-                , subq_0.ds__extract_year AS metric_time__extract_year
-                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_0.ds__extract_month AS metric_time__extract_month
-                , subq_0.ds__extract_day AS metric_time__extract_day
-                , subq_0.ds__extract_dow AS metric_time__extract_dow
-                , subq_0.ds__extract_doy AS metric_time__extract_doy
-                , subq_0.listing
-                , subq_0.guest
-                , subq_0.host
-                , subq_0.booking__listing
-                , subq_0.booking__guest
-                , subq_0.booking__host
-                , subq_0.is_instant
-                , subq_0.booking__is_instant
-                , subq_0.bookings
-                , subq_0.instant_bookings
-                , subq_0.booking_value
-                , subq_0.max_booking_value
-                , subq_0.min_booking_value
-                , subq_0.bookers
-                , subq_0.average_booking_value
-                , subq_0.referred_bookings
-                , subq_0.median_booking_value
-                , subq_0.booking_value_p99
-                , subq_0.discrete_booking_value_p99
-                , subq_0.approximate_continuous_booking_value_p99
-                , subq_0.approximate_discrete_booking_value_p99
+                subq_1.ds__day AS ds__day
+                , subq_1.ds__week AS ds__week
+                , subq_1.ds__month AS ds__month
+                , subq_1.ds__quarter AS ds__quarter
+                , subq_1.ds__year AS ds__year
+                , subq_1.ds__extract_year AS ds__extract_year
+                , subq_1.ds__extract_quarter AS ds__extract_quarter
+                , subq_1.ds__extract_month AS ds__extract_month
+                , subq_1.ds__extract_day AS ds__extract_day
+                , subq_1.ds__extract_dow AS ds__extract_dow
+                , subq_1.ds__extract_doy AS ds__extract_doy
+                , subq_1.ds_partitioned__day AS ds_partitioned__day
+                , subq_1.ds_partitioned__week AS ds_partitioned__week
+                , subq_1.ds_partitioned__month AS ds_partitioned__month
+                , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
+                , subq_1.ds_partitioned__year AS ds_partitioned__year
+                , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
+                , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+                , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
+                , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
+                , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+                , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+                , subq_1.paid_at__day AS paid_at__day
+                , subq_1.paid_at__week AS paid_at__week
+                , subq_1.paid_at__month AS paid_at__month
+                , subq_1.paid_at__quarter AS paid_at__quarter
+                , subq_1.paid_at__year AS paid_at__year
+                , subq_1.paid_at__extract_year AS paid_at__extract_year
+                , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
+                , subq_1.paid_at__extract_month AS paid_at__extract_month
+                , subq_1.paid_at__extract_day AS paid_at__extract_day
+                , subq_1.paid_at__extract_dow AS paid_at__extract_dow
+                , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+                , subq_1.booking__ds__day AS booking__ds__day
+                , subq_1.booking__ds__week AS booking__ds__week
+                , subq_1.booking__ds__month AS booking__ds__month
+                , subq_1.booking__ds__quarter AS booking__ds__quarter
+                , subq_1.booking__ds__year AS booking__ds__year
+                , subq_1.booking__ds__extract_year AS booking__ds__extract_year
+                , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
+                , subq_1.booking__ds__extract_month AS booking__ds__extract_month
+                , subq_1.booking__ds__extract_day AS booking__ds__extract_day
+                , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
+                , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
+                , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
+                , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
+                , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
+                , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+                , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
+                , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+                , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+                , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+                , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+                , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+                , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+                , subq_1.booking__paid_at__day AS booking__paid_at__day
+                , subq_1.booking__paid_at__week AS booking__paid_at__week
+                , subq_1.booking__paid_at__month AS booking__paid_at__month
+                , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
+                , subq_1.booking__paid_at__year AS booking__paid_at__year
+                , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
+                , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+                , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
+                , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
+                , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+                , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                , subq_1.metric_time__week AS metric_time__week
+                , subq_1.metric_time__month AS metric_time__month
+                , subq_1.metric_time__quarter AS metric_time__quarter
+                , subq_1.metric_time__year AS metric_time__year
+                , subq_1.metric_time__extract_year AS metric_time__extract_year
+                , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+                , subq_1.metric_time__extract_month AS metric_time__extract_month
+                , subq_1.metric_time__extract_day AS metric_time__extract_day
+                , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+                , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+                , subq_2.metric_time__day AS metric_time__day
+                , subq_1.listing AS listing
+                , subq_1.guest AS guest
+                , subq_1.host AS host
+                , subq_1.booking__listing AS booking__listing
+                , subq_1.booking__guest AS booking__guest
+                , subq_1.booking__host AS booking__host
+                , subq_1.is_instant AS is_instant
+                , subq_1.booking__is_instant AS booking__is_instant
+                , subq_1.bookings AS bookings
+                , subq_1.instant_bookings AS instant_bookings
+                , subq_1.booking_value AS booking_value
+                , subq_1.max_booking_value AS max_booking_value
+                , subq_1.min_booking_value AS min_booking_value
+                , subq_1.bookers AS bookers
+                , subq_1.average_booking_value AS average_booking_value
+                , subq_1.referred_bookings AS referred_bookings
+                , subq_1.median_booking_value AS median_booking_value
+                , subq_1.booking_value_p99 AS booking_value_p99
+                , subq_1.discrete_booking_value_p99 AS discrete_booking_value_p99
+                , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+                , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
               FROM (
-                -- Read Elements From Semantic Model 'bookings_source'
+                -- Time Spine
                 SELECT
-                  1 AS bookings
-                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                  , bookings_source_src_28000.booking_value
-                  , bookings_source_src_28000.booking_value AS max_booking_value
-                  , bookings_source_src_28000.booking_value AS min_booking_value
-                  , bookings_source_src_28000.guest_id AS bookers
-                  , bookings_source_src_28000.booking_value AS average_booking_value
-                  , bookings_source_src_28000.booking_value AS booking_payments
-                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-                  , bookings_source_src_28000.booking_value AS median_booking_value
-                  , bookings_source_src_28000.booking_value AS booking_value_p99
-                  , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
-                  , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
-                  , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
-                  , bookings_source_src_28000.is_instant
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                  , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                  , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                  , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                  , bookings_source_src_28000.is_instant AS booking__is_instant
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                  , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                  , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                  , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                  , bookings_source_src_28000.listing_id AS listing
-                  , bookings_source_src_28000.guest_id AS guest
-                  , bookings_source_src_28000.host_id AS host
-                  , bookings_source_src_28000.listing_id AS booking__listing
-                  , bookings_source_src_28000.guest_id AS booking__guest
-                  , bookings_source_src_28000.host_id AS booking__host
-                FROM ***************************.fct_bookings bookings_source_src_28000
-              ) subq_0
-            ) subq_1
-            ON
-              subq_2.metric_time__day - MAKE_INTERVAL(days => 5) = subq_1.metric_time__day
-          ) subq_4
-        ) subq_5
-        GROUP BY
-          subq_5.metric_time__day
-      ) subq_6
-    ) subq_7
-  ) subq_8
-  ON
-    subq_9.metric_time__day - MAKE_INTERVAL(days => 2) = subq_8.metric_time__day
-) subq_11
+                  subq_3.ds AS metric_time__day
+                FROM ***************************.mf_time_spine subq_3
+              ) subq_2
+              INNER JOIN (
+                -- Metric Time Dimension 'ds'
+                SELECT
+                  subq_0.ds__day
+                  , subq_0.ds__week
+                  , subq_0.ds__month
+                  , subq_0.ds__quarter
+                  , subq_0.ds__year
+                  , subq_0.ds__extract_year
+                  , subq_0.ds__extract_quarter
+                  , subq_0.ds__extract_month
+                  , subq_0.ds__extract_day
+                  , subq_0.ds__extract_dow
+                  , subq_0.ds__extract_doy
+                  , subq_0.ds_partitioned__day
+                  , subq_0.ds_partitioned__week
+                  , subq_0.ds_partitioned__month
+                  , subq_0.ds_partitioned__quarter
+                  , subq_0.ds_partitioned__year
+                  , subq_0.ds_partitioned__extract_year
+                  , subq_0.ds_partitioned__extract_quarter
+                  , subq_0.ds_partitioned__extract_month
+                  , subq_0.ds_partitioned__extract_day
+                  , subq_0.ds_partitioned__extract_dow
+                  , subq_0.ds_partitioned__extract_doy
+                  , subq_0.paid_at__day
+                  , subq_0.paid_at__week
+                  , subq_0.paid_at__month
+                  , subq_0.paid_at__quarter
+                  , subq_0.paid_at__year
+                  , subq_0.paid_at__extract_year
+                  , subq_0.paid_at__extract_quarter
+                  , subq_0.paid_at__extract_month
+                  , subq_0.paid_at__extract_day
+                  , subq_0.paid_at__extract_dow
+                  , subq_0.paid_at__extract_doy
+                  , subq_0.booking__ds__day
+                  , subq_0.booking__ds__week
+                  , subq_0.booking__ds__month
+                  , subq_0.booking__ds__quarter
+                  , subq_0.booking__ds__year
+                  , subq_0.booking__ds__extract_year
+                  , subq_0.booking__ds__extract_quarter
+                  , subq_0.booking__ds__extract_month
+                  , subq_0.booking__ds__extract_day
+                  , subq_0.booking__ds__extract_dow
+                  , subq_0.booking__ds__extract_doy
+                  , subq_0.booking__ds_partitioned__day
+                  , subq_0.booking__ds_partitioned__week
+                  , subq_0.booking__ds_partitioned__month
+                  , subq_0.booking__ds_partitioned__quarter
+                  , subq_0.booking__ds_partitioned__year
+                  , subq_0.booking__ds_partitioned__extract_year
+                  , subq_0.booking__ds_partitioned__extract_quarter
+                  , subq_0.booking__ds_partitioned__extract_month
+                  , subq_0.booking__ds_partitioned__extract_day
+                  , subq_0.booking__ds_partitioned__extract_dow
+                  , subq_0.booking__ds_partitioned__extract_doy
+                  , subq_0.booking__paid_at__day
+                  , subq_0.booking__paid_at__week
+                  , subq_0.booking__paid_at__month
+                  , subq_0.booking__paid_at__quarter
+                  , subq_0.booking__paid_at__year
+                  , subq_0.booking__paid_at__extract_year
+                  , subq_0.booking__paid_at__extract_quarter
+                  , subq_0.booking__paid_at__extract_month
+                  , subq_0.booking__paid_at__extract_day
+                  , subq_0.booking__paid_at__extract_dow
+                  , subq_0.booking__paid_at__extract_doy
+                  , subq_0.ds__day AS metric_time__day
+                  , subq_0.ds__week AS metric_time__week
+                  , subq_0.ds__month AS metric_time__month
+                  , subq_0.ds__quarter AS metric_time__quarter
+                  , subq_0.ds__year AS metric_time__year
+                  , subq_0.ds__extract_year AS metric_time__extract_year
+                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_0.ds__extract_month AS metric_time__extract_month
+                  , subq_0.ds__extract_day AS metric_time__extract_day
+                  , subq_0.ds__extract_dow AS metric_time__extract_dow
+                  , subq_0.ds__extract_doy AS metric_time__extract_doy
+                  , subq_0.listing
+                  , subq_0.guest
+                  , subq_0.host
+                  , subq_0.booking__listing
+                  , subq_0.booking__guest
+                  , subq_0.booking__host
+                  , subq_0.is_instant
+                  , subq_0.booking__is_instant
+                  , subq_0.bookings
+                  , subq_0.instant_bookings
+                  , subq_0.booking_value
+                  , subq_0.max_booking_value
+                  , subq_0.min_booking_value
+                  , subq_0.bookers
+                  , subq_0.average_booking_value
+                  , subq_0.referred_bookings
+                  , subq_0.median_booking_value
+                  , subq_0.booking_value_p99
+                  , subq_0.discrete_booking_value_p99
+                  , subq_0.approximate_continuous_booking_value_p99
+                  , subq_0.approximate_discrete_booking_value_p99
+                FROM (
+                  -- Read Elements From Semantic Model 'bookings_source'
+                  SELECT
+                    1 AS bookings
+                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                    , bookings_source_src_28000.booking_value
+                    , bookings_source_src_28000.booking_value AS max_booking_value
+                    , bookings_source_src_28000.booking_value AS min_booking_value
+                    , bookings_source_src_28000.guest_id AS bookers
+                    , bookings_source_src_28000.booking_value AS average_booking_value
+                    , bookings_source_src_28000.booking_value AS booking_payments
+                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                    , bookings_source_src_28000.booking_value AS median_booking_value
+                    , bookings_source_src_28000.booking_value AS booking_value_p99
+                    , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                    , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                    , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                    , bookings_source_src_28000.is_instant
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                    , bookings_source_src_28000.is_instant AS booking__is_instant
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                    , bookings_source_src_28000.listing_id AS listing
+                    , bookings_source_src_28000.guest_id AS guest
+                    , bookings_source_src_28000.host_id AS host
+                    , bookings_source_src_28000.listing_id AS booking__listing
+                    , bookings_source_src_28000.guest_id AS booking__guest
+                    , bookings_source_src_28000.host_id AS booking__host
+                  FROM ***************************.fct_bookings bookings_source_src_28000
+                ) subq_0
+              ) subq_1
+              ON
+                subq_2.metric_time__day - MAKE_INTERVAL(days => 5) = subq_1.metric_time__day
+            ) subq_4
+          ) subq_5
+          GROUP BY
+            subq_5.metric_time__day
+        ) subq_6
+      ) subq_7
+    ) subq_8
+    ON
+      subq_9.metric_time__day - MAKE_INTERVAL(days => 2) = subq_8.metric_time__day
+  ) subq_11
+  WHERE subq_11.metric_time__day BETWEEN '2020-01-12' AND '2020-01-13'
+) subq_12

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_offsets_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_offsets_with_time_constraint__plan0_optimized.sql
@@ -8,16 +8,11 @@ SELECT
   , 2 * bookings_offset_once AS bookings_offset_twice
 FROM (
   -- Join to Time Spine Dataset
+  -- Constrain Time Range to [2020-01-12T00:00:00, 2020-01-13T00:00:00]
   SELECT
-    subq_21.metric_time__day AS metric_time__day
-    , subq_20.bookings_offset_once AS bookings_offset_once
-  FROM (
-    -- Time Spine
-    SELECT
-      ds AS metric_time__day
-    FROM ***************************.mf_time_spine subq_22
-    WHERE ds BETWEEN '2020-01-12' AND '2020-01-13'
-  ) subq_21
+    subq_23.ds AS metric_time__day
+    , subq_21.bookings_offset_once AS bookings_offset_once
+  FROM ***************************.mf_time_spine subq_23
   INNER JOIN (
     -- Compute Metrics via Expressions
     SELECT
@@ -29,9 +24,9 @@ FROM (
       -- Aggregate Measures
       -- Compute Metrics via Expressions
       SELECT
-        subq_15.ds AS metric_time__day
-        , SUM(subq_13.bookings) AS bookings
-      FROM ***************************.mf_time_spine subq_15
+        subq_16.ds AS metric_time__day
+        , SUM(subq_14.bookings) AS bookings
+      FROM ***************************.mf_time_spine subq_16
       INNER JOIN (
         -- Read Elements From Semantic Model 'bookings_source'
         -- Metric Time Dimension 'ds'
@@ -39,13 +34,14 @@ FROM (
           DATE_TRUNC('day', ds) AS metric_time__day
           , 1 AS bookings
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_13
+      ) subq_14
       ON
-        subq_15.ds - MAKE_INTERVAL(days => 5) = subq_13.metric_time__day
+        subq_16.ds - MAKE_INTERVAL(days => 5) = subq_14.metric_time__day
       GROUP BY
-        subq_15.ds
-    ) subq_19
-  ) subq_20
+        subq_16.ds
+    ) subq_20
+  ) subq_21
   ON
-    subq_21.metric_time__day - MAKE_INTERVAL(days => 2) = subq_20.metric_time__day
-) subq_23
+    subq_23.ds - MAKE_INTERVAL(days => 2) = subq_21.metric_time__day
+  WHERE subq_23.ds BETWEEN '2020-01-12' AND '2020-01-13'
+) subq_25

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_time_offset_metric_with_time_constraint__plan0.sql
@@ -4,331 +4,433 @@ sql_engine: Postgres
 ---
 -- Compute Metrics via Expressions
 SELECT
-  subq_7.metric_time__day
+  subq_8.metric_time__day
   , bookings_5_days_ago AS bookings_5_day_lag
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_6.metric_time__day
-    , subq_6.bookings AS bookings_5_days_ago
+    subq_7.metric_time__day
+    , subq_7.bookings AS bookings_5_days_ago
   FROM (
     -- Aggregate Measures
     SELECT
-      subq_5.metric_time__day
-      , SUM(subq_5.bookings) AS bookings
+      subq_6.metric_time__day
+      , SUM(subq_6.bookings) AS bookings
     FROM (
       -- Pass Only Elements: ['bookings', 'metric_time__day']
       SELECT
-        subq_4.metric_time__day
-        , subq_4.bookings
+        subq_5.metric_time__day
+        , subq_5.bookings
       FROM (
-        -- Join to Time Spine Dataset
+        -- Constrain Time Range to [2019-12-19T00:00:00, 2020-01-02T00:00:00]
         SELECT
-          subq_1.ds__day AS ds__day
-          , subq_1.ds__week AS ds__week
-          , subq_1.ds__month AS ds__month
-          , subq_1.ds__quarter AS ds__quarter
-          , subq_1.ds__year AS ds__year
-          , subq_1.ds__extract_year AS ds__extract_year
-          , subq_1.ds__extract_quarter AS ds__extract_quarter
-          , subq_1.ds__extract_month AS ds__extract_month
-          , subq_1.ds__extract_day AS ds__extract_day
-          , subq_1.ds__extract_dow AS ds__extract_dow
-          , subq_1.ds__extract_doy AS ds__extract_doy
-          , subq_1.ds_partitioned__day AS ds_partitioned__day
-          , subq_1.ds_partitioned__week AS ds_partitioned__week
-          , subq_1.ds_partitioned__month AS ds_partitioned__month
-          , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
-          , subq_1.ds_partitioned__year AS ds_partitioned__year
-          , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
-          , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
-          , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
-          , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
-          , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
-          , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
-          , subq_1.paid_at__day AS paid_at__day
-          , subq_1.paid_at__week AS paid_at__week
-          , subq_1.paid_at__month AS paid_at__month
-          , subq_1.paid_at__quarter AS paid_at__quarter
-          , subq_1.paid_at__year AS paid_at__year
-          , subq_1.paid_at__extract_year AS paid_at__extract_year
-          , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
-          , subq_1.paid_at__extract_month AS paid_at__extract_month
-          , subq_1.paid_at__extract_day AS paid_at__extract_day
-          , subq_1.paid_at__extract_dow AS paid_at__extract_dow
-          , subq_1.paid_at__extract_doy AS paid_at__extract_doy
-          , subq_1.booking__ds__day AS booking__ds__day
-          , subq_1.booking__ds__week AS booking__ds__week
-          , subq_1.booking__ds__month AS booking__ds__month
-          , subq_1.booking__ds__quarter AS booking__ds__quarter
-          , subq_1.booking__ds__year AS booking__ds__year
-          , subq_1.booking__ds__extract_year AS booking__ds__extract_year
-          , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
-          , subq_1.booking__ds__extract_month AS booking__ds__extract_month
-          , subq_1.booking__ds__extract_day AS booking__ds__extract_day
-          , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
-          , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
-          , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
-          , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
-          , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
-          , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
-          , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
-          , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
-          , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
-          , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
-          , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
-          , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
-          , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
-          , subq_1.booking__paid_at__day AS booking__paid_at__day
-          , subq_1.booking__paid_at__week AS booking__paid_at__week
-          , subq_1.booking__paid_at__month AS booking__paid_at__month
-          , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
-          , subq_1.booking__paid_at__year AS booking__paid_at__year
-          , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
-          , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
-          , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
-          , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
-          , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
-          , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
-          , subq_1.metric_time__week AS metric_time__week
-          , subq_1.metric_time__month AS metric_time__month
-          , subq_1.metric_time__quarter AS metric_time__quarter
-          , subq_1.metric_time__year AS metric_time__year
-          , subq_1.metric_time__extract_year AS metric_time__extract_year
-          , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
-          , subq_1.metric_time__extract_month AS metric_time__extract_month
-          , subq_1.metric_time__extract_day AS metric_time__extract_day
-          , subq_1.metric_time__extract_dow AS metric_time__extract_dow
-          , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-          , subq_2.metric_time__day AS metric_time__day
-          , subq_1.listing AS listing
-          , subq_1.guest AS guest
-          , subq_1.host AS host
-          , subq_1.booking__listing AS booking__listing
-          , subq_1.booking__guest AS booking__guest
-          , subq_1.booking__host AS booking__host
-          , subq_1.is_instant AS is_instant
-          , subq_1.booking__is_instant AS booking__is_instant
-          , subq_1.bookings AS bookings
-          , subq_1.instant_bookings AS instant_bookings
-          , subq_1.booking_value AS booking_value
-          , subq_1.max_booking_value AS max_booking_value
-          , subq_1.min_booking_value AS min_booking_value
-          , subq_1.bookers AS bookers
-          , subq_1.average_booking_value AS average_booking_value
-          , subq_1.referred_bookings AS referred_bookings
-          , subq_1.median_booking_value AS median_booking_value
-          , subq_1.booking_value_p99 AS booking_value_p99
-          , subq_1.discrete_booking_value_p99 AS discrete_booking_value_p99
-          , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
-          , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+          subq_4.metric_time__day
+          , subq_4.ds__day
+          , subq_4.ds__week
+          , subq_4.ds__month
+          , subq_4.ds__quarter
+          , subq_4.ds__year
+          , subq_4.ds__extract_year
+          , subq_4.ds__extract_quarter
+          , subq_4.ds__extract_month
+          , subq_4.ds__extract_day
+          , subq_4.ds__extract_dow
+          , subq_4.ds__extract_doy
+          , subq_4.ds_partitioned__day
+          , subq_4.ds_partitioned__week
+          , subq_4.ds_partitioned__month
+          , subq_4.ds_partitioned__quarter
+          , subq_4.ds_partitioned__year
+          , subq_4.ds_partitioned__extract_year
+          , subq_4.ds_partitioned__extract_quarter
+          , subq_4.ds_partitioned__extract_month
+          , subq_4.ds_partitioned__extract_day
+          , subq_4.ds_partitioned__extract_dow
+          , subq_4.ds_partitioned__extract_doy
+          , subq_4.paid_at__day
+          , subq_4.paid_at__week
+          , subq_4.paid_at__month
+          , subq_4.paid_at__quarter
+          , subq_4.paid_at__year
+          , subq_4.paid_at__extract_year
+          , subq_4.paid_at__extract_quarter
+          , subq_4.paid_at__extract_month
+          , subq_4.paid_at__extract_day
+          , subq_4.paid_at__extract_dow
+          , subq_4.paid_at__extract_doy
+          , subq_4.booking__ds__day
+          , subq_4.booking__ds__week
+          , subq_4.booking__ds__month
+          , subq_4.booking__ds__quarter
+          , subq_4.booking__ds__year
+          , subq_4.booking__ds__extract_year
+          , subq_4.booking__ds__extract_quarter
+          , subq_4.booking__ds__extract_month
+          , subq_4.booking__ds__extract_day
+          , subq_4.booking__ds__extract_dow
+          , subq_4.booking__ds__extract_doy
+          , subq_4.booking__ds_partitioned__day
+          , subq_4.booking__ds_partitioned__week
+          , subq_4.booking__ds_partitioned__month
+          , subq_4.booking__ds_partitioned__quarter
+          , subq_4.booking__ds_partitioned__year
+          , subq_4.booking__ds_partitioned__extract_year
+          , subq_4.booking__ds_partitioned__extract_quarter
+          , subq_4.booking__ds_partitioned__extract_month
+          , subq_4.booking__ds_partitioned__extract_day
+          , subq_4.booking__ds_partitioned__extract_dow
+          , subq_4.booking__ds_partitioned__extract_doy
+          , subq_4.booking__paid_at__day
+          , subq_4.booking__paid_at__week
+          , subq_4.booking__paid_at__month
+          , subq_4.booking__paid_at__quarter
+          , subq_4.booking__paid_at__year
+          , subq_4.booking__paid_at__extract_year
+          , subq_4.booking__paid_at__extract_quarter
+          , subq_4.booking__paid_at__extract_month
+          , subq_4.booking__paid_at__extract_day
+          , subq_4.booking__paid_at__extract_dow
+          , subq_4.booking__paid_at__extract_doy
+          , subq_4.metric_time__week
+          , subq_4.metric_time__month
+          , subq_4.metric_time__quarter
+          , subq_4.metric_time__year
+          , subq_4.metric_time__extract_year
+          , subq_4.metric_time__extract_quarter
+          , subq_4.metric_time__extract_month
+          , subq_4.metric_time__extract_day
+          , subq_4.metric_time__extract_dow
+          , subq_4.metric_time__extract_doy
+          , subq_4.listing
+          , subq_4.guest
+          , subq_4.host
+          , subq_4.booking__listing
+          , subq_4.booking__guest
+          , subq_4.booking__host
+          , subq_4.is_instant
+          , subq_4.booking__is_instant
+          , subq_4.bookings
+          , subq_4.instant_bookings
+          , subq_4.booking_value
+          , subq_4.max_booking_value
+          , subq_4.min_booking_value
+          , subq_4.bookers
+          , subq_4.average_booking_value
+          , subq_4.referred_bookings
+          , subq_4.median_booking_value
+          , subq_4.booking_value_p99
+          , subq_4.discrete_booking_value_p99
+          , subq_4.approximate_continuous_booking_value_p99
+          , subq_4.approximate_discrete_booking_value_p99
         FROM (
-          -- Time Spine
+          -- Join to Time Spine Dataset
           SELECT
-            subq_3.ds AS metric_time__day
-          FROM ***************************.mf_time_spine subq_3
-          WHERE subq_3.ds BETWEEN '2019-12-19' AND '2020-01-02'
-        ) subq_2
-        INNER JOIN (
-          -- Metric Time Dimension 'ds'
-          SELECT
-            subq_0.ds__day
-            , subq_0.ds__week
-            , subq_0.ds__month
-            , subq_0.ds__quarter
-            , subq_0.ds__year
-            , subq_0.ds__extract_year
-            , subq_0.ds__extract_quarter
-            , subq_0.ds__extract_month
-            , subq_0.ds__extract_day
-            , subq_0.ds__extract_dow
-            , subq_0.ds__extract_doy
-            , subq_0.ds_partitioned__day
-            , subq_0.ds_partitioned__week
-            , subq_0.ds_partitioned__month
-            , subq_0.ds_partitioned__quarter
-            , subq_0.ds_partitioned__year
-            , subq_0.ds_partitioned__extract_year
-            , subq_0.ds_partitioned__extract_quarter
-            , subq_0.ds_partitioned__extract_month
-            , subq_0.ds_partitioned__extract_day
-            , subq_0.ds_partitioned__extract_dow
-            , subq_0.ds_partitioned__extract_doy
-            , subq_0.paid_at__day
-            , subq_0.paid_at__week
-            , subq_0.paid_at__month
-            , subq_0.paid_at__quarter
-            , subq_0.paid_at__year
-            , subq_0.paid_at__extract_year
-            , subq_0.paid_at__extract_quarter
-            , subq_0.paid_at__extract_month
-            , subq_0.paid_at__extract_day
-            , subq_0.paid_at__extract_dow
-            , subq_0.paid_at__extract_doy
-            , subq_0.booking__ds__day
-            , subq_0.booking__ds__week
-            , subq_0.booking__ds__month
-            , subq_0.booking__ds__quarter
-            , subq_0.booking__ds__year
-            , subq_0.booking__ds__extract_year
-            , subq_0.booking__ds__extract_quarter
-            , subq_0.booking__ds__extract_month
-            , subq_0.booking__ds__extract_day
-            , subq_0.booking__ds__extract_dow
-            , subq_0.booking__ds__extract_doy
-            , subq_0.booking__ds_partitioned__day
-            , subq_0.booking__ds_partitioned__week
-            , subq_0.booking__ds_partitioned__month
-            , subq_0.booking__ds_partitioned__quarter
-            , subq_0.booking__ds_partitioned__year
-            , subq_0.booking__ds_partitioned__extract_year
-            , subq_0.booking__ds_partitioned__extract_quarter
-            , subq_0.booking__ds_partitioned__extract_month
-            , subq_0.booking__ds_partitioned__extract_day
-            , subq_0.booking__ds_partitioned__extract_dow
-            , subq_0.booking__ds_partitioned__extract_doy
-            , subq_0.booking__paid_at__day
-            , subq_0.booking__paid_at__week
-            , subq_0.booking__paid_at__month
-            , subq_0.booking__paid_at__quarter
-            , subq_0.booking__paid_at__year
-            , subq_0.booking__paid_at__extract_year
-            , subq_0.booking__paid_at__extract_quarter
-            , subq_0.booking__paid_at__extract_month
-            , subq_0.booking__paid_at__extract_day
-            , subq_0.booking__paid_at__extract_dow
-            , subq_0.booking__paid_at__extract_doy
-            , subq_0.ds__day AS metric_time__day
-            , subq_0.ds__week AS metric_time__week
-            , subq_0.ds__month AS metric_time__month
-            , subq_0.ds__quarter AS metric_time__quarter
-            , subq_0.ds__year AS metric_time__year
-            , subq_0.ds__extract_year AS metric_time__extract_year
-            , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-            , subq_0.ds__extract_month AS metric_time__extract_month
-            , subq_0.ds__extract_day AS metric_time__extract_day
-            , subq_0.ds__extract_dow AS metric_time__extract_dow
-            , subq_0.ds__extract_doy AS metric_time__extract_doy
-            , subq_0.listing
-            , subq_0.guest
-            , subq_0.host
-            , subq_0.booking__listing
-            , subq_0.booking__guest
-            , subq_0.booking__host
-            , subq_0.is_instant
-            , subq_0.booking__is_instant
-            , subq_0.bookings
-            , subq_0.instant_bookings
-            , subq_0.booking_value
-            , subq_0.max_booking_value
-            , subq_0.min_booking_value
-            , subq_0.bookers
-            , subq_0.average_booking_value
-            , subq_0.referred_bookings
-            , subq_0.median_booking_value
-            , subq_0.booking_value_p99
-            , subq_0.discrete_booking_value_p99
-            , subq_0.approximate_continuous_booking_value_p99
-            , subq_0.approximate_discrete_booking_value_p99
+            subq_1.ds__day AS ds__day
+            , subq_1.ds__week AS ds__week
+            , subq_1.ds__month AS ds__month
+            , subq_1.ds__quarter AS ds__quarter
+            , subq_1.ds__year AS ds__year
+            , subq_1.ds__extract_year AS ds__extract_year
+            , subq_1.ds__extract_quarter AS ds__extract_quarter
+            , subq_1.ds__extract_month AS ds__extract_month
+            , subq_1.ds__extract_day AS ds__extract_day
+            , subq_1.ds__extract_dow AS ds__extract_dow
+            , subq_1.ds__extract_doy AS ds__extract_doy
+            , subq_1.ds_partitioned__day AS ds_partitioned__day
+            , subq_1.ds_partitioned__week AS ds_partitioned__week
+            , subq_1.ds_partitioned__month AS ds_partitioned__month
+            , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
+            , subq_1.ds_partitioned__year AS ds_partitioned__year
+            , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
+            , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+            , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
+            , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
+            , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+            , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+            , subq_1.paid_at__day AS paid_at__day
+            , subq_1.paid_at__week AS paid_at__week
+            , subq_1.paid_at__month AS paid_at__month
+            , subq_1.paid_at__quarter AS paid_at__quarter
+            , subq_1.paid_at__year AS paid_at__year
+            , subq_1.paid_at__extract_year AS paid_at__extract_year
+            , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
+            , subq_1.paid_at__extract_month AS paid_at__extract_month
+            , subq_1.paid_at__extract_day AS paid_at__extract_day
+            , subq_1.paid_at__extract_dow AS paid_at__extract_dow
+            , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+            , subq_1.booking__ds__day AS booking__ds__day
+            , subq_1.booking__ds__week AS booking__ds__week
+            , subq_1.booking__ds__month AS booking__ds__month
+            , subq_1.booking__ds__quarter AS booking__ds__quarter
+            , subq_1.booking__ds__year AS booking__ds__year
+            , subq_1.booking__ds__extract_year AS booking__ds__extract_year
+            , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
+            , subq_1.booking__ds__extract_month AS booking__ds__extract_month
+            , subq_1.booking__ds__extract_day AS booking__ds__extract_day
+            , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
+            , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
+            , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
+            , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
+            , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
+            , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+            , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
+            , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+            , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+            , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+            , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+            , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+            , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+            , subq_1.booking__paid_at__day AS booking__paid_at__day
+            , subq_1.booking__paid_at__week AS booking__paid_at__week
+            , subq_1.booking__paid_at__month AS booking__paid_at__month
+            , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
+            , subq_1.booking__paid_at__year AS booking__paid_at__year
+            , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
+            , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+            , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
+            , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
+            , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+            , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_1.metric_time__week AS metric_time__week
+            , subq_1.metric_time__month AS metric_time__month
+            , subq_1.metric_time__quarter AS metric_time__quarter
+            , subq_1.metric_time__year AS metric_time__year
+            , subq_1.metric_time__extract_year AS metric_time__extract_year
+            , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_1.metric_time__extract_month AS metric_time__extract_month
+            , subq_1.metric_time__extract_day AS metric_time__extract_day
+            , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_2.metric_time__day AS metric_time__day
+            , subq_1.listing AS listing
+            , subq_1.guest AS guest
+            , subq_1.host AS host
+            , subq_1.booking__listing AS booking__listing
+            , subq_1.booking__guest AS booking__guest
+            , subq_1.booking__host AS booking__host
+            , subq_1.is_instant AS is_instant
+            , subq_1.booking__is_instant AS booking__is_instant
+            , subq_1.bookings AS bookings
+            , subq_1.instant_bookings AS instant_bookings
+            , subq_1.booking_value AS booking_value
+            , subq_1.max_booking_value AS max_booking_value
+            , subq_1.min_booking_value AS min_booking_value
+            , subq_1.bookers AS bookers
+            , subq_1.average_booking_value AS average_booking_value
+            , subq_1.referred_bookings AS referred_bookings
+            , subq_1.median_booking_value AS median_booking_value
+            , subq_1.booking_value_p99 AS booking_value_p99
+            , subq_1.discrete_booking_value_p99 AS discrete_booking_value_p99
+            , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+            , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Read Elements From Semantic Model 'bookings_source'
+            -- Time Spine
             SELECT
-              1 AS bookings
-              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-              , bookings_source_src_28000.booking_value
-              , bookings_source_src_28000.booking_value AS max_booking_value
-              , bookings_source_src_28000.booking_value AS min_booking_value
-              , bookings_source_src_28000.guest_id AS bookers
-              , bookings_source_src_28000.booking_value AS average_booking_value
-              , bookings_source_src_28000.booking_value AS booking_payments
-              , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-              , bookings_source_src_28000.booking_value AS median_booking_value
-              , bookings_source_src_28000.booking_value AS booking_value_p99
-              , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
-              , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
-              , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
-              , bookings_source_src_28000.is_instant
-              , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-              , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-              , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-              , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-              , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-              , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-              , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-              , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
-              , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-              , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-              , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-              , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-              , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-              , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-              , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-              , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
-              , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-              , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-              , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-              , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-              , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-              , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-              , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-              , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
-              , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-              , bookings_source_src_28000.is_instant AS booking__is_instant
-              , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-              , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-              , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-              , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-              , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-              , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-              , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-              , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
-              , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-              , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-              , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-              , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-              , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-              , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-              , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-              , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
-              , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-              , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-              , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-              , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-              , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-              , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-              , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
-              , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-              , bookings_source_src_28000.listing_id AS listing
-              , bookings_source_src_28000.guest_id AS guest
-              , bookings_source_src_28000.host_id AS host
-              , bookings_source_src_28000.listing_id AS booking__listing
-              , bookings_source_src_28000.guest_id AS booking__guest
-              , bookings_source_src_28000.host_id AS booking__host
-            FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_0
-        ) subq_1
-        ON
-          subq_2.metric_time__day - MAKE_INTERVAL(days => 5) = subq_1.metric_time__day
-      ) subq_4
-    ) subq_5
+              subq_3.ds AS metric_time__day
+            FROM ***************************.mf_time_spine subq_3
+          ) subq_2
+          INNER JOIN (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.ds_partitioned__day
+              , subq_0.ds_partitioned__week
+              , subq_0.ds_partitioned__month
+              , subq_0.ds_partitioned__quarter
+              , subq_0.ds_partitioned__year
+              , subq_0.ds_partitioned__extract_year
+              , subq_0.ds_partitioned__extract_quarter
+              , subq_0.ds_partitioned__extract_month
+              , subq_0.ds_partitioned__extract_day
+              , subq_0.ds_partitioned__extract_dow
+              , subq_0.ds_partitioned__extract_doy
+              , subq_0.paid_at__day
+              , subq_0.paid_at__week
+              , subq_0.paid_at__month
+              , subq_0.paid_at__quarter
+              , subq_0.paid_at__year
+              , subq_0.paid_at__extract_year
+              , subq_0.paid_at__extract_quarter
+              , subq_0.paid_at__extract_month
+              , subq_0.paid_at__extract_day
+              , subq_0.paid_at__extract_dow
+              , subq_0.paid_at__extract_doy
+              , subq_0.booking__ds__day
+              , subq_0.booking__ds__week
+              , subq_0.booking__ds__month
+              , subq_0.booking__ds__quarter
+              , subq_0.booking__ds__year
+              , subq_0.booking__ds__extract_year
+              , subq_0.booking__ds__extract_quarter
+              , subq_0.booking__ds__extract_month
+              , subq_0.booking__ds__extract_day
+              , subq_0.booking__ds__extract_dow
+              , subq_0.booking__ds__extract_doy
+              , subq_0.booking__ds_partitioned__day
+              , subq_0.booking__ds_partitioned__week
+              , subq_0.booking__ds_partitioned__month
+              , subq_0.booking__ds_partitioned__quarter
+              , subq_0.booking__ds_partitioned__year
+              , subq_0.booking__ds_partitioned__extract_year
+              , subq_0.booking__ds_partitioned__extract_quarter
+              , subq_0.booking__ds_partitioned__extract_month
+              , subq_0.booking__ds_partitioned__extract_day
+              , subq_0.booking__ds_partitioned__extract_dow
+              , subq_0.booking__ds_partitioned__extract_doy
+              , subq_0.booking__paid_at__day
+              , subq_0.booking__paid_at__week
+              , subq_0.booking__paid_at__month
+              , subq_0.booking__paid_at__quarter
+              , subq_0.booking__paid_at__year
+              , subq_0.booking__paid_at__extract_year
+              , subq_0.booking__paid_at__extract_quarter
+              , subq_0.booking__paid_at__extract_month
+              , subq_0.booking__paid_at__extract_day
+              , subq_0.booking__paid_at__extract_dow
+              , subq_0.booking__paid_at__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.listing
+              , subq_0.guest
+              , subq_0.host
+              , subq_0.booking__listing
+              , subq_0.booking__guest
+              , subq_0.booking__host
+              , subq_0.is_instant
+              , subq_0.booking__is_instant
+              , subq_0.bookings
+              , subq_0.instant_bookings
+              , subq_0.booking_value
+              , subq_0.max_booking_value
+              , subq_0.min_booking_value
+              , subq_0.bookers
+              , subq_0.average_booking_value
+              , subq_0.referred_bookings
+              , subq_0.median_booking_value
+              , subq_0.booking_value_p99
+              , subq_0.discrete_booking_value_p99
+              , subq_0.approximate_continuous_booking_value_p99
+              , subq_0.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Semantic Model 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_28000.booking_value
+                , bookings_source_src_28000.booking_value AS max_booking_value
+                , bookings_source_src_28000.booking_value AS min_booking_value
+                , bookings_source_src_28000.guest_id AS bookers
+                , bookings_source_src_28000.booking_value AS average_booking_value
+                , bookings_source_src_28000.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_28000.booking_value AS median_booking_value
+                , bookings_source_src_28000.booking_value AS booking_value_p99
+                , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_28000.is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_28000.is_instant AS booking__is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_28000.listing_id AS listing
+                , bookings_source_src_28000.guest_id AS guest
+                , bookings_source_src_28000.host_id AS host
+                , bookings_source_src_28000.listing_id AS booking__listing
+                , bookings_source_src_28000.guest_id AS booking__guest
+                , bookings_source_src_28000.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_28000
+            ) subq_0
+          ) subq_1
+          ON
+            subq_2.metric_time__day - MAKE_INTERVAL(days => 5) = subq_1.metric_time__day
+        ) subq_4
+        WHERE subq_4.metric_time__day BETWEEN '2019-12-19' AND '2020-01-02'
+      ) subq_5
+    ) subq_6
     GROUP BY
-      subq_5.metric_time__day
-  ) subq_6
-) subq_7
+      subq_6.metric_time__day
+  ) subq_7
+) subq_8

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_time_offset_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_time_offset_metric_with_time_constraint__plan0_optimized.sql
@@ -8,19 +8,14 @@ SELECT
   , bookings_5_days_ago AS bookings_5_day_lag
 FROM (
   -- Join to Time Spine Dataset
+  -- Constrain Time Range to [2019-12-19T00:00:00, 2020-01-02T00:00:00]
   -- Pass Only Elements: ['bookings', 'metric_time__day']
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT
-    subq_10.metric_time__day AS metric_time__day
-    , SUM(subq_9.bookings) AS bookings_5_days_ago
-  FROM (
-    -- Time Spine
-    SELECT
-      ds AS metric_time__day
-    FROM ***************************.mf_time_spine subq_11
-    WHERE ds BETWEEN '2019-12-19' AND '2020-01-02'
-  ) subq_10
+    subq_12.ds AS metric_time__day
+    , SUM(subq_10.bookings) AS bookings_5_days_ago
+  FROM ***************************.mf_time_spine subq_12
   INNER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -28,9 +23,10 @@ FROM (
       DATE_TRUNC('day', ds) AS metric_time__day
       , 1 AS bookings
     FROM ***************************.fct_bookings bookings_source_src_28000
-  ) subq_9
+  ) subq_10
   ON
-    subq_10.metric_time__day - MAKE_INTERVAL(days => 5) = subq_9.metric_time__day
+    subq_12.ds - MAKE_INTERVAL(days => 5) = subq_10.metric_time__day
+  WHERE subq_12.ds BETWEEN '2019-12-19' AND '2020-01-02'
   GROUP BY
-    subq_10.metric_time__day
-) subq_15
+    subq_12.ds
+) subq_17

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
@@ -228,7 +228,6 @@ FROM (
             SELECT
               subq_6.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_6
-            WHERE subq_6.ds BETWEEN '2019-12-19' AND '2020-01-02'
           ) subq_5
           INNER JOIN (
             -- Join Self Over Time Range

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_time_offset_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_time_offset_metric_with_time_constraint__plan0_optimized.sql
@@ -13,15 +13,9 @@ FROM (
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT
-    subq_17.metric_time__day AS metric_time__day
+    subq_18.ds AS metric_time__day
     , COUNT(DISTINCT subq_16.bookers) AS every_2_days_bookers_2_days_ago
-  FROM (
-    -- Time Spine
-    SELECT
-      ds AS metric_time__day
-    FROM ***************************.mf_time_spine subq_18
-    WHERE ds BETWEEN '2019-12-19' AND '2020-01-02'
-  ) subq_17
+  FROM ***************************.mf_time_spine subq_18
   INNER JOIN (
     -- Join Self Over Time Range
     SELECT
@@ -38,8 +32,8 @@ FROM (
       )
   ) subq_16
   ON
-    DATEADD(day, -2, subq_17.metric_time__day) = subq_16.metric_time__day
-  WHERE subq_17.metric_time__day BETWEEN '2019-12-19' AND '2020-01-02'
+    DATEADD(day, -2, subq_18.ds) = subq_16.metric_time__day
+  WHERE subq_18.ds BETWEEN '2019-12-19' AND '2020-01-02'
   GROUP BY
-    subq_17.metric_time__day
+    subq_18.ds
 ) subq_23

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_nested_offsets_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_nested_offsets_with_time_constraint__plan0.sql
@@ -4,351 +4,357 @@ sql_engine: Redshift
 ---
 -- Compute Metrics via Expressions
 SELECT
-  subq_11.metric_time__day
+  subq_12.metric_time__day
   , 2 * bookings_offset_once AS bookings_offset_twice
 FROM (
-  -- Join to Time Spine Dataset
+  -- Constrain Time Range to [2020-01-12T00:00:00, 2020-01-13T00:00:00]
   SELECT
-    subq_9.metric_time__day AS metric_time__day
-    , subq_8.bookings_offset_once AS bookings_offset_once
+    subq_11.metric_time__day
+    , subq_11.bookings_offset_once
   FROM (
-    -- Time Spine
+    -- Join to Time Spine Dataset
     SELECT
-      subq_10.ds AS metric_time__day
-    FROM ***************************.mf_time_spine subq_10
-    WHERE subq_10.ds BETWEEN '2020-01-12' AND '2020-01-13'
-  ) subq_9
-  INNER JOIN (
-    -- Compute Metrics via Expressions
-    SELECT
-      subq_7.metric_time__day
-      , 2 * bookings AS bookings_offset_once
+      subq_9.metric_time__day AS metric_time__day
+      , subq_8.bookings_offset_once AS bookings_offset_once
     FROM (
+      -- Time Spine
+      SELECT
+        subq_10.ds AS metric_time__day
+      FROM ***************************.mf_time_spine subq_10
+    ) subq_9
+    INNER JOIN (
       -- Compute Metrics via Expressions
       SELECT
-        subq_6.metric_time__day
-        , subq_6.bookings
+        subq_7.metric_time__day
+        , 2 * bookings AS bookings_offset_once
       FROM (
-        -- Aggregate Measures
+        -- Compute Metrics via Expressions
         SELECT
-          subq_5.metric_time__day
-          , SUM(subq_5.bookings) AS bookings
+          subq_6.metric_time__day
+          , subq_6.bookings
         FROM (
-          -- Pass Only Elements: ['bookings', 'metric_time__day']
+          -- Aggregate Measures
           SELECT
-            subq_4.metric_time__day
-            , subq_4.bookings
+            subq_5.metric_time__day
+            , SUM(subq_5.bookings) AS bookings
           FROM (
-            -- Join to Time Spine Dataset
+            -- Pass Only Elements: ['bookings', 'metric_time__day']
             SELECT
-              subq_1.ds__day AS ds__day
-              , subq_1.ds__week AS ds__week
-              , subq_1.ds__month AS ds__month
-              , subq_1.ds__quarter AS ds__quarter
-              , subq_1.ds__year AS ds__year
-              , subq_1.ds__extract_year AS ds__extract_year
-              , subq_1.ds__extract_quarter AS ds__extract_quarter
-              , subq_1.ds__extract_month AS ds__extract_month
-              , subq_1.ds__extract_day AS ds__extract_day
-              , subq_1.ds__extract_dow AS ds__extract_dow
-              , subq_1.ds__extract_doy AS ds__extract_doy
-              , subq_1.ds_partitioned__day AS ds_partitioned__day
-              , subq_1.ds_partitioned__week AS ds_partitioned__week
-              , subq_1.ds_partitioned__month AS ds_partitioned__month
-              , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
-              , subq_1.ds_partitioned__year AS ds_partitioned__year
-              , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
-              , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
-              , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
-              , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
-              , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
-              , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
-              , subq_1.paid_at__day AS paid_at__day
-              , subq_1.paid_at__week AS paid_at__week
-              , subq_1.paid_at__month AS paid_at__month
-              , subq_1.paid_at__quarter AS paid_at__quarter
-              , subq_1.paid_at__year AS paid_at__year
-              , subq_1.paid_at__extract_year AS paid_at__extract_year
-              , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
-              , subq_1.paid_at__extract_month AS paid_at__extract_month
-              , subq_1.paid_at__extract_day AS paid_at__extract_day
-              , subq_1.paid_at__extract_dow AS paid_at__extract_dow
-              , subq_1.paid_at__extract_doy AS paid_at__extract_doy
-              , subq_1.booking__ds__day AS booking__ds__day
-              , subq_1.booking__ds__week AS booking__ds__week
-              , subq_1.booking__ds__month AS booking__ds__month
-              , subq_1.booking__ds__quarter AS booking__ds__quarter
-              , subq_1.booking__ds__year AS booking__ds__year
-              , subq_1.booking__ds__extract_year AS booking__ds__extract_year
-              , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
-              , subq_1.booking__ds__extract_month AS booking__ds__extract_month
-              , subq_1.booking__ds__extract_day AS booking__ds__extract_day
-              , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
-              , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
-              , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
-              , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
-              , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
-              , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
-              , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
-              , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
-              , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
-              , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
-              , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
-              , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
-              , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
-              , subq_1.booking__paid_at__day AS booking__paid_at__day
-              , subq_1.booking__paid_at__week AS booking__paid_at__week
-              , subq_1.booking__paid_at__month AS booking__paid_at__month
-              , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
-              , subq_1.booking__paid_at__year AS booking__paid_at__year
-              , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
-              , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
-              , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
-              , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
-              , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
-              , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
-              , subq_1.metric_time__week AS metric_time__week
-              , subq_1.metric_time__month AS metric_time__month
-              , subq_1.metric_time__quarter AS metric_time__quarter
-              , subq_1.metric_time__year AS metric_time__year
-              , subq_1.metric_time__extract_year AS metric_time__extract_year
-              , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
-              , subq_1.metric_time__extract_month AS metric_time__extract_month
-              , subq_1.metric_time__extract_day AS metric_time__extract_day
-              , subq_1.metric_time__extract_dow AS metric_time__extract_dow
-              , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-              , subq_2.metric_time__day AS metric_time__day
-              , subq_1.listing AS listing
-              , subq_1.guest AS guest
-              , subq_1.host AS host
-              , subq_1.booking__listing AS booking__listing
-              , subq_1.booking__guest AS booking__guest
-              , subq_1.booking__host AS booking__host
-              , subq_1.is_instant AS is_instant
-              , subq_1.booking__is_instant AS booking__is_instant
-              , subq_1.bookings AS bookings
-              , subq_1.instant_bookings AS instant_bookings
-              , subq_1.booking_value AS booking_value
-              , subq_1.max_booking_value AS max_booking_value
-              , subq_1.min_booking_value AS min_booking_value
-              , subq_1.bookers AS bookers
-              , subq_1.average_booking_value AS average_booking_value
-              , subq_1.referred_bookings AS referred_bookings
-              , subq_1.median_booking_value AS median_booking_value
-              , subq_1.booking_value_p99 AS booking_value_p99
-              , subq_1.discrete_booking_value_p99 AS discrete_booking_value_p99
-              , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
-              , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+              subq_4.metric_time__day
+              , subq_4.bookings
             FROM (
-              -- Time Spine
+              -- Join to Time Spine Dataset
               SELECT
-                subq_3.ds AS metric_time__day
-              FROM ***************************.mf_time_spine subq_3
-            ) subq_2
-            INNER JOIN (
-              -- Metric Time Dimension 'ds'
-              SELECT
-                subq_0.ds__day
-                , subq_0.ds__week
-                , subq_0.ds__month
-                , subq_0.ds__quarter
-                , subq_0.ds__year
-                , subq_0.ds__extract_year
-                , subq_0.ds__extract_quarter
-                , subq_0.ds__extract_month
-                , subq_0.ds__extract_day
-                , subq_0.ds__extract_dow
-                , subq_0.ds__extract_doy
-                , subq_0.ds_partitioned__day
-                , subq_0.ds_partitioned__week
-                , subq_0.ds_partitioned__month
-                , subq_0.ds_partitioned__quarter
-                , subq_0.ds_partitioned__year
-                , subq_0.ds_partitioned__extract_year
-                , subq_0.ds_partitioned__extract_quarter
-                , subq_0.ds_partitioned__extract_month
-                , subq_0.ds_partitioned__extract_day
-                , subq_0.ds_partitioned__extract_dow
-                , subq_0.ds_partitioned__extract_doy
-                , subq_0.paid_at__day
-                , subq_0.paid_at__week
-                , subq_0.paid_at__month
-                , subq_0.paid_at__quarter
-                , subq_0.paid_at__year
-                , subq_0.paid_at__extract_year
-                , subq_0.paid_at__extract_quarter
-                , subq_0.paid_at__extract_month
-                , subq_0.paid_at__extract_day
-                , subq_0.paid_at__extract_dow
-                , subq_0.paid_at__extract_doy
-                , subq_0.booking__ds__day
-                , subq_0.booking__ds__week
-                , subq_0.booking__ds__month
-                , subq_0.booking__ds__quarter
-                , subq_0.booking__ds__year
-                , subq_0.booking__ds__extract_year
-                , subq_0.booking__ds__extract_quarter
-                , subq_0.booking__ds__extract_month
-                , subq_0.booking__ds__extract_day
-                , subq_0.booking__ds__extract_dow
-                , subq_0.booking__ds__extract_doy
-                , subq_0.booking__ds_partitioned__day
-                , subq_0.booking__ds_partitioned__week
-                , subq_0.booking__ds_partitioned__month
-                , subq_0.booking__ds_partitioned__quarter
-                , subq_0.booking__ds_partitioned__year
-                , subq_0.booking__ds_partitioned__extract_year
-                , subq_0.booking__ds_partitioned__extract_quarter
-                , subq_0.booking__ds_partitioned__extract_month
-                , subq_0.booking__ds_partitioned__extract_day
-                , subq_0.booking__ds_partitioned__extract_dow
-                , subq_0.booking__ds_partitioned__extract_doy
-                , subq_0.booking__paid_at__day
-                , subq_0.booking__paid_at__week
-                , subq_0.booking__paid_at__month
-                , subq_0.booking__paid_at__quarter
-                , subq_0.booking__paid_at__year
-                , subq_0.booking__paid_at__extract_year
-                , subq_0.booking__paid_at__extract_quarter
-                , subq_0.booking__paid_at__extract_month
-                , subq_0.booking__paid_at__extract_day
-                , subq_0.booking__paid_at__extract_dow
-                , subq_0.booking__paid_at__extract_doy
-                , subq_0.ds__day AS metric_time__day
-                , subq_0.ds__week AS metric_time__week
-                , subq_0.ds__month AS metric_time__month
-                , subq_0.ds__quarter AS metric_time__quarter
-                , subq_0.ds__year AS metric_time__year
-                , subq_0.ds__extract_year AS metric_time__extract_year
-                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_0.ds__extract_month AS metric_time__extract_month
-                , subq_0.ds__extract_day AS metric_time__extract_day
-                , subq_0.ds__extract_dow AS metric_time__extract_dow
-                , subq_0.ds__extract_doy AS metric_time__extract_doy
-                , subq_0.listing
-                , subq_0.guest
-                , subq_0.host
-                , subq_0.booking__listing
-                , subq_0.booking__guest
-                , subq_0.booking__host
-                , subq_0.is_instant
-                , subq_0.booking__is_instant
-                , subq_0.bookings
-                , subq_0.instant_bookings
-                , subq_0.booking_value
-                , subq_0.max_booking_value
-                , subq_0.min_booking_value
-                , subq_0.bookers
-                , subq_0.average_booking_value
-                , subq_0.referred_bookings
-                , subq_0.median_booking_value
-                , subq_0.booking_value_p99
-                , subq_0.discrete_booking_value_p99
-                , subq_0.approximate_continuous_booking_value_p99
-                , subq_0.approximate_discrete_booking_value_p99
+                subq_1.ds__day AS ds__day
+                , subq_1.ds__week AS ds__week
+                , subq_1.ds__month AS ds__month
+                , subq_1.ds__quarter AS ds__quarter
+                , subq_1.ds__year AS ds__year
+                , subq_1.ds__extract_year AS ds__extract_year
+                , subq_1.ds__extract_quarter AS ds__extract_quarter
+                , subq_1.ds__extract_month AS ds__extract_month
+                , subq_1.ds__extract_day AS ds__extract_day
+                , subq_1.ds__extract_dow AS ds__extract_dow
+                , subq_1.ds__extract_doy AS ds__extract_doy
+                , subq_1.ds_partitioned__day AS ds_partitioned__day
+                , subq_1.ds_partitioned__week AS ds_partitioned__week
+                , subq_1.ds_partitioned__month AS ds_partitioned__month
+                , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
+                , subq_1.ds_partitioned__year AS ds_partitioned__year
+                , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
+                , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+                , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
+                , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
+                , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+                , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+                , subq_1.paid_at__day AS paid_at__day
+                , subq_1.paid_at__week AS paid_at__week
+                , subq_1.paid_at__month AS paid_at__month
+                , subq_1.paid_at__quarter AS paid_at__quarter
+                , subq_1.paid_at__year AS paid_at__year
+                , subq_1.paid_at__extract_year AS paid_at__extract_year
+                , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
+                , subq_1.paid_at__extract_month AS paid_at__extract_month
+                , subq_1.paid_at__extract_day AS paid_at__extract_day
+                , subq_1.paid_at__extract_dow AS paid_at__extract_dow
+                , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+                , subq_1.booking__ds__day AS booking__ds__day
+                , subq_1.booking__ds__week AS booking__ds__week
+                , subq_1.booking__ds__month AS booking__ds__month
+                , subq_1.booking__ds__quarter AS booking__ds__quarter
+                , subq_1.booking__ds__year AS booking__ds__year
+                , subq_1.booking__ds__extract_year AS booking__ds__extract_year
+                , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
+                , subq_1.booking__ds__extract_month AS booking__ds__extract_month
+                , subq_1.booking__ds__extract_day AS booking__ds__extract_day
+                , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
+                , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
+                , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
+                , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
+                , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
+                , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+                , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
+                , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+                , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+                , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+                , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+                , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+                , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+                , subq_1.booking__paid_at__day AS booking__paid_at__day
+                , subq_1.booking__paid_at__week AS booking__paid_at__week
+                , subq_1.booking__paid_at__month AS booking__paid_at__month
+                , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
+                , subq_1.booking__paid_at__year AS booking__paid_at__year
+                , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
+                , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+                , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
+                , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
+                , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+                , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                , subq_1.metric_time__week AS metric_time__week
+                , subq_1.metric_time__month AS metric_time__month
+                , subq_1.metric_time__quarter AS metric_time__quarter
+                , subq_1.metric_time__year AS metric_time__year
+                , subq_1.metric_time__extract_year AS metric_time__extract_year
+                , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+                , subq_1.metric_time__extract_month AS metric_time__extract_month
+                , subq_1.metric_time__extract_day AS metric_time__extract_day
+                , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+                , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+                , subq_2.metric_time__day AS metric_time__day
+                , subq_1.listing AS listing
+                , subq_1.guest AS guest
+                , subq_1.host AS host
+                , subq_1.booking__listing AS booking__listing
+                , subq_1.booking__guest AS booking__guest
+                , subq_1.booking__host AS booking__host
+                , subq_1.is_instant AS is_instant
+                , subq_1.booking__is_instant AS booking__is_instant
+                , subq_1.bookings AS bookings
+                , subq_1.instant_bookings AS instant_bookings
+                , subq_1.booking_value AS booking_value
+                , subq_1.max_booking_value AS max_booking_value
+                , subq_1.min_booking_value AS min_booking_value
+                , subq_1.bookers AS bookers
+                , subq_1.average_booking_value AS average_booking_value
+                , subq_1.referred_bookings AS referred_bookings
+                , subq_1.median_booking_value AS median_booking_value
+                , subq_1.booking_value_p99 AS booking_value_p99
+                , subq_1.discrete_booking_value_p99 AS discrete_booking_value_p99
+                , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+                , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
               FROM (
-                -- Read Elements From Semantic Model 'bookings_source'
+                -- Time Spine
                 SELECT
-                  1 AS bookings
-                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                  , bookings_source_src_28000.booking_value
-                  , bookings_source_src_28000.booking_value AS max_booking_value
-                  , bookings_source_src_28000.booking_value AS min_booking_value
-                  , bookings_source_src_28000.guest_id AS bookers
-                  , bookings_source_src_28000.booking_value AS average_booking_value
-                  , bookings_source_src_28000.booking_value AS booking_payments
-                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-                  , bookings_source_src_28000.booking_value AS median_booking_value
-                  , bookings_source_src_28000.booking_value AS booking_value_p99
-                  , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
-                  , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
-                  , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
-                  , bookings_source_src_28000.is_instant
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS ds__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS ds_partitioned__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS paid_at__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                  , bookings_source_src_28000.is_instant AS booking__is_instant
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS booking__ds__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS booking__ds_partitioned__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS booking__paid_at__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                  , bookings_source_src_28000.listing_id AS listing
-                  , bookings_source_src_28000.guest_id AS guest
-                  , bookings_source_src_28000.host_id AS host
-                  , bookings_source_src_28000.listing_id AS booking__listing
-                  , bookings_source_src_28000.guest_id AS booking__guest
-                  , bookings_source_src_28000.host_id AS booking__host
-                FROM ***************************.fct_bookings bookings_source_src_28000
-              ) subq_0
-            ) subq_1
-            ON
-              DATEADD(day, -5, subq_2.metric_time__day) = subq_1.metric_time__day
-          ) subq_4
-        ) subq_5
-        GROUP BY
-          subq_5.metric_time__day
-      ) subq_6
-    ) subq_7
-  ) subq_8
-  ON
-    DATEADD(day, -2, subq_9.metric_time__day) = subq_8.metric_time__day
-) subq_11
+                  subq_3.ds AS metric_time__day
+                FROM ***************************.mf_time_spine subq_3
+              ) subq_2
+              INNER JOIN (
+                -- Metric Time Dimension 'ds'
+                SELECT
+                  subq_0.ds__day
+                  , subq_0.ds__week
+                  , subq_0.ds__month
+                  , subq_0.ds__quarter
+                  , subq_0.ds__year
+                  , subq_0.ds__extract_year
+                  , subq_0.ds__extract_quarter
+                  , subq_0.ds__extract_month
+                  , subq_0.ds__extract_day
+                  , subq_0.ds__extract_dow
+                  , subq_0.ds__extract_doy
+                  , subq_0.ds_partitioned__day
+                  , subq_0.ds_partitioned__week
+                  , subq_0.ds_partitioned__month
+                  , subq_0.ds_partitioned__quarter
+                  , subq_0.ds_partitioned__year
+                  , subq_0.ds_partitioned__extract_year
+                  , subq_0.ds_partitioned__extract_quarter
+                  , subq_0.ds_partitioned__extract_month
+                  , subq_0.ds_partitioned__extract_day
+                  , subq_0.ds_partitioned__extract_dow
+                  , subq_0.ds_partitioned__extract_doy
+                  , subq_0.paid_at__day
+                  , subq_0.paid_at__week
+                  , subq_0.paid_at__month
+                  , subq_0.paid_at__quarter
+                  , subq_0.paid_at__year
+                  , subq_0.paid_at__extract_year
+                  , subq_0.paid_at__extract_quarter
+                  , subq_0.paid_at__extract_month
+                  , subq_0.paid_at__extract_day
+                  , subq_0.paid_at__extract_dow
+                  , subq_0.paid_at__extract_doy
+                  , subq_0.booking__ds__day
+                  , subq_0.booking__ds__week
+                  , subq_0.booking__ds__month
+                  , subq_0.booking__ds__quarter
+                  , subq_0.booking__ds__year
+                  , subq_0.booking__ds__extract_year
+                  , subq_0.booking__ds__extract_quarter
+                  , subq_0.booking__ds__extract_month
+                  , subq_0.booking__ds__extract_day
+                  , subq_0.booking__ds__extract_dow
+                  , subq_0.booking__ds__extract_doy
+                  , subq_0.booking__ds_partitioned__day
+                  , subq_0.booking__ds_partitioned__week
+                  , subq_0.booking__ds_partitioned__month
+                  , subq_0.booking__ds_partitioned__quarter
+                  , subq_0.booking__ds_partitioned__year
+                  , subq_0.booking__ds_partitioned__extract_year
+                  , subq_0.booking__ds_partitioned__extract_quarter
+                  , subq_0.booking__ds_partitioned__extract_month
+                  , subq_0.booking__ds_partitioned__extract_day
+                  , subq_0.booking__ds_partitioned__extract_dow
+                  , subq_0.booking__ds_partitioned__extract_doy
+                  , subq_0.booking__paid_at__day
+                  , subq_0.booking__paid_at__week
+                  , subq_0.booking__paid_at__month
+                  , subq_0.booking__paid_at__quarter
+                  , subq_0.booking__paid_at__year
+                  , subq_0.booking__paid_at__extract_year
+                  , subq_0.booking__paid_at__extract_quarter
+                  , subq_0.booking__paid_at__extract_month
+                  , subq_0.booking__paid_at__extract_day
+                  , subq_0.booking__paid_at__extract_dow
+                  , subq_0.booking__paid_at__extract_doy
+                  , subq_0.ds__day AS metric_time__day
+                  , subq_0.ds__week AS metric_time__week
+                  , subq_0.ds__month AS metric_time__month
+                  , subq_0.ds__quarter AS metric_time__quarter
+                  , subq_0.ds__year AS metric_time__year
+                  , subq_0.ds__extract_year AS metric_time__extract_year
+                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_0.ds__extract_month AS metric_time__extract_month
+                  , subq_0.ds__extract_day AS metric_time__extract_day
+                  , subq_0.ds__extract_dow AS metric_time__extract_dow
+                  , subq_0.ds__extract_doy AS metric_time__extract_doy
+                  , subq_0.listing
+                  , subq_0.guest
+                  , subq_0.host
+                  , subq_0.booking__listing
+                  , subq_0.booking__guest
+                  , subq_0.booking__host
+                  , subq_0.is_instant
+                  , subq_0.booking__is_instant
+                  , subq_0.bookings
+                  , subq_0.instant_bookings
+                  , subq_0.booking_value
+                  , subq_0.max_booking_value
+                  , subq_0.min_booking_value
+                  , subq_0.bookers
+                  , subq_0.average_booking_value
+                  , subq_0.referred_bookings
+                  , subq_0.median_booking_value
+                  , subq_0.booking_value_p99
+                  , subq_0.discrete_booking_value_p99
+                  , subq_0.approximate_continuous_booking_value_p99
+                  , subq_0.approximate_discrete_booking_value_p99
+                FROM (
+                  -- Read Elements From Semantic Model 'bookings_source'
+                  SELECT
+                    1 AS bookings
+                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                    , bookings_source_src_28000.booking_value
+                    , bookings_source_src_28000.booking_value AS max_booking_value
+                    , bookings_source_src_28000.booking_value AS min_booking_value
+                    , bookings_source_src_28000.guest_id AS bookers
+                    , bookings_source_src_28000.booking_value AS average_booking_value
+                    , bookings_source_src_28000.booking_value AS booking_payments
+                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                    , bookings_source_src_28000.booking_value AS median_booking_value
+                    , bookings_source_src_28000.booking_value AS booking_value_p99
+                    , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                    , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                    , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                    , bookings_source_src_28000.is_instant
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                    , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                    , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                    , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                    , bookings_source_src_28000.is_instant AS booking__is_instant
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                    , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS booking__ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                    , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS booking__ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                    , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS booking__paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                    , bookings_source_src_28000.listing_id AS listing
+                    , bookings_source_src_28000.guest_id AS guest
+                    , bookings_source_src_28000.host_id AS host
+                    , bookings_source_src_28000.listing_id AS booking__listing
+                    , bookings_source_src_28000.guest_id AS booking__guest
+                    , bookings_source_src_28000.host_id AS booking__host
+                  FROM ***************************.fct_bookings bookings_source_src_28000
+                ) subq_0
+              ) subq_1
+              ON
+                DATEADD(day, -5, subq_2.metric_time__day) = subq_1.metric_time__day
+            ) subq_4
+          ) subq_5
+          GROUP BY
+            subq_5.metric_time__day
+        ) subq_6
+      ) subq_7
+    ) subq_8
+    ON
+      DATEADD(day, -2, subq_9.metric_time__day) = subq_8.metric_time__day
+  ) subq_11
+  WHERE subq_11.metric_time__day BETWEEN '2020-01-12' AND '2020-01-13'
+) subq_12

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_nested_offsets_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_nested_offsets_with_time_constraint__plan0_optimized.sql
@@ -8,16 +8,11 @@ SELECT
   , 2 * bookings_offset_once AS bookings_offset_twice
 FROM (
   -- Join to Time Spine Dataset
+  -- Constrain Time Range to [2020-01-12T00:00:00, 2020-01-13T00:00:00]
   SELECT
-    subq_21.metric_time__day AS metric_time__day
-    , subq_20.bookings_offset_once AS bookings_offset_once
-  FROM (
-    -- Time Spine
-    SELECT
-      ds AS metric_time__day
-    FROM ***************************.mf_time_spine subq_22
-    WHERE ds BETWEEN '2020-01-12' AND '2020-01-13'
-  ) subq_21
+    subq_23.ds AS metric_time__day
+    , subq_21.bookings_offset_once AS bookings_offset_once
+  FROM ***************************.mf_time_spine subq_23
   INNER JOIN (
     -- Compute Metrics via Expressions
     SELECT
@@ -29,9 +24,9 @@ FROM (
       -- Aggregate Measures
       -- Compute Metrics via Expressions
       SELECT
-        subq_15.ds AS metric_time__day
-        , SUM(subq_13.bookings) AS bookings
-      FROM ***************************.mf_time_spine subq_15
+        subq_16.ds AS metric_time__day
+        , SUM(subq_14.bookings) AS bookings
+      FROM ***************************.mf_time_spine subq_16
       INNER JOIN (
         -- Read Elements From Semantic Model 'bookings_source'
         -- Metric Time Dimension 'ds'
@@ -39,13 +34,14 @@ FROM (
           DATE_TRUNC('day', ds) AS metric_time__day
           , 1 AS bookings
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_13
+      ) subq_14
       ON
-        DATEADD(day, -5, subq_15.ds) = subq_13.metric_time__day
+        DATEADD(day, -5, subq_16.ds) = subq_14.metric_time__day
       GROUP BY
-        subq_15.ds
-    ) subq_19
-  ) subq_20
+        subq_16.ds
+    ) subq_20
+  ) subq_21
   ON
-    DATEADD(day, -2, subq_21.metric_time__day) = subq_20.metric_time__day
-) subq_23
+    DATEADD(day, -2, subq_23.ds) = subq_21.metric_time__day
+  WHERE subq_23.ds BETWEEN '2020-01-12' AND '2020-01-13'
+) subq_25

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_time_offset_metric_with_time_constraint__plan0.sql
@@ -4,331 +4,433 @@ sql_engine: Redshift
 ---
 -- Compute Metrics via Expressions
 SELECT
-  subq_7.metric_time__day
+  subq_8.metric_time__day
   , bookings_5_days_ago AS bookings_5_day_lag
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_6.metric_time__day
-    , subq_6.bookings AS bookings_5_days_ago
+    subq_7.metric_time__day
+    , subq_7.bookings AS bookings_5_days_ago
   FROM (
     -- Aggregate Measures
     SELECT
-      subq_5.metric_time__day
-      , SUM(subq_5.bookings) AS bookings
+      subq_6.metric_time__day
+      , SUM(subq_6.bookings) AS bookings
     FROM (
       -- Pass Only Elements: ['bookings', 'metric_time__day']
       SELECT
-        subq_4.metric_time__day
-        , subq_4.bookings
+        subq_5.metric_time__day
+        , subq_5.bookings
       FROM (
-        -- Join to Time Spine Dataset
+        -- Constrain Time Range to [2019-12-19T00:00:00, 2020-01-02T00:00:00]
         SELECT
-          subq_1.ds__day AS ds__day
-          , subq_1.ds__week AS ds__week
-          , subq_1.ds__month AS ds__month
-          , subq_1.ds__quarter AS ds__quarter
-          , subq_1.ds__year AS ds__year
-          , subq_1.ds__extract_year AS ds__extract_year
-          , subq_1.ds__extract_quarter AS ds__extract_quarter
-          , subq_1.ds__extract_month AS ds__extract_month
-          , subq_1.ds__extract_day AS ds__extract_day
-          , subq_1.ds__extract_dow AS ds__extract_dow
-          , subq_1.ds__extract_doy AS ds__extract_doy
-          , subq_1.ds_partitioned__day AS ds_partitioned__day
-          , subq_1.ds_partitioned__week AS ds_partitioned__week
-          , subq_1.ds_partitioned__month AS ds_partitioned__month
-          , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
-          , subq_1.ds_partitioned__year AS ds_partitioned__year
-          , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
-          , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
-          , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
-          , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
-          , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
-          , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
-          , subq_1.paid_at__day AS paid_at__day
-          , subq_1.paid_at__week AS paid_at__week
-          , subq_1.paid_at__month AS paid_at__month
-          , subq_1.paid_at__quarter AS paid_at__quarter
-          , subq_1.paid_at__year AS paid_at__year
-          , subq_1.paid_at__extract_year AS paid_at__extract_year
-          , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
-          , subq_1.paid_at__extract_month AS paid_at__extract_month
-          , subq_1.paid_at__extract_day AS paid_at__extract_day
-          , subq_1.paid_at__extract_dow AS paid_at__extract_dow
-          , subq_1.paid_at__extract_doy AS paid_at__extract_doy
-          , subq_1.booking__ds__day AS booking__ds__day
-          , subq_1.booking__ds__week AS booking__ds__week
-          , subq_1.booking__ds__month AS booking__ds__month
-          , subq_1.booking__ds__quarter AS booking__ds__quarter
-          , subq_1.booking__ds__year AS booking__ds__year
-          , subq_1.booking__ds__extract_year AS booking__ds__extract_year
-          , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
-          , subq_1.booking__ds__extract_month AS booking__ds__extract_month
-          , subq_1.booking__ds__extract_day AS booking__ds__extract_day
-          , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
-          , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
-          , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
-          , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
-          , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
-          , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
-          , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
-          , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
-          , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
-          , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
-          , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
-          , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
-          , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
-          , subq_1.booking__paid_at__day AS booking__paid_at__day
-          , subq_1.booking__paid_at__week AS booking__paid_at__week
-          , subq_1.booking__paid_at__month AS booking__paid_at__month
-          , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
-          , subq_1.booking__paid_at__year AS booking__paid_at__year
-          , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
-          , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
-          , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
-          , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
-          , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
-          , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
-          , subq_1.metric_time__week AS metric_time__week
-          , subq_1.metric_time__month AS metric_time__month
-          , subq_1.metric_time__quarter AS metric_time__quarter
-          , subq_1.metric_time__year AS metric_time__year
-          , subq_1.metric_time__extract_year AS metric_time__extract_year
-          , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
-          , subq_1.metric_time__extract_month AS metric_time__extract_month
-          , subq_1.metric_time__extract_day AS metric_time__extract_day
-          , subq_1.metric_time__extract_dow AS metric_time__extract_dow
-          , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-          , subq_2.metric_time__day AS metric_time__day
-          , subq_1.listing AS listing
-          , subq_1.guest AS guest
-          , subq_1.host AS host
-          , subq_1.booking__listing AS booking__listing
-          , subq_1.booking__guest AS booking__guest
-          , subq_1.booking__host AS booking__host
-          , subq_1.is_instant AS is_instant
-          , subq_1.booking__is_instant AS booking__is_instant
-          , subq_1.bookings AS bookings
-          , subq_1.instant_bookings AS instant_bookings
-          , subq_1.booking_value AS booking_value
-          , subq_1.max_booking_value AS max_booking_value
-          , subq_1.min_booking_value AS min_booking_value
-          , subq_1.bookers AS bookers
-          , subq_1.average_booking_value AS average_booking_value
-          , subq_1.referred_bookings AS referred_bookings
-          , subq_1.median_booking_value AS median_booking_value
-          , subq_1.booking_value_p99 AS booking_value_p99
-          , subq_1.discrete_booking_value_p99 AS discrete_booking_value_p99
-          , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
-          , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+          subq_4.metric_time__day
+          , subq_4.ds__day
+          , subq_4.ds__week
+          , subq_4.ds__month
+          , subq_4.ds__quarter
+          , subq_4.ds__year
+          , subq_4.ds__extract_year
+          , subq_4.ds__extract_quarter
+          , subq_4.ds__extract_month
+          , subq_4.ds__extract_day
+          , subq_4.ds__extract_dow
+          , subq_4.ds__extract_doy
+          , subq_4.ds_partitioned__day
+          , subq_4.ds_partitioned__week
+          , subq_4.ds_partitioned__month
+          , subq_4.ds_partitioned__quarter
+          , subq_4.ds_partitioned__year
+          , subq_4.ds_partitioned__extract_year
+          , subq_4.ds_partitioned__extract_quarter
+          , subq_4.ds_partitioned__extract_month
+          , subq_4.ds_partitioned__extract_day
+          , subq_4.ds_partitioned__extract_dow
+          , subq_4.ds_partitioned__extract_doy
+          , subq_4.paid_at__day
+          , subq_4.paid_at__week
+          , subq_4.paid_at__month
+          , subq_4.paid_at__quarter
+          , subq_4.paid_at__year
+          , subq_4.paid_at__extract_year
+          , subq_4.paid_at__extract_quarter
+          , subq_4.paid_at__extract_month
+          , subq_4.paid_at__extract_day
+          , subq_4.paid_at__extract_dow
+          , subq_4.paid_at__extract_doy
+          , subq_4.booking__ds__day
+          , subq_4.booking__ds__week
+          , subq_4.booking__ds__month
+          , subq_4.booking__ds__quarter
+          , subq_4.booking__ds__year
+          , subq_4.booking__ds__extract_year
+          , subq_4.booking__ds__extract_quarter
+          , subq_4.booking__ds__extract_month
+          , subq_4.booking__ds__extract_day
+          , subq_4.booking__ds__extract_dow
+          , subq_4.booking__ds__extract_doy
+          , subq_4.booking__ds_partitioned__day
+          , subq_4.booking__ds_partitioned__week
+          , subq_4.booking__ds_partitioned__month
+          , subq_4.booking__ds_partitioned__quarter
+          , subq_4.booking__ds_partitioned__year
+          , subq_4.booking__ds_partitioned__extract_year
+          , subq_4.booking__ds_partitioned__extract_quarter
+          , subq_4.booking__ds_partitioned__extract_month
+          , subq_4.booking__ds_partitioned__extract_day
+          , subq_4.booking__ds_partitioned__extract_dow
+          , subq_4.booking__ds_partitioned__extract_doy
+          , subq_4.booking__paid_at__day
+          , subq_4.booking__paid_at__week
+          , subq_4.booking__paid_at__month
+          , subq_4.booking__paid_at__quarter
+          , subq_4.booking__paid_at__year
+          , subq_4.booking__paid_at__extract_year
+          , subq_4.booking__paid_at__extract_quarter
+          , subq_4.booking__paid_at__extract_month
+          , subq_4.booking__paid_at__extract_day
+          , subq_4.booking__paid_at__extract_dow
+          , subq_4.booking__paid_at__extract_doy
+          , subq_4.metric_time__week
+          , subq_4.metric_time__month
+          , subq_4.metric_time__quarter
+          , subq_4.metric_time__year
+          , subq_4.metric_time__extract_year
+          , subq_4.metric_time__extract_quarter
+          , subq_4.metric_time__extract_month
+          , subq_4.metric_time__extract_day
+          , subq_4.metric_time__extract_dow
+          , subq_4.metric_time__extract_doy
+          , subq_4.listing
+          , subq_4.guest
+          , subq_4.host
+          , subq_4.booking__listing
+          , subq_4.booking__guest
+          , subq_4.booking__host
+          , subq_4.is_instant
+          , subq_4.booking__is_instant
+          , subq_4.bookings
+          , subq_4.instant_bookings
+          , subq_4.booking_value
+          , subq_4.max_booking_value
+          , subq_4.min_booking_value
+          , subq_4.bookers
+          , subq_4.average_booking_value
+          , subq_4.referred_bookings
+          , subq_4.median_booking_value
+          , subq_4.booking_value_p99
+          , subq_4.discrete_booking_value_p99
+          , subq_4.approximate_continuous_booking_value_p99
+          , subq_4.approximate_discrete_booking_value_p99
         FROM (
-          -- Time Spine
+          -- Join to Time Spine Dataset
           SELECT
-            subq_3.ds AS metric_time__day
-          FROM ***************************.mf_time_spine subq_3
-          WHERE subq_3.ds BETWEEN '2019-12-19' AND '2020-01-02'
-        ) subq_2
-        INNER JOIN (
-          -- Metric Time Dimension 'ds'
-          SELECT
-            subq_0.ds__day
-            , subq_0.ds__week
-            , subq_0.ds__month
-            , subq_0.ds__quarter
-            , subq_0.ds__year
-            , subq_0.ds__extract_year
-            , subq_0.ds__extract_quarter
-            , subq_0.ds__extract_month
-            , subq_0.ds__extract_day
-            , subq_0.ds__extract_dow
-            , subq_0.ds__extract_doy
-            , subq_0.ds_partitioned__day
-            , subq_0.ds_partitioned__week
-            , subq_0.ds_partitioned__month
-            , subq_0.ds_partitioned__quarter
-            , subq_0.ds_partitioned__year
-            , subq_0.ds_partitioned__extract_year
-            , subq_0.ds_partitioned__extract_quarter
-            , subq_0.ds_partitioned__extract_month
-            , subq_0.ds_partitioned__extract_day
-            , subq_0.ds_partitioned__extract_dow
-            , subq_0.ds_partitioned__extract_doy
-            , subq_0.paid_at__day
-            , subq_0.paid_at__week
-            , subq_0.paid_at__month
-            , subq_0.paid_at__quarter
-            , subq_0.paid_at__year
-            , subq_0.paid_at__extract_year
-            , subq_0.paid_at__extract_quarter
-            , subq_0.paid_at__extract_month
-            , subq_0.paid_at__extract_day
-            , subq_0.paid_at__extract_dow
-            , subq_0.paid_at__extract_doy
-            , subq_0.booking__ds__day
-            , subq_0.booking__ds__week
-            , subq_0.booking__ds__month
-            , subq_0.booking__ds__quarter
-            , subq_0.booking__ds__year
-            , subq_0.booking__ds__extract_year
-            , subq_0.booking__ds__extract_quarter
-            , subq_0.booking__ds__extract_month
-            , subq_0.booking__ds__extract_day
-            , subq_0.booking__ds__extract_dow
-            , subq_0.booking__ds__extract_doy
-            , subq_0.booking__ds_partitioned__day
-            , subq_0.booking__ds_partitioned__week
-            , subq_0.booking__ds_partitioned__month
-            , subq_0.booking__ds_partitioned__quarter
-            , subq_0.booking__ds_partitioned__year
-            , subq_0.booking__ds_partitioned__extract_year
-            , subq_0.booking__ds_partitioned__extract_quarter
-            , subq_0.booking__ds_partitioned__extract_month
-            , subq_0.booking__ds_partitioned__extract_day
-            , subq_0.booking__ds_partitioned__extract_dow
-            , subq_0.booking__ds_partitioned__extract_doy
-            , subq_0.booking__paid_at__day
-            , subq_0.booking__paid_at__week
-            , subq_0.booking__paid_at__month
-            , subq_0.booking__paid_at__quarter
-            , subq_0.booking__paid_at__year
-            , subq_0.booking__paid_at__extract_year
-            , subq_0.booking__paid_at__extract_quarter
-            , subq_0.booking__paid_at__extract_month
-            , subq_0.booking__paid_at__extract_day
-            , subq_0.booking__paid_at__extract_dow
-            , subq_0.booking__paid_at__extract_doy
-            , subq_0.ds__day AS metric_time__day
-            , subq_0.ds__week AS metric_time__week
-            , subq_0.ds__month AS metric_time__month
-            , subq_0.ds__quarter AS metric_time__quarter
-            , subq_0.ds__year AS metric_time__year
-            , subq_0.ds__extract_year AS metric_time__extract_year
-            , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-            , subq_0.ds__extract_month AS metric_time__extract_month
-            , subq_0.ds__extract_day AS metric_time__extract_day
-            , subq_0.ds__extract_dow AS metric_time__extract_dow
-            , subq_0.ds__extract_doy AS metric_time__extract_doy
-            , subq_0.listing
-            , subq_0.guest
-            , subq_0.host
-            , subq_0.booking__listing
-            , subq_0.booking__guest
-            , subq_0.booking__host
-            , subq_0.is_instant
-            , subq_0.booking__is_instant
-            , subq_0.bookings
-            , subq_0.instant_bookings
-            , subq_0.booking_value
-            , subq_0.max_booking_value
-            , subq_0.min_booking_value
-            , subq_0.bookers
-            , subq_0.average_booking_value
-            , subq_0.referred_bookings
-            , subq_0.median_booking_value
-            , subq_0.booking_value_p99
-            , subq_0.discrete_booking_value_p99
-            , subq_0.approximate_continuous_booking_value_p99
-            , subq_0.approximate_discrete_booking_value_p99
+            subq_1.ds__day AS ds__day
+            , subq_1.ds__week AS ds__week
+            , subq_1.ds__month AS ds__month
+            , subq_1.ds__quarter AS ds__quarter
+            , subq_1.ds__year AS ds__year
+            , subq_1.ds__extract_year AS ds__extract_year
+            , subq_1.ds__extract_quarter AS ds__extract_quarter
+            , subq_1.ds__extract_month AS ds__extract_month
+            , subq_1.ds__extract_day AS ds__extract_day
+            , subq_1.ds__extract_dow AS ds__extract_dow
+            , subq_1.ds__extract_doy AS ds__extract_doy
+            , subq_1.ds_partitioned__day AS ds_partitioned__day
+            , subq_1.ds_partitioned__week AS ds_partitioned__week
+            , subq_1.ds_partitioned__month AS ds_partitioned__month
+            , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
+            , subq_1.ds_partitioned__year AS ds_partitioned__year
+            , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
+            , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+            , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
+            , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
+            , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+            , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+            , subq_1.paid_at__day AS paid_at__day
+            , subq_1.paid_at__week AS paid_at__week
+            , subq_1.paid_at__month AS paid_at__month
+            , subq_1.paid_at__quarter AS paid_at__quarter
+            , subq_1.paid_at__year AS paid_at__year
+            , subq_1.paid_at__extract_year AS paid_at__extract_year
+            , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
+            , subq_1.paid_at__extract_month AS paid_at__extract_month
+            , subq_1.paid_at__extract_day AS paid_at__extract_day
+            , subq_1.paid_at__extract_dow AS paid_at__extract_dow
+            , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+            , subq_1.booking__ds__day AS booking__ds__day
+            , subq_1.booking__ds__week AS booking__ds__week
+            , subq_1.booking__ds__month AS booking__ds__month
+            , subq_1.booking__ds__quarter AS booking__ds__quarter
+            , subq_1.booking__ds__year AS booking__ds__year
+            , subq_1.booking__ds__extract_year AS booking__ds__extract_year
+            , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
+            , subq_1.booking__ds__extract_month AS booking__ds__extract_month
+            , subq_1.booking__ds__extract_day AS booking__ds__extract_day
+            , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
+            , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
+            , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
+            , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
+            , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
+            , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+            , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
+            , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+            , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+            , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+            , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+            , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+            , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+            , subq_1.booking__paid_at__day AS booking__paid_at__day
+            , subq_1.booking__paid_at__week AS booking__paid_at__week
+            , subq_1.booking__paid_at__month AS booking__paid_at__month
+            , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
+            , subq_1.booking__paid_at__year AS booking__paid_at__year
+            , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
+            , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+            , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
+            , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
+            , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+            , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_1.metric_time__week AS metric_time__week
+            , subq_1.metric_time__month AS metric_time__month
+            , subq_1.metric_time__quarter AS metric_time__quarter
+            , subq_1.metric_time__year AS metric_time__year
+            , subq_1.metric_time__extract_year AS metric_time__extract_year
+            , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_1.metric_time__extract_month AS metric_time__extract_month
+            , subq_1.metric_time__extract_day AS metric_time__extract_day
+            , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_2.metric_time__day AS metric_time__day
+            , subq_1.listing AS listing
+            , subq_1.guest AS guest
+            , subq_1.host AS host
+            , subq_1.booking__listing AS booking__listing
+            , subq_1.booking__guest AS booking__guest
+            , subq_1.booking__host AS booking__host
+            , subq_1.is_instant AS is_instant
+            , subq_1.booking__is_instant AS booking__is_instant
+            , subq_1.bookings AS bookings
+            , subq_1.instant_bookings AS instant_bookings
+            , subq_1.booking_value AS booking_value
+            , subq_1.max_booking_value AS max_booking_value
+            , subq_1.min_booking_value AS min_booking_value
+            , subq_1.bookers AS bookers
+            , subq_1.average_booking_value AS average_booking_value
+            , subq_1.referred_bookings AS referred_bookings
+            , subq_1.median_booking_value AS median_booking_value
+            , subq_1.booking_value_p99 AS booking_value_p99
+            , subq_1.discrete_booking_value_p99 AS discrete_booking_value_p99
+            , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+            , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Read Elements From Semantic Model 'bookings_source'
+            -- Time Spine
             SELECT
-              1 AS bookings
-              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-              , bookings_source_src_28000.booking_value
-              , bookings_source_src_28000.booking_value AS max_booking_value
-              , bookings_source_src_28000.booking_value AS min_booking_value
-              , bookings_source_src_28000.guest_id AS bookers
-              , bookings_source_src_28000.booking_value AS average_booking_value
-              , bookings_source_src_28000.booking_value AS booking_payments
-              , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-              , bookings_source_src_28000.booking_value AS median_booking_value
-              , bookings_source_src_28000.booking_value AS booking_value_p99
-              , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
-              , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
-              , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
-              , bookings_source_src_28000.is_instant
-              , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-              , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-              , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-              , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-              , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-              , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-              , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-              , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS ds__extract_dow
-              , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-              , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-              , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-              , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-              , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-              , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-              , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-              , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS ds_partitioned__extract_dow
-              , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-              , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-              , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-              , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-              , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-              , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-              , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-              , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS paid_at__extract_dow
-              , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-              , bookings_source_src_28000.is_instant AS booking__is_instant
-              , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-              , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-              , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-              , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-              , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-              , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-              , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-              , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS booking__ds__extract_dow
-              , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-              , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-              , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-              , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-              , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-              , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-              , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-              , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS booking__ds_partitioned__extract_dow
-              , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-              , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-              , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-              , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-              , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-              , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-              , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS booking__paid_at__extract_dow
-              , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-              , bookings_source_src_28000.listing_id AS listing
-              , bookings_source_src_28000.guest_id AS guest
-              , bookings_source_src_28000.host_id AS host
-              , bookings_source_src_28000.listing_id AS booking__listing
-              , bookings_source_src_28000.guest_id AS booking__guest
-              , bookings_source_src_28000.host_id AS booking__host
-            FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_0
-        ) subq_1
-        ON
-          DATEADD(day, -5, subq_2.metric_time__day) = subq_1.metric_time__day
-      ) subq_4
-    ) subq_5
+              subq_3.ds AS metric_time__day
+            FROM ***************************.mf_time_spine subq_3
+          ) subq_2
+          INNER JOIN (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.ds_partitioned__day
+              , subq_0.ds_partitioned__week
+              , subq_0.ds_partitioned__month
+              , subq_0.ds_partitioned__quarter
+              , subq_0.ds_partitioned__year
+              , subq_0.ds_partitioned__extract_year
+              , subq_0.ds_partitioned__extract_quarter
+              , subq_0.ds_partitioned__extract_month
+              , subq_0.ds_partitioned__extract_day
+              , subq_0.ds_partitioned__extract_dow
+              , subq_0.ds_partitioned__extract_doy
+              , subq_0.paid_at__day
+              , subq_0.paid_at__week
+              , subq_0.paid_at__month
+              , subq_0.paid_at__quarter
+              , subq_0.paid_at__year
+              , subq_0.paid_at__extract_year
+              , subq_0.paid_at__extract_quarter
+              , subq_0.paid_at__extract_month
+              , subq_0.paid_at__extract_day
+              , subq_0.paid_at__extract_dow
+              , subq_0.paid_at__extract_doy
+              , subq_0.booking__ds__day
+              , subq_0.booking__ds__week
+              , subq_0.booking__ds__month
+              , subq_0.booking__ds__quarter
+              , subq_0.booking__ds__year
+              , subq_0.booking__ds__extract_year
+              , subq_0.booking__ds__extract_quarter
+              , subq_0.booking__ds__extract_month
+              , subq_0.booking__ds__extract_day
+              , subq_0.booking__ds__extract_dow
+              , subq_0.booking__ds__extract_doy
+              , subq_0.booking__ds_partitioned__day
+              , subq_0.booking__ds_partitioned__week
+              , subq_0.booking__ds_partitioned__month
+              , subq_0.booking__ds_partitioned__quarter
+              , subq_0.booking__ds_partitioned__year
+              , subq_0.booking__ds_partitioned__extract_year
+              , subq_0.booking__ds_partitioned__extract_quarter
+              , subq_0.booking__ds_partitioned__extract_month
+              , subq_0.booking__ds_partitioned__extract_day
+              , subq_0.booking__ds_partitioned__extract_dow
+              , subq_0.booking__ds_partitioned__extract_doy
+              , subq_0.booking__paid_at__day
+              , subq_0.booking__paid_at__week
+              , subq_0.booking__paid_at__month
+              , subq_0.booking__paid_at__quarter
+              , subq_0.booking__paid_at__year
+              , subq_0.booking__paid_at__extract_year
+              , subq_0.booking__paid_at__extract_quarter
+              , subq_0.booking__paid_at__extract_month
+              , subq_0.booking__paid_at__extract_day
+              , subq_0.booking__paid_at__extract_dow
+              , subq_0.booking__paid_at__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.listing
+              , subq_0.guest
+              , subq_0.host
+              , subq_0.booking__listing
+              , subq_0.booking__guest
+              , subq_0.booking__host
+              , subq_0.is_instant
+              , subq_0.booking__is_instant
+              , subq_0.bookings
+              , subq_0.instant_bookings
+              , subq_0.booking_value
+              , subq_0.max_booking_value
+              , subq_0.min_booking_value
+              , subq_0.bookers
+              , subq_0.average_booking_value
+              , subq_0.referred_bookings
+              , subq_0.median_booking_value
+              , subq_0.booking_value_p99
+              , subq_0.discrete_booking_value_p99
+              , subq_0.approximate_continuous_booking_value_p99
+              , subq_0.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Semantic Model 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_28000.booking_value
+                , bookings_source_src_28000.booking_value AS max_booking_value
+                , bookings_source_src_28000.booking_value AS min_booking_value
+                , bookings_source_src_28000.guest_id AS bookers
+                , bookings_source_src_28000.booking_value AS average_booking_value
+                , bookings_source_src_28000.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_28000.booking_value AS median_booking_value
+                , bookings_source_src_28000.booking_value AS booking_value_p99
+                , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_28000.is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_28000.is_instant AS booking__is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS booking__ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS booking__ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS booking__paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_28000.listing_id AS listing
+                , bookings_source_src_28000.guest_id AS guest
+                , bookings_source_src_28000.host_id AS host
+                , bookings_source_src_28000.listing_id AS booking__listing
+                , bookings_source_src_28000.guest_id AS booking__guest
+                , bookings_source_src_28000.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_28000
+            ) subq_0
+          ) subq_1
+          ON
+            DATEADD(day, -5, subq_2.metric_time__day) = subq_1.metric_time__day
+        ) subq_4
+        WHERE subq_4.metric_time__day BETWEEN '2019-12-19' AND '2020-01-02'
+      ) subq_5
+    ) subq_6
     GROUP BY
-      subq_5.metric_time__day
-  ) subq_6
-) subq_7
+      subq_6.metric_time__day
+  ) subq_7
+) subq_8

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_time_offset_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_time_offset_metric_with_time_constraint__plan0_optimized.sql
@@ -8,19 +8,14 @@ SELECT
   , bookings_5_days_ago AS bookings_5_day_lag
 FROM (
   -- Join to Time Spine Dataset
+  -- Constrain Time Range to [2019-12-19T00:00:00, 2020-01-02T00:00:00]
   -- Pass Only Elements: ['bookings', 'metric_time__day']
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT
-    subq_10.metric_time__day AS metric_time__day
-    , SUM(subq_9.bookings) AS bookings_5_days_ago
-  FROM (
-    -- Time Spine
-    SELECT
-      ds AS metric_time__day
-    FROM ***************************.mf_time_spine subq_11
-    WHERE ds BETWEEN '2019-12-19' AND '2020-01-02'
-  ) subq_10
+    subq_12.ds AS metric_time__day
+    , SUM(subq_10.bookings) AS bookings_5_days_ago
+  FROM ***************************.mf_time_spine subq_12
   INNER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -28,9 +23,10 @@ FROM (
       DATE_TRUNC('day', ds) AS metric_time__day
       , 1 AS bookings
     FROM ***************************.fct_bookings bookings_source_src_28000
-  ) subq_9
+  ) subq_10
   ON
-    DATEADD(day, -5, subq_10.metric_time__day) = subq_9.metric_time__day
+    DATEADD(day, -5, subq_12.ds) = subq_10.metric_time__day
+  WHERE subq_12.ds BETWEEN '2019-12-19' AND '2020-01-02'
   GROUP BY
-    subq_10.metric_time__day
-) subq_15
+    subq_12.ds
+) subq_17

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
@@ -228,7 +228,6 @@ FROM (
             SELECT
               subq_6.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_6
-            WHERE subq_6.ds BETWEEN '2019-12-19' AND '2020-01-02'
           ) subq_5
           INNER JOIN (
             -- Join Self Over Time Range

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_time_offset_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_time_offset_metric_with_time_constraint__plan0_optimized.sql
@@ -13,15 +13,9 @@ FROM (
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT
-    subq_17.metric_time__day AS metric_time__day
+    subq_18.ds AS metric_time__day
     , COUNT(DISTINCT subq_16.bookers) AS every_2_days_bookers_2_days_ago
-  FROM (
-    -- Time Spine
-    SELECT
-      ds AS metric_time__day
-    FROM ***************************.mf_time_spine subq_18
-    WHERE ds BETWEEN '2019-12-19' AND '2020-01-02'
-  ) subq_17
+  FROM ***************************.mf_time_spine subq_18
   INNER JOIN (
     -- Join Self Over Time Range
     SELECT
@@ -38,8 +32,8 @@ FROM (
       )
   ) subq_16
   ON
-    DATEADD(day, -2, subq_17.metric_time__day) = subq_16.metric_time__day
-  WHERE subq_17.metric_time__day BETWEEN '2019-12-19' AND '2020-01-02'
+    DATEADD(day, -2, subq_18.ds) = subq_16.metric_time__day
+  WHERE subq_18.ds BETWEEN '2019-12-19' AND '2020-01-02'
   GROUP BY
-    subq_17.metric_time__day
+    subq_18.ds
 ) subq_23

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_nested_offsets_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_nested_offsets_with_time_constraint__plan0.sql
@@ -4,351 +4,357 @@ sql_engine: Snowflake
 ---
 -- Compute Metrics via Expressions
 SELECT
-  subq_11.metric_time__day
+  subq_12.metric_time__day
   , 2 * bookings_offset_once AS bookings_offset_twice
 FROM (
-  -- Join to Time Spine Dataset
+  -- Constrain Time Range to [2020-01-12T00:00:00, 2020-01-13T00:00:00]
   SELECT
-    subq_9.metric_time__day AS metric_time__day
-    , subq_8.bookings_offset_once AS bookings_offset_once
+    subq_11.metric_time__day
+    , subq_11.bookings_offset_once
   FROM (
-    -- Time Spine
+    -- Join to Time Spine Dataset
     SELECT
-      subq_10.ds AS metric_time__day
-    FROM ***************************.mf_time_spine subq_10
-    WHERE subq_10.ds BETWEEN '2020-01-12' AND '2020-01-13'
-  ) subq_9
-  INNER JOIN (
-    -- Compute Metrics via Expressions
-    SELECT
-      subq_7.metric_time__day
-      , 2 * bookings AS bookings_offset_once
+      subq_9.metric_time__day AS metric_time__day
+      , subq_8.bookings_offset_once AS bookings_offset_once
     FROM (
+      -- Time Spine
+      SELECT
+        subq_10.ds AS metric_time__day
+      FROM ***************************.mf_time_spine subq_10
+    ) subq_9
+    INNER JOIN (
       -- Compute Metrics via Expressions
       SELECT
-        subq_6.metric_time__day
-        , subq_6.bookings
+        subq_7.metric_time__day
+        , 2 * bookings AS bookings_offset_once
       FROM (
-        -- Aggregate Measures
+        -- Compute Metrics via Expressions
         SELECT
-          subq_5.metric_time__day
-          , SUM(subq_5.bookings) AS bookings
+          subq_6.metric_time__day
+          , subq_6.bookings
         FROM (
-          -- Pass Only Elements: ['bookings', 'metric_time__day']
+          -- Aggregate Measures
           SELECT
-            subq_4.metric_time__day
-            , subq_4.bookings
+            subq_5.metric_time__day
+            , SUM(subq_5.bookings) AS bookings
           FROM (
-            -- Join to Time Spine Dataset
+            -- Pass Only Elements: ['bookings', 'metric_time__day']
             SELECT
-              subq_1.ds__day AS ds__day
-              , subq_1.ds__week AS ds__week
-              , subq_1.ds__month AS ds__month
-              , subq_1.ds__quarter AS ds__quarter
-              , subq_1.ds__year AS ds__year
-              , subq_1.ds__extract_year AS ds__extract_year
-              , subq_1.ds__extract_quarter AS ds__extract_quarter
-              , subq_1.ds__extract_month AS ds__extract_month
-              , subq_1.ds__extract_day AS ds__extract_day
-              , subq_1.ds__extract_dow AS ds__extract_dow
-              , subq_1.ds__extract_doy AS ds__extract_doy
-              , subq_1.ds_partitioned__day AS ds_partitioned__day
-              , subq_1.ds_partitioned__week AS ds_partitioned__week
-              , subq_1.ds_partitioned__month AS ds_partitioned__month
-              , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
-              , subq_1.ds_partitioned__year AS ds_partitioned__year
-              , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
-              , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
-              , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
-              , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
-              , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
-              , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
-              , subq_1.paid_at__day AS paid_at__day
-              , subq_1.paid_at__week AS paid_at__week
-              , subq_1.paid_at__month AS paid_at__month
-              , subq_1.paid_at__quarter AS paid_at__quarter
-              , subq_1.paid_at__year AS paid_at__year
-              , subq_1.paid_at__extract_year AS paid_at__extract_year
-              , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
-              , subq_1.paid_at__extract_month AS paid_at__extract_month
-              , subq_1.paid_at__extract_day AS paid_at__extract_day
-              , subq_1.paid_at__extract_dow AS paid_at__extract_dow
-              , subq_1.paid_at__extract_doy AS paid_at__extract_doy
-              , subq_1.booking__ds__day AS booking__ds__day
-              , subq_1.booking__ds__week AS booking__ds__week
-              , subq_1.booking__ds__month AS booking__ds__month
-              , subq_1.booking__ds__quarter AS booking__ds__quarter
-              , subq_1.booking__ds__year AS booking__ds__year
-              , subq_1.booking__ds__extract_year AS booking__ds__extract_year
-              , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
-              , subq_1.booking__ds__extract_month AS booking__ds__extract_month
-              , subq_1.booking__ds__extract_day AS booking__ds__extract_day
-              , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
-              , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
-              , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
-              , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
-              , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
-              , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
-              , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
-              , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
-              , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
-              , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
-              , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
-              , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
-              , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
-              , subq_1.booking__paid_at__day AS booking__paid_at__day
-              , subq_1.booking__paid_at__week AS booking__paid_at__week
-              , subq_1.booking__paid_at__month AS booking__paid_at__month
-              , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
-              , subq_1.booking__paid_at__year AS booking__paid_at__year
-              , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
-              , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
-              , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
-              , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
-              , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
-              , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
-              , subq_1.metric_time__week AS metric_time__week
-              , subq_1.metric_time__month AS metric_time__month
-              , subq_1.metric_time__quarter AS metric_time__quarter
-              , subq_1.metric_time__year AS metric_time__year
-              , subq_1.metric_time__extract_year AS metric_time__extract_year
-              , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
-              , subq_1.metric_time__extract_month AS metric_time__extract_month
-              , subq_1.metric_time__extract_day AS metric_time__extract_day
-              , subq_1.metric_time__extract_dow AS metric_time__extract_dow
-              , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-              , subq_2.metric_time__day AS metric_time__day
-              , subq_1.listing AS listing
-              , subq_1.guest AS guest
-              , subq_1.host AS host
-              , subq_1.booking__listing AS booking__listing
-              , subq_1.booking__guest AS booking__guest
-              , subq_1.booking__host AS booking__host
-              , subq_1.is_instant AS is_instant
-              , subq_1.booking__is_instant AS booking__is_instant
-              , subq_1.bookings AS bookings
-              , subq_1.instant_bookings AS instant_bookings
-              , subq_1.booking_value AS booking_value
-              , subq_1.max_booking_value AS max_booking_value
-              , subq_1.min_booking_value AS min_booking_value
-              , subq_1.bookers AS bookers
-              , subq_1.average_booking_value AS average_booking_value
-              , subq_1.referred_bookings AS referred_bookings
-              , subq_1.median_booking_value AS median_booking_value
-              , subq_1.booking_value_p99 AS booking_value_p99
-              , subq_1.discrete_booking_value_p99 AS discrete_booking_value_p99
-              , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
-              , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+              subq_4.metric_time__day
+              , subq_4.bookings
             FROM (
-              -- Time Spine
+              -- Join to Time Spine Dataset
               SELECT
-                subq_3.ds AS metric_time__day
-              FROM ***************************.mf_time_spine subq_3
-            ) subq_2
-            INNER JOIN (
-              -- Metric Time Dimension 'ds'
-              SELECT
-                subq_0.ds__day
-                , subq_0.ds__week
-                , subq_0.ds__month
-                , subq_0.ds__quarter
-                , subq_0.ds__year
-                , subq_0.ds__extract_year
-                , subq_0.ds__extract_quarter
-                , subq_0.ds__extract_month
-                , subq_0.ds__extract_day
-                , subq_0.ds__extract_dow
-                , subq_0.ds__extract_doy
-                , subq_0.ds_partitioned__day
-                , subq_0.ds_partitioned__week
-                , subq_0.ds_partitioned__month
-                , subq_0.ds_partitioned__quarter
-                , subq_0.ds_partitioned__year
-                , subq_0.ds_partitioned__extract_year
-                , subq_0.ds_partitioned__extract_quarter
-                , subq_0.ds_partitioned__extract_month
-                , subq_0.ds_partitioned__extract_day
-                , subq_0.ds_partitioned__extract_dow
-                , subq_0.ds_partitioned__extract_doy
-                , subq_0.paid_at__day
-                , subq_0.paid_at__week
-                , subq_0.paid_at__month
-                , subq_0.paid_at__quarter
-                , subq_0.paid_at__year
-                , subq_0.paid_at__extract_year
-                , subq_0.paid_at__extract_quarter
-                , subq_0.paid_at__extract_month
-                , subq_0.paid_at__extract_day
-                , subq_0.paid_at__extract_dow
-                , subq_0.paid_at__extract_doy
-                , subq_0.booking__ds__day
-                , subq_0.booking__ds__week
-                , subq_0.booking__ds__month
-                , subq_0.booking__ds__quarter
-                , subq_0.booking__ds__year
-                , subq_0.booking__ds__extract_year
-                , subq_0.booking__ds__extract_quarter
-                , subq_0.booking__ds__extract_month
-                , subq_0.booking__ds__extract_day
-                , subq_0.booking__ds__extract_dow
-                , subq_0.booking__ds__extract_doy
-                , subq_0.booking__ds_partitioned__day
-                , subq_0.booking__ds_partitioned__week
-                , subq_0.booking__ds_partitioned__month
-                , subq_0.booking__ds_partitioned__quarter
-                , subq_0.booking__ds_partitioned__year
-                , subq_0.booking__ds_partitioned__extract_year
-                , subq_0.booking__ds_partitioned__extract_quarter
-                , subq_0.booking__ds_partitioned__extract_month
-                , subq_0.booking__ds_partitioned__extract_day
-                , subq_0.booking__ds_partitioned__extract_dow
-                , subq_0.booking__ds_partitioned__extract_doy
-                , subq_0.booking__paid_at__day
-                , subq_0.booking__paid_at__week
-                , subq_0.booking__paid_at__month
-                , subq_0.booking__paid_at__quarter
-                , subq_0.booking__paid_at__year
-                , subq_0.booking__paid_at__extract_year
-                , subq_0.booking__paid_at__extract_quarter
-                , subq_0.booking__paid_at__extract_month
-                , subq_0.booking__paid_at__extract_day
-                , subq_0.booking__paid_at__extract_dow
-                , subq_0.booking__paid_at__extract_doy
-                , subq_0.ds__day AS metric_time__day
-                , subq_0.ds__week AS metric_time__week
-                , subq_0.ds__month AS metric_time__month
-                , subq_0.ds__quarter AS metric_time__quarter
-                , subq_0.ds__year AS metric_time__year
-                , subq_0.ds__extract_year AS metric_time__extract_year
-                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_0.ds__extract_month AS metric_time__extract_month
-                , subq_0.ds__extract_day AS metric_time__extract_day
-                , subq_0.ds__extract_dow AS metric_time__extract_dow
-                , subq_0.ds__extract_doy AS metric_time__extract_doy
-                , subq_0.listing
-                , subq_0.guest
-                , subq_0.host
-                , subq_0.booking__listing
-                , subq_0.booking__guest
-                , subq_0.booking__host
-                , subq_0.is_instant
-                , subq_0.booking__is_instant
-                , subq_0.bookings
-                , subq_0.instant_bookings
-                , subq_0.booking_value
-                , subq_0.max_booking_value
-                , subq_0.min_booking_value
-                , subq_0.bookers
-                , subq_0.average_booking_value
-                , subq_0.referred_bookings
-                , subq_0.median_booking_value
-                , subq_0.booking_value_p99
-                , subq_0.discrete_booking_value_p99
-                , subq_0.approximate_continuous_booking_value_p99
-                , subq_0.approximate_discrete_booking_value_p99
+                subq_1.ds__day AS ds__day
+                , subq_1.ds__week AS ds__week
+                , subq_1.ds__month AS ds__month
+                , subq_1.ds__quarter AS ds__quarter
+                , subq_1.ds__year AS ds__year
+                , subq_1.ds__extract_year AS ds__extract_year
+                , subq_1.ds__extract_quarter AS ds__extract_quarter
+                , subq_1.ds__extract_month AS ds__extract_month
+                , subq_1.ds__extract_day AS ds__extract_day
+                , subq_1.ds__extract_dow AS ds__extract_dow
+                , subq_1.ds__extract_doy AS ds__extract_doy
+                , subq_1.ds_partitioned__day AS ds_partitioned__day
+                , subq_1.ds_partitioned__week AS ds_partitioned__week
+                , subq_1.ds_partitioned__month AS ds_partitioned__month
+                , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
+                , subq_1.ds_partitioned__year AS ds_partitioned__year
+                , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
+                , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+                , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
+                , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
+                , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+                , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+                , subq_1.paid_at__day AS paid_at__day
+                , subq_1.paid_at__week AS paid_at__week
+                , subq_1.paid_at__month AS paid_at__month
+                , subq_1.paid_at__quarter AS paid_at__quarter
+                , subq_1.paid_at__year AS paid_at__year
+                , subq_1.paid_at__extract_year AS paid_at__extract_year
+                , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
+                , subq_1.paid_at__extract_month AS paid_at__extract_month
+                , subq_1.paid_at__extract_day AS paid_at__extract_day
+                , subq_1.paid_at__extract_dow AS paid_at__extract_dow
+                , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+                , subq_1.booking__ds__day AS booking__ds__day
+                , subq_1.booking__ds__week AS booking__ds__week
+                , subq_1.booking__ds__month AS booking__ds__month
+                , subq_1.booking__ds__quarter AS booking__ds__quarter
+                , subq_1.booking__ds__year AS booking__ds__year
+                , subq_1.booking__ds__extract_year AS booking__ds__extract_year
+                , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
+                , subq_1.booking__ds__extract_month AS booking__ds__extract_month
+                , subq_1.booking__ds__extract_day AS booking__ds__extract_day
+                , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
+                , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
+                , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
+                , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
+                , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
+                , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+                , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
+                , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+                , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+                , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+                , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+                , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+                , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+                , subq_1.booking__paid_at__day AS booking__paid_at__day
+                , subq_1.booking__paid_at__week AS booking__paid_at__week
+                , subq_1.booking__paid_at__month AS booking__paid_at__month
+                , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
+                , subq_1.booking__paid_at__year AS booking__paid_at__year
+                , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
+                , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+                , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
+                , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
+                , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+                , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                , subq_1.metric_time__week AS metric_time__week
+                , subq_1.metric_time__month AS metric_time__month
+                , subq_1.metric_time__quarter AS metric_time__quarter
+                , subq_1.metric_time__year AS metric_time__year
+                , subq_1.metric_time__extract_year AS metric_time__extract_year
+                , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+                , subq_1.metric_time__extract_month AS metric_time__extract_month
+                , subq_1.metric_time__extract_day AS metric_time__extract_day
+                , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+                , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+                , subq_2.metric_time__day AS metric_time__day
+                , subq_1.listing AS listing
+                , subq_1.guest AS guest
+                , subq_1.host AS host
+                , subq_1.booking__listing AS booking__listing
+                , subq_1.booking__guest AS booking__guest
+                , subq_1.booking__host AS booking__host
+                , subq_1.is_instant AS is_instant
+                , subq_1.booking__is_instant AS booking__is_instant
+                , subq_1.bookings AS bookings
+                , subq_1.instant_bookings AS instant_bookings
+                , subq_1.booking_value AS booking_value
+                , subq_1.max_booking_value AS max_booking_value
+                , subq_1.min_booking_value AS min_booking_value
+                , subq_1.bookers AS bookers
+                , subq_1.average_booking_value AS average_booking_value
+                , subq_1.referred_bookings AS referred_bookings
+                , subq_1.median_booking_value AS median_booking_value
+                , subq_1.booking_value_p99 AS booking_value_p99
+                , subq_1.discrete_booking_value_p99 AS discrete_booking_value_p99
+                , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+                , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
               FROM (
-                -- Read Elements From Semantic Model 'bookings_source'
+                -- Time Spine
                 SELECT
-                  1 AS bookings
-                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                  , bookings_source_src_28000.booking_value
-                  , bookings_source_src_28000.booking_value AS max_booking_value
-                  , bookings_source_src_28000.booking_value AS min_booking_value
-                  , bookings_source_src_28000.guest_id AS bookers
-                  , bookings_source_src_28000.booking_value AS average_booking_value
-                  , bookings_source_src_28000.booking_value AS booking_payments
-                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-                  , bookings_source_src_28000.booking_value AS median_booking_value
-                  , bookings_source_src_28000.booking_value AS booking_value_p99
-                  , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
-                  , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
-                  , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
-                  , bookings_source_src_28000.is_instant
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                  , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS ds__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                  , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                  , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                  , bookings_source_src_28000.is_instant AS booking__is_instant
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                  , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                  , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                  , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                  , bookings_source_src_28000.listing_id AS listing
-                  , bookings_source_src_28000.guest_id AS guest
-                  , bookings_source_src_28000.host_id AS host
-                  , bookings_source_src_28000.listing_id AS booking__listing
-                  , bookings_source_src_28000.guest_id AS booking__guest
-                  , bookings_source_src_28000.host_id AS booking__host
-                FROM ***************************.fct_bookings bookings_source_src_28000
-              ) subq_0
-            ) subq_1
-            ON
-              DATEADD(day, -5, subq_2.metric_time__day) = subq_1.metric_time__day
-          ) subq_4
-        ) subq_5
-        GROUP BY
-          subq_5.metric_time__day
-      ) subq_6
-    ) subq_7
-  ) subq_8
-  ON
-    DATEADD(day, -2, subq_9.metric_time__day) = subq_8.metric_time__day
-) subq_11
+                  subq_3.ds AS metric_time__day
+                FROM ***************************.mf_time_spine subq_3
+              ) subq_2
+              INNER JOIN (
+                -- Metric Time Dimension 'ds'
+                SELECT
+                  subq_0.ds__day
+                  , subq_0.ds__week
+                  , subq_0.ds__month
+                  , subq_0.ds__quarter
+                  , subq_0.ds__year
+                  , subq_0.ds__extract_year
+                  , subq_0.ds__extract_quarter
+                  , subq_0.ds__extract_month
+                  , subq_0.ds__extract_day
+                  , subq_0.ds__extract_dow
+                  , subq_0.ds__extract_doy
+                  , subq_0.ds_partitioned__day
+                  , subq_0.ds_partitioned__week
+                  , subq_0.ds_partitioned__month
+                  , subq_0.ds_partitioned__quarter
+                  , subq_0.ds_partitioned__year
+                  , subq_0.ds_partitioned__extract_year
+                  , subq_0.ds_partitioned__extract_quarter
+                  , subq_0.ds_partitioned__extract_month
+                  , subq_0.ds_partitioned__extract_day
+                  , subq_0.ds_partitioned__extract_dow
+                  , subq_0.ds_partitioned__extract_doy
+                  , subq_0.paid_at__day
+                  , subq_0.paid_at__week
+                  , subq_0.paid_at__month
+                  , subq_0.paid_at__quarter
+                  , subq_0.paid_at__year
+                  , subq_0.paid_at__extract_year
+                  , subq_0.paid_at__extract_quarter
+                  , subq_0.paid_at__extract_month
+                  , subq_0.paid_at__extract_day
+                  , subq_0.paid_at__extract_dow
+                  , subq_0.paid_at__extract_doy
+                  , subq_0.booking__ds__day
+                  , subq_0.booking__ds__week
+                  , subq_0.booking__ds__month
+                  , subq_0.booking__ds__quarter
+                  , subq_0.booking__ds__year
+                  , subq_0.booking__ds__extract_year
+                  , subq_0.booking__ds__extract_quarter
+                  , subq_0.booking__ds__extract_month
+                  , subq_0.booking__ds__extract_day
+                  , subq_0.booking__ds__extract_dow
+                  , subq_0.booking__ds__extract_doy
+                  , subq_0.booking__ds_partitioned__day
+                  , subq_0.booking__ds_partitioned__week
+                  , subq_0.booking__ds_partitioned__month
+                  , subq_0.booking__ds_partitioned__quarter
+                  , subq_0.booking__ds_partitioned__year
+                  , subq_0.booking__ds_partitioned__extract_year
+                  , subq_0.booking__ds_partitioned__extract_quarter
+                  , subq_0.booking__ds_partitioned__extract_month
+                  , subq_0.booking__ds_partitioned__extract_day
+                  , subq_0.booking__ds_partitioned__extract_dow
+                  , subq_0.booking__ds_partitioned__extract_doy
+                  , subq_0.booking__paid_at__day
+                  , subq_0.booking__paid_at__week
+                  , subq_0.booking__paid_at__month
+                  , subq_0.booking__paid_at__quarter
+                  , subq_0.booking__paid_at__year
+                  , subq_0.booking__paid_at__extract_year
+                  , subq_0.booking__paid_at__extract_quarter
+                  , subq_0.booking__paid_at__extract_month
+                  , subq_0.booking__paid_at__extract_day
+                  , subq_0.booking__paid_at__extract_dow
+                  , subq_0.booking__paid_at__extract_doy
+                  , subq_0.ds__day AS metric_time__day
+                  , subq_0.ds__week AS metric_time__week
+                  , subq_0.ds__month AS metric_time__month
+                  , subq_0.ds__quarter AS metric_time__quarter
+                  , subq_0.ds__year AS metric_time__year
+                  , subq_0.ds__extract_year AS metric_time__extract_year
+                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_0.ds__extract_month AS metric_time__extract_month
+                  , subq_0.ds__extract_day AS metric_time__extract_day
+                  , subq_0.ds__extract_dow AS metric_time__extract_dow
+                  , subq_0.ds__extract_doy AS metric_time__extract_doy
+                  , subq_0.listing
+                  , subq_0.guest
+                  , subq_0.host
+                  , subq_0.booking__listing
+                  , subq_0.booking__guest
+                  , subq_0.booking__host
+                  , subq_0.is_instant
+                  , subq_0.booking__is_instant
+                  , subq_0.bookings
+                  , subq_0.instant_bookings
+                  , subq_0.booking_value
+                  , subq_0.max_booking_value
+                  , subq_0.min_booking_value
+                  , subq_0.bookers
+                  , subq_0.average_booking_value
+                  , subq_0.referred_bookings
+                  , subq_0.median_booking_value
+                  , subq_0.booking_value_p99
+                  , subq_0.discrete_booking_value_p99
+                  , subq_0.approximate_continuous_booking_value_p99
+                  , subq_0.approximate_discrete_booking_value_p99
+                FROM (
+                  -- Read Elements From Semantic Model 'bookings_source'
+                  SELECT
+                    1 AS bookings
+                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                    , bookings_source_src_28000.booking_value
+                    , bookings_source_src_28000.booking_value AS max_booking_value
+                    , bookings_source_src_28000.booking_value AS min_booking_value
+                    , bookings_source_src_28000.guest_id AS bookers
+                    , bookings_source_src_28000.booking_value AS average_booking_value
+                    , bookings_source_src_28000.booking_value AS booking_payments
+                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                    , bookings_source_src_28000.booking_value AS median_booking_value
+                    , bookings_source_src_28000.booking_value AS booking_value_p99
+                    , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                    , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                    , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                    , bookings_source_src_28000.is_instant
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                    , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                    , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                    , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                    , bookings_source_src_28000.is_instant AS booking__is_instant
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                    , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                    , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                    , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                    , bookings_source_src_28000.listing_id AS listing
+                    , bookings_source_src_28000.guest_id AS guest
+                    , bookings_source_src_28000.host_id AS host
+                    , bookings_source_src_28000.listing_id AS booking__listing
+                    , bookings_source_src_28000.guest_id AS booking__guest
+                    , bookings_source_src_28000.host_id AS booking__host
+                  FROM ***************************.fct_bookings bookings_source_src_28000
+                ) subq_0
+              ) subq_1
+              ON
+                DATEADD(day, -5, subq_2.metric_time__day) = subq_1.metric_time__day
+            ) subq_4
+          ) subq_5
+          GROUP BY
+            subq_5.metric_time__day
+        ) subq_6
+      ) subq_7
+    ) subq_8
+    ON
+      DATEADD(day, -2, subq_9.metric_time__day) = subq_8.metric_time__day
+  ) subq_11
+  WHERE subq_11.metric_time__day BETWEEN '2020-01-12' AND '2020-01-13'
+) subq_12

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_nested_offsets_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_nested_offsets_with_time_constraint__plan0_optimized.sql
@@ -8,16 +8,11 @@ SELECT
   , 2 * bookings_offset_once AS bookings_offset_twice
 FROM (
   -- Join to Time Spine Dataset
+  -- Constrain Time Range to [2020-01-12T00:00:00, 2020-01-13T00:00:00]
   SELECT
-    subq_21.metric_time__day AS metric_time__day
-    , subq_20.bookings_offset_once AS bookings_offset_once
-  FROM (
-    -- Time Spine
-    SELECT
-      ds AS metric_time__day
-    FROM ***************************.mf_time_spine subq_22
-    WHERE ds BETWEEN '2020-01-12' AND '2020-01-13'
-  ) subq_21
+    subq_23.ds AS metric_time__day
+    , subq_21.bookings_offset_once AS bookings_offset_once
+  FROM ***************************.mf_time_spine subq_23
   INNER JOIN (
     -- Compute Metrics via Expressions
     SELECT
@@ -29,9 +24,9 @@ FROM (
       -- Aggregate Measures
       -- Compute Metrics via Expressions
       SELECT
-        subq_15.ds AS metric_time__day
-        , SUM(subq_13.bookings) AS bookings
-      FROM ***************************.mf_time_spine subq_15
+        subq_16.ds AS metric_time__day
+        , SUM(subq_14.bookings) AS bookings
+      FROM ***************************.mf_time_spine subq_16
       INNER JOIN (
         -- Read Elements From Semantic Model 'bookings_source'
         -- Metric Time Dimension 'ds'
@@ -39,13 +34,14 @@ FROM (
           DATE_TRUNC('day', ds) AS metric_time__day
           , 1 AS bookings
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_13
+      ) subq_14
       ON
-        DATEADD(day, -5, subq_15.ds) = subq_13.metric_time__day
+        DATEADD(day, -5, subq_16.ds) = subq_14.metric_time__day
       GROUP BY
-        subq_15.ds
-    ) subq_19
-  ) subq_20
+        subq_16.ds
+    ) subq_20
+  ) subq_21
   ON
-    DATEADD(day, -2, subq_21.metric_time__day) = subq_20.metric_time__day
-) subq_23
+    DATEADD(day, -2, subq_23.ds) = subq_21.metric_time__day
+  WHERE subq_23.ds BETWEEN '2020-01-12' AND '2020-01-13'
+) subq_25

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_time_offset_metric_with_time_constraint__plan0.sql
@@ -4,331 +4,433 @@ sql_engine: Snowflake
 ---
 -- Compute Metrics via Expressions
 SELECT
-  subq_7.metric_time__day
+  subq_8.metric_time__day
   , bookings_5_days_ago AS bookings_5_day_lag
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_6.metric_time__day
-    , subq_6.bookings AS bookings_5_days_ago
+    subq_7.metric_time__day
+    , subq_7.bookings AS bookings_5_days_ago
   FROM (
     -- Aggregate Measures
     SELECT
-      subq_5.metric_time__day
-      , SUM(subq_5.bookings) AS bookings
+      subq_6.metric_time__day
+      , SUM(subq_6.bookings) AS bookings
     FROM (
       -- Pass Only Elements: ['bookings', 'metric_time__day']
       SELECT
-        subq_4.metric_time__day
-        , subq_4.bookings
+        subq_5.metric_time__day
+        , subq_5.bookings
       FROM (
-        -- Join to Time Spine Dataset
+        -- Constrain Time Range to [2019-12-19T00:00:00, 2020-01-02T00:00:00]
         SELECT
-          subq_1.ds__day AS ds__day
-          , subq_1.ds__week AS ds__week
-          , subq_1.ds__month AS ds__month
-          , subq_1.ds__quarter AS ds__quarter
-          , subq_1.ds__year AS ds__year
-          , subq_1.ds__extract_year AS ds__extract_year
-          , subq_1.ds__extract_quarter AS ds__extract_quarter
-          , subq_1.ds__extract_month AS ds__extract_month
-          , subq_1.ds__extract_day AS ds__extract_day
-          , subq_1.ds__extract_dow AS ds__extract_dow
-          , subq_1.ds__extract_doy AS ds__extract_doy
-          , subq_1.ds_partitioned__day AS ds_partitioned__day
-          , subq_1.ds_partitioned__week AS ds_partitioned__week
-          , subq_1.ds_partitioned__month AS ds_partitioned__month
-          , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
-          , subq_1.ds_partitioned__year AS ds_partitioned__year
-          , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
-          , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
-          , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
-          , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
-          , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
-          , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
-          , subq_1.paid_at__day AS paid_at__day
-          , subq_1.paid_at__week AS paid_at__week
-          , subq_1.paid_at__month AS paid_at__month
-          , subq_1.paid_at__quarter AS paid_at__quarter
-          , subq_1.paid_at__year AS paid_at__year
-          , subq_1.paid_at__extract_year AS paid_at__extract_year
-          , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
-          , subq_1.paid_at__extract_month AS paid_at__extract_month
-          , subq_1.paid_at__extract_day AS paid_at__extract_day
-          , subq_1.paid_at__extract_dow AS paid_at__extract_dow
-          , subq_1.paid_at__extract_doy AS paid_at__extract_doy
-          , subq_1.booking__ds__day AS booking__ds__day
-          , subq_1.booking__ds__week AS booking__ds__week
-          , subq_1.booking__ds__month AS booking__ds__month
-          , subq_1.booking__ds__quarter AS booking__ds__quarter
-          , subq_1.booking__ds__year AS booking__ds__year
-          , subq_1.booking__ds__extract_year AS booking__ds__extract_year
-          , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
-          , subq_1.booking__ds__extract_month AS booking__ds__extract_month
-          , subq_1.booking__ds__extract_day AS booking__ds__extract_day
-          , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
-          , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
-          , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
-          , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
-          , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
-          , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
-          , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
-          , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
-          , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
-          , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
-          , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
-          , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
-          , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
-          , subq_1.booking__paid_at__day AS booking__paid_at__day
-          , subq_1.booking__paid_at__week AS booking__paid_at__week
-          , subq_1.booking__paid_at__month AS booking__paid_at__month
-          , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
-          , subq_1.booking__paid_at__year AS booking__paid_at__year
-          , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
-          , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
-          , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
-          , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
-          , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
-          , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
-          , subq_1.metric_time__week AS metric_time__week
-          , subq_1.metric_time__month AS metric_time__month
-          , subq_1.metric_time__quarter AS metric_time__quarter
-          , subq_1.metric_time__year AS metric_time__year
-          , subq_1.metric_time__extract_year AS metric_time__extract_year
-          , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
-          , subq_1.metric_time__extract_month AS metric_time__extract_month
-          , subq_1.metric_time__extract_day AS metric_time__extract_day
-          , subq_1.metric_time__extract_dow AS metric_time__extract_dow
-          , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-          , subq_2.metric_time__day AS metric_time__day
-          , subq_1.listing AS listing
-          , subq_1.guest AS guest
-          , subq_1.host AS host
-          , subq_1.booking__listing AS booking__listing
-          , subq_1.booking__guest AS booking__guest
-          , subq_1.booking__host AS booking__host
-          , subq_1.is_instant AS is_instant
-          , subq_1.booking__is_instant AS booking__is_instant
-          , subq_1.bookings AS bookings
-          , subq_1.instant_bookings AS instant_bookings
-          , subq_1.booking_value AS booking_value
-          , subq_1.max_booking_value AS max_booking_value
-          , subq_1.min_booking_value AS min_booking_value
-          , subq_1.bookers AS bookers
-          , subq_1.average_booking_value AS average_booking_value
-          , subq_1.referred_bookings AS referred_bookings
-          , subq_1.median_booking_value AS median_booking_value
-          , subq_1.booking_value_p99 AS booking_value_p99
-          , subq_1.discrete_booking_value_p99 AS discrete_booking_value_p99
-          , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
-          , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+          subq_4.metric_time__day
+          , subq_4.ds__day
+          , subq_4.ds__week
+          , subq_4.ds__month
+          , subq_4.ds__quarter
+          , subq_4.ds__year
+          , subq_4.ds__extract_year
+          , subq_4.ds__extract_quarter
+          , subq_4.ds__extract_month
+          , subq_4.ds__extract_day
+          , subq_4.ds__extract_dow
+          , subq_4.ds__extract_doy
+          , subq_4.ds_partitioned__day
+          , subq_4.ds_partitioned__week
+          , subq_4.ds_partitioned__month
+          , subq_4.ds_partitioned__quarter
+          , subq_4.ds_partitioned__year
+          , subq_4.ds_partitioned__extract_year
+          , subq_4.ds_partitioned__extract_quarter
+          , subq_4.ds_partitioned__extract_month
+          , subq_4.ds_partitioned__extract_day
+          , subq_4.ds_partitioned__extract_dow
+          , subq_4.ds_partitioned__extract_doy
+          , subq_4.paid_at__day
+          , subq_4.paid_at__week
+          , subq_4.paid_at__month
+          , subq_4.paid_at__quarter
+          , subq_4.paid_at__year
+          , subq_4.paid_at__extract_year
+          , subq_4.paid_at__extract_quarter
+          , subq_4.paid_at__extract_month
+          , subq_4.paid_at__extract_day
+          , subq_4.paid_at__extract_dow
+          , subq_4.paid_at__extract_doy
+          , subq_4.booking__ds__day
+          , subq_4.booking__ds__week
+          , subq_4.booking__ds__month
+          , subq_4.booking__ds__quarter
+          , subq_4.booking__ds__year
+          , subq_4.booking__ds__extract_year
+          , subq_4.booking__ds__extract_quarter
+          , subq_4.booking__ds__extract_month
+          , subq_4.booking__ds__extract_day
+          , subq_4.booking__ds__extract_dow
+          , subq_4.booking__ds__extract_doy
+          , subq_4.booking__ds_partitioned__day
+          , subq_4.booking__ds_partitioned__week
+          , subq_4.booking__ds_partitioned__month
+          , subq_4.booking__ds_partitioned__quarter
+          , subq_4.booking__ds_partitioned__year
+          , subq_4.booking__ds_partitioned__extract_year
+          , subq_4.booking__ds_partitioned__extract_quarter
+          , subq_4.booking__ds_partitioned__extract_month
+          , subq_4.booking__ds_partitioned__extract_day
+          , subq_4.booking__ds_partitioned__extract_dow
+          , subq_4.booking__ds_partitioned__extract_doy
+          , subq_4.booking__paid_at__day
+          , subq_4.booking__paid_at__week
+          , subq_4.booking__paid_at__month
+          , subq_4.booking__paid_at__quarter
+          , subq_4.booking__paid_at__year
+          , subq_4.booking__paid_at__extract_year
+          , subq_4.booking__paid_at__extract_quarter
+          , subq_4.booking__paid_at__extract_month
+          , subq_4.booking__paid_at__extract_day
+          , subq_4.booking__paid_at__extract_dow
+          , subq_4.booking__paid_at__extract_doy
+          , subq_4.metric_time__week
+          , subq_4.metric_time__month
+          , subq_4.metric_time__quarter
+          , subq_4.metric_time__year
+          , subq_4.metric_time__extract_year
+          , subq_4.metric_time__extract_quarter
+          , subq_4.metric_time__extract_month
+          , subq_4.metric_time__extract_day
+          , subq_4.metric_time__extract_dow
+          , subq_4.metric_time__extract_doy
+          , subq_4.listing
+          , subq_4.guest
+          , subq_4.host
+          , subq_4.booking__listing
+          , subq_4.booking__guest
+          , subq_4.booking__host
+          , subq_4.is_instant
+          , subq_4.booking__is_instant
+          , subq_4.bookings
+          , subq_4.instant_bookings
+          , subq_4.booking_value
+          , subq_4.max_booking_value
+          , subq_4.min_booking_value
+          , subq_4.bookers
+          , subq_4.average_booking_value
+          , subq_4.referred_bookings
+          , subq_4.median_booking_value
+          , subq_4.booking_value_p99
+          , subq_4.discrete_booking_value_p99
+          , subq_4.approximate_continuous_booking_value_p99
+          , subq_4.approximate_discrete_booking_value_p99
         FROM (
-          -- Time Spine
+          -- Join to Time Spine Dataset
           SELECT
-            subq_3.ds AS metric_time__day
-          FROM ***************************.mf_time_spine subq_3
-          WHERE subq_3.ds BETWEEN '2019-12-19' AND '2020-01-02'
-        ) subq_2
-        INNER JOIN (
-          -- Metric Time Dimension 'ds'
-          SELECT
-            subq_0.ds__day
-            , subq_0.ds__week
-            , subq_0.ds__month
-            , subq_0.ds__quarter
-            , subq_0.ds__year
-            , subq_0.ds__extract_year
-            , subq_0.ds__extract_quarter
-            , subq_0.ds__extract_month
-            , subq_0.ds__extract_day
-            , subq_0.ds__extract_dow
-            , subq_0.ds__extract_doy
-            , subq_0.ds_partitioned__day
-            , subq_0.ds_partitioned__week
-            , subq_0.ds_partitioned__month
-            , subq_0.ds_partitioned__quarter
-            , subq_0.ds_partitioned__year
-            , subq_0.ds_partitioned__extract_year
-            , subq_0.ds_partitioned__extract_quarter
-            , subq_0.ds_partitioned__extract_month
-            , subq_0.ds_partitioned__extract_day
-            , subq_0.ds_partitioned__extract_dow
-            , subq_0.ds_partitioned__extract_doy
-            , subq_0.paid_at__day
-            , subq_0.paid_at__week
-            , subq_0.paid_at__month
-            , subq_0.paid_at__quarter
-            , subq_0.paid_at__year
-            , subq_0.paid_at__extract_year
-            , subq_0.paid_at__extract_quarter
-            , subq_0.paid_at__extract_month
-            , subq_0.paid_at__extract_day
-            , subq_0.paid_at__extract_dow
-            , subq_0.paid_at__extract_doy
-            , subq_0.booking__ds__day
-            , subq_0.booking__ds__week
-            , subq_0.booking__ds__month
-            , subq_0.booking__ds__quarter
-            , subq_0.booking__ds__year
-            , subq_0.booking__ds__extract_year
-            , subq_0.booking__ds__extract_quarter
-            , subq_0.booking__ds__extract_month
-            , subq_0.booking__ds__extract_day
-            , subq_0.booking__ds__extract_dow
-            , subq_0.booking__ds__extract_doy
-            , subq_0.booking__ds_partitioned__day
-            , subq_0.booking__ds_partitioned__week
-            , subq_0.booking__ds_partitioned__month
-            , subq_0.booking__ds_partitioned__quarter
-            , subq_0.booking__ds_partitioned__year
-            , subq_0.booking__ds_partitioned__extract_year
-            , subq_0.booking__ds_partitioned__extract_quarter
-            , subq_0.booking__ds_partitioned__extract_month
-            , subq_0.booking__ds_partitioned__extract_day
-            , subq_0.booking__ds_partitioned__extract_dow
-            , subq_0.booking__ds_partitioned__extract_doy
-            , subq_0.booking__paid_at__day
-            , subq_0.booking__paid_at__week
-            , subq_0.booking__paid_at__month
-            , subq_0.booking__paid_at__quarter
-            , subq_0.booking__paid_at__year
-            , subq_0.booking__paid_at__extract_year
-            , subq_0.booking__paid_at__extract_quarter
-            , subq_0.booking__paid_at__extract_month
-            , subq_0.booking__paid_at__extract_day
-            , subq_0.booking__paid_at__extract_dow
-            , subq_0.booking__paid_at__extract_doy
-            , subq_0.ds__day AS metric_time__day
-            , subq_0.ds__week AS metric_time__week
-            , subq_0.ds__month AS metric_time__month
-            , subq_0.ds__quarter AS metric_time__quarter
-            , subq_0.ds__year AS metric_time__year
-            , subq_0.ds__extract_year AS metric_time__extract_year
-            , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-            , subq_0.ds__extract_month AS metric_time__extract_month
-            , subq_0.ds__extract_day AS metric_time__extract_day
-            , subq_0.ds__extract_dow AS metric_time__extract_dow
-            , subq_0.ds__extract_doy AS metric_time__extract_doy
-            , subq_0.listing
-            , subq_0.guest
-            , subq_0.host
-            , subq_0.booking__listing
-            , subq_0.booking__guest
-            , subq_0.booking__host
-            , subq_0.is_instant
-            , subq_0.booking__is_instant
-            , subq_0.bookings
-            , subq_0.instant_bookings
-            , subq_0.booking_value
-            , subq_0.max_booking_value
-            , subq_0.min_booking_value
-            , subq_0.bookers
-            , subq_0.average_booking_value
-            , subq_0.referred_bookings
-            , subq_0.median_booking_value
-            , subq_0.booking_value_p99
-            , subq_0.discrete_booking_value_p99
-            , subq_0.approximate_continuous_booking_value_p99
-            , subq_0.approximate_discrete_booking_value_p99
+            subq_1.ds__day AS ds__day
+            , subq_1.ds__week AS ds__week
+            , subq_1.ds__month AS ds__month
+            , subq_1.ds__quarter AS ds__quarter
+            , subq_1.ds__year AS ds__year
+            , subq_1.ds__extract_year AS ds__extract_year
+            , subq_1.ds__extract_quarter AS ds__extract_quarter
+            , subq_1.ds__extract_month AS ds__extract_month
+            , subq_1.ds__extract_day AS ds__extract_day
+            , subq_1.ds__extract_dow AS ds__extract_dow
+            , subq_1.ds__extract_doy AS ds__extract_doy
+            , subq_1.ds_partitioned__day AS ds_partitioned__day
+            , subq_1.ds_partitioned__week AS ds_partitioned__week
+            , subq_1.ds_partitioned__month AS ds_partitioned__month
+            , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
+            , subq_1.ds_partitioned__year AS ds_partitioned__year
+            , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
+            , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+            , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
+            , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
+            , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+            , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+            , subq_1.paid_at__day AS paid_at__day
+            , subq_1.paid_at__week AS paid_at__week
+            , subq_1.paid_at__month AS paid_at__month
+            , subq_1.paid_at__quarter AS paid_at__quarter
+            , subq_1.paid_at__year AS paid_at__year
+            , subq_1.paid_at__extract_year AS paid_at__extract_year
+            , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
+            , subq_1.paid_at__extract_month AS paid_at__extract_month
+            , subq_1.paid_at__extract_day AS paid_at__extract_day
+            , subq_1.paid_at__extract_dow AS paid_at__extract_dow
+            , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+            , subq_1.booking__ds__day AS booking__ds__day
+            , subq_1.booking__ds__week AS booking__ds__week
+            , subq_1.booking__ds__month AS booking__ds__month
+            , subq_1.booking__ds__quarter AS booking__ds__quarter
+            , subq_1.booking__ds__year AS booking__ds__year
+            , subq_1.booking__ds__extract_year AS booking__ds__extract_year
+            , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
+            , subq_1.booking__ds__extract_month AS booking__ds__extract_month
+            , subq_1.booking__ds__extract_day AS booking__ds__extract_day
+            , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
+            , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
+            , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
+            , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
+            , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
+            , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+            , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
+            , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+            , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+            , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+            , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+            , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+            , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+            , subq_1.booking__paid_at__day AS booking__paid_at__day
+            , subq_1.booking__paid_at__week AS booking__paid_at__week
+            , subq_1.booking__paid_at__month AS booking__paid_at__month
+            , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
+            , subq_1.booking__paid_at__year AS booking__paid_at__year
+            , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
+            , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+            , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
+            , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
+            , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+            , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_1.metric_time__week AS metric_time__week
+            , subq_1.metric_time__month AS metric_time__month
+            , subq_1.metric_time__quarter AS metric_time__quarter
+            , subq_1.metric_time__year AS metric_time__year
+            , subq_1.metric_time__extract_year AS metric_time__extract_year
+            , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_1.metric_time__extract_month AS metric_time__extract_month
+            , subq_1.metric_time__extract_day AS metric_time__extract_day
+            , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_2.metric_time__day AS metric_time__day
+            , subq_1.listing AS listing
+            , subq_1.guest AS guest
+            , subq_1.host AS host
+            , subq_1.booking__listing AS booking__listing
+            , subq_1.booking__guest AS booking__guest
+            , subq_1.booking__host AS booking__host
+            , subq_1.is_instant AS is_instant
+            , subq_1.booking__is_instant AS booking__is_instant
+            , subq_1.bookings AS bookings
+            , subq_1.instant_bookings AS instant_bookings
+            , subq_1.booking_value AS booking_value
+            , subq_1.max_booking_value AS max_booking_value
+            , subq_1.min_booking_value AS min_booking_value
+            , subq_1.bookers AS bookers
+            , subq_1.average_booking_value AS average_booking_value
+            , subq_1.referred_bookings AS referred_bookings
+            , subq_1.median_booking_value AS median_booking_value
+            , subq_1.booking_value_p99 AS booking_value_p99
+            , subq_1.discrete_booking_value_p99 AS discrete_booking_value_p99
+            , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+            , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Read Elements From Semantic Model 'bookings_source'
+            -- Time Spine
             SELECT
-              1 AS bookings
-              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-              , bookings_source_src_28000.booking_value
-              , bookings_source_src_28000.booking_value AS max_booking_value
-              , bookings_source_src_28000.booking_value AS min_booking_value
-              , bookings_source_src_28000.guest_id AS bookers
-              , bookings_source_src_28000.booking_value AS average_booking_value
-              , bookings_source_src_28000.booking_value AS booking_payments
-              , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-              , bookings_source_src_28000.booking_value AS median_booking_value
-              , bookings_source_src_28000.booking_value AS booking_value_p99
-              , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
-              , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
-              , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
-              , bookings_source_src_28000.is_instant
-              , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-              , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-              , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-              , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-              , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-              , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-              , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-              , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS ds__extract_dow
-              , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-              , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-              , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-              , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-              , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-              , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-              , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-              , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
-              , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-              , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-              , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-              , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-              , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-              , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-              , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-              , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
-              , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-              , bookings_source_src_28000.is_instant AS booking__is_instant
-              , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-              , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-              , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-              , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-              , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-              , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-              , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-              , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
-              , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-              , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-              , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-              , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-              , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-              , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-              , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-              , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
-              , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-              , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-              , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-              , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-              , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-              , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-              , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
-              , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-              , bookings_source_src_28000.listing_id AS listing
-              , bookings_source_src_28000.guest_id AS guest
-              , bookings_source_src_28000.host_id AS host
-              , bookings_source_src_28000.listing_id AS booking__listing
-              , bookings_source_src_28000.guest_id AS booking__guest
-              , bookings_source_src_28000.host_id AS booking__host
-            FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_0
-        ) subq_1
-        ON
-          DATEADD(day, -5, subq_2.metric_time__day) = subq_1.metric_time__day
-      ) subq_4
-    ) subq_5
+              subq_3.ds AS metric_time__day
+            FROM ***************************.mf_time_spine subq_3
+          ) subq_2
+          INNER JOIN (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.ds_partitioned__day
+              , subq_0.ds_partitioned__week
+              , subq_0.ds_partitioned__month
+              , subq_0.ds_partitioned__quarter
+              , subq_0.ds_partitioned__year
+              , subq_0.ds_partitioned__extract_year
+              , subq_0.ds_partitioned__extract_quarter
+              , subq_0.ds_partitioned__extract_month
+              , subq_0.ds_partitioned__extract_day
+              , subq_0.ds_partitioned__extract_dow
+              , subq_0.ds_partitioned__extract_doy
+              , subq_0.paid_at__day
+              , subq_0.paid_at__week
+              , subq_0.paid_at__month
+              , subq_0.paid_at__quarter
+              , subq_0.paid_at__year
+              , subq_0.paid_at__extract_year
+              , subq_0.paid_at__extract_quarter
+              , subq_0.paid_at__extract_month
+              , subq_0.paid_at__extract_day
+              , subq_0.paid_at__extract_dow
+              , subq_0.paid_at__extract_doy
+              , subq_0.booking__ds__day
+              , subq_0.booking__ds__week
+              , subq_0.booking__ds__month
+              , subq_0.booking__ds__quarter
+              , subq_0.booking__ds__year
+              , subq_0.booking__ds__extract_year
+              , subq_0.booking__ds__extract_quarter
+              , subq_0.booking__ds__extract_month
+              , subq_0.booking__ds__extract_day
+              , subq_0.booking__ds__extract_dow
+              , subq_0.booking__ds__extract_doy
+              , subq_0.booking__ds_partitioned__day
+              , subq_0.booking__ds_partitioned__week
+              , subq_0.booking__ds_partitioned__month
+              , subq_0.booking__ds_partitioned__quarter
+              , subq_0.booking__ds_partitioned__year
+              , subq_0.booking__ds_partitioned__extract_year
+              , subq_0.booking__ds_partitioned__extract_quarter
+              , subq_0.booking__ds_partitioned__extract_month
+              , subq_0.booking__ds_partitioned__extract_day
+              , subq_0.booking__ds_partitioned__extract_dow
+              , subq_0.booking__ds_partitioned__extract_doy
+              , subq_0.booking__paid_at__day
+              , subq_0.booking__paid_at__week
+              , subq_0.booking__paid_at__month
+              , subq_0.booking__paid_at__quarter
+              , subq_0.booking__paid_at__year
+              , subq_0.booking__paid_at__extract_year
+              , subq_0.booking__paid_at__extract_quarter
+              , subq_0.booking__paid_at__extract_month
+              , subq_0.booking__paid_at__extract_day
+              , subq_0.booking__paid_at__extract_dow
+              , subq_0.booking__paid_at__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.listing
+              , subq_0.guest
+              , subq_0.host
+              , subq_0.booking__listing
+              , subq_0.booking__guest
+              , subq_0.booking__host
+              , subq_0.is_instant
+              , subq_0.booking__is_instant
+              , subq_0.bookings
+              , subq_0.instant_bookings
+              , subq_0.booking_value
+              , subq_0.max_booking_value
+              , subq_0.min_booking_value
+              , subq_0.bookers
+              , subq_0.average_booking_value
+              , subq_0.referred_bookings
+              , subq_0.median_booking_value
+              , subq_0.booking_value_p99
+              , subq_0.discrete_booking_value_p99
+              , subq_0.approximate_continuous_booking_value_p99
+              , subq_0.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Semantic Model 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_28000.booking_value
+                , bookings_source_src_28000.booking_value AS max_booking_value
+                , bookings_source_src_28000.booking_value AS min_booking_value
+                , bookings_source_src_28000.guest_id AS bookers
+                , bookings_source_src_28000.booking_value AS average_booking_value
+                , bookings_source_src_28000.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_28000.booking_value AS median_booking_value
+                , bookings_source_src_28000.booking_value AS booking_value_p99
+                , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_28000.is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_28000.is_instant AS booking__is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_28000.listing_id AS listing
+                , bookings_source_src_28000.guest_id AS guest
+                , bookings_source_src_28000.host_id AS host
+                , bookings_source_src_28000.listing_id AS booking__listing
+                , bookings_source_src_28000.guest_id AS booking__guest
+                , bookings_source_src_28000.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_28000
+            ) subq_0
+          ) subq_1
+          ON
+            DATEADD(day, -5, subq_2.metric_time__day) = subq_1.metric_time__day
+        ) subq_4
+        WHERE subq_4.metric_time__day BETWEEN '2019-12-19' AND '2020-01-02'
+      ) subq_5
+    ) subq_6
     GROUP BY
-      subq_5.metric_time__day
-  ) subq_6
-) subq_7
+      subq_6.metric_time__day
+  ) subq_7
+) subq_8

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_time_offset_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_time_offset_metric_with_time_constraint__plan0_optimized.sql
@@ -8,19 +8,14 @@ SELECT
   , bookings_5_days_ago AS bookings_5_day_lag
 FROM (
   -- Join to Time Spine Dataset
+  -- Constrain Time Range to [2019-12-19T00:00:00, 2020-01-02T00:00:00]
   -- Pass Only Elements: ['bookings', 'metric_time__day']
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT
-    subq_10.metric_time__day AS metric_time__day
-    , SUM(subq_9.bookings) AS bookings_5_days_ago
-  FROM (
-    -- Time Spine
-    SELECT
-      ds AS metric_time__day
-    FROM ***************************.mf_time_spine subq_11
-    WHERE ds BETWEEN '2019-12-19' AND '2020-01-02'
-  ) subq_10
+    subq_12.ds AS metric_time__day
+    , SUM(subq_10.bookings) AS bookings_5_days_ago
+  FROM ***************************.mf_time_spine subq_12
   INNER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -28,9 +23,10 @@ FROM (
       DATE_TRUNC('day', ds) AS metric_time__day
       , 1 AS bookings
     FROM ***************************.fct_bookings bookings_source_src_28000
-  ) subq_9
+  ) subq_10
   ON
-    DATEADD(day, -5, subq_10.metric_time__day) = subq_9.metric_time__day
+    DATEADD(day, -5, subq_12.ds) = subq_10.metric_time__day
+  WHERE subq_12.ds BETWEEN '2019-12-19' AND '2020-01-02'
   GROUP BY
-    subq_10.metric_time__day
-) subq_15
+    subq_12.ds
+) subq_17

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
@@ -228,7 +228,6 @@ FROM (
             SELECT
               subq_6.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_6
-            WHERE subq_6.ds BETWEEN timestamp '2019-12-19' AND timestamp '2020-01-02'
           ) subq_5
           INNER JOIN (
             -- Join Self Over Time Range

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_time_offset_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_time_offset_metric_with_time_constraint__plan0_optimized.sql
@@ -13,15 +13,9 @@ FROM (
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT
-    subq_17.metric_time__day AS metric_time__day
+    subq_18.ds AS metric_time__day
     , COUNT(DISTINCT subq_16.bookers) AS every_2_days_bookers_2_days_ago
-  FROM (
-    -- Time Spine
-    SELECT
-      ds AS metric_time__day
-    FROM ***************************.mf_time_spine subq_18
-    WHERE ds BETWEEN timestamp '2019-12-19' AND timestamp '2020-01-02'
-  ) subq_17
+  FROM ***************************.mf_time_spine subq_18
   INNER JOIN (
     -- Join Self Over Time Range
     SELECT
@@ -38,8 +32,8 @@ FROM (
       )
   ) subq_16
   ON
-    DATE_ADD('day', -2, subq_17.metric_time__day) = subq_16.metric_time__day
-  WHERE subq_17.metric_time__day BETWEEN timestamp '2019-12-19' AND timestamp '2020-01-02'
+    DATE_ADD('day', -2, subq_18.ds) = subq_16.metric_time__day
+  WHERE subq_18.ds BETWEEN timestamp '2019-12-19' AND timestamp '2020-01-02'
   GROUP BY
-    subq_17.metric_time__day
+    subq_18.ds
 ) subq_23

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_nested_offsets_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_nested_offsets_with_time_constraint__plan0.sql
@@ -4,351 +4,357 @@ sql_engine: Trino
 ---
 -- Compute Metrics via Expressions
 SELECT
-  subq_11.metric_time__day
+  subq_12.metric_time__day
   , 2 * bookings_offset_once AS bookings_offset_twice
 FROM (
-  -- Join to Time Spine Dataset
+  -- Constrain Time Range to [2020-01-12T00:00:00, 2020-01-13T00:00:00]
   SELECT
-    subq_9.metric_time__day AS metric_time__day
-    , subq_8.bookings_offset_once AS bookings_offset_once
+    subq_11.metric_time__day
+    , subq_11.bookings_offset_once
   FROM (
-    -- Time Spine
+    -- Join to Time Spine Dataset
     SELECT
-      subq_10.ds AS metric_time__day
-    FROM ***************************.mf_time_spine subq_10
-    WHERE subq_10.ds BETWEEN timestamp '2020-01-12' AND timestamp '2020-01-13'
-  ) subq_9
-  INNER JOIN (
-    -- Compute Metrics via Expressions
-    SELECT
-      subq_7.metric_time__day
-      , 2 * bookings AS bookings_offset_once
+      subq_9.metric_time__day AS metric_time__day
+      , subq_8.bookings_offset_once AS bookings_offset_once
     FROM (
+      -- Time Spine
+      SELECT
+        subq_10.ds AS metric_time__day
+      FROM ***************************.mf_time_spine subq_10
+    ) subq_9
+    INNER JOIN (
       -- Compute Metrics via Expressions
       SELECT
-        subq_6.metric_time__day
-        , subq_6.bookings
+        subq_7.metric_time__day
+        , 2 * bookings AS bookings_offset_once
       FROM (
-        -- Aggregate Measures
+        -- Compute Metrics via Expressions
         SELECT
-          subq_5.metric_time__day
-          , SUM(subq_5.bookings) AS bookings
+          subq_6.metric_time__day
+          , subq_6.bookings
         FROM (
-          -- Pass Only Elements: ['bookings', 'metric_time__day']
+          -- Aggregate Measures
           SELECT
-            subq_4.metric_time__day
-            , subq_4.bookings
+            subq_5.metric_time__day
+            , SUM(subq_5.bookings) AS bookings
           FROM (
-            -- Join to Time Spine Dataset
+            -- Pass Only Elements: ['bookings', 'metric_time__day']
             SELECT
-              subq_1.ds__day AS ds__day
-              , subq_1.ds__week AS ds__week
-              , subq_1.ds__month AS ds__month
-              , subq_1.ds__quarter AS ds__quarter
-              , subq_1.ds__year AS ds__year
-              , subq_1.ds__extract_year AS ds__extract_year
-              , subq_1.ds__extract_quarter AS ds__extract_quarter
-              , subq_1.ds__extract_month AS ds__extract_month
-              , subq_1.ds__extract_day AS ds__extract_day
-              , subq_1.ds__extract_dow AS ds__extract_dow
-              , subq_1.ds__extract_doy AS ds__extract_doy
-              , subq_1.ds_partitioned__day AS ds_partitioned__day
-              , subq_1.ds_partitioned__week AS ds_partitioned__week
-              , subq_1.ds_partitioned__month AS ds_partitioned__month
-              , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
-              , subq_1.ds_partitioned__year AS ds_partitioned__year
-              , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
-              , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
-              , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
-              , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
-              , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
-              , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
-              , subq_1.paid_at__day AS paid_at__day
-              , subq_1.paid_at__week AS paid_at__week
-              , subq_1.paid_at__month AS paid_at__month
-              , subq_1.paid_at__quarter AS paid_at__quarter
-              , subq_1.paid_at__year AS paid_at__year
-              , subq_1.paid_at__extract_year AS paid_at__extract_year
-              , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
-              , subq_1.paid_at__extract_month AS paid_at__extract_month
-              , subq_1.paid_at__extract_day AS paid_at__extract_day
-              , subq_1.paid_at__extract_dow AS paid_at__extract_dow
-              , subq_1.paid_at__extract_doy AS paid_at__extract_doy
-              , subq_1.booking__ds__day AS booking__ds__day
-              , subq_1.booking__ds__week AS booking__ds__week
-              , subq_1.booking__ds__month AS booking__ds__month
-              , subq_1.booking__ds__quarter AS booking__ds__quarter
-              , subq_1.booking__ds__year AS booking__ds__year
-              , subq_1.booking__ds__extract_year AS booking__ds__extract_year
-              , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
-              , subq_1.booking__ds__extract_month AS booking__ds__extract_month
-              , subq_1.booking__ds__extract_day AS booking__ds__extract_day
-              , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
-              , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
-              , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
-              , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
-              , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
-              , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
-              , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
-              , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
-              , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
-              , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
-              , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
-              , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
-              , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
-              , subq_1.booking__paid_at__day AS booking__paid_at__day
-              , subq_1.booking__paid_at__week AS booking__paid_at__week
-              , subq_1.booking__paid_at__month AS booking__paid_at__month
-              , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
-              , subq_1.booking__paid_at__year AS booking__paid_at__year
-              , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
-              , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
-              , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
-              , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
-              , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
-              , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
-              , subq_1.metric_time__week AS metric_time__week
-              , subq_1.metric_time__month AS metric_time__month
-              , subq_1.metric_time__quarter AS metric_time__quarter
-              , subq_1.metric_time__year AS metric_time__year
-              , subq_1.metric_time__extract_year AS metric_time__extract_year
-              , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
-              , subq_1.metric_time__extract_month AS metric_time__extract_month
-              , subq_1.metric_time__extract_day AS metric_time__extract_day
-              , subq_1.metric_time__extract_dow AS metric_time__extract_dow
-              , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-              , subq_2.metric_time__day AS metric_time__day
-              , subq_1.listing AS listing
-              , subq_1.guest AS guest
-              , subq_1.host AS host
-              , subq_1.booking__listing AS booking__listing
-              , subq_1.booking__guest AS booking__guest
-              , subq_1.booking__host AS booking__host
-              , subq_1.is_instant AS is_instant
-              , subq_1.booking__is_instant AS booking__is_instant
-              , subq_1.bookings AS bookings
-              , subq_1.instant_bookings AS instant_bookings
-              , subq_1.booking_value AS booking_value
-              , subq_1.max_booking_value AS max_booking_value
-              , subq_1.min_booking_value AS min_booking_value
-              , subq_1.bookers AS bookers
-              , subq_1.average_booking_value AS average_booking_value
-              , subq_1.referred_bookings AS referred_bookings
-              , subq_1.median_booking_value AS median_booking_value
-              , subq_1.booking_value_p99 AS booking_value_p99
-              , subq_1.discrete_booking_value_p99 AS discrete_booking_value_p99
-              , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
-              , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+              subq_4.metric_time__day
+              , subq_4.bookings
             FROM (
-              -- Time Spine
+              -- Join to Time Spine Dataset
               SELECT
-                subq_3.ds AS metric_time__day
-              FROM ***************************.mf_time_spine subq_3
-            ) subq_2
-            INNER JOIN (
-              -- Metric Time Dimension 'ds'
-              SELECT
-                subq_0.ds__day
-                , subq_0.ds__week
-                , subq_0.ds__month
-                , subq_0.ds__quarter
-                , subq_0.ds__year
-                , subq_0.ds__extract_year
-                , subq_0.ds__extract_quarter
-                , subq_0.ds__extract_month
-                , subq_0.ds__extract_day
-                , subq_0.ds__extract_dow
-                , subq_0.ds__extract_doy
-                , subq_0.ds_partitioned__day
-                , subq_0.ds_partitioned__week
-                , subq_0.ds_partitioned__month
-                , subq_0.ds_partitioned__quarter
-                , subq_0.ds_partitioned__year
-                , subq_0.ds_partitioned__extract_year
-                , subq_0.ds_partitioned__extract_quarter
-                , subq_0.ds_partitioned__extract_month
-                , subq_0.ds_partitioned__extract_day
-                , subq_0.ds_partitioned__extract_dow
-                , subq_0.ds_partitioned__extract_doy
-                , subq_0.paid_at__day
-                , subq_0.paid_at__week
-                , subq_0.paid_at__month
-                , subq_0.paid_at__quarter
-                , subq_0.paid_at__year
-                , subq_0.paid_at__extract_year
-                , subq_0.paid_at__extract_quarter
-                , subq_0.paid_at__extract_month
-                , subq_0.paid_at__extract_day
-                , subq_0.paid_at__extract_dow
-                , subq_0.paid_at__extract_doy
-                , subq_0.booking__ds__day
-                , subq_0.booking__ds__week
-                , subq_0.booking__ds__month
-                , subq_0.booking__ds__quarter
-                , subq_0.booking__ds__year
-                , subq_0.booking__ds__extract_year
-                , subq_0.booking__ds__extract_quarter
-                , subq_0.booking__ds__extract_month
-                , subq_0.booking__ds__extract_day
-                , subq_0.booking__ds__extract_dow
-                , subq_0.booking__ds__extract_doy
-                , subq_0.booking__ds_partitioned__day
-                , subq_0.booking__ds_partitioned__week
-                , subq_0.booking__ds_partitioned__month
-                , subq_0.booking__ds_partitioned__quarter
-                , subq_0.booking__ds_partitioned__year
-                , subq_0.booking__ds_partitioned__extract_year
-                , subq_0.booking__ds_partitioned__extract_quarter
-                , subq_0.booking__ds_partitioned__extract_month
-                , subq_0.booking__ds_partitioned__extract_day
-                , subq_0.booking__ds_partitioned__extract_dow
-                , subq_0.booking__ds_partitioned__extract_doy
-                , subq_0.booking__paid_at__day
-                , subq_0.booking__paid_at__week
-                , subq_0.booking__paid_at__month
-                , subq_0.booking__paid_at__quarter
-                , subq_0.booking__paid_at__year
-                , subq_0.booking__paid_at__extract_year
-                , subq_0.booking__paid_at__extract_quarter
-                , subq_0.booking__paid_at__extract_month
-                , subq_0.booking__paid_at__extract_day
-                , subq_0.booking__paid_at__extract_dow
-                , subq_0.booking__paid_at__extract_doy
-                , subq_0.ds__day AS metric_time__day
-                , subq_0.ds__week AS metric_time__week
-                , subq_0.ds__month AS metric_time__month
-                , subq_0.ds__quarter AS metric_time__quarter
-                , subq_0.ds__year AS metric_time__year
-                , subq_0.ds__extract_year AS metric_time__extract_year
-                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_0.ds__extract_month AS metric_time__extract_month
-                , subq_0.ds__extract_day AS metric_time__extract_day
-                , subq_0.ds__extract_dow AS metric_time__extract_dow
-                , subq_0.ds__extract_doy AS metric_time__extract_doy
-                , subq_0.listing
-                , subq_0.guest
-                , subq_0.host
-                , subq_0.booking__listing
-                , subq_0.booking__guest
-                , subq_0.booking__host
-                , subq_0.is_instant
-                , subq_0.booking__is_instant
-                , subq_0.bookings
-                , subq_0.instant_bookings
-                , subq_0.booking_value
-                , subq_0.max_booking_value
-                , subq_0.min_booking_value
-                , subq_0.bookers
-                , subq_0.average_booking_value
-                , subq_0.referred_bookings
-                , subq_0.median_booking_value
-                , subq_0.booking_value_p99
-                , subq_0.discrete_booking_value_p99
-                , subq_0.approximate_continuous_booking_value_p99
-                , subq_0.approximate_discrete_booking_value_p99
+                subq_1.ds__day AS ds__day
+                , subq_1.ds__week AS ds__week
+                , subq_1.ds__month AS ds__month
+                , subq_1.ds__quarter AS ds__quarter
+                , subq_1.ds__year AS ds__year
+                , subq_1.ds__extract_year AS ds__extract_year
+                , subq_1.ds__extract_quarter AS ds__extract_quarter
+                , subq_1.ds__extract_month AS ds__extract_month
+                , subq_1.ds__extract_day AS ds__extract_day
+                , subq_1.ds__extract_dow AS ds__extract_dow
+                , subq_1.ds__extract_doy AS ds__extract_doy
+                , subq_1.ds_partitioned__day AS ds_partitioned__day
+                , subq_1.ds_partitioned__week AS ds_partitioned__week
+                , subq_1.ds_partitioned__month AS ds_partitioned__month
+                , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
+                , subq_1.ds_partitioned__year AS ds_partitioned__year
+                , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
+                , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+                , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
+                , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
+                , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+                , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+                , subq_1.paid_at__day AS paid_at__day
+                , subq_1.paid_at__week AS paid_at__week
+                , subq_1.paid_at__month AS paid_at__month
+                , subq_1.paid_at__quarter AS paid_at__quarter
+                , subq_1.paid_at__year AS paid_at__year
+                , subq_1.paid_at__extract_year AS paid_at__extract_year
+                , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
+                , subq_1.paid_at__extract_month AS paid_at__extract_month
+                , subq_1.paid_at__extract_day AS paid_at__extract_day
+                , subq_1.paid_at__extract_dow AS paid_at__extract_dow
+                , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+                , subq_1.booking__ds__day AS booking__ds__day
+                , subq_1.booking__ds__week AS booking__ds__week
+                , subq_1.booking__ds__month AS booking__ds__month
+                , subq_1.booking__ds__quarter AS booking__ds__quarter
+                , subq_1.booking__ds__year AS booking__ds__year
+                , subq_1.booking__ds__extract_year AS booking__ds__extract_year
+                , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
+                , subq_1.booking__ds__extract_month AS booking__ds__extract_month
+                , subq_1.booking__ds__extract_day AS booking__ds__extract_day
+                , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
+                , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
+                , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
+                , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
+                , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
+                , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+                , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
+                , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+                , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+                , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+                , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+                , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+                , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+                , subq_1.booking__paid_at__day AS booking__paid_at__day
+                , subq_1.booking__paid_at__week AS booking__paid_at__week
+                , subq_1.booking__paid_at__month AS booking__paid_at__month
+                , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
+                , subq_1.booking__paid_at__year AS booking__paid_at__year
+                , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
+                , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+                , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
+                , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
+                , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+                , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                , subq_1.metric_time__week AS metric_time__week
+                , subq_1.metric_time__month AS metric_time__month
+                , subq_1.metric_time__quarter AS metric_time__quarter
+                , subq_1.metric_time__year AS metric_time__year
+                , subq_1.metric_time__extract_year AS metric_time__extract_year
+                , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+                , subq_1.metric_time__extract_month AS metric_time__extract_month
+                , subq_1.metric_time__extract_day AS metric_time__extract_day
+                , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+                , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+                , subq_2.metric_time__day AS metric_time__day
+                , subq_1.listing AS listing
+                , subq_1.guest AS guest
+                , subq_1.host AS host
+                , subq_1.booking__listing AS booking__listing
+                , subq_1.booking__guest AS booking__guest
+                , subq_1.booking__host AS booking__host
+                , subq_1.is_instant AS is_instant
+                , subq_1.booking__is_instant AS booking__is_instant
+                , subq_1.bookings AS bookings
+                , subq_1.instant_bookings AS instant_bookings
+                , subq_1.booking_value AS booking_value
+                , subq_1.max_booking_value AS max_booking_value
+                , subq_1.min_booking_value AS min_booking_value
+                , subq_1.bookers AS bookers
+                , subq_1.average_booking_value AS average_booking_value
+                , subq_1.referred_bookings AS referred_bookings
+                , subq_1.median_booking_value AS median_booking_value
+                , subq_1.booking_value_p99 AS booking_value_p99
+                , subq_1.discrete_booking_value_p99 AS discrete_booking_value_p99
+                , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+                , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
               FROM (
-                -- Read Elements From Semantic Model 'bookings_source'
+                -- Time Spine
                 SELECT
-                  1 AS bookings
-                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                  , bookings_source_src_28000.booking_value
-                  , bookings_source_src_28000.booking_value AS max_booking_value
-                  , bookings_source_src_28000.booking_value AS min_booking_value
-                  , bookings_source_src_28000.guest_id AS bookers
-                  , bookings_source_src_28000.booking_value AS average_booking_value
-                  , bookings_source_src_28000.booking_value AS booking_payments
-                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-                  , bookings_source_src_28000.booking_value AS median_booking_value
-                  , bookings_source_src_28000.booking_value AS booking_value_p99
-                  , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
-                  , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
-                  , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
-                  , bookings_source_src_28000.is_instant
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                  , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS ds__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                  , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                  , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                  , bookings_source_src_28000.is_instant AS booking__is_instant
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                  , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                  , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                  , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                  , bookings_source_src_28000.listing_id AS listing
-                  , bookings_source_src_28000.guest_id AS guest
-                  , bookings_source_src_28000.host_id AS host
-                  , bookings_source_src_28000.listing_id AS booking__listing
-                  , bookings_source_src_28000.guest_id AS booking__guest
-                  , bookings_source_src_28000.host_id AS booking__host
-                FROM ***************************.fct_bookings bookings_source_src_28000
-              ) subq_0
-            ) subq_1
-            ON
-              DATE_ADD('day', -5, subq_2.metric_time__day) = subq_1.metric_time__day
-          ) subq_4
-        ) subq_5
-        GROUP BY
-          subq_5.metric_time__day
-      ) subq_6
-    ) subq_7
-  ) subq_8
-  ON
-    DATE_ADD('day', -2, subq_9.metric_time__day) = subq_8.metric_time__day
-) subq_11
+                  subq_3.ds AS metric_time__day
+                FROM ***************************.mf_time_spine subq_3
+              ) subq_2
+              INNER JOIN (
+                -- Metric Time Dimension 'ds'
+                SELECT
+                  subq_0.ds__day
+                  , subq_0.ds__week
+                  , subq_0.ds__month
+                  , subq_0.ds__quarter
+                  , subq_0.ds__year
+                  , subq_0.ds__extract_year
+                  , subq_0.ds__extract_quarter
+                  , subq_0.ds__extract_month
+                  , subq_0.ds__extract_day
+                  , subq_0.ds__extract_dow
+                  , subq_0.ds__extract_doy
+                  , subq_0.ds_partitioned__day
+                  , subq_0.ds_partitioned__week
+                  , subq_0.ds_partitioned__month
+                  , subq_0.ds_partitioned__quarter
+                  , subq_0.ds_partitioned__year
+                  , subq_0.ds_partitioned__extract_year
+                  , subq_0.ds_partitioned__extract_quarter
+                  , subq_0.ds_partitioned__extract_month
+                  , subq_0.ds_partitioned__extract_day
+                  , subq_0.ds_partitioned__extract_dow
+                  , subq_0.ds_partitioned__extract_doy
+                  , subq_0.paid_at__day
+                  , subq_0.paid_at__week
+                  , subq_0.paid_at__month
+                  , subq_0.paid_at__quarter
+                  , subq_0.paid_at__year
+                  , subq_0.paid_at__extract_year
+                  , subq_0.paid_at__extract_quarter
+                  , subq_0.paid_at__extract_month
+                  , subq_0.paid_at__extract_day
+                  , subq_0.paid_at__extract_dow
+                  , subq_0.paid_at__extract_doy
+                  , subq_0.booking__ds__day
+                  , subq_0.booking__ds__week
+                  , subq_0.booking__ds__month
+                  , subq_0.booking__ds__quarter
+                  , subq_0.booking__ds__year
+                  , subq_0.booking__ds__extract_year
+                  , subq_0.booking__ds__extract_quarter
+                  , subq_0.booking__ds__extract_month
+                  , subq_0.booking__ds__extract_day
+                  , subq_0.booking__ds__extract_dow
+                  , subq_0.booking__ds__extract_doy
+                  , subq_0.booking__ds_partitioned__day
+                  , subq_0.booking__ds_partitioned__week
+                  , subq_0.booking__ds_partitioned__month
+                  , subq_0.booking__ds_partitioned__quarter
+                  , subq_0.booking__ds_partitioned__year
+                  , subq_0.booking__ds_partitioned__extract_year
+                  , subq_0.booking__ds_partitioned__extract_quarter
+                  , subq_0.booking__ds_partitioned__extract_month
+                  , subq_0.booking__ds_partitioned__extract_day
+                  , subq_0.booking__ds_partitioned__extract_dow
+                  , subq_0.booking__ds_partitioned__extract_doy
+                  , subq_0.booking__paid_at__day
+                  , subq_0.booking__paid_at__week
+                  , subq_0.booking__paid_at__month
+                  , subq_0.booking__paid_at__quarter
+                  , subq_0.booking__paid_at__year
+                  , subq_0.booking__paid_at__extract_year
+                  , subq_0.booking__paid_at__extract_quarter
+                  , subq_0.booking__paid_at__extract_month
+                  , subq_0.booking__paid_at__extract_day
+                  , subq_0.booking__paid_at__extract_dow
+                  , subq_0.booking__paid_at__extract_doy
+                  , subq_0.ds__day AS metric_time__day
+                  , subq_0.ds__week AS metric_time__week
+                  , subq_0.ds__month AS metric_time__month
+                  , subq_0.ds__quarter AS metric_time__quarter
+                  , subq_0.ds__year AS metric_time__year
+                  , subq_0.ds__extract_year AS metric_time__extract_year
+                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_0.ds__extract_month AS metric_time__extract_month
+                  , subq_0.ds__extract_day AS metric_time__extract_day
+                  , subq_0.ds__extract_dow AS metric_time__extract_dow
+                  , subq_0.ds__extract_doy AS metric_time__extract_doy
+                  , subq_0.listing
+                  , subq_0.guest
+                  , subq_0.host
+                  , subq_0.booking__listing
+                  , subq_0.booking__guest
+                  , subq_0.booking__host
+                  , subq_0.is_instant
+                  , subq_0.booking__is_instant
+                  , subq_0.bookings
+                  , subq_0.instant_bookings
+                  , subq_0.booking_value
+                  , subq_0.max_booking_value
+                  , subq_0.min_booking_value
+                  , subq_0.bookers
+                  , subq_0.average_booking_value
+                  , subq_0.referred_bookings
+                  , subq_0.median_booking_value
+                  , subq_0.booking_value_p99
+                  , subq_0.discrete_booking_value_p99
+                  , subq_0.approximate_continuous_booking_value_p99
+                  , subq_0.approximate_discrete_booking_value_p99
+                FROM (
+                  -- Read Elements From Semantic Model 'bookings_source'
+                  SELECT
+                    1 AS bookings
+                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                    , bookings_source_src_28000.booking_value
+                    , bookings_source_src_28000.booking_value AS max_booking_value
+                    , bookings_source_src_28000.booking_value AS min_booking_value
+                    , bookings_source_src_28000.guest_id AS bookers
+                    , bookings_source_src_28000.booking_value AS average_booking_value
+                    , bookings_source_src_28000.booking_value AS booking_payments
+                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                    , bookings_source_src_28000.booking_value AS median_booking_value
+                    , bookings_source_src_28000.booking_value AS booking_value_p99
+                    , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                    , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                    , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                    , bookings_source_src_28000.is_instant
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                    , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                    , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                    , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                    , bookings_source_src_28000.is_instant AS booking__is_instant
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                    , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                    , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                    , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                    , bookings_source_src_28000.listing_id AS listing
+                    , bookings_source_src_28000.guest_id AS guest
+                    , bookings_source_src_28000.host_id AS host
+                    , bookings_source_src_28000.listing_id AS booking__listing
+                    , bookings_source_src_28000.guest_id AS booking__guest
+                    , bookings_source_src_28000.host_id AS booking__host
+                  FROM ***************************.fct_bookings bookings_source_src_28000
+                ) subq_0
+              ) subq_1
+              ON
+                DATE_ADD('day', -5, subq_2.metric_time__day) = subq_1.metric_time__day
+            ) subq_4
+          ) subq_5
+          GROUP BY
+            subq_5.metric_time__day
+        ) subq_6
+      ) subq_7
+    ) subq_8
+    ON
+      DATE_ADD('day', -2, subq_9.metric_time__day) = subq_8.metric_time__day
+  ) subq_11
+  WHERE subq_11.metric_time__day BETWEEN timestamp '2020-01-12' AND timestamp '2020-01-13'
+) subq_12

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_nested_offsets_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_nested_offsets_with_time_constraint__plan0_optimized.sql
@@ -8,16 +8,11 @@ SELECT
   , 2 * bookings_offset_once AS bookings_offset_twice
 FROM (
   -- Join to Time Spine Dataset
+  -- Constrain Time Range to [2020-01-12T00:00:00, 2020-01-13T00:00:00]
   SELECT
-    subq_21.metric_time__day AS metric_time__day
-    , subq_20.bookings_offset_once AS bookings_offset_once
-  FROM (
-    -- Time Spine
-    SELECT
-      ds AS metric_time__day
-    FROM ***************************.mf_time_spine subq_22
-    WHERE ds BETWEEN timestamp '2020-01-12' AND timestamp '2020-01-13'
-  ) subq_21
+    subq_23.ds AS metric_time__day
+    , subq_21.bookings_offset_once AS bookings_offset_once
+  FROM ***************************.mf_time_spine subq_23
   INNER JOIN (
     -- Compute Metrics via Expressions
     SELECT
@@ -29,9 +24,9 @@ FROM (
       -- Aggregate Measures
       -- Compute Metrics via Expressions
       SELECT
-        subq_15.ds AS metric_time__day
-        , SUM(subq_13.bookings) AS bookings
-      FROM ***************************.mf_time_spine subq_15
+        subq_16.ds AS metric_time__day
+        , SUM(subq_14.bookings) AS bookings
+      FROM ***************************.mf_time_spine subq_16
       INNER JOIN (
         -- Read Elements From Semantic Model 'bookings_source'
         -- Metric Time Dimension 'ds'
@@ -39,13 +34,14 @@ FROM (
           DATE_TRUNC('day', ds) AS metric_time__day
           , 1 AS bookings
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_13
+      ) subq_14
       ON
-        DATE_ADD('day', -5, subq_15.ds) = subq_13.metric_time__day
+        DATE_ADD('day', -5, subq_16.ds) = subq_14.metric_time__day
       GROUP BY
-        subq_15.ds
-    ) subq_19
-  ) subq_20
+        subq_16.ds
+    ) subq_20
+  ) subq_21
   ON
-    DATE_ADD('day', -2, subq_21.metric_time__day) = subq_20.metric_time__day
-) subq_23
+    DATE_ADD('day', -2, subq_23.ds) = subq_21.metric_time__day
+  WHERE subq_23.ds BETWEEN timestamp '2020-01-12' AND timestamp '2020-01-13'
+) subq_25

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_time_offset_metric_with_time_constraint__plan0.sql
@@ -4,331 +4,433 @@ sql_engine: Trino
 ---
 -- Compute Metrics via Expressions
 SELECT
-  subq_7.metric_time__day
+  subq_8.metric_time__day
   , bookings_5_days_ago AS bookings_5_day_lag
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_6.metric_time__day
-    , subq_6.bookings AS bookings_5_days_ago
+    subq_7.metric_time__day
+    , subq_7.bookings AS bookings_5_days_ago
   FROM (
     -- Aggregate Measures
     SELECT
-      subq_5.metric_time__day
-      , SUM(subq_5.bookings) AS bookings
+      subq_6.metric_time__day
+      , SUM(subq_6.bookings) AS bookings
     FROM (
       -- Pass Only Elements: ['bookings', 'metric_time__day']
       SELECT
-        subq_4.metric_time__day
-        , subq_4.bookings
+        subq_5.metric_time__day
+        , subq_5.bookings
       FROM (
-        -- Join to Time Spine Dataset
+        -- Constrain Time Range to [2019-12-19T00:00:00, 2020-01-02T00:00:00]
         SELECT
-          subq_1.ds__day AS ds__day
-          , subq_1.ds__week AS ds__week
-          , subq_1.ds__month AS ds__month
-          , subq_1.ds__quarter AS ds__quarter
-          , subq_1.ds__year AS ds__year
-          , subq_1.ds__extract_year AS ds__extract_year
-          , subq_1.ds__extract_quarter AS ds__extract_quarter
-          , subq_1.ds__extract_month AS ds__extract_month
-          , subq_1.ds__extract_day AS ds__extract_day
-          , subq_1.ds__extract_dow AS ds__extract_dow
-          , subq_1.ds__extract_doy AS ds__extract_doy
-          , subq_1.ds_partitioned__day AS ds_partitioned__day
-          , subq_1.ds_partitioned__week AS ds_partitioned__week
-          , subq_1.ds_partitioned__month AS ds_partitioned__month
-          , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
-          , subq_1.ds_partitioned__year AS ds_partitioned__year
-          , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
-          , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
-          , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
-          , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
-          , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
-          , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
-          , subq_1.paid_at__day AS paid_at__day
-          , subq_1.paid_at__week AS paid_at__week
-          , subq_1.paid_at__month AS paid_at__month
-          , subq_1.paid_at__quarter AS paid_at__quarter
-          , subq_1.paid_at__year AS paid_at__year
-          , subq_1.paid_at__extract_year AS paid_at__extract_year
-          , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
-          , subq_1.paid_at__extract_month AS paid_at__extract_month
-          , subq_1.paid_at__extract_day AS paid_at__extract_day
-          , subq_1.paid_at__extract_dow AS paid_at__extract_dow
-          , subq_1.paid_at__extract_doy AS paid_at__extract_doy
-          , subq_1.booking__ds__day AS booking__ds__day
-          , subq_1.booking__ds__week AS booking__ds__week
-          , subq_1.booking__ds__month AS booking__ds__month
-          , subq_1.booking__ds__quarter AS booking__ds__quarter
-          , subq_1.booking__ds__year AS booking__ds__year
-          , subq_1.booking__ds__extract_year AS booking__ds__extract_year
-          , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
-          , subq_1.booking__ds__extract_month AS booking__ds__extract_month
-          , subq_1.booking__ds__extract_day AS booking__ds__extract_day
-          , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
-          , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
-          , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
-          , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
-          , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
-          , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
-          , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
-          , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
-          , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
-          , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
-          , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
-          , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
-          , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
-          , subq_1.booking__paid_at__day AS booking__paid_at__day
-          , subq_1.booking__paid_at__week AS booking__paid_at__week
-          , subq_1.booking__paid_at__month AS booking__paid_at__month
-          , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
-          , subq_1.booking__paid_at__year AS booking__paid_at__year
-          , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
-          , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
-          , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
-          , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
-          , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
-          , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
-          , subq_1.metric_time__week AS metric_time__week
-          , subq_1.metric_time__month AS metric_time__month
-          , subq_1.metric_time__quarter AS metric_time__quarter
-          , subq_1.metric_time__year AS metric_time__year
-          , subq_1.metric_time__extract_year AS metric_time__extract_year
-          , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
-          , subq_1.metric_time__extract_month AS metric_time__extract_month
-          , subq_1.metric_time__extract_day AS metric_time__extract_day
-          , subq_1.metric_time__extract_dow AS metric_time__extract_dow
-          , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-          , subq_2.metric_time__day AS metric_time__day
-          , subq_1.listing AS listing
-          , subq_1.guest AS guest
-          , subq_1.host AS host
-          , subq_1.booking__listing AS booking__listing
-          , subq_1.booking__guest AS booking__guest
-          , subq_1.booking__host AS booking__host
-          , subq_1.is_instant AS is_instant
-          , subq_1.booking__is_instant AS booking__is_instant
-          , subq_1.bookings AS bookings
-          , subq_1.instant_bookings AS instant_bookings
-          , subq_1.booking_value AS booking_value
-          , subq_1.max_booking_value AS max_booking_value
-          , subq_1.min_booking_value AS min_booking_value
-          , subq_1.bookers AS bookers
-          , subq_1.average_booking_value AS average_booking_value
-          , subq_1.referred_bookings AS referred_bookings
-          , subq_1.median_booking_value AS median_booking_value
-          , subq_1.booking_value_p99 AS booking_value_p99
-          , subq_1.discrete_booking_value_p99 AS discrete_booking_value_p99
-          , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
-          , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+          subq_4.metric_time__day
+          , subq_4.ds__day
+          , subq_4.ds__week
+          , subq_4.ds__month
+          , subq_4.ds__quarter
+          , subq_4.ds__year
+          , subq_4.ds__extract_year
+          , subq_4.ds__extract_quarter
+          , subq_4.ds__extract_month
+          , subq_4.ds__extract_day
+          , subq_4.ds__extract_dow
+          , subq_4.ds__extract_doy
+          , subq_4.ds_partitioned__day
+          , subq_4.ds_partitioned__week
+          , subq_4.ds_partitioned__month
+          , subq_4.ds_partitioned__quarter
+          , subq_4.ds_partitioned__year
+          , subq_4.ds_partitioned__extract_year
+          , subq_4.ds_partitioned__extract_quarter
+          , subq_4.ds_partitioned__extract_month
+          , subq_4.ds_partitioned__extract_day
+          , subq_4.ds_partitioned__extract_dow
+          , subq_4.ds_partitioned__extract_doy
+          , subq_4.paid_at__day
+          , subq_4.paid_at__week
+          , subq_4.paid_at__month
+          , subq_4.paid_at__quarter
+          , subq_4.paid_at__year
+          , subq_4.paid_at__extract_year
+          , subq_4.paid_at__extract_quarter
+          , subq_4.paid_at__extract_month
+          , subq_4.paid_at__extract_day
+          , subq_4.paid_at__extract_dow
+          , subq_4.paid_at__extract_doy
+          , subq_4.booking__ds__day
+          , subq_4.booking__ds__week
+          , subq_4.booking__ds__month
+          , subq_4.booking__ds__quarter
+          , subq_4.booking__ds__year
+          , subq_4.booking__ds__extract_year
+          , subq_4.booking__ds__extract_quarter
+          , subq_4.booking__ds__extract_month
+          , subq_4.booking__ds__extract_day
+          , subq_4.booking__ds__extract_dow
+          , subq_4.booking__ds__extract_doy
+          , subq_4.booking__ds_partitioned__day
+          , subq_4.booking__ds_partitioned__week
+          , subq_4.booking__ds_partitioned__month
+          , subq_4.booking__ds_partitioned__quarter
+          , subq_4.booking__ds_partitioned__year
+          , subq_4.booking__ds_partitioned__extract_year
+          , subq_4.booking__ds_partitioned__extract_quarter
+          , subq_4.booking__ds_partitioned__extract_month
+          , subq_4.booking__ds_partitioned__extract_day
+          , subq_4.booking__ds_partitioned__extract_dow
+          , subq_4.booking__ds_partitioned__extract_doy
+          , subq_4.booking__paid_at__day
+          , subq_4.booking__paid_at__week
+          , subq_4.booking__paid_at__month
+          , subq_4.booking__paid_at__quarter
+          , subq_4.booking__paid_at__year
+          , subq_4.booking__paid_at__extract_year
+          , subq_4.booking__paid_at__extract_quarter
+          , subq_4.booking__paid_at__extract_month
+          , subq_4.booking__paid_at__extract_day
+          , subq_4.booking__paid_at__extract_dow
+          , subq_4.booking__paid_at__extract_doy
+          , subq_4.metric_time__week
+          , subq_4.metric_time__month
+          , subq_4.metric_time__quarter
+          , subq_4.metric_time__year
+          , subq_4.metric_time__extract_year
+          , subq_4.metric_time__extract_quarter
+          , subq_4.metric_time__extract_month
+          , subq_4.metric_time__extract_day
+          , subq_4.metric_time__extract_dow
+          , subq_4.metric_time__extract_doy
+          , subq_4.listing
+          , subq_4.guest
+          , subq_4.host
+          , subq_4.booking__listing
+          , subq_4.booking__guest
+          , subq_4.booking__host
+          , subq_4.is_instant
+          , subq_4.booking__is_instant
+          , subq_4.bookings
+          , subq_4.instant_bookings
+          , subq_4.booking_value
+          , subq_4.max_booking_value
+          , subq_4.min_booking_value
+          , subq_4.bookers
+          , subq_4.average_booking_value
+          , subq_4.referred_bookings
+          , subq_4.median_booking_value
+          , subq_4.booking_value_p99
+          , subq_4.discrete_booking_value_p99
+          , subq_4.approximate_continuous_booking_value_p99
+          , subq_4.approximate_discrete_booking_value_p99
         FROM (
-          -- Time Spine
+          -- Join to Time Spine Dataset
           SELECT
-            subq_3.ds AS metric_time__day
-          FROM ***************************.mf_time_spine subq_3
-          WHERE subq_3.ds BETWEEN timestamp '2019-12-19' AND timestamp '2020-01-02'
-        ) subq_2
-        INNER JOIN (
-          -- Metric Time Dimension 'ds'
-          SELECT
-            subq_0.ds__day
-            , subq_0.ds__week
-            , subq_0.ds__month
-            , subq_0.ds__quarter
-            , subq_0.ds__year
-            , subq_0.ds__extract_year
-            , subq_0.ds__extract_quarter
-            , subq_0.ds__extract_month
-            , subq_0.ds__extract_day
-            , subq_0.ds__extract_dow
-            , subq_0.ds__extract_doy
-            , subq_0.ds_partitioned__day
-            , subq_0.ds_partitioned__week
-            , subq_0.ds_partitioned__month
-            , subq_0.ds_partitioned__quarter
-            , subq_0.ds_partitioned__year
-            , subq_0.ds_partitioned__extract_year
-            , subq_0.ds_partitioned__extract_quarter
-            , subq_0.ds_partitioned__extract_month
-            , subq_0.ds_partitioned__extract_day
-            , subq_0.ds_partitioned__extract_dow
-            , subq_0.ds_partitioned__extract_doy
-            , subq_0.paid_at__day
-            , subq_0.paid_at__week
-            , subq_0.paid_at__month
-            , subq_0.paid_at__quarter
-            , subq_0.paid_at__year
-            , subq_0.paid_at__extract_year
-            , subq_0.paid_at__extract_quarter
-            , subq_0.paid_at__extract_month
-            , subq_0.paid_at__extract_day
-            , subq_0.paid_at__extract_dow
-            , subq_0.paid_at__extract_doy
-            , subq_0.booking__ds__day
-            , subq_0.booking__ds__week
-            , subq_0.booking__ds__month
-            , subq_0.booking__ds__quarter
-            , subq_0.booking__ds__year
-            , subq_0.booking__ds__extract_year
-            , subq_0.booking__ds__extract_quarter
-            , subq_0.booking__ds__extract_month
-            , subq_0.booking__ds__extract_day
-            , subq_0.booking__ds__extract_dow
-            , subq_0.booking__ds__extract_doy
-            , subq_0.booking__ds_partitioned__day
-            , subq_0.booking__ds_partitioned__week
-            , subq_0.booking__ds_partitioned__month
-            , subq_0.booking__ds_partitioned__quarter
-            , subq_0.booking__ds_partitioned__year
-            , subq_0.booking__ds_partitioned__extract_year
-            , subq_0.booking__ds_partitioned__extract_quarter
-            , subq_0.booking__ds_partitioned__extract_month
-            , subq_0.booking__ds_partitioned__extract_day
-            , subq_0.booking__ds_partitioned__extract_dow
-            , subq_0.booking__ds_partitioned__extract_doy
-            , subq_0.booking__paid_at__day
-            , subq_0.booking__paid_at__week
-            , subq_0.booking__paid_at__month
-            , subq_0.booking__paid_at__quarter
-            , subq_0.booking__paid_at__year
-            , subq_0.booking__paid_at__extract_year
-            , subq_0.booking__paid_at__extract_quarter
-            , subq_0.booking__paid_at__extract_month
-            , subq_0.booking__paid_at__extract_day
-            , subq_0.booking__paid_at__extract_dow
-            , subq_0.booking__paid_at__extract_doy
-            , subq_0.ds__day AS metric_time__day
-            , subq_0.ds__week AS metric_time__week
-            , subq_0.ds__month AS metric_time__month
-            , subq_0.ds__quarter AS metric_time__quarter
-            , subq_0.ds__year AS metric_time__year
-            , subq_0.ds__extract_year AS metric_time__extract_year
-            , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-            , subq_0.ds__extract_month AS metric_time__extract_month
-            , subq_0.ds__extract_day AS metric_time__extract_day
-            , subq_0.ds__extract_dow AS metric_time__extract_dow
-            , subq_0.ds__extract_doy AS metric_time__extract_doy
-            , subq_0.listing
-            , subq_0.guest
-            , subq_0.host
-            , subq_0.booking__listing
-            , subq_0.booking__guest
-            , subq_0.booking__host
-            , subq_0.is_instant
-            , subq_0.booking__is_instant
-            , subq_0.bookings
-            , subq_0.instant_bookings
-            , subq_0.booking_value
-            , subq_0.max_booking_value
-            , subq_0.min_booking_value
-            , subq_0.bookers
-            , subq_0.average_booking_value
-            , subq_0.referred_bookings
-            , subq_0.median_booking_value
-            , subq_0.booking_value_p99
-            , subq_0.discrete_booking_value_p99
-            , subq_0.approximate_continuous_booking_value_p99
-            , subq_0.approximate_discrete_booking_value_p99
+            subq_1.ds__day AS ds__day
+            , subq_1.ds__week AS ds__week
+            , subq_1.ds__month AS ds__month
+            , subq_1.ds__quarter AS ds__quarter
+            , subq_1.ds__year AS ds__year
+            , subq_1.ds__extract_year AS ds__extract_year
+            , subq_1.ds__extract_quarter AS ds__extract_quarter
+            , subq_1.ds__extract_month AS ds__extract_month
+            , subq_1.ds__extract_day AS ds__extract_day
+            , subq_1.ds__extract_dow AS ds__extract_dow
+            , subq_1.ds__extract_doy AS ds__extract_doy
+            , subq_1.ds_partitioned__day AS ds_partitioned__day
+            , subq_1.ds_partitioned__week AS ds_partitioned__week
+            , subq_1.ds_partitioned__month AS ds_partitioned__month
+            , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
+            , subq_1.ds_partitioned__year AS ds_partitioned__year
+            , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
+            , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+            , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
+            , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
+            , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+            , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+            , subq_1.paid_at__day AS paid_at__day
+            , subq_1.paid_at__week AS paid_at__week
+            , subq_1.paid_at__month AS paid_at__month
+            , subq_1.paid_at__quarter AS paid_at__quarter
+            , subq_1.paid_at__year AS paid_at__year
+            , subq_1.paid_at__extract_year AS paid_at__extract_year
+            , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
+            , subq_1.paid_at__extract_month AS paid_at__extract_month
+            , subq_1.paid_at__extract_day AS paid_at__extract_day
+            , subq_1.paid_at__extract_dow AS paid_at__extract_dow
+            , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+            , subq_1.booking__ds__day AS booking__ds__day
+            , subq_1.booking__ds__week AS booking__ds__week
+            , subq_1.booking__ds__month AS booking__ds__month
+            , subq_1.booking__ds__quarter AS booking__ds__quarter
+            , subq_1.booking__ds__year AS booking__ds__year
+            , subq_1.booking__ds__extract_year AS booking__ds__extract_year
+            , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
+            , subq_1.booking__ds__extract_month AS booking__ds__extract_month
+            , subq_1.booking__ds__extract_day AS booking__ds__extract_day
+            , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
+            , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
+            , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
+            , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
+            , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
+            , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+            , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
+            , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+            , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+            , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+            , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+            , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+            , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+            , subq_1.booking__paid_at__day AS booking__paid_at__day
+            , subq_1.booking__paid_at__week AS booking__paid_at__week
+            , subq_1.booking__paid_at__month AS booking__paid_at__month
+            , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
+            , subq_1.booking__paid_at__year AS booking__paid_at__year
+            , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
+            , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+            , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
+            , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
+            , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+            , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_1.metric_time__week AS metric_time__week
+            , subq_1.metric_time__month AS metric_time__month
+            , subq_1.metric_time__quarter AS metric_time__quarter
+            , subq_1.metric_time__year AS metric_time__year
+            , subq_1.metric_time__extract_year AS metric_time__extract_year
+            , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_1.metric_time__extract_month AS metric_time__extract_month
+            , subq_1.metric_time__extract_day AS metric_time__extract_day
+            , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_2.metric_time__day AS metric_time__day
+            , subq_1.listing AS listing
+            , subq_1.guest AS guest
+            , subq_1.host AS host
+            , subq_1.booking__listing AS booking__listing
+            , subq_1.booking__guest AS booking__guest
+            , subq_1.booking__host AS booking__host
+            , subq_1.is_instant AS is_instant
+            , subq_1.booking__is_instant AS booking__is_instant
+            , subq_1.bookings AS bookings
+            , subq_1.instant_bookings AS instant_bookings
+            , subq_1.booking_value AS booking_value
+            , subq_1.max_booking_value AS max_booking_value
+            , subq_1.min_booking_value AS min_booking_value
+            , subq_1.bookers AS bookers
+            , subq_1.average_booking_value AS average_booking_value
+            , subq_1.referred_bookings AS referred_bookings
+            , subq_1.median_booking_value AS median_booking_value
+            , subq_1.booking_value_p99 AS booking_value_p99
+            , subq_1.discrete_booking_value_p99 AS discrete_booking_value_p99
+            , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+            , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Read Elements From Semantic Model 'bookings_source'
+            -- Time Spine
             SELECT
-              1 AS bookings
-              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-              , bookings_source_src_28000.booking_value
-              , bookings_source_src_28000.booking_value AS max_booking_value
-              , bookings_source_src_28000.booking_value AS min_booking_value
-              , bookings_source_src_28000.guest_id AS bookers
-              , bookings_source_src_28000.booking_value AS average_booking_value
-              , bookings_source_src_28000.booking_value AS booking_payments
-              , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-              , bookings_source_src_28000.booking_value AS median_booking_value
-              , bookings_source_src_28000.booking_value AS booking_value_p99
-              , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
-              , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
-              , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
-              , bookings_source_src_28000.is_instant
-              , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-              , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-              , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-              , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-              , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-              , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-              , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-              , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS ds__extract_dow
-              , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-              , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-              , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-              , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-              , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-              , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-              , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-              , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
-              , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-              , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-              , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-              , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-              , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-              , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-              , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-              , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
-              , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-              , bookings_source_src_28000.is_instant AS booking__is_instant
-              , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-              , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-              , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-              , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-              , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-              , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-              , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-              , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-              , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-              , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
-              , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-              , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-              , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-              , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-              , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-              , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-              , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-              , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-              , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-              , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-              , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
-              , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-              , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-              , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-              , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-              , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-              , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-              , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-              , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-              , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-              , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-              , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
-              , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-              , bookings_source_src_28000.listing_id AS listing
-              , bookings_source_src_28000.guest_id AS guest
-              , bookings_source_src_28000.host_id AS host
-              , bookings_source_src_28000.listing_id AS booking__listing
-              , bookings_source_src_28000.guest_id AS booking__guest
-              , bookings_source_src_28000.host_id AS booking__host
-            FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_0
-        ) subq_1
-        ON
-          DATE_ADD('day', -5, subq_2.metric_time__day) = subq_1.metric_time__day
-      ) subq_4
-    ) subq_5
+              subq_3.ds AS metric_time__day
+            FROM ***************************.mf_time_spine subq_3
+          ) subq_2
+          INNER JOIN (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.ds_partitioned__day
+              , subq_0.ds_partitioned__week
+              , subq_0.ds_partitioned__month
+              , subq_0.ds_partitioned__quarter
+              , subq_0.ds_partitioned__year
+              , subq_0.ds_partitioned__extract_year
+              , subq_0.ds_partitioned__extract_quarter
+              , subq_0.ds_partitioned__extract_month
+              , subq_0.ds_partitioned__extract_day
+              , subq_0.ds_partitioned__extract_dow
+              , subq_0.ds_partitioned__extract_doy
+              , subq_0.paid_at__day
+              , subq_0.paid_at__week
+              , subq_0.paid_at__month
+              , subq_0.paid_at__quarter
+              , subq_0.paid_at__year
+              , subq_0.paid_at__extract_year
+              , subq_0.paid_at__extract_quarter
+              , subq_0.paid_at__extract_month
+              , subq_0.paid_at__extract_day
+              , subq_0.paid_at__extract_dow
+              , subq_0.paid_at__extract_doy
+              , subq_0.booking__ds__day
+              , subq_0.booking__ds__week
+              , subq_0.booking__ds__month
+              , subq_0.booking__ds__quarter
+              , subq_0.booking__ds__year
+              , subq_0.booking__ds__extract_year
+              , subq_0.booking__ds__extract_quarter
+              , subq_0.booking__ds__extract_month
+              , subq_0.booking__ds__extract_day
+              , subq_0.booking__ds__extract_dow
+              , subq_0.booking__ds__extract_doy
+              , subq_0.booking__ds_partitioned__day
+              , subq_0.booking__ds_partitioned__week
+              , subq_0.booking__ds_partitioned__month
+              , subq_0.booking__ds_partitioned__quarter
+              , subq_0.booking__ds_partitioned__year
+              , subq_0.booking__ds_partitioned__extract_year
+              , subq_0.booking__ds_partitioned__extract_quarter
+              , subq_0.booking__ds_partitioned__extract_month
+              , subq_0.booking__ds_partitioned__extract_day
+              , subq_0.booking__ds_partitioned__extract_dow
+              , subq_0.booking__ds_partitioned__extract_doy
+              , subq_0.booking__paid_at__day
+              , subq_0.booking__paid_at__week
+              , subq_0.booking__paid_at__month
+              , subq_0.booking__paid_at__quarter
+              , subq_0.booking__paid_at__year
+              , subq_0.booking__paid_at__extract_year
+              , subq_0.booking__paid_at__extract_quarter
+              , subq_0.booking__paid_at__extract_month
+              , subq_0.booking__paid_at__extract_day
+              , subq_0.booking__paid_at__extract_dow
+              , subq_0.booking__paid_at__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.listing
+              , subq_0.guest
+              , subq_0.host
+              , subq_0.booking__listing
+              , subq_0.booking__guest
+              , subq_0.booking__host
+              , subq_0.is_instant
+              , subq_0.booking__is_instant
+              , subq_0.bookings
+              , subq_0.instant_bookings
+              , subq_0.booking_value
+              , subq_0.max_booking_value
+              , subq_0.min_booking_value
+              , subq_0.bookers
+              , subq_0.average_booking_value
+              , subq_0.referred_bookings
+              , subq_0.median_booking_value
+              , subq_0.booking_value_p99
+              , subq_0.discrete_booking_value_p99
+              , subq_0.approximate_continuous_booking_value_p99
+              , subq_0.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Semantic Model 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_28000.booking_value
+                , bookings_source_src_28000.booking_value AS max_booking_value
+                , bookings_source_src_28000.booking_value AS min_booking_value
+                , bookings_source_src_28000.guest_id AS bookers
+                , bookings_source_src_28000.booking_value AS average_booking_value
+                , bookings_source_src_28000.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_28000.booking_value AS median_booking_value
+                , bookings_source_src_28000.booking_value AS booking_value_p99
+                , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_28000.is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_28000.is_instant AS booking__is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_28000.listing_id AS listing
+                , bookings_source_src_28000.guest_id AS guest
+                , bookings_source_src_28000.host_id AS host
+                , bookings_source_src_28000.listing_id AS booking__listing
+                , bookings_source_src_28000.guest_id AS booking__guest
+                , bookings_source_src_28000.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_28000
+            ) subq_0
+          ) subq_1
+          ON
+            DATE_ADD('day', -5, subq_2.metric_time__day) = subq_1.metric_time__day
+        ) subq_4
+        WHERE subq_4.metric_time__day BETWEEN timestamp '2019-12-19' AND timestamp '2020-01-02'
+      ) subq_5
+    ) subq_6
     GROUP BY
-      subq_5.metric_time__day
-  ) subq_6
-) subq_7
+      subq_6.metric_time__day
+  ) subq_7
+) subq_8

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_time_offset_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_time_offset_metric_with_time_constraint__plan0_optimized.sql
@@ -8,19 +8,14 @@ SELECT
   , bookings_5_days_ago AS bookings_5_day_lag
 FROM (
   -- Join to Time Spine Dataset
+  -- Constrain Time Range to [2019-12-19T00:00:00, 2020-01-02T00:00:00]
   -- Pass Only Elements: ['bookings', 'metric_time__day']
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT
-    subq_10.metric_time__day AS metric_time__day
-    , SUM(subq_9.bookings) AS bookings_5_days_ago
-  FROM (
-    -- Time Spine
-    SELECT
-      ds AS metric_time__day
-    FROM ***************************.mf_time_spine subq_11
-    WHERE ds BETWEEN timestamp '2019-12-19' AND timestamp '2020-01-02'
-  ) subq_10
+    subq_12.ds AS metric_time__day
+    , SUM(subq_10.bookings) AS bookings_5_days_ago
+  FROM ***************************.mf_time_spine subq_12
   INNER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -28,9 +23,10 @@ FROM (
       DATE_TRUNC('day', ds) AS metric_time__day
       , 1 AS bookings
     FROM ***************************.fct_bookings bookings_source_src_28000
-  ) subq_9
+  ) subq_10
   ON
-    DATE_ADD('day', -5, subq_10.metric_time__day) = subq_9.metric_time__day
+    DATE_ADD('day', -5, subq_12.ds) = subq_10.metric_time__day
+  WHERE subq_12.ds BETWEEN timestamp '2019-12-19' AND timestamp '2020-01-02'
   GROUP BY
-    subq_10.metric_time__day
-) subq_15
+    subq_12.ds
+) subq_17


### PR DESCRIPTION
Time constraints were being applied before time offsets in some scenarios. This is incorrect because the values will change during the offset. This fixes that. Customers likely never saw this bug because time constraints are only available to open source users, and this may never have been released to them.