### PR TITLE
Use Time Spine description that aligns with other `ReadSqlSourceNodes`

### DIFF
--- a/metricflow-semantics/metricflow_semantics/time/time_spine_source.py
+++ b/metricflow-semantics/metricflow_semantics/time/time_spine_source.py
@@ -15,8 +15,6 @@ from metricflow_semantics.time.granularity import ExpandedTimeGranularity
 
 logger = logging.getLogger(__name__)
 
-TIME_SPINE_DATA_SET_DESCRIPTION = "Time Spine"
-
 
 @dataclass(frozen=True)
 class TimeSpineSource:
@@ -148,3 +146,8 @@ class TimeSpineSource:
             required_time_spines.add(time_spine_sources[max(compatible_time_spines_for_standard_grains)])
 
         return tuple(required_time_spines)
+
+    @property
+    def data_set_description(self) -> str:
+        """Description to be displayed when this time spine is used in a data set."""
+        return f"Read From Time Spine '{self.table_name}'"

--- a/metricflow/dataset/convert_semantic_model.py
+++ b/metricflow/dataset/convert_semantic_model.py
@@ -34,7 +34,7 @@ from metricflow_semantics.specs.entity_spec import EntitySpec
 from metricflow_semantics.specs.time_dimension_spec import DEFAULT_TIME_GRANULARITY, TimeDimensionSpec
 from metricflow_semantics.sql.sql_table import SqlTable
 from metricflow_semantics.time.granularity import ExpandedTimeGranularity
-from metricflow_semantics.time.time_spine_source import TIME_SPINE_DATA_SET_DESCRIPTION, TimeSpineSource
+from metricflow_semantics.time.time_spine_source import TimeSpineSource
 
 from metricflow.dataset.semantic_model_adapter import SemanticModelDataSet
 from metricflow.dataset.sql_dataset import SqlDataSet
@@ -568,7 +568,7 @@ class SemanticModelToDataSetConverter:
         return SqlDataSet(
             instance_set=InstanceSet(time_dimension_instances=tuple(time_dimension_instances)),
             sql_select_node=SqlSelectStatementNode.create(
-                description=TIME_SPINE_DATA_SET_DESCRIPTION,
+                description=time_spine_source.data_set_description,
                 select_columns=tuple(select_columns),
                 from_source=SqlTableNode.create(sql_table=time_spine_source.spine_table),
                 from_source_alias=from_source_alias,

--- a/metricflow/plan_conversion/dataflow_to_sql.py
+++ b/metricflow/plan_conversion/dataflow_to_sql.py
@@ -41,7 +41,7 @@ from metricflow_semantics.sql.sql_join_type import SqlJoinType
 from metricflow_semantics.sql.sql_table import SqlTable
 from metricflow_semantics.time.granularity import ExpandedTimeGranularity
 from metricflow_semantics.time.time_constants import ISO8601_PYTHON_FORMAT, ISO8601_PYTHON_TS_FORMAT
-from metricflow_semantics.time.time_spine_source import TIME_SPINE_DATA_SET_DESCRIPTION, TimeSpineSource
+from metricflow_semantics.time.time_spine_source import TimeSpineSource
 from typing_extensions import override
 
 from metricflow.dataflow.dataflow_plan import (
@@ -400,7 +400,7 @@ class DataflowNodeToSqlSubqueryVisitor(DataflowPlanNodeVisitor[SqlDataSet]):
         )
 
         inner_sql_select_node = SqlSelectStatementNode.create(
-            description=TIME_SPINE_DATA_SET_DESCRIPTION,
+            description=time_spine_source.data_set_description,
             select_columns=select_columns,
             from_source=SqlTableNode.create(sql_table=time_spine_source.spine_table),
             from_source_alias=time_spine_table_alias,

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/BigQuery/test_conversion_metric_join_to_timespine_and_fill_nulls_with_0__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/BigQuery/test_conversion_metric_join_to_timespine_and_fill_nulls_with_0__plan0.sql
@@ -20,7 +20,7 @@ FROM (
       subq_4.metric_time__day AS metric_time__day
       , subq_3.visits AS visits
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         subq_5.ds AS metric_time__day
       FROM ***************************.mf_time_spine subq_5
@@ -128,7 +128,7 @@ FROM (
       subq_17.metric_time__day AS metric_time__day
       , subq_16.buys AS buys
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         subq_18.ds AS metric_time__day
       FROM ***************************.mf_time_spine subq_18

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Databricks/test_conversion_metric_join_to_timespine_and_fill_nulls_with_0__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Databricks/test_conversion_metric_join_to_timespine_and_fill_nulls_with_0__plan0.sql
@@ -20,7 +20,7 @@ FROM (
       subq_4.metric_time__day AS metric_time__day
       , subq_3.visits AS visits
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         subq_5.ds AS metric_time__day
       FROM ***************************.mf_time_spine subq_5
@@ -128,7 +128,7 @@ FROM (
       subq_17.metric_time__day AS metric_time__day
       , subq_16.buys AS buys
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         subq_18.ds AS metric_time__day
       FROM ***************************.mf_time_spine subq_18

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/DuckDB/test_conversion_metric_join_to_timespine_and_fill_nulls_with_0__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/DuckDB/test_conversion_metric_join_to_timespine_and_fill_nulls_with_0__plan0.sql
@@ -20,7 +20,7 @@ FROM (
       subq_4.metric_time__day AS metric_time__day
       , subq_3.visits AS visits
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         subq_5.ds AS metric_time__day
       FROM ***************************.mf_time_spine subq_5
@@ -128,7 +128,7 @@ FROM (
       subq_17.metric_time__day AS metric_time__day
       , subq_16.buys AS buys
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         subq_18.ds AS metric_time__day
       FROM ***************************.mf_time_spine subq_18

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Postgres/test_conversion_metric_join_to_timespine_and_fill_nulls_with_0__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Postgres/test_conversion_metric_join_to_timespine_and_fill_nulls_with_0__plan0.sql
@@ -20,7 +20,7 @@ FROM (
       subq_4.metric_time__day AS metric_time__day
       , subq_3.visits AS visits
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         subq_5.ds AS metric_time__day
       FROM ***************************.mf_time_spine subq_5
@@ -128,7 +128,7 @@ FROM (
       subq_17.metric_time__day AS metric_time__day
       , subq_16.buys AS buys
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         subq_18.ds AS metric_time__day
       FROM ***************************.mf_time_spine subq_18

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Redshift/test_conversion_metric_join_to_timespine_and_fill_nulls_with_0__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Redshift/test_conversion_metric_join_to_timespine_and_fill_nulls_with_0__plan0.sql
@@ -20,7 +20,7 @@ FROM (
       subq_4.metric_time__day AS metric_time__day
       , subq_3.visits AS visits
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         subq_5.ds AS metric_time__day
       FROM ***************************.mf_time_spine subq_5
@@ -128,7 +128,7 @@ FROM (
       subq_17.metric_time__day AS metric_time__day
       , subq_16.buys AS buys
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         subq_18.ds AS metric_time__day
       FROM ***************************.mf_time_spine subq_18

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Snowflake/test_conversion_metric_join_to_timespine_and_fill_nulls_with_0__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Snowflake/test_conversion_metric_join_to_timespine_and_fill_nulls_with_0__plan0.sql
@@ -20,7 +20,7 @@ FROM (
       subq_4.metric_time__day AS metric_time__day
       , subq_3.visits AS visits
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         subq_5.ds AS metric_time__day
       FROM ***************************.mf_time_spine subq_5
@@ -128,7 +128,7 @@ FROM (
       subq_17.metric_time__day AS metric_time__day
       , subq_16.buys AS buys
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         subq_18.ds AS metric_time__day
       FROM ***************************.mf_time_spine subq_18

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Trino/test_conversion_metric_join_to_timespine_and_fill_nulls_with_0__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Trino/test_conversion_metric_join_to_timespine_and_fill_nulls_with_0__plan0.sql
@@ -20,7 +20,7 @@ FROM (
       subq_4.metric_time__day AS metric_time__day
       , subq_3.visits AS visits
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         subq_5.ds AS metric_time__day
       FROM ***************************.mf_time_spine subq_5
@@ -128,7 +128,7 @@ FROM (
       subq_17.metric_time__day AS metric_time__day
       , subq_16.buys AS buys
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         subq_18.ds AS metric_time__day
       FROM ***************************.mf_time_spine subq_18

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/test_conversion_metric_join_to_timespine_and_fill_nulls_with_0__plan0.xml
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/test_conversion_metric_join_to_timespine_and_fill_nulls_with_0__plan0.xml
@@ -66,7 +66,7 @@ docstring:
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
-                    <!-- description = 'Time Spine' -->
+                    <!-- description = "Read From Time Spine 'mf_time_spine'" -->
                     <!-- node_id = NodeId(id_str='ss_4') -->
                     <!-- col0 =                                                -->
                     <!--   SqlSelectColumn(                                    -->
@@ -504,7 +504,7 @@ docstring:
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
-                    <!-- description = 'Time Spine' -->
+                    <!-- description = "Read From Time Spine 'mf_time_spine'" -->
                     <!-- node_id = NodeId(id_str='ss_16') -->
                     <!-- col0 =                                                 -->
                     <!--   SqlSelectColumn(                                     -->

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_all_time_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_all_time_metric_with_non_default_grains__plan0.sql
@@ -84,7 +84,7 @@ FROM (
             , subq_1.revenue_instance__user AS revenue_instance__user
             , subq_1.txn_revenue AS txn_revenue
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
               , DATETIME_TRUNC(subq_3.ds, isoweek) AS metric_time__week

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
@@ -97,7 +97,7 @@ FROM (
           , subq_2.revenue_instance__user AS revenue_instance__user
           , subq_2.txn_revenue AS txn_revenue
         FROM (
-          -- Time Spine
+          -- Read From Time Spine 'mf_time_spine'
           SELECT
             subq_4.ds AS metric_time__day
           FROM ***************************.mf_time_spine subq_4

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
@@ -13,7 +13,7 @@ SELECT
   subq_12.metric_time__day AS metric_time__day
   , SUM(subq_11.txn_revenue) AS revenue_all_time
 FROM (
-  -- Time Spine
+  -- Read From Time Spine 'mf_time_spine'
   SELECT
     ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_13

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_agg_time_and_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_agg_time_and_metric_time__plan0.sql
@@ -61,7 +61,7 @@ FROM (
         , subq_1.revenue_instance__user AS revenue_instance__user
         , subq_1.txn_revenue AS txn_revenue
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine'
         SELECT
           DATETIME_TRUNC(subq_3.ds, month) AS revenue_instance__ds__month
           , subq_3.ds AS metric_time__day

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_agg_time_dimension__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_agg_time_dimension__plan0.sql
@@ -58,7 +58,7 @@ FROM (
         , subq_1.revenue_instance__user AS revenue_instance__user
         , subq_1.txn_revenue AS txn_revenue
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine'
         SELECT
           subq_3.ds AS revenue_instance__ds__day
         FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_multiple_agg_time_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_multiple_agg_time_dimensions__plan0.sql
@@ -61,7 +61,7 @@ FROM (
         , subq_1.revenue_instance__user AS revenue_instance__user
         , subq_1.txn_revenue AS txn_revenue
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine'
         SELECT
           subq_3.ds AS revenue_instance__ds__day
           , DATETIME_TRUNC(subq_3.ds, month) AS revenue_instance__ds__month

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_multiple_metric_time_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_multiple_metric_time_dimensions__plan0.sql
@@ -61,7 +61,7 @@ FROM (
         , subq_1.revenue_instance__user AS revenue_instance__user
         , subq_1.txn_revenue AS txn_revenue
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine'
         SELECT
           subq_3.ds AS metric_time__day
           , DATETIME_TRUNC(subq_3.ds, month) AS metric_time__month

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_non_adjustable_time_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_non_adjustable_time_filter__plan0.sql
@@ -225,7 +225,7 @@ FROM (
           , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
           , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
         FROM (
-          -- Time Spine
+          -- Read From Time Spine 'mf_time_spine'
           SELECT
             subq_3.ds AS metric_time__day
           FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_non_default_grain__plan0.sql
@@ -75,7 +75,7 @@ FROM (
             , subq_1.revenue_instance__user AS revenue_instance__user
             , subq_1.txn_revenue AS txn_revenue
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
               , DATETIME_TRUNC(subq_3.ds, isoweek) AS metric_time__week

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_time_constraint__plan0.sql
@@ -101,7 +101,7 @@ FROM (
           , subq_2.revenue_instance__user AS revenue_instance__user
           , subq_2.txn_revenue AS txn_revenue
         FROM (
-          -- Time Spine
+          -- Read From Time Spine 'mf_time_spine'
           SELECT
             subq_4.ds AS metric_time__day
           FROM ***************************.mf_time_spine subq_4

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
@@ -17,7 +17,7 @@ SELECT
   subq_12.metric_time__day AS metric_time__day
   , SUM(subq_11.txn_revenue) AS trailing_2_months_revenue
 FROM (
-  -- Time Spine
+  -- Read From Time Spine 'mf_time_spine'
   SELECT
     ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_13

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_cumulative_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_cumulative_metric_with_non_default_grains__plan0.sql
@@ -76,7 +76,7 @@ FROM (
               , subq_1.revenue_instance__user AS revenue_instance__user
               , subq_1.txn_revenue AS txn_revenue
             FROM (
-              -- Time Spine
+              -- Read From Time Spine 'mf_time_spine'
               SELECT
                 subq_3.ds AS metric_time__day
                 , DATETIME_TRUNC(subq_3.ds, isoweek) AS metric_time__week

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_grain_to_date_metric_with_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_grain_to_date_metric_with_non_default_grain__plan0.sql
@@ -75,7 +75,7 @@ FROM (
             , subq_1.revenue_instance__user AS revenue_instance__user
             , subq_1.txn_revenue AS txn_revenue
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
               , DATETIME_TRUNC(subq_3.ds, month) AS metric_time__month

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_grain_to_date_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_grain_to_date_metric_with_non_default_grains__plan0.sql
@@ -84,7 +84,7 @@ FROM (
             , subq_1.revenue_instance__user AS revenue_instance__user
             , subq_1.txn_revenue AS txn_revenue
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               DATETIME_TRUNC(subq_3.ds, quarter) AS revenue_instance__ds__quarter
               , DATETIME_TRUNC(subq_3.ds, year) AS revenue_instance__ds__year

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_window_metric_with_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_window_metric_with_non_default_grain__plan0.sql
@@ -71,7 +71,7 @@ FROM (
             , subq_1.revenue_instance__user AS revenue_instance__user
             , subq_1.txn_revenue AS txn_revenue
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
               , DATETIME_TRUNC(subq_3.ds, year) AS metric_time__year

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_window_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_window_metric_with_non_default_grains__plan0.sql
@@ -38,7 +38,7 @@ FROM (
         , subq_7.metric_time__week AS metric_time__week
         , subq_6.bookers AS bookers
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine'
         SELECT
           DATETIME_TRUNC(subq_8.ds, month) AS booking__ds__month
           , subq_8.ds AS metric_time__day
@@ -161,7 +161,7 @@ FROM (
               , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
               , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             FROM (
-              -- Time Spine
+              -- Read From Time Spine 'mf_time_spine'
               SELECT
                 DATETIME_TRUNC(subq_3.ds, month) AS booking__ds__month
                 , subq_3.ds AS metric_time__day

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_all_time_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_all_time_metric_with_non_default_grains__plan0.sql
@@ -84,7 +84,7 @@ FROM (
             , subq_1.revenue_instance__user AS revenue_instance__user
             , subq_1.txn_revenue AS txn_revenue
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
               , DATE_TRUNC('week', subq_3.ds) AS metric_time__week

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
@@ -97,7 +97,7 @@ FROM (
           , subq_2.revenue_instance__user AS revenue_instance__user
           , subq_2.txn_revenue AS txn_revenue
         FROM (
-          -- Time Spine
+          -- Read From Time Spine 'mf_time_spine'
           SELECT
             subq_4.ds AS metric_time__day
           FROM ***************************.mf_time_spine subq_4

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
@@ -13,7 +13,7 @@ SELECT
   subq_12.metric_time__day AS metric_time__day
   , SUM(subq_11.txn_revenue) AS revenue_all_time
 FROM (
-  -- Time Spine
+  -- Read From Time Spine 'mf_time_spine'
   SELECT
     ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_13

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_with_agg_time_and_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_with_agg_time_and_metric_time__plan0.sql
@@ -61,7 +61,7 @@ FROM (
         , subq_1.revenue_instance__user AS revenue_instance__user
         , subq_1.txn_revenue AS txn_revenue
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine'
         SELECT
           DATE_TRUNC('month', subq_3.ds) AS revenue_instance__ds__month
           , subq_3.ds AS metric_time__day

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_with_agg_time_dimension__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_with_agg_time_dimension__plan0.sql
@@ -58,7 +58,7 @@ FROM (
         , subq_1.revenue_instance__user AS revenue_instance__user
         , subq_1.txn_revenue AS txn_revenue
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine'
         SELECT
           subq_3.ds AS revenue_instance__ds__day
         FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_with_multiple_agg_time_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_with_multiple_agg_time_dimensions__plan0.sql
@@ -61,7 +61,7 @@ FROM (
         , subq_1.revenue_instance__user AS revenue_instance__user
         , subq_1.txn_revenue AS txn_revenue
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine'
         SELECT
           subq_3.ds AS revenue_instance__ds__day
           , DATE_TRUNC('month', subq_3.ds) AS revenue_instance__ds__month

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_with_multiple_metric_time_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_with_multiple_metric_time_dimensions__plan0.sql
@@ -61,7 +61,7 @@ FROM (
         , subq_1.revenue_instance__user AS revenue_instance__user
         , subq_1.txn_revenue AS txn_revenue
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine'
         SELECT
           subq_3.ds AS metric_time__day
           , DATE_TRUNC('month', subq_3.ds) AS metric_time__month

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_with_non_adjustable_time_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_with_non_adjustable_time_filter__plan0.sql
@@ -225,7 +225,7 @@ FROM (
           , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
           , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
         FROM (
-          -- Time Spine
+          -- Read From Time Spine 'mf_time_spine'
           SELECT
             subq_3.ds AS metric_time__day
           FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_with_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_with_non_default_grain__plan0.sql
@@ -75,7 +75,7 @@ FROM (
             , subq_1.revenue_instance__user AS revenue_instance__user
             , subq_1.txn_revenue AS txn_revenue
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
               , DATE_TRUNC('week', subq_3.ds) AS metric_time__week

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_with_time_constraint__plan0.sql
@@ -101,7 +101,7 @@ FROM (
           , subq_2.revenue_instance__user AS revenue_instance__user
           , subq_2.txn_revenue AS txn_revenue
         FROM (
-          -- Time Spine
+          -- Read From Time Spine 'mf_time_spine'
           SELECT
             subq_4.ds AS metric_time__day
           FROM ***************************.mf_time_spine subq_4

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
@@ -17,7 +17,7 @@ SELECT
   subq_12.metric_time__day AS metric_time__day
   , SUM(subq_11.txn_revenue) AS trailing_2_months_revenue
 FROM (
-  -- Time Spine
+  -- Read From Time Spine 'mf_time_spine'
   SELECT
     ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_13

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_cumulative_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_cumulative_metric_with_non_default_grains__plan0.sql
@@ -76,7 +76,7 @@ FROM (
               , subq_1.revenue_instance__user AS revenue_instance__user
               , subq_1.txn_revenue AS txn_revenue
             FROM (
-              -- Time Spine
+              -- Read From Time Spine 'mf_time_spine'
               SELECT
                 subq_3.ds AS metric_time__day
                 , DATE_TRUNC('week', subq_3.ds) AS metric_time__week

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_grain_to_date_metric_with_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_grain_to_date_metric_with_non_default_grain__plan0.sql
@@ -75,7 +75,7 @@ FROM (
             , subq_1.revenue_instance__user AS revenue_instance__user
             , subq_1.txn_revenue AS txn_revenue
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
               , DATE_TRUNC('month', subq_3.ds) AS metric_time__month

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_grain_to_date_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_grain_to_date_metric_with_non_default_grains__plan0.sql
@@ -84,7 +84,7 @@ FROM (
             , subq_1.revenue_instance__user AS revenue_instance__user
             , subq_1.txn_revenue AS txn_revenue
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               DATE_TRUNC('quarter', subq_3.ds) AS revenue_instance__ds__quarter
               , DATE_TRUNC('year', subq_3.ds) AS revenue_instance__ds__year

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_window_metric_with_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_window_metric_with_non_default_grain__plan0.sql
@@ -71,7 +71,7 @@ FROM (
             , subq_1.revenue_instance__user AS revenue_instance__user
             , subq_1.txn_revenue AS txn_revenue
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
               , DATE_TRUNC('year', subq_3.ds) AS metric_time__year

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_window_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_window_metric_with_non_default_grains__plan0.sql
@@ -38,7 +38,7 @@ FROM (
         , subq_7.metric_time__week AS metric_time__week
         , subq_6.bookers AS bookers
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine'
         SELECT
           DATE_TRUNC('month', subq_8.ds) AS booking__ds__month
           , subq_8.ds AS metric_time__day
@@ -161,7 +161,7 @@ FROM (
               , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
               , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             FROM (
-              -- Time Spine
+              -- Read From Time Spine 'mf_time_spine'
               SELECT
                 DATE_TRUNC('month', subq_3.ds) AS booking__ds__month
                 , subq_3.ds AS metric_time__day

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_all_time_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_all_time_metric_with_non_default_grains__plan0.sql
@@ -84,7 +84,7 @@ FROM (
             , subq_1.revenue_instance__user AS revenue_instance__user
             , subq_1.txn_revenue AS txn_revenue
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
               , DATE_TRUNC('week', subq_3.ds) AS metric_time__week

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
@@ -97,7 +97,7 @@ FROM (
           , subq_2.revenue_instance__user AS revenue_instance__user
           , subq_2.txn_revenue AS txn_revenue
         FROM (
-          -- Time Spine
+          -- Read From Time Spine 'mf_time_spine'
           SELECT
             subq_4.ds AS metric_time__day
           FROM ***************************.mf_time_spine subq_4

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
@@ -13,7 +13,7 @@ SELECT
   subq_12.metric_time__day AS metric_time__day
   , SUM(subq_11.txn_revenue) AS revenue_all_time
 FROM (
-  -- Time Spine
+  -- Read From Time Spine 'mf_time_spine'
   SELECT
     ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_13

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_agg_time_and_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_agg_time_and_metric_time__plan0.sql
@@ -61,7 +61,7 @@ FROM (
         , subq_1.revenue_instance__user AS revenue_instance__user
         , subq_1.txn_revenue AS txn_revenue
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine'
         SELECT
           DATE_TRUNC('month', subq_3.ds) AS revenue_instance__ds__month
           , subq_3.ds AS metric_time__day

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_agg_time_dimension__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_agg_time_dimension__plan0.sql
@@ -58,7 +58,7 @@ FROM (
         , subq_1.revenue_instance__user AS revenue_instance__user
         , subq_1.txn_revenue AS txn_revenue
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine'
         SELECT
           subq_3.ds AS revenue_instance__ds__day
         FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_multiple_agg_time_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_multiple_agg_time_dimensions__plan0.sql
@@ -61,7 +61,7 @@ FROM (
         , subq_1.revenue_instance__user AS revenue_instance__user
         , subq_1.txn_revenue AS txn_revenue
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine'
         SELECT
           subq_3.ds AS revenue_instance__ds__day
           , DATE_TRUNC('month', subq_3.ds) AS revenue_instance__ds__month

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_multiple_metric_time_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_multiple_metric_time_dimensions__plan0.sql
@@ -61,7 +61,7 @@ FROM (
         , subq_1.revenue_instance__user AS revenue_instance__user
         , subq_1.txn_revenue AS txn_revenue
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine'
         SELECT
           subq_3.ds AS metric_time__day
           , DATE_TRUNC('month', subq_3.ds) AS metric_time__month

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_non_adjustable_time_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_non_adjustable_time_filter__plan0.sql
@@ -225,7 +225,7 @@ FROM (
           , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
           , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
         FROM (
-          -- Time Spine
+          -- Read From Time Spine 'mf_time_spine'
           SELECT
             subq_3.ds AS metric_time__day
           FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_non_default_grain__plan0.sql
@@ -75,7 +75,7 @@ FROM (
             , subq_1.revenue_instance__user AS revenue_instance__user
             , subq_1.txn_revenue AS txn_revenue
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
               , DATE_TRUNC('week', subq_3.ds) AS metric_time__week

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_time_constraint__plan0.sql
@@ -101,7 +101,7 @@ FROM (
           , subq_2.revenue_instance__user AS revenue_instance__user
           , subq_2.txn_revenue AS txn_revenue
         FROM (
-          -- Time Spine
+          -- Read From Time Spine 'mf_time_spine'
           SELECT
             subq_4.ds AS metric_time__day
           FROM ***************************.mf_time_spine subq_4

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
@@ -17,7 +17,7 @@ SELECT
   subq_12.metric_time__day AS metric_time__day
   , SUM(subq_11.txn_revenue) AS trailing_2_months_revenue
 FROM (
-  -- Time Spine
+  -- Read From Time Spine 'mf_time_spine'
   SELECT
     ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_13

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_cumulative_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_cumulative_metric_with_non_default_grains__plan0.sql
@@ -76,7 +76,7 @@ FROM (
               , subq_1.revenue_instance__user AS revenue_instance__user
               , subq_1.txn_revenue AS txn_revenue
             FROM (
-              -- Time Spine
+              -- Read From Time Spine 'mf_time_spine'
               SELECT
                 subq_3.ds AS metric_time__day
                 , DATE_TRUNC('week', subq_3.ds) AS metric_time__week

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_grain_to_date_metric_with_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_grain_to_date_metric_with_non_default_grain__plan0.sql
@@ -75,7 +75,7 @@ FROM (
             , subq_1.revenue_instance__user AS revenue_instance__user
             , subq_1.txn_revenue AS txn_revenue
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
               , DATE_TRUNC('month', subq_3.ds) AS metric_time__month

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_grain_to_date_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_grain_to_date_metric_with_non_default_grains__plan0.sql
@@ -84,7 +84,7 @@ FROM (
             , subq_1.revenue_instance__user AS revenue_instance__user
             , subq_1.txn_revenue AS txn_revenue
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               DATE_TRUNC('quarter', subq_3.ds) AS revenue_instance__ds__quarter
               , DATE_TRUNC('year', subq_3.ds) AS revenue_instance__ds__year

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_window_metric_with_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_window_metric_with_non_default_grain__plan0.sql
@@ -71,7 +71,7 @@ FROM (
             , subq_1.revenue_instance__user AS revenue_instance__user
             , subq_1.txn_revenue AS txn_revenue
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
               , DATE_TRUNC('year', subq_3.ds) AS metric_time__year

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_window_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_window_metric_with_non_default_grains__plan0.sql
@@ -38,7 +38,7 @@ FROM (
         , subq_7.metric_time__week AS metric_time__week
         , subq_6.bookers AS bookers
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine'
         SELECT
           DATE_TRUNC('month', subq_8.ds) AS booking__ds__month
           , subq_8.ds AS metric_time__day
@@ -161,7 +161,7 @@ FROM (
               , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
               , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             FROM (
-              -- Time Spine
+              -- Read From Time Spine 'mf_time_spine'
               SELECT
                 DATE_TRUNC('month', subq_3.ds) AS booking__ds__month
                 , subq_3.ds AS metric_time__day

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_all_time_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_all_time_metric_with_non_default_grains__plan0.sql
@@ -84,7 +84,7 @@ FROM (
             , subq_1.revenue_instance__user AS revenue_instance__user
             , subq_1.txn_revenue AS txn_revenue
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
               , DATE_TRUNC('week', subq_3.ds) AS metric_time__week

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
@@ -97,7 +97,7 @@ FROM (
           , subq_2.revenue_instance__user AS revenue_instance__user
           , subq_2.txn_revenue AS txn_revenue
         FROM (
-          -- Time Spine
+          -- Read From Time Spine 'mf_time_spine'
           SELECT
             subq_4.ds AS metric_time__day
           FROM ***************************.mf_time_spine subq_4

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
@@ -13,7 +13,7 @@ SELECT
   subq_12.metric_time__day AS metric_time__day
   , SUM(subq_11.txn_revenue) AS revenue_all_time
 FROM (
-  -- Time Spine
+  -- Read From Time Spine 'mf_time_spine'
   SELECT
     ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_13

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_with_agg_time_and_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_with_agg_time_and_metric_time__plan0.sql
@@ -61,7 +61,7 @@ FROM (
         , subq_1.revenue_instance__user AS revenue_instance__user
         , subq_1.txn_revenue AS txn_revenue
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine'
         SELECT
           DATE_TRUNC('month', subq_3.ds) AS revenue_instance__ds__month
           , subq_3.ds AS metric_time__day

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_with_agg_time_dimension__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_with_agg_time_dimension__plan0.sql
@@ -58,7 +58,7 @@ FROM (
         , subq_1.revenue_instance__user AS revenue_instance__user
         , subq_1.txn_revenue AS txn_revenue
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine'
         SELECT
           subq_3.ds AS revenue_instance__ds__day
         FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_with_multiple_agg_time_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_with_multiple_agg_time_dimensions__plan0.sql
@@ -61,7 +61,7 @@ FROM (
         , subq_1.revenue_instance__user AS revenue_instance__user
         , subq_1.txn_revenue AS txn_revenue
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine'
         SELECT
           subq_3.ds AS revenue_instance__ds__day
           , DATE_TRUNC('month', subq_3.ds) AS revenue_instance__ds__month

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_with_multiple_metric_time_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_with_multiple_metric_time_dimensions__plan0.sql
@@ -61,7 +61,7 @@ FROM (
         , subq_1.revenue_instance__user AS revenue_instance__user
         , subq_1.txn_revenue AS txn_revenue
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine'
         SELECT
           subq_3.ds AS metric_time__day
           , DATE_TRUNC('month', subq_3.ds) AS metric_time__month

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_with_non_adjustable_time_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_with_non_adjustable_time_filter__plan0.sql
@@ -225,7 +225,7 @@ FROM (
           , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
           , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
         FROM (
-          -- Time Spine
+          -- Read From Time Spine 'mf_time_spine'
           SELECT
             subq_3.ds AS metric_time__day
           FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_with_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_with_non_default_grain__plan0.sql
@@ -75,7 +75,7 @@ FROM (
             , subq_1.revenue_instance__user AS revenue_instance__user
             , subq_1.txn_revenue AS txn_revenue
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
               , DATE_TRUNC('week', subq_3.ds) AS metric_time__week

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_with_time_constraint__plan0.sql
@@ -101,7 +101,7 @@ FROM (
           , subq_2.revenue_instance__user AS revenue_instance__user
           , subq_2.txn_revenue AS txn_revenue
         FROM (
-          -- Time Spine
+          -- Read From Time Spine 'mf_time_spine'
           SELECT
             subq_4.ds AS metric_time__day
           FROM ***************************.mf_time_spine subq_4

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
@@ -17,7 +17,7 @@ SELECT
   subq_12.metric_time__day AS metric_time__day
   , SUM(subq_11.txn_revenue) AS trailing_2_months_revenue
 FROM (
-  -- Time Spine
+  -- Read From Time Spine 'mf_time_spine'
   SELECT
     ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_13

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_cumulative_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_cumulative_metric_with_non_default_grains__plan0.sql
@@ -76,7 +76,7 @@ FROM (
               , subq_1.revenue_instance__user AS revenue_instance__user
               , subq_1.txn_revenue AS txn_revenue
             FROM (
-              -- Time Spine
+              -- Read From Time Spine 'mf_time_spine'
               SELECT
                 subq_3.ds AS metric_time__day
                 , DATE_TRUNC('week', subq_3.ds) AS metric_time__week

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_grain_to_date_metric_with_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_grain_to_date_metric_with_non_default_grain__plan0.sql
@@ -75,7 +75,7 @@ FROM (
             , subq_1.revenue_instance__user AS revenue_instance__user
             , subq_1.txn_revenue AS txn_revenue
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
               , DATE_TRUNC('month', subq_3.ds) AS metric_time__month

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_grain_to_date_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_grain_to_date_metric_with_non_default_grains__plan0.sql
@@ -84,7 +84,7 @@ FROM (
             , subq_1.revenue_instance__user AS revenue_instance__user
             , subq_1.txn_revenue AS txn_revenue
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               DATE_TRUNC('quarter', subq_3.ds) AS revenue_instance__ds__quarter
               , DATE_TRUNC('year', subq_3.ds) AS revenue_instance__ds__year

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_window_metric_with_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_window_metric_with_non_default_grain__plan0.sql
@@ -71,7 +71,7 @@ FROM (
             , subq_1.revenue_instance__user AS revenue_instance__user
             , subq_1.txn_revenue AS txn_revenue
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
               , DATE_TRUNC('year', subq_3.ds) AS metric_time__year

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_window_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_window_metric_with_non_default_grains__plan0.sql
@@ -38,7 +38,7 @@ FROM (
         , subq_7.metric_time__week AS metric_time__week
         , subq_6.bookers AS bookers
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine'
         SELECT
           DATE_TRUNC('month', subq_8.ds) AS booking__ds__month
           , subq_8.ds AS metric_time__day
@@ -161,7 +161,7 @@ FROM (
               , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
               , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             FROM (
-              -- Time Spine
+              -- Read From Time Spine 'mf_time_spine'
               SELECT
                 DATE_TRUNC('month', subq_3.ds) AS booking__ds__month
                 , subq_3.ds AS metric_time__day

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_all_time_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_all_time_metric_with_non_default_grains__plan0.sql
@@ -84,7 +84,7 @@ FROM (
             , subq_1.revenue_instance__user AS revenue_instance__user
             , subq_1.txn_revenue AS txn_revenue
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
               , DATE_TRUNC('week', subq_3.ds) AS metric_time__week

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
@@ -97,7 +97,7 @@ FROM (
           , subq_2.revenue_instance__user AS revenue_instance__user
           , subq_2.txn_revenue AS txn_revenue
         FROM (
-          -- Time Spine
+          -- Read From Time Spine 'mf_time_spine'
           SELECT
             subq_4.ds AS metric_time__day
           FROM ***************************.mf_time_spine subq_4

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
@@ -13,7 +13,7 @@ SELECT
   subq_12.metric_time__day AS metric_time__day
   , SUM(subq_11.txn_revenue) AS revenue_all_time
 FROM (
-  -- Time Spine
+  -- Read From Time Spine 'mf_time_spine'
   SELECT
     ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_13

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_with_agg_time_and_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_with_agg_time_and_metric_time__plan0.sql
@@ -61,7 +61,7 @@ FROM (
         , subq_1.revenue_instance__user AS revenue_instance__user
         , subq_1.txn_revenue AS txn_revenue
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine'
         SELECT
           DATE_TRUNC('month', subq_3.ds) AS revenue_instance__ds__month
           , subq_3.ds AS metric_time__day

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_with_agg_time_dimension__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_with_agg_time_dimension__plan0.sql
@@ -58,7 +58,7 @@ FROM (
         , subq_1.revenue_instance__user AS revenue_instance__user
         , subq_1.txn_revenue AS txn_revenue
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine'
         SELECT
           subq_3.ds AS revenue_instance__ds__day
         FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_with_multiple_agg_time_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_with_multiple_agg_time_dimensions__plan0.sql
@@ -61,7 +61,7 @@ FROM (
         , subq_1.revenue_instance__user AS revenue_instance__user
         , subq_1.txn_revenue AS txn_revenue
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine'
         SELECT
           subq_3.ds AS revenue_instance__ds__day
           , DATE_TRUNC('month', subq_3.ds) AS revenue_instance__ds__month

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_with_multiple_metric_time_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_with_multiple_metric_time_dimensions__plan0.sql
@@ -61,7 +61,7 @@ FROM (
         , subq_1.revenue_instance__user AS revenue_instance__user
         , subq_1.txn_revenue AS txn_revenue
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine'
         SELECT
           subq_3.ds AS metric_time__day
           , DATE_TRUNC('month', subq_3.ds) AS metric_time__month

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_with_non_adjustable_time_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_with_non_adjustable_time_filter__plan0.sql
@@ -225,7 +225,7 @@ FROM (
           , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
           , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
         FROM (
-          -- Time Spine
+          -- Read From Time Spine 'mf_time_spine'
           SELECT
             subq_3.ds AS metric_time__day
           FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_with_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_with_non_default_grain__plan0.sql
@@ -75,7 +75,7 @@ FROM (
             , subq_1.revenue_instance__user AS revenue_instance__user
             , subq_1.txn_revenue AS txn_revenue
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
               , DATE_TRUNC('week', subq_3.ds) AS metric_time__week

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_with_time_constraint__plan0.sql
@@ -101,7 +101,7 @@ FROM (
           , subq_2.revenue_instance__user AS revenue_instance__user
           , subq_2.txn_revenue AS txn_revenue
         FROM (
-          -- Time Spine
+          -- Read From Time Spine 'mf_time_spine'
           SELECT
             subq_4.ds AS metric_time__day
           FROM ***************************.mf_time_spine subq_4

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
@@ -17,7 +17,7 @@ SELECT
   subq_12.metric_time__day AS metric_time__day
   , SUM(subq_11.txn_revenue) AS trailing_2_months_revenue
 FROM (
-  -- Time Spine
+  -- Read From Time Spine 'mf_time_spine'
   SELECT
     ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_13

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_cumulative_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_cumulative_metric_with_non_default_grains__plan0.sql
@@ -76,7 +76,7 @@ FROM (
               , subq_1.revenue_instance__user AS revenue_instance__user
               , subq_1.txn_revenue AS txn_revenue
             FROM (
-              -- Time Spine
+              -- Read From Time Spine 'mf_time_spine'
               SELECT
                 subq_3.ds AS metric_time__day
                 , DATE_TRUNC('week', subq_3.ds) AS metric_time__week

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_grain_to_date_metric_with_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_grain_to_date_metric_with_non_default_grain__plan0.sql
@@ -75,7 +75,7 @@ FROM (
             , subq_1.revenue_instance__user AS revenue_instance__user
             , subq_1.txn_revenue AS txn_revenue
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
               , DATE_TRUNC('month', subq_3.ds) AS metric_time__month

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_grain_to_date_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_grain_to_date_metric_with_non_default_grains__plan0.sql
@@ -84,7 +84,7 @@ FROM (
             , subq_1.revenue_instance__user AS revenue_instance__user
             , subq_1.txn_revenue AS txn_revenue
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               DATE_TRUNC('quarter', subq_3.ds) AS revenue_instance__ds__quarter
               , DATE_TRUNC('year', subq_3.ds) AS revenue_instance__ds__year

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_window_metric_with_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_window_metric_with_non_default_grain__plan0.sql
@@ -71,7 +71,7 @@ FROM (
             , subq_1.revenue_instance__user AS revenue_instance__user
             , subq_1.txn_revenue AS txn_revenue
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
               , DATE_TRUNC('year', subq_3.ds) AS metric_time__year

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_window_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_window_metric_with_non_default_grains__plan0.sql
@@ -38,7 +38,7 @@ FROM (
         , subq_7.metric_time__week AS metric_time__week
         , subq_6.bookers AS bookers
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine'
         SELECT
           DATE_TRUNC('month', subq_8.ds) AS booking__ds__month
           , subq_8.ds AS metric_time__day
@@ -161,7 +161,7 @@ FROM (
               , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
               , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             FROM (
-              -- Time Spine
+              -- Read From Time Spine 'mf_time_spine'
               SELECT
                 DATE_TRUNC('month', subq_3.ds) AS booking__ds__month
                 , subq_3.ds AS metric_time__day

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_all_time_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_all_time_metric_with_non_default_grains__plan0.sql
@@ -84,7 +84,7 @@ FROM (
             , subq_1.revenue_instance__user AS revenue_instance__user
             , subq_1.txn_revenue AS txn_revenue
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
               , DATE_TRUNC('week', subq_3.ds) AS metric_time__week

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
@@ -97,7 +97,7 @@ FROM (
           , subq_2.revenue_instance__user AS revenue_instance__user
           , subq_2.txn_revenue AS txn_revenue
         FROM (
-          -- Time Spine
+          -- Read From Time Spine 'mf_time_spine'
           SELECT
             subq_4.ds AS metric_time__day
           FROM ***************************.mf_time_spine subq_4

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
@@ -13,7 +13,7 @@ SELECT
   subq_12.metric_time__day AS metric_time__day
   , SUM(subq_11.txn_revenue) AS revenue_all_time
 FROM (
-  -- Time Spine
+  -- Read From Time Spine 'mf_time_spine'
   SELECT
     ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_13

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_with_agg_time_and_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_with_agg_time_and_metric_time__plan0.sql
@@ -61,7 +61,7 @@ FROM (
         , subq_1.revenue_instance__user AS revenue_instance__user
         , subq_1.txn_revenue AS txn_revenue
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine'
         SELECT
           DATE_TRUNC('month', subq_3.ds) AS revenue_instance__ds__month
           , subq_3.ds AS metric_time__day

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_with_agg_time_dimension__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_with_agg_time_dimension__plan0.sql
@@ -58,7 +58,7 @@ FROM (
         , subq_1.revenue_instance__user AS revenue_instance__user
         , subq_1.txn_revenue AS txn_revenue
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine'
         SELECT
           subq_3.ds AS revenue_instance__ds__day
         FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_with_multiple_agg_time_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_with_multiple_agg_time_dimensions__plan0.sql
@@ -61,7 +61,7 @@ FROM (
         , subq_1.revenue_instance__user AS revenue_instance__user
         , subq_1.txn_revenue AS txn_revenue
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine'
         SELECT
           subq_3.ds AS revenue_instance__ds__day
           , DATE_TRUNC('month', subq_3.ds) AS revenue_instance__ds__month

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_with_multiple_metric_time_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_with_multiple_metric_time_dimensions__plan0.sql
@@ -61,7 +61,7 @@ FROM (
         , subq_1.revenue_instance__user AS revenue_instance__user
         , subq_1.txn_revenue AS txn_revenue
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine'
         SELECT
           subq_3.ds AS metric_time__day
           , DATE_TRUNC('month', subq_3.ds) AS metric_time__month

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_with_non_adjustable_time_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_with_non_adjustable_time_filter__plan0.sql
@@ -225,7 +225,7 @@ FROM (
           , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
           , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
         FROM (
-          -- Time Spine
+          -- Read From Time Spine 'mf_time_spine'
           SELECT
             subq_3.ds AS metric_time__day
           FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_with_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_with_non_default_grain__plan0.sql
@@ -75,7 +75,7 @@ FROM (
             , subq_1.revenue_instance__user AS revenue_instance__user
             , subq_1.txn_revenue AS txn_revenue
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
               , DATE_TRUNC('week', subq_3.ds) AS metric_time__week

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_with_time_constraint__plan0.sql
@@ -101,7 +101,7 @@ FROM (
           , subq_2.revenue_instance__user AS revenue_instance__user
           , subq_2.txn_revenue AS txn_revenue
         FROM (
-          -- Time Spine
+          -- Read From Time Spine 'mf_time_spine'
           SELECT
             subq_4.ds AS metric_time__day
           FROM ***************************.mf_time_spine subq_4

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
@@ -17,7 +17,7 @@ SELECT
   subq_12.metric_time__day AS metric_time__day
   , SUM(subq_11.txn_revenue) AS trailing_2_months_revenue
 FROM (
-  -- Time Spine
+  -- Read From Time Spine 'mf_time_spine'
   SELECT
     ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_13

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_cumulative_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_cumulative_metric_with_non_default_grains__plan0.sql
@@ -76,7 +76,7 @@ FROM (
               , subq_1.revenue_instance__user AS revenue_instance__user
               , subq_1.txn_revenue AS txn_revenue
             FROM (
-              -- Time Spine
+              -- Read From Time Spine 'mf_time_spine'
               SELECT
                 subq_3.ds AS metric_time__day
                 , DATE_TRUNC('week', subq_3.ds) AS metric_time__week

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_grain_to_date_metric_with_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_grain_to_date_metric_with_non_default_grain__plan0.sql
@@ -75,7 +75,7 @@ FROM (
             , subq_1.revenue_instance__user AS revenue_instance__user
             , subq_1.txn_revenue AS txn_revenue
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
               , DATE_TRUNC('month', subq_3.ds) AS metric_time__month

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_grain_to_date_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_grain_to_date_metric_with_non_default_grains__plan0.sql
@@ -84,7 +84,7 @@ FROM (
             , subq_1.revenue_instance__user AS revenue_instance__user
             , subq_1.txn_revenue AS txn_revenue
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               DATE_TRUNC('quarter', subq_3.ds) AS revenue_instance__ds__quarter
               , DATE_TRUNC('year', subq_3.ds) AS revenue_instance__ds__year

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_window_metric_with_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_window_metric_with_non_default_grain__plan0.sql
@@ -71,7 +71,7 @@ FROM (
             , subq_1.revenue_instance__user AS revenue_instance__user
             , subq_1.txn_revenue AS txn_revenue
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
               , DATE_TRUNC('year', subq_3.ds) AS metric_time__year

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_window_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_window_metric_with_non_default_grains__plan0.sql
@@ -38,7 +38,7 @@ FROM (
         , subq_7.metric_time__week AS metric_time__week
         , subq_6.bookers AS bookers
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine'
         SELECT
           DATE_TRUNC('month', subq_8.ds) AS booking__ds__month
           , subq_8.ds AS metric_time__day
@@ -161,7 +161,7 @@ FROM (
               , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
               , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             FROM (
-              -- Time Spine
+              -- Read From Time Spine 'mf_time_spine'
               SELECT
                 DATE_TRUNC('month', subq_3.ds) AS booking__ds__month
                 , subq_3.ds AS metric_time__day

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_all_time_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_all_time_metric_with_non_default_grains__plan0.sql
@@ -84,7 +84,7 @@ FROM (
             , subq_1.revenue_instance__user AS revenue_instance__user
             , subq_1.txn_revenue AS txn_revenue
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
               , DATE_TRUNC('week', subq_3.ds) AS metric_time__week

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
@@ -97,7 +97,7 @@ FROM (
           , subq_2.revenue_instance__user AS revenue_instance__user
           , subq_2.txn_revenue AS txn_revenue
         FROM (
-          -- Time Spine
+          -- Read From Time Spine 'mf_time_spine'
           SELECT
             subq_4.ds AS metric_time__day
           FROM ***************************.mf_time_spine subq_4

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
@@ -13,7 +13,7 @@ SELECT
   subq_12.metric_time__day AS metric_time__day
   , SUM(subq_11.txn_revenue) AS revenue_all_time
 FROM (
-  -- Time Spine
+  -- Read From Time Spine 'mf_time_spine'
   SELECT
     ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_13

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_with_agg_time_and_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_with_agg_time_and_metric_time__plan0.sql
@@ -61,7 +61,7 @@ FROM (
         , subq_1.revenue_instance__user AS revenue_instance__user
         , subq_1.txn_revenue AS txn_revenue
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine'
         SELECT
           DATE_TRUNC('month', subq_3.ds) AS revenue_instance__ds__month
           , subq_3.ds AS metric_time__day

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_with_agg_time_dimension__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_with_agg_time_dimension__plan0.sql
@@ -58,7 +58,7 @@ FROM (
         , subq_1.revenue_instance__user AS revenue_instance__user
         , subq_1.txn_revenue AS txn_revenue
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine'
         SELECT
           subq_3.ds AS revenue_instance__ds__day
         FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_with_multiple_agg_time_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_with_multiple_agg_time_dimensions__plan0.sql
@@ -61,7 +61,7 @@ FROM (
         , subq_1.revenue_instance__user AS revenue_instance__user
         , subq_1.txn_revenue AS txn_revenue
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine'
         SELECT
           subq_3.ds AS revenue_instance__ds__day
           , DATE_TRUNC('month', subq_3.ds) AS revenue_instance__ds__month

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_with_multiple_metric_time_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_with_multiple_metric_time_dimensions__plan0.sql
@@ -61,7 +61,7 @@ FROM (
         , subq_1.revenue_instance__user AS revenue_instance__user
         , subq_1.txn_revenue AS txn_revenue
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine'
         SELECT
           subq_3.ds AS metric_time__day
           , DATE_TRUNC('month', subq_3.ds) AS metric_time__month

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_with_non_adjustable_time_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_with_non_adjustable_time_filter__plan0.sql
@@ -225,7 +225,7 @@ FROM (
           , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
           , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
         FROM (
-          -- Time Spine
+          -- Read From Time Spine 'mf_time_spine'
           SELECT
             subq_3.ds AS metric_time__day
           FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_with_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_with_non_default_grain__plan0.sql
@@ -75,7 +75,7 @@ FROM (
             , subq_1.revenue_instance__user AS revenue_instance__user
             , subq_1.txn_revenue AS txn_revenue
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
               , DATE_TRUNC('week', subq_3.ds) AS metric_time__week

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_with_time_constraint__plan0.sql
@@ -101,7 +101,7 @@ FROM (
           , subq_2.revenue_instance__user AS revenue_instance__user
           , subq_2.txn_revenue AS txn_revenue
         FROM (
-          -- Time Spine
+          -- Read From Time Spine 'mf_time_spine'
           SELECT
             subq_4.ds AS metric_time__day
           FROM ***************************.mf_time_spine subq_4

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
@@ -17,7 +17,7 @@ SELECT
   subq_12.metric_time__day AS metric_time__day
   , SUM(subq_11.txn_revenue) AS trailing_2_months_revenue
 FROM (
-  -- Time Spine
+  -- Read From Time Spine 'mf_time_spine'
   SELECT
     ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_13

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_derived_cumulative_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_derived_cumulative_metric_with_non_default_grains__plan0.sql
@@ -76,7 +76,7 @@ FROM (
               , subq_1.revenue_instance__user AS revenue_instance__user
               , subq_1.txn_revenue AS txn_revenue
             FROM (
-              -- Time Spine
+              -- Read From Time Spine 'mf_time_spine'
               SELECT
                 subq_3.ds AS metric_time__day
                 , DATE_TRUNC('week', subq_3.ds) AS metric_time__week

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_grain_to_date_metric_with_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_grain_to_date_metric_with_non_default_grain__plan0.sql
@@ -75,7 +75,7 @@ FROM (
             , subq_1.revenue_instance__user AS revenue_instance__user
             , subq_1.txn_revenue AS txn_revenue
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
               , DATE_TRUNC('month', subq_3.ds) AS metric_time__month

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_grain_to_date_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_grain_to_date_metric_with_non_default_grains__plan0.sql
@@ -84,7 +84,7 @@ FROM (
             , subq_1.revenue_instance__user AS revenue_instance__user
             , subq_1.txn_revenue AS txn_revenue
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               DATE_TRUNC('quarter', subq_3.ds) AS revenue_instance__ds__quarter
               , DATE_TRUNC('year', subq_3.ds) AS revenue_instance__ds__year

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_window_metric_with_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_window_metric_with_non_default_grain__plan0.sql
@@ -71,7 +71,7 @@ FROM (
             , subq_1.revenue_instance__user AS revenue_instance__user
             , subq_1.txn_revenue AS txn_revenue
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
               , DATE_TRUNC('year', subq_3.ds) AS metric_time__year

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_window_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_window_metric_with_non_default_grains__plan0.sql
@@ -38,7 +38,7 @@ FROM (
         , subq_7.metric_time__week AS metric_time__week
         , subq_6.bookers AS bookers
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine'
         SELECT
           DATE_TRUNC('month', subq_8.ds) AS booking__ds__month
           , subq_8.ds AS metric_time__day
@@ -161,7 +161,7 @@ FROM (
               , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
               , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             FROM (
-              -- Time Spine
+              -- Read From Time Spine 'mf_time_spine'
               SELECT
                 DATE_TRUNC('month', subq_3.ds) AS booking__ds__month
                 , subq_3.ds AS metric_time__day

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_custom_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_custom_granularity__plan0.sql
@@ -71,7 +71,7 @@ FROM (
             , subq_1.txn_revenue AS txn_revenue
             , subq_4.martian_day AS metric_time__martian_day
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_metric_grouped_by_custom_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_metric_grouped_by_custom_grain__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_5.metric_time__martian_day AS metric_time__martian_day
     , subq_4.bookings AS bookings
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       subq_6.martian_day AS metric_time__martian_day
     FROM ***************************.mf_time_spine subq_6

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_metric_grouped_by_custom_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_metric_grouped_by_custom_grain__plan0_optimized.sql
@@ -8,7 +8,7 @@ SELECT
   subq_13.metric_time__martian_day AS metric_time__martian_day
   , subq_12.bookings AS bookings_join_to_time_spine
 FROM (
-  -- Time Spine
+  -- Read From Time Spine 'mf_time_spine'
   SELECT
     martian_day AS metric_time__martian_day
   FROM ***************************.mf_time_spine subq_14

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/BigQuery/test_no_metric_custom_granularity_joined_to_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/BigQuery/test_no_metric_custom_granularity_joined_to_non_default_grain__plan0.sql
@@ -411,7 +411,7 @@ FROM (
         , subq_1.ds__extract_doy AS metric_time__extract_doy
         , subq_1.ds__martian_day AS metric_time__martian_day
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine'
         SELECT
           DATETIME_TRUNC(time_spine_src_28006.ds, day) AS ds__day
           , DATETIME_TRUNC(time_spine_src_28006.ds, isoweek) AS ds__week

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/BigQuery/test_no_metric_custom_granularity_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/BigQuery/test_no_metric_custom_granularity_metric_time__plan0.sql
@@ -35,7 +35,7 @@ FROM (
     , subq_0.ds__martian_day AS metric_time__martian_day
     , subq_1.martian_day AS metric_time__martian_day
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       DATETIME_TRUNC(time_spine_src_28006.ds, day) AS ds__day
       , DATETIME_TRUNC(time_spine_src_28006.ds, isoweek) AS ds__week

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/BigQuery/test_offset_metric_with_custom_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/BigQuery/test_offset_metric_with_custom_granularity__plan0.sql
@@ -125,7 +125,7 @@ FROM (
           , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           , subq_4.martian_day AS booking__ds__martian_day
         FROM (
-          -- Time Spine
+          -- Read From Time Spine 'mf_time_spine'
           SELECT
             subq_3.ds AS booking__ds__day
           FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/BigQuery/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/BigQuery/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
@@ -227,7 +227,7 @@ FROM (
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             , subq_4.martian_day AS metric_time__martian_day
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Databricks/test_cumulative_metric_with_custom_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Databricks/test_cumulative_metric_with_custom_granularity__plan0.sql
@@ -71,7 +71,7 @@ FROM (
             , subq_1.txn_revenue AS txn_revenue
             , subq_4.martian_day AS metric_time__martian_day
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Databricks/test_join_to_time_spine_metric_grouped_by_custom_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Databricks/test_join_to_time_spine_metric_grouped_by_custom_grain__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_5.metric_time__martian_day AS metric_time__martian_day
     , subq_4.bookings AS bookings
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       subq_6.martian_day AS metric_time__martian_day
     FROM ***************************.mf_time_spine subq_6

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Databricks/test_join_to_time_spine_metric_grouped_by_custom_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Databricks/test_join_to_time_spine_metric_grouped_by_custom_grain__plan0_optimized.sql
@@ -8,7 +8,7 @@ SELECT
   subq_13.metric_time__martian_day AS metric_time__martian_day
   , subq_12.bookings AS bookings_join_to_time_spine
 FROM (
-  -- Time Spine
+  -- Read From Time Spine 'mf_time_spine'
   SELECT
     martian_day AS metric_time__martian_day
   FROM ***************************.mf_time_spine subq_14

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Databricks/test_no_metric_custom_granularity_joined_to_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Databricks/test_no_metric_custom_granularity_joined_to_non_default_grain__plan0.sql
@@ -411,7 +411,7 @@ FROM (
         , subq_1.ds__extract_doy AS metric_time__extract_doy
         , subq_1.ds__martian_day AS metric_time__martian_day
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine'
         SELECT
           DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
           , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Databricks/test_no_metric_custom_granularity_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Databricks/test_no_metric_custom_granularity_metric_time__plan0.sql
@@ -35,7 +35,7 @@ FROM (
     , subq_0.ds__martian_day AS metric_time__martian_day
     , subq_1.martian_day AS metric_time__martian_day
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
       , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Databricks/test_offset_metric_with_custom_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Databricks/test_offset_metric_with_custom_granularity__plan0.sql
@@ -125,7 +125,7 @@ FROM (
           , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           , subq_4.martian_day AS booking__ds__martian_day
         FROM (
-          -- Time Spine
+          -- Read From Time Spine 'mf_time_spine'
           SELECT
             subq_3.ds AS booking__ds__day
           FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Databricks/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Databricks/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
@@ -227,7 +227,7 @@ FROM (
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             , subq_4.martian_day AS metric_time__martian_day
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_custom_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_custom_granularity__plan0.sql
@@ -71,7 +71,7 @@ FROM (
             , subq_1.txn_revenue AS txn_revenue
             , subq_4.martian_day AS metric_time__martian_day
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_metric_grouped_by_custom_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_metric_grouped_by_custom_grain__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_5.metric_time__martian_day AS metric_time__martian_day
     , subq_4.bookings AS bookings
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       subq_6.martian_day AS metric_time__martian_day
     FROM ***************************.mf_time_spine subq_6

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_metric_grouped_by_custom_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_metric_grouped_by_custom_grain__plan0_optimized.sql
@@ -8,7 +8,7 @@ SELECT
   subq_13.metric_time__martian_day AS metric_time__martian_day
   , subq_12.bookings AS bookings_join_to_time_spine
 FROM (
-  -- Time Spine
+  -- Read From Time Spine 'mf_time_spine'
   SELECT
     martian_day AS metric_time__martian_day
   FROM ***************************.mf_time_spine subq_14

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/DuckDB/test_no_metric_custom_granularity_joined_to_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/DuckDB/test_no_metric_custom_granularity_joined_to_non_default_grain__plan0.sql
@@ -411,7 +411,7 @@ FROM (
         , subq_1.ds__extract_doy AS metric_time__extract_doy
         , subq_1.ds__martian_day AS metric_time__martian_day
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine'
         SELECT
           DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
           , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/DuckDB/test_no_metric_custom_granularity_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/DuckDB/test_no_metric_custom_granularity_metric_time__plan0.sql
@@ -35,7 +35,7 @@ FROM (
     , subq_0.ds__martian_day AS metric_time__martian_day
     , subq_1.martian_day AS metric_time__martian_day
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
       , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/DuckDB/test_offset_metric_with_custom_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/DuckDB/test_offset_metric_with_custom_granularity__plan0.sql
@@ -125,7 +125,7 @@ FROM (
           , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           , subq_4.martian_day AS booking__ds__martian_day
         FROM (
-          -- Time Spine
+          -- Read From Time Spine 'mf_time_spine'
           SELECT
             subq_3.ds AS booking__ds__day
           FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/DuckDB/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/DuckDB/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
@@ -227,7 +227,7 @@ FROM (
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             , subq_4.martian_day AS metric_time__martian_day
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Postgres/test_cumulative_metric_with_custom_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Postgres/test_cumulative_metric_with_custom_granularity__plan0.sql
@@ -71,7 +71,7 @@ FROM (
             , subq_1.txn_revenue AS txn_revenue
             , subq_4.martian_day AS metric_time__martian_day
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Postgres/test_join_to_time_spine_metric_grouped_by_custom_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Postgres/test_join_to_time_spine_metric_grouped_by_custom_grain__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_5.metric_time__martian_day AS metric_time__martian_day
     , subq_4.bookings AS bookings
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       subq_6.martian_day AS metric_time__martian_day
     FROM ***************************.mf_time_spine subq_6

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Postgres/test_join_to_time_spine_metric_grouped_by_custom_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Postgres/test_join_to_time_spine_metric_grouped_by_custom_grain__plan0_optimized.sql
@@ -8,7 +8,7 @@ SELECT
   subq_13.metric_time__martian_day AS metric_time__martian_day
   , subq_12.bookings AS bookings_join_to_time_spine
 FROM (
-  -- Time Spine
+  -- Read From Time Spine 'mf_time_spine'
   SELECT
     martian_day AS metric_time__martian_day
   FROM ***************************.mf_time_spine subq_14

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Postgres/test_no_metric_custom_granularity_joined_to_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Postgres/test_no_metric_custom_granularity_joined_to_non_default_grain__plan0.sql
@@ -411,7 +411,7 @@ FROM (
         , subq_1.ds__extract_doy AS metric_time__extract_doy
         , subq_1.ds__martian_day AS metric_time__martian_day
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine'
         SELECT
           DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
           , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Postgres/test_no_metric_custom_granularity_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Postgres/test_no_metric_custom_granularity_metric_time__plan0.sql
@@ -35,7 +35,7 @@ FROM (
     , subq_0.ds__martian_day AS metric_time__martian_day
     , subq_1.martian_day AS metric_time__martian_day
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
       , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Postgres/test_offset_metric_with_custom_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Postgres/test_offset_metric_with_custom_granularity__plan0.sql
@@ -125,7 +125,7 @@ FROM (
           , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           , subq_4.martian_day AS booking__ds__martian_day
         FROM (
-          -- Time Spine
+          -- Read From Time Spine 'mf_time_spine'
           SELECT
             subq_3.ds AS booking__ds__day
           FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Postgres/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Postgres/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
@@ -227,7 +227,7 @@ FROM (
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             , subq_4.martian_day AS metric_time__martian_day
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Redshift/test_cumulative_metric_with_custom_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Redshift/test_cumulative_metric_with_custom_granularity__plan0.sql
@@ -71,7 +71,7 @@ FROM (
             , subq_1.txn_revenue AS txn_revenue
             , subq_4.martian_day AS metric_time__martian_day
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Redshift/test_join_to_time_spine_metric_grouped_by_custom_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Redshift/test_join_to_time_spine_metric_grouped_by_custom_grain__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_5.metric_time__martian_day AS metric_time__martian_day
     , subq_4.bookings AS bookings
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       subq_6.martian_day AS metric_time__martian_day
     FROM ***************************.mf_time_spine subq_6

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Redshift/test_join_to_time_spine_metric_grouped_by_custom_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Redshift/test_join_to_time_spine_metric_grouped_by_custom_grain__plan0_optimized.sql
@@ -8,7 +8,7 @@ SELECT
   subq_13.metric_time__martian_day AS metric_time__martian_day
   , subq_12.bookings AS bookings_join_to_time_spine
 FROM (
-  -- Time Spine
+  -- Read From Time Spine 'mf_time_spine'
   SELECT
     martian_day AS metric_time__martian_day
   FROM ***************************.mf_time_spine subq_14

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Redshift/test_no_metric_custom_granularity_joined_to_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Redshift/test_no_metric_custom_granularity_joined_to_non_default_grain__plan0.sql
@@ -411,7 +411,7 @@ FROM (
         , subq_1.ds__extract_doy AS metric_time__extract_doy
         , subq_1.ds__martian_day AS metric_time__martian_day
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine'
         SELECT
           DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
           , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Redshift/test_no_metric_custom_granularity_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Redshift/test_no_metric_custom_granularity_metric_time__plan0.sql
@@ -35,7 +35,7 @@ FROM (
     , subq_0.ds__martian_day AS metric_time__martian_day
     , subq_1.martian_day AS metric_time__martian_day
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
       , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Redshift/test_offset_metric_with_custom_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Redshift/test_offset_metric_with_custom_granularity__plan0.sql
@@ -125,7 +125,7 @@ FROM (
           , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           , subq_4.martian_day AS booking__ds__martian_day
         FROM (
-          -- Time Spine
+          -- Read From Time Spine 'mf_time_spine'
           SELECT
             subq_3.ds AS booking__ds__day
           FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Redshift/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Redshift/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
@@ -227,7 +227,7 @@ FROM (
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             , subq_4.martian_day AS metric_time__martian_day
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Snowflake/test_cumulative_metric_with_custom_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Snowflake/test_cumulative_metric_with_custom_granularity__plan0.sql
@@ -71,7 +71,7 @@ FROM (
             , subq_1.txn_revenue AS txn_revenue
             , subq_4.martian_day AS metric_time__martian_day
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_metric_grouped_by_custom_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_metric_grouped_by_custom_grain__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_5.metric_time__martian_day AS metric_time__martian_day
     , subq_4.bookings AS bookings
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       subq_6.martian_day AS metric_time__martian_day
     FROM ***************************.mf_time_spine subq_6

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_metric_grouped_by_custom_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_metric_grouped_by_custom_grain__plan0_optimized.sql
@@ -8,7 +8,7 @@ SELECT
   subq_13.metric_time__martian_day AS metric_time__martian_day
   , subq_12.bookings AS bookings_join_to_time_spine
 FROM (
-  -- Time Spine
+  -- Read From Time Spine 'mf_time_spine'
   SELECT
     martian_day AS metric_time__martian_day
   FROM ***************************.mf_time_spine subq_14

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Snowflake/test_no_metric_custom_granularity_joined_to_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Snowflake/test_no_metric_custom_granularity_joined_to_non_default_grain__plan0.sql
@@ -411,7 +411,7 @@ FROM (
         , subq_1.ds__extract_doy AS metric_time__extract_doy
         , subq_1.ds__martian_day AS metric_time__martian_day
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine'
         SELECT
           DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
           , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Snowflake/test_no_metric_custom_granularity_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Snowflake/test_no_metric_custom_granularity_metric_time__plan0.sql
@@ -35,7 +35,7 @@ FROM (
     , subq_0.ds__martian_day AS metric_time__martian_day
     , subq_1.martian_day AS metric_time__martian_day
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
       , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Snowflake/test_offset_metric_with_custom_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Snowflake/test_offset_metric_with_custom_granularity__plan0.sql
@@ -125,7 +125,7 @@ FROM (
           , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           , subq_4.martian_day AS booking__ds__martian_day
         FROM (
-          -- Time Spine
+          -- Read From Time Spine 'mf_time_spine'
           SELECT
             subq_3.ds AS booking__ds__day
           FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Snowflake/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Snowflake/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
@@ -227,7 +227,7 @@ FROM (
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             , subq_4.martian_day AS metric_time__martian_day
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Trino/test_cumulative_metric_with_custom_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Trino/test_cumulative_metric_with_custom_granularity__plan0.sql
@@ -71,7 +71,7 @@ FROM (
             , subq_1.txn_revenue AS txn_revenue
             , subq_4.martian_day AS metric_time__martian_day
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Trino/test_join_to_time_spine_metric_grouped_by_custom_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Trino/test_join_to_time_spine_metric_grouped_by_custom_grain__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_5.metric_time__martian_day AS metric_time__martian_day
     , subq_4.bookings AS bookings
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       subq_6.martian_day AS metric_time__martian_day
     FROM ***************************.mf_time_spine subq_6

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Trino/test_join_to_time_spine_metric_grouped_by_custom_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Trino/test_join_to_time_spine_metric_grouped_by_custom_grain__plan0_optimized.sql
@@ -8,7 +8,7 @@ SELECT
   subq_13.metric_time__martian_day AS metric_time__martian_day
   , subq_12.bookings AS bookings_join_to_time_spine
 FROM (
-  -- Time Spine
+  -- Read From Time Spine 'mf_time_spine'
   SELECT
     martian_day AS metric_time__martian_day
   FROM ***************************.mf_time_spine subq_14

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Trino/test_no_metric_custom_granularity_joined_to_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Trino/test_no_metric_custom_granularity_joined_to_non_default_grain__plan0.sql
@@ -411,7 +411,7 @@ FROM (
         , subq_1.ds__extract_doy AS metric_time__extract_doy
         , subq_1.ds__martian_day AS metric_time__martian_day
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine'
         SELECT
           DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
           , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Trino/test_no_metric_custom_granularity_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Trino/test_no_metric_custom_granularity_metric_time__plan0.sql
@@ -35,7 +35,7 @@ FROM (
     , subq_0.ds__martian_day AS metric_time__martian_day
     , subq_1.martian_day AS metric_time__martian_day
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
       , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Trino/test_offset_metric_with_custom_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Trino/test_offset_metric_with_custom_granularity__plan0.sql
@@ -125,7 +125,7 @@ FROM (
           , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           , subq_4.martian_day AS booking__ds__martian_day
         FROM (
-          -- Time Spine
+          -- Read From Time Spine 'mf_time_spine'
           SELECT
             subq_3.ds AS booking__ds__day
           FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Trino/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Trino/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
@@ -227,7 +227,7 @@ FROM (
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             , subq_4.martian_day AS metric_time__martian_day
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_node_with_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_node_with_offset_to_grain__plan0.sql
@@ -10,7 +10,7 @@ SELECT
   , subq_4.listing AS listing
   , subq_4.booking_fees AS booking_fees
 FROM (
-  -- Time Spine
+  -- Read From Time Spine 'mf_time_spine'
   SELECT
     subq_6.ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_6

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_node_with_offset_to_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_node_with_offset_to_grain__plan0_optimized.sql
@@ -10,7 +10,7 @@ SELECT
   , subq_11.listing AS listing
   , subq_11.booking_fees AS booking_fees
 FROM (
-  -- Time Spine
+  -- Read From Time Spine 'mf_time_spine'
   SELECT
     ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_13

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_node_with_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_node_with_offset_window__plan0.sql
@@ -10,7 +10,7 @@ SELECT
   , subq_4.listing AS listing
   , subq_4.booking_fees AS booking_fees
 FROM (
-  -- Time Spine
+  -- Read From Time Spine 'mf_time_spine'
   SELECT
     subq_6.ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_6

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_node_with_offset_window__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_node_with_offset_window__plan0_optimized.sql
@@ -10,7 +10,7 @@ SELECT
   , subq_11.listing AS listing
   , subq_11.booking_fees AS booking_fees
 FROM (
-  -- Time Spine
+  -- Read From Time Spine 'mf_time_spine'
   SELECT
     ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_13

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_node_without_offset__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_node_without_offset__plan0.sql
@@ -10,7 +10,7 @@ SELECT
   , subq_4.listing AS listing
   , subq_4.booking_fees AS booking_fees
 FROM (
-  -- Time Spine
+  -- Read From Time Spine 'mf_time_spine'
   SELECT
     subq_6.ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_6

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_node_without_offset__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_node_without_offset__plan0_optimized.sql
@@ -10,7 +10,7 @@ SELECT
   , subq_11.listing AS listing
   , subq_11.booking_fees AS booking_fees
 FROM (
-  -- Time Spine
+  -- Read From Time Spine 'mf_time_spine'
   SELECT
     ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_13

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_join_to_time_spine_node_with_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_join_to_time_spine_node_with_offset_to_grain__plan0.sql
@@ -10,7 +10,7 @@ SELECT
   , subq_4.listing AS listing
   , subq_4.booking_fees AS booking_fees
 FROM (
-  -- Time Spine
+  -- Read From Time Spine 'mf_time_spine'
   SELECT
     subq_6.ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_6

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_join_to_time_spine_node_with_offset_to_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_join_to_time_spine_node_with_offset_to_grain__plan0_optimized.sql
@@ -10,7 +10,7 @@ SELECT
   , subq_11.listing AS listing
   , subq_11.booking_fees AS booking_fees
 FROM (
-  -- Time Spine
+  -- Read From Time Spine 'mf_time_spine'
   SELECT
     ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_13

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_join_to_time_spine_node_with_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_join_to_time_spine_node_with_offset_window__plan0.sql
@@ -10,7 +10,7 @@ SELECT
   , subq_4.listing AS listing
   , subq_4.booking_fees AS booking_fees
 FROM (
-  -- Time Spine
+  -- Read From Time Spine 'mf_time_spine'
   SELECT
     subq_6.ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_6

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_join_to_time_spine_node_with_offset_window__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_join_to_time_spine_node_with_offset_window__plan0_optimized.sql
@@ -10,7 +10,7 @@ SELECT
   , subq_11.listing AS listing
   , subq_11.booking_fees AS booking_fees
 FROM (
-  -- Time Spine
+  -- Read From Time Spine 'mf_time_spine'
   SELECT
     ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_13

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_join_to_time_spine_node_without_offset__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_join_to_time_spine_node_without_offset__plan0.sql
@@ -10,7 +10,7 @@ SELECT
   , subq_4.listing AS listing
   , subq_4.booking_fees AS booking_fees
 FROM (
-  -- Time Spine
+  -- Read From Time Spine 'mf_time_spine'
   SELECT
     subq_6.ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_6

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_join_to_time_spine_node_without_offset__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_join_to_time_spine_node_without_offset__plan0_optimized.sql
@@ -10,7 +10,7 @@ SELECT
   , subq_11.listing AS listing
   , subq_11.booking_fees AS booking_fees
 FROM (
-  -- Time Spine
+  -- Read From Time Spine 'mf_time_spine'
   SELECT
     ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_13

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_node_with_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_node_with_offset_to_grain__plan0.sql
@@ -10,7 +10,7 @@ SELECT
   , subq_4.listing AS listing
   , subq_4.booking_fees AS booking_fees
 FROM (
-  -- Time Spine
+  -- Read From Time Spine 'mf_time_spine'
   SELECT
     subq_6.ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_6

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_node_with_offset_to_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_node_with_offset_to_grain__plan0_optimized.sql
@@ -10,7 +10,7 @@ SELECT
   , subq_11.listing AS listing
   , subq_11.booking_fees AS booking_fees
 FROM (
-  -- Time Spine
+  -- Read From Time Spine 'mf_time_spine'
   SELECT
     ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_13

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_node_with_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_node_with_offset_window__plan0.sql
@@ -10,7 +10,7 @@ SELECT
   , subq_4.listing AS listing
   , subq_4.booking_fees AS booking_fees
 FROM (
-  -- Time Spine
+  -- Read From Time Spine 'mf_time_spine'
   SELECT
     subq_6.ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_6

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_node_with_offset_window__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_node_with_offset_window__plan0_optimized.sql
@@ -10,7 +10,7 @@ SELECT
   , subq_11.listing AS listing
   , subq_11.booking_fees AS booking_fees
 FROM (
-  -- Time Spine
+  -- Read From Time Spine 'mf_time_spine'
   SELECT
     ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_13

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_node_without_offset__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_node_without_offset__plan0.sql
@@ -10,7 +10,7 @@ SELECT
   , subq_4.listing AS listing
   , subq_4.booking_fees AS booking_fees
 FROM (
-  -- Time Spine
+  -- Read From Time Spine 'mf_time_spine'
   SELECT
     subq_6.ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_6

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_node_without_offset__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_node_without_offset__plan0_optimized.sql
@@ -10,7 +10,7 @@ SELECT
   , subq_11.listing AS listing
   , subq_11.booking_fees AS booking_fees
 FROM (
-  -- Time Spine
+  -- Read From Time Spine 'mf_time_spine'
   SELECT
     ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_13

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_join_to_time_spine_node_with_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_join_to_time_spine_node_with_offset_to_grain__plan0.sql
@@ -10,7 +10,7 @@ SELECT
   , subq_4.listing AS listing
   , subq_4.booking_fees AS booking_fees
 FROM (
-  -- Time Spine
+  -- Read From Time Spine 'mf_time_spine'
   SELECT
     subq_6.ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_6

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_join_to_time_spine_node_with_offset_to_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_join_to_time_spine_node_with_offset_to_grain__plan0_optimized.sql
@@ -10,7 +10,7 @@ SELECT
   , subq_11.listing AS listing
   , subq_11.booking_fees AS booking_fees
 FROM (
-  -- Time Spine
+  -- Read From Time Spine 'mf_time_spine'
   SELECT
     ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_13

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_join_to_time_spine_node_with_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_join_to_time_spine_node_with_offset_window__plan0.sql
@@ -10,7 +10,7 @@ SELECT
   , subq_4.listing AS listing
   , subq_4.booking_fees AS booking_fees
 FROM (
-  -- Time Spine
+  -- Read From Time Spine 'mf_time_spine'
   SELECT
     subq_6.ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_6

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_join_to_time_spine_node_with_offset_window__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_join_to_time_spine_node_with_offset_window__plan0_optimized.sql
@@ -10,7 +10,7 @@ SELECT
   , subq_11.listing AS listing
   , subq_11.booking_fees AS booking_fees
 FROM (
-  -- Time Spine
+  -- Read From Time Spine 'mf_time_spine'
   SELECT
     ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_13

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_join_to_time_spine_node_without_offset__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_join_to_time_spine_node_without_offset__plan0.sql
@@ -10,7 +10,7 @@ SELECT
   , subq_4.listing AS listing
   , subq_4.booking_fees AS booking_fees
 FROM (
-  -- Time Spine
+  -- Read From Time Spine 'mf_time_spine'
   SELECT
     subq_6.ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_6

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_join_to_time_spine_node_without_offset__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_join_to_time_spine_node_without_offset__plan0_optimized.sql
@@ -10,7 +10,7 @@ SELECT
   , subq_11.listing AS listing
   , subq_11.booking_fees AS booking_fees
 FROM (
-  -- Time Spine
+  -- Read From Time Spine 'mf_time_spine'
   SELECT
     ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_13

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_join_to_time_spine_node_with_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_join_to_time_spine_node_with_offset_to_grain__plan0.sql
@@ -10,7 +10,7 @@ SELECT
   , subq_4.listing AS listing
   , subq_4.booking_fees AS booking_fees
 FROM (
-  -- Time Spine
+  -- Read From Time Spine 'mf_time_spine'
   SELECT
     subq_6.ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_6

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_join_to_time_spine_node_with_offset_to_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_join_to_time_spine_node_with_offset_to_grain__plan0_optimized.sql
@@ -10,7 +10,7 @@ SELECT
   , subq_11.listing AS listing
   , subq_11.booking_fees AS booking_fees
 FROM (
-  -- Time Spine
+  -- Read From Time Spine 'mf_time_spine'
   SELECT
     ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_13

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_join_to_time_spine_node_with_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_join_to_time_spine_node_with_offset_window__plan0.sql
@@ -10,7 +10,7 @@ SELECT
   , subq_4.listing AS listing
   , subq_4.booking_fees AS booking_fees
 FROM (
-  -- Time Spine
+  -- Read From Time Spine 'mf_time_spine'
   SELECT
     subq_6.ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_6

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_join_to_time_spine_node_with_offset_window__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_join_to_time_spine_node_with_offset_window__plan0_optimized.sql
@@ -10,7 +10,7 @@ SELECT
   , subq_11.listing AS listing
   , subq_11.booking_fees AS booking_fees
 FROM (
-  -- Time Spine
+  -- Read From Time Spine 'mf_time_spine'
   SELECT
     ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_13

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_join_to_time_spine_node_without_offset__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_join_to_time_spine_node_without_offset__plan0.sql
@@ -10,7 +10,7 @@ SELECT
   , subq_4.listing AS listing
   , subq_4.booking_fees AS booking_fees
 FROM (
-  -- Time Spine
+  -- Read From Time Spine 'mf_time_spine'
   SELECT
     subq_6.ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_6

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_join_to_time_spine_node_without_offset__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_join_to_time_spine_node_without_offset__plan0_optimized.sql
@@ -10,7 +10,7 @@ SELECT
   , subq_11.listing AS listing
   , subq_11.booking_fees AS booking_fees
 FROM (
-  -- Time Spine
+  -- Read From Time Spine 'mf_time_spine'
   SELECT
     ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_13

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_node_with_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_node_with_offset_to_grain__plan0.sql
@@ -10,7 +10,7 @@ SELECT
   , subq_4.listing AS listing
   , subq_4.booking_fees AS booking_fees
 FROM (
-  -- Time Spine
+  -- Read From Time Spine 'mf_time_spine'
   SELECT
     subq_6.ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_6

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_node_with_offset_to_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_node_with_offset_to_grain__plan0_optimized.sql
@@ -10,7 +10,7 @@ SELECT
   , subq_11.listing AS listing
   , subq_11.booking_fees AS booking_fees
 FROM (
-  -- Time Spine
+  -- Read From Time Spine 'mf_time_spine'
   SELECT
     ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_13

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_node_with_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_node_with_offset_window__plan0.sql
@@ -10,7 +10,7 @@ SELECT
   , subq_4.listing AS listing
   , subq_4.booking_fees AS booking_fees
 FROM (
-  -- Time Spine
+  -- Read From Time Spine 'mf_time_spine'
   SELECT
     subq_6.ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_6

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_node_with_offset_window__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_node_with_offset_window__plan0_optimized.sql
@@ -10,7 +10,7 @@ SELECT
   , subq_11.listing AS listing
   , subq_11.booking_fees AS booking_fees
 FROM (
-  -- Time Spine
+  -- Read From Time Spine 'mf_time_spine'
   SELECT
     ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_13

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_node_without_offset__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_node_without_offset__plan0.sql
@@ -10,7 +10,7 @@ SELECT
   , subq_4.listing AS listing
   , subq_4.booking_fees AS booking_fees
 FROM (
-  -- Time Spine
+  -- Read From Time Spine 'mf_time_spine'
   SELECT
     subq_6.ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_6

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_node_without_offset__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_node_without_offset__plan0_optimized.sql
@@ -10,7 +10,7 @@ SELECT
   , subq_11.listing AS listing
   , subq_11.booking_fees AS booking_fees
 FROM (
-  -- Time Spine
+  -- Read From Time Spine 'mf_time_spine'
   SELECT
     ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_13

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Trino/test_join_to_time_spine_node_with_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Trino/test_join_to_time_spine_node_with_offset_to_grain__plan0.sql
@@ -10,7 +10,7 @@ SELECT
   , subq_4.listing AS listing
   , subq_4.booking_fees AS booking_fees
 FROM (
-  -- Time Spine
+  -- Read From Time Spine 'mf_time_spine'
   SELECT
     subq_6.ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_6

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Trino/test_join_to_time_spine_node_with_offset_to_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Trino/test_join_to_time_spine_node_with_offset_to_grain__plan0_optimized.sql
@@ -10,7 +10,7 @@ SELECT
   , subq_11.listing AS listing
   , subq_11.booking_fees AS booking_fees
 FROM (
-  -- Time Spine
+  -- Read From Time Spine 'mf_time_spine'
   SELECT
     ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_13

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Trino/test_join_to_time_spine_node_with_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Trino/test_join_to_time_spine_node_with_offset_window__plan0.sql
@@ -10,7 +10,7 @@ SELECT
   , subq_4.listing AS listing
   , subq_4.booking_fees AS booking_fees
 FROM (
-  -- Time Spine
+  -- Read From Time Spine 'mf_time_spine'
   SELECT
     subq_6.ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_6

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Trino/test_join_to_time_spine_node_with_offset_window__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Trino/test_join_to_time_spine_node_with_offset_window__plan0_optimized.sql
@@ -10,7 +10,7 @@ SELECT
   , subq_11.listing AS listing
   , subq_11.booking_fees AS booking_fees
 FROM (
-  -- Time Spine
+  -- Read From Time Spine 'mf_time_spine'
   SELECT
     ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_13

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Trino/test_join_to_time_spine_node_without_offset__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Trino/test_join_to_time_spine_node_without_offset__plan0.sql
@@ -10,7 +10,7 @@ SELECT
   , subq_4.listing AS listing
   , subq_4.booking_fees AS booking_fees
 FROM (
-  -- Time Spine
+  -- Read From Time Spine 'mf_time_spine'
   SELECT
     subq_6.ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_6

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Trino/test_join_to_time_spine_node_without_offset__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Trino/test_join_to_time_spine_node_without_offset__plan0_optimized.sql
@@ -10,7 +10,7 @@ SELECT
   , subq_11.listing AS listing
   , subq_11.booking_fees AS booking_fees
 FROM (
-  -- Time Spine
+  -- Read From Time Spine 'mf_time_spine'
   SELECT
     ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_13

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_join_to_time_spine_node_with_offset_to_grain__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_join_to_time_spine_node_with_offset_to_grain__plan0.xml
@@ -21,7 +21,7 @@ docstring:
         <!-- where = None -->
         <!-- distinct = False -->
         <SqlSelectStatementNode>
-            <!-- description = 'Time Spine' -->
+            <!-- description = "Read From Time Spine 'mf_time_spine'" -->
             <!-- node_id = NodeId(id_str='ss_5') -->
             <!-- col0 =                                                                                                -->
             <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_106), column_alias='metric_time__day') -->

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_join_to_time_spine_node_with_offset_window__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_join_to_time_spine_node_with_offset_window__plan0.xml
@@ -21,7 +21,7 @@ docstring:
         <!-- where = None -->
         <!-- distinct = False -->
         <SqlSelectStatementNode>
-            <!-- description = 'Time Spine' -->
+            <!-- description = "Read From Time Spine 'mf_time_spine'" -->
             <!-- node_id = NodeId(id_str='ss_5') -->
             <!-- col0 =                                                                                                -->
             <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_106), column_alias='metric_time__day') -->

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_join_to_time_spine_node_without_offset__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_join_to_time_spine_node_without_offset__plan0.xml
@@ -21,7 +21,7 @@ docstring:
         <!-- where = None -->
         <!-- distinct = False -->
         <SqlSelectStatementNode>
-            <!-- description = 'Time Spine' -->
+            <!-- description = "Read From Time Spine 'mf_time_spine'" -->
             <!-- node_id = NodeId(id_str='ss_5') -->
             <!-- col0 =                                                                                                -->
             <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_106), column_alias='metric_time__day') -->

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
@@ -224,7 +224,7 @@ FROM (
             , subq_4.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_4.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_6.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_6
@@ -331,7 +331,7 @@ FROM (
               , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
               , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             FROM (
-              -- Time Spine
+              -- Read From Time Spine 'mf_time_spine'
               SELECT
                 subq_3.ds AS metric_time__day
               FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
@@ -46,7 +46,7 @@ FROM (
           , subq_1.booking_monthly__listing AS booking_monthly__listing
           , subq_1.bookings_monthly AS bookings_monthly
         FROM (
-          -- Time Spine
+          -- Read From Time Spine 'mf_time_spine'
           SELECT
             DATETIME_TRUNC(subq_3.ds, month) AS metric_time__month
           FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_metric_with_month_dimension_and_offset_window__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_metric_with_month_dimension_and_offset_window__plan0_optimized.sql
@@ -15,7 +15,7 @@ FROM (
     subq_10.metric_time__month AS metric_time__month
     , SUM(monthly_bookings_source_src_16000.bookings_monthly) AS bookings_last_month
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       DATETIME_TRUNC(ds, month) AS metric_time__month
     FROM ***************************.mf_time_spine subq_11

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_to_grain__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_8.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_8

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_to_grain_and_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_to_grain_and_granularity__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_8.ds AS metric_time__day
               , DATETIME_TRUNC(subq_8.ds, isoweek) AS metric_time__week

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_window__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_8.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_8

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_window_and_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_window_and_granularity__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_8.ds AS metric_time__day
               , DATETIME_TRUNC(subq_8.ds, quarter) AS metric_time__quarter

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
@@ -129,7 +129,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_3
@@ -454,7 +454,7 @@ FROM (
             , subq_9.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_9.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_11.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_11

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0.sql
@@ -129,7 +129,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
               , DATETIME_TRUNC(subq_3.ds, year) AS metric_time__year
@@ -456,7 +456,7 @@ FROM (
             , subq_9.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_9.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_11.ds AS metric_time__day
               , DATETIME_TRUNC(subq_11.ds, year) AS metric_time__year

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
@@ -548,7 +548,7 @@ FROM (
               , subq_7.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
               , subq_7.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             FROM (
-              -- Time Spine
+              -- Read From Time Spine 'mf_time_spine'
               SELECT
                 subq_9.ds AS metric_time__day
               FROM ***************************.mf_time_spine subq_9

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_offset_cumulative_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_offset_cumulative_metric__plan0.sql
@@ -123,7 +123,7 @@ FROM (
           , subq_4.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
           , subq_4.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
         FROM (
-          -- Time Spine
+          -- Read From Time Spine 'mf_time_spine'
           SELECT
             subq_6.ds AS metric_time__day
           FROM ***************************.mf_time_spine subq_6
@@ -230,7 +230,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_offset_metric_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_offset_metric_with_agg_time_dim__plan0.sql
@@ -129,7 +129,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS booking__ds__day
             FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_offset_metric_with_one_input_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_offset_metric_with_one_input_metric__plan0.sql
@@ -123,7 +123,7 @@ FROM (
           , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
           , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
         FROM (
-          -- Time Spine
+          -- Read From Time Spine 'mf_time_spine'
           SELECT
             subq_3.ds AS metric_time__day
           FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0.sql
@@ -24,7 +24,7 @@ FROM (
         , subq_8.booking__is_instant AS booking__is_instant
         , subq_8.bookings_offset_once AS bookings_offset_once
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine'
         SELECT
           subq_10.ds AS metric_time__day
         FROM ***************************.mf_time_spine subq_10
@@ -155,7 +155,7 @@ FROM (
                   , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                   , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
                 FROM (
-                  -- Time Spine
+                  -- Read From Time Spine 'mf_time_spine'
                   SELECT
                     subq_3.ds AS metric_time__day
                   FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0.sql
@@ -18,7 +18,7 @@ FROM (
       subq_6.metric_time__day AS metric_time__day
       , subq_5.booking_fees_start_of_month AS booking_fees_start_of_month
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         subq_7.ds AS metric_time__day
       FROM ***************************.mf_time_spine subq_7

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_offsets__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_offsets__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_9.metric_time__day AS metric_time__day
     , subq_8.bookings_offset_once AS bookings_offset_once
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       subq_10.ds AS metric_time__day
     FROM ***************************.mf_time_spine subq_10
@@ -139,7 +139,7 @@ FROM (
               , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
               , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             FROM (
-              -- Time Spine
+              -- Read From Time Spine 'mf_time_spine'
               SELECT
                 subq_3.ds AS metric_time__day
               FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_offsets_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_offsets_with_time_constraint__plan0.sql
@@ -17,7 +17,7 @@ FROM (
       subq_9.metric_time__day AS metric_time__day
       , subq_8.bookings_offset_once AS bookings_offset_once
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         subq_10.ds AS metric_time__day
       FROM ***************************.mf_time_spine subq_10
@@ -144,7 +144,7 @@ FROM (
                 , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                 , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
               FROM (
-                -- Time Spine
+                -- Read From Time Spine 'mf_time_spine'
                 SELECT
                   subq_3.ds AS metric_time__day
                 FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_offsets_with_where_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_offsets_with_where_constraint__plan0.sql
@@ -17,7 +17,7 @@ FROM (
       subq_9.metric_time__day AS metric_time__day
       , subq_8.bookings_offset_once AS bookings_offset_once
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         subq_10.ds AS metric_time__day
       FROM ***************************.mf_time_spine subq_10
@@ -144,7 +144,7 @@ FROM (
                 , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                 , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
               FROM (
-                -- Time Spine
+                -- Read From Time Spine 'mf_time_spine'
                 SELECT
                   subq_3.ds AS metric_time__day
                 FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0.sql
@@ -226,7 +226,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
               , DATETIME_TRUNC(subq_3.ds, month) AS metric_time__month

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_offset_to_grain_metric_multiple_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_offset_to_grain_metric_multiple_granularities__plan0.sql
@@ -133,7 +133,7 @@ FROM (
           , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
           , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
         FROM (
-          -- Time Spine
+          -- Read From Time Spine 'mf_time_spine'
           SELECT
             subq_3.ds AS metric_time__day
             , DATETIME_TRUNC(subq_3.ds, month) AS metric_time__month

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_offset_to_grain_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_offset_to_grain_with_agg_time_dim__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_8.ds AS booking__ds__day
             FROM ***************************.mf_time_spine subq_8

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_offset_window_metric_filter_and_query_have_different_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_offset_window_metric_filter_and_query_have_different_granularities__plan0.sql
@@ -232,7 +232,7 @@ FROM (
               , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
               , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             FROM (
-              -- Time Spine
+              -- Read From Time Spine 'mf_time_spine'
               SELECT
                 subq_3.ds AS metric_time__day
                 , DATETIME_TRUNC(subq_3.ds, month) AS metric_time__month

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_offset_window_metric_multiple_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_offset_window_metric_multiple_granularities__plan0.sql
@@ -141,7 +141,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
               , DATETIME_TRUNC(subq_3.ds, month) AS metric_time__month

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_offset_window_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_offset_window_with_agg_time_dim__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_8.ds AS booking__ds__day
             FROM ***************************.mf_time_spine subq_8

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_time_offset_metric_with_time_constraint__plan0.sql
@@ -224,7 +224,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
@@ -224,7 +224,7 @@ FROM (
             , subq_4.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_4.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_6.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_6
@@ -331,7 +331,7 @@ FROM (
               , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
               , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             FROM (
-              -- Time Spine
+              -- Read From Time Spine 'mf_time_spine'
               SELECT
                 subq_3.ds AS metric_time__day
               FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
@@ -46,7 +46,7 @@ FROM (
           , subq_1.booking_monthly__listing AS booking_monthly__listing
           , subq_1.bookings_monthly AS bookings_monthly
         FROM (
-          -- Time Spine
+          -- Read From Time Spine 'mf_time_spine'
           SELECT
             DATE_TRUNC('month', subq_3.ds) AS metric_time__month
           FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_metric_with_month_dimension_and_offset_window__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_metric_with_month_dimension_and_offset_window__plan0_optimized.sql
@@ -15,7 +15,7 @@ FROM (
     subq_10.metric_time__month AS metric_time__month
     , SUM(monthly_bookings_source_src_16000.bookings_monthly) AS bookings_last_month
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       DATE_TRUNC('month', ds) AS metric_time__month
     FROM ***************************.mf_time_spine subq_11

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_to_grain__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_8.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_8

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_to_grain_and_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_to_grain_and_granularity__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_8.ds AS metric_time__day
               , DATE_TRUNC('week', subq_8.ds) AS metric_time__week

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_window__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_8.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_8

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_window_and_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_window_and_granularity__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_8.ds AS metric_time__day
               , DATE_TRUNC('quarter', subq_8.ds) AS metric_time__quarter

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
@@ -129,7 +129,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_3
@@ -454,7 +454,7 @@ FROM (
             , subq_9.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_9.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_11.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_11

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0.sql
@@ -129,7 +129,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
               , DATE_TRUNC('year', subq_3.ds) AS metric_time__year
@@ -456,7 +456,7 @@ FROM (
             , subq_9.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_9.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_11.ds AS metric_time__day
               , DATE_TRUNC('year', subq_11.ds) AS metric_time__year

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
@@ -548,7 +548,7 @@ FROM (
               , subq_7.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
               , subq_7.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             FROM (
-              -- Time Spine
+              -- Read From Time Spine 'mf_time_spine'
               SELECT
                 subq_9.ds AS metric_time__day
               FROM ***************************.mf_time_spine subq_9

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_offset_cumulative_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_offset_cumulative_metric__plan0.sql
@@ -123,7 +123,7 @@ FROM (
           , subq_4.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
           , subq_4.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
         FROM (
-          -- Time Spine
+          -- Read From Time Spine 'mf_time_spine'
           SELECT
             subq_6.ds AS metric_time__day
           FROM ***************************.mf_time_spine subq_6
@@ -230,7 +230,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_offset_metric_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_offset_metric_with_agg_time_dim__plan0.sql
@@ -129,7 +129,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS booking__ds__day
             FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_offset_metric_with_one_input_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_offset_metric_with_one_input_metric__plan0.sql
@@ -123,7 +123,7 @@ FROM (
           , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
           , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
         FROM (
-          -- Time Spine
+          -- Read From Time Spine 'mf_time_spine'
           SELECT
             subq_3.ds AS metric_time__day
           FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0.sql
@@ -24,7 +24,7 @@ FROM (
         , subq_8.booking__is_instant AS booking__is_instant
         , subq_8.bookings_offset_once AS bookings_offset_once
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine'
         SELECT
           subq_10.ds AS metric_time__day
         FROM ***************************.mf_time_spine subq_10
@@ -155,7 +155,7 @@ FROM (
                   , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                   , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
                 FROM (
-                  -- Time Spine
+                  -- Read From Time Spine 'mf_time_spine'
                   SELECT
                     subq_3.ds AS metric_time__day
                   FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0.sql
@@ -18,7 +18,7 @@ FROM (
       subq_6.metric_time__day AS metric_time__day
       , subq_5.booking_fees_start_of_month AS booking_fees_start_of_month
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         subq_7.ds AS metric_time__day
       FROM ***************************.mf_time_spine subq_7

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_offsets__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_offsets__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_9.metric_time__day AS metric_time__day
     , subq_8.bookings_offset_once AS bookings_offset_once
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       subq_10.ds AS metric_time__day
     FROM ***************************.mf_time_spine subq_10
@@ -139,7 +139,7 @@ FROM (
               , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
               , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             FROM (
-              -- Time Spine
+              -- Read From Time Spine 'mf_time_spine'
               SELECT
                 subq_3.ds AS metric_time__day
               FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_offsets_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_offsets_with_time_constraint__plan0.sql
@@ -17,7 +17,7 @@ FROM (
       subq_9.metric_time__day AS metric_time__day
       , subq_8.bookings_offset_once AS bookings_offset_once
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         subq_10.ds AS metric_time__day
       FROM ***************************.mf_time_spine subq_10
@@ -144,7 +144,7 @@ FROM (
                 , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                 , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
               FROM (
-                -- Time Spine
+                -- Read From Time Spine 'mf_time_spine'
                 SELECT
                   subq_3.ds AS metric_time__day
                 FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_offsets_with_where_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_offsets_with_where_constraint__plan0.sql
@@ -17,7 +17,7 @@ FROM (
       subq_9.metric_time__day AS metric_time__day
       , subq_8.bookings_offset_once AS bookings_offset_once
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         subq_10.ds AS metric_time__day
       FROM ***************************.mf_time_spine subq_10
@@ -144,7 +144,7 @@ FROM (
                 , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                 , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
               FROM (
-                -- Time Spine
+                -- Read From Time Spine 'mf_time_spine'
                 SELECT
                   subq_3.ds AS metric_time__day
                 FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0.sql
@@ -226,7 +226,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
               , DATE_TRUNC('month', subq_3.ds) AS metric_time__month

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_offset_to_grain_metric_multiple_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_offset_to_grain_metric_multiple_granularities__plan0.sql
@@ -133,7 +133,7 @@ FROM (
           , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
           , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
         FROM (
-          -- Time Spine
+          -- Read From Time Spine 'mf_time_spine'
           SELECT
             subq_3.ds AS metric_time__day
             , DATE_TRUNC('month', subq_3.ds) AS metric_time__month

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_offset_to_grain_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_offset_to_grain_with_agg_time_dim__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_8.ds AS booking__ds__day
             FROM ***************************.mf_time_spine subq_8

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_offset_window_metric_filter_and_query_have_different_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_offset_window_metric_filter_and_query_have_different_granularities__plan0.sql
@@ -232,7 +232,7 @@ FROM (
               , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
               , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             FROM (
-              -- Time Spine
+              -- Read From Time Spine 'mf_time_spine'
               SELECT
                 subq_3.ds AS metric_time__day
                 , DATE_TRUNC('month', subq_3.ds) AS metric_time__month

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_offset_window_metric_multiple_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_offset_window_metric_multiple_granularities__plan0.sql
@@ -141,7 +141,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
               , DATE_TRUNC('month', subq_3.ds) AS metric_time__month

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_offset_window_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_offset_window_with_agg_time_dim__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_8.ds AS booking__ds__day
             FROM ***************************.mf_time_spine subq_8

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_time_offset_metric_with_time_constraint__plan0.sql
@@ -224,7 +224,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
@@ -224,7 +224,7 @@ FROM (
             , subq_4.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_4.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_6.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_6
@@ -331,7 +331,7 @@ FROM (
               , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
               , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             FROM (
-              -- Time Spine
+              -- Read From Time Spine 'mf_time_spine'
               SELECT
                 subq_3.ds AS metric_time__day
               FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
@@ -46,7 +46,7 @@ FROM (
           , subq_1.booking_monthly__listing AS booking_monthly__listing
           , subq_1.bookings_monthly AS bookings_monthly
         FROM (
-          -- Time Spine
+          -- Read From Time Spine 'mf_time_spine'
           SELECT
             DATE_TRUNC('month', subq_3.ds) AS metric_time__month
           FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_metric_with_month_dimension_and_offset_window__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_metric_with_month_dimension_and_offset_window__plan0_optimized.sql
@@ -15,7 +15,7 @@ FROM (
     subq_10.metric_time__month AS metric_time__month
     , SUM(monthly_bookings_source_src_16000.bookings_monthly) AS bookings_last_month
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       DATE_TRUNC('month', ds) AS metric_time__month
     FROM ***************************.mf_time_spine subq_11

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_to_grain__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_8.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_8

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_to_grain_and_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_to_grain_and_granularity__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_8.ds AS metric_time__day
               , DATE_TRUNC('week', subq_8.ds) AS metric_time__week

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_window__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_8.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_8

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_window_and_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_window_and_granularity__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_8.ds AS metric_time__day
               , DATE_TRUNC('quarter', subq_8.ds) AS metric_time__quarter

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
@@ -129,7 +129,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_3
@@ -454,7 +454,7 @@ FROM (
             , subq_9.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_9.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_11.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_11

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0.sql
@@ -129,7 +129,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
               , DATE_TRUNC('year', subq_3.ds) AS metric_time__year
@@ -456,7 +456,7 @@ FROM (
             , subq_9.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_9.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_11.ds AS metric_time__day
               , DATE_TRUNC('year', subq_11.ds) AS metric_time__year

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
@@ -548,7 +548,7 @@ FROM (
               , subq_7.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
               , subq_7.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             FROM (
-              -- Time Spine
+              -- Read From Time Spine 'mf_time_spine'
               SELECT
                 subq_9.ds AS metric_time__day
               FROM ***************************.mf_time_spine subq_9

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_offset_cumulative_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_offset_cumulative_metric__plan0.sql
@@ -123,7 +123,7 @@ FROM (
           , subq_4.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
           , subq_4.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
         FROM (
-          -- Time Spine
+          -- Read From Time Spine 'mf_time_spine'
           SELECT
             subq_6.ds AS metric_time__day
           FROM ***************************.mf_time_spine subq_6
@@ -230,7 +230,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_offset_metric_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_offset_metric_with_agg_time_dim__plan0.sql
@@ -129,7 +129,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS booking__ds__day
             FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_offset_metric_with_one_input_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_offset_metric_with_one_input_metric__plan0.sql
@@ -123,7 +123,7 @@ FROM (
           , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
           , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
         FROM (
-          -- Time Spine
+          -- Read From Time Spine 'mf_time_spine'
           SELECT
             subq_3.ds AS metric_time__day
           FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0.sql
@@ -24,7 +24,7 @@ FROM (
         , subq_8.booking__is_instant AS booking__is_instant
         , subq_8.bookings_offset_once AS bookings_offset_once
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine'
         SELECT
           subq_10.ds AS metric_time__day
         FROM ***************************.mf_time_spine subq_10
@@ -155,7 +155,7 @@ FROM (
                   , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                   , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
                 FROM (
-                  -- Time Spine
+                  -- Read From Time Spine 'mf_time_spine'
                   SELECT
                     subq_3.ds AS metric_time__day
                   FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0.sql
@@ -18,7 +18,7 @@ FROM (
       subq_6.metric_time__day AS metric_time__day
       , subq_5.booking_fees_start_of_month AS booking_fees_start_of_month
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         subq_7.ds AS metric_time__day
       FROM ***************************.mf_time_spine subq_7

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_offsets__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_offsets__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_9.metric_time__day AS metric_time__day
     , subq_8.bookings_offset_once AS bookings_offset_once
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       subq_10.ds AS metric_time__day
     FROM ***************************.mf_time_spine subq_10
@@ -139,7 +139,7 @@ FROM (
               , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
               , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             FROM (
-              -- Time Spine
+              -- Read From Time Spine 'mf_time_spine'
               SELECT
                 subq_3.ds AS metric_time__day
               FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_offsets_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_offsets_with_time_constraint__plan0.sql
@@ -17,7 +17,7 @@ FROM (
       subq_9.metric_time__day AS metric_time__day
       , subq_8.bookings_offset_once AS bookings_offset_once
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         subq_10.ds AS metric_time__day
       FROM ***************************.mf_time_spine subq_10
@@ -144,7 +144,7 @@ FROM (
                 , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                 , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
               FROM (
-                -- Time Spine
+                -- Read From Time Spine 'mf_time_spine'
                 SELECT
                   subq_3.ds AS metric_time__day
                 FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_offsets_with_where_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_offsets_with_where_constraint__plan0.sql
@@ -17,7 +17,7 @@ FROM (
       subq_9.metric_time__day AS metric_time__day
       , subq_8.bookings_offset_once AS bookings_offset_once
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         subq_10.ds AS metric_time__day
       FROM ***************************.mf_time_spine subq_10
@@ -144,7 +144,7 @@ FROM (
                 , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                 , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
               FROM (
-                -- Time Spine
+                -- Read From Time Spine 'mf_time_spine'
                 SELECT
                   subq_3.ds AS metric_time__day
                 FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0.sql
@@ -226,7 +226,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
               , DATE_TRUNC('month', subq_3.ds) AS metric_time__month

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_offset_to_grain_metric_multiple_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_offset_to_grain_metric_multiple_granularities__plan0.sql
@@ -133,7 +133,7 @@ FROM (
           , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
           , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
         FROM (
-          -- Time Spine
+          -- Read From Time Spine 'mf_time_spine'
           SELECT
             subq_3.ds AS metric_time__day
             , DATE_TRUNC('month', subq_3.ds) AS metric_time__month

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_offset_to_grain_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_offset_to_grain_with_agg_time_dim__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_8.ds AS booking__ds__day
             FROM ***************************.mf_time_spine subq_8

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_offset_window_metric_filter_and_query_have_different_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_offset_window_metric_filter_and_query_have_different_granularities__plan0.sql
@@ -232,7 +232,7 @@ FROM (
               , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
               , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             FROM (
-              -- Time Spine
+              -- Read From Time Spine 'mf_time_spine'
               SELECT
                 subq_3.ds AS metric_time__day
                 , DATE_TRUNC('month', subq_3.ds) AS metric_time__month

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_offset_window_metric_multiple_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_offset_window_metric_multiple_granularities__plan0.sql
@@ -141,7 +141,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
               , DATE_TRUNC('month', subq_3.ds) AS metric_time__month

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_offset_window_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_offset_window_with_agg_time_dim__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_8.ds AS booking__ds__day
             FROM ***************************.mf_time_spine subq_8

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_time_offset_metric_with_time_constraint__plan0.sql
@@ -224,7 +224,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
@@ -224,7 +224,7 @@ FROM (
             , subq_4.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_4.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_6.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_6
@@ -331,7 +331,7 @@ FROM (
               , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
               , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             FROM (
-              -- Time Spine
+              -- Read From Time Spine 'mf_time_spine'
               SELECT
                 subq_3.ds AS metric_time__day
               FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
@@ -46,7 +46,7 @@ FROM (
           , subq_1.booking_monthly__listing AS booking_monthly__listing
           , subq_1.bookings_monthly AS bookings_monthly
         FROM (
-          -- Time Spine
+          -- Read From Time Spine 'mf_time_spine'
           SELECT
             DATE_TRUNC('month', subq_3.ds) AS metric_time__month
           FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_metric_with_month_dimension_and_offset_window__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_metric_with_month_dimension_and_offset_window__plan0_optimized.sql
@@ -15,7 +15,7 @@ FROM (
     subq_10.metric_time__month AS metric_time__month
     , SUM(monthly_bookings_source_src_16000.bookings_monthly) AS bookings_last_month
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       DATE_TRUNC('month', ds) AS metric_time__month
     FROM ***************************.mf_time_spine subq_11

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_to_grain__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_8.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_8

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_to_grain_and_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_to_grain_and_granularity__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_8.ds AS metric_time__day
               , DATE_TRUNC('week', subq_8.ds) AS metric_time__week

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_window__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_8.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_8

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_window_and_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_window_and_granularity__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_8.ds AS metric_time__day
               , DATE_TRUNC('quarter', subq_8.ds) AS metric_time__quarter

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
@@ -129,7 +129,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_3
@@ -454,7 +454,7 @@ FROM (
             , subq_9.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_9.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_11.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_11

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0.sql
@@ -129,7 +129,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
               , DATE_TRUNC('year', subq_3.ds) AS metric_time__year
@@ -456,7 +456,7 @@ FROM (
             , subq_9.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_9.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_11.ds AS metric_time__day
               , DATE_TRUNC('year', subq_11.ds) AS metric_time__year

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
@@ -548,7 +548,7 @@ FROM (
               , subq_7.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
               , subq_7.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             FROM (
-              -- Time Spine
+              -- Read From Time Spine 'mf_time_spine'
               SELECT
                 subq_9.ds AS metric_time__day
               FROM ***************************.mf_time_spine subq_9

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_offset_cumulative_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_offset_cumulative_metric__plan0.sql
@@ -123,7 +123,7 @@ FROM (
           , subq_4.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
           , subq_4.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
         FROM (
-          -- Time Spine
+          -- Read From Time Spine 'mf_time_spine'
           SELECT
             subq_6.ds AS metric_time__day
           FROM ***************************.mf_time_spine subq_6
@@ -230,7 +230,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_offset_metric_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_offset_metric_with_agg_time_dim__plan0.sql
@@ -129,7 +129,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS booking__ds__day
             FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_offset_metric_with_one_input_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_offset_metric_with_one_input_metric__plan0.sql
@@ -123,7 +123,7 @@ FROM (
           , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
           , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
         FROM (
-          -- Time Spine
+          -- Read From Time Spine 'mf_time_spine'
           SELECT
             subq_3.ds AS metric_time__day
           FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0.sql
@@ -24,7 +24,7 @@ FROM (
         , subq_8.booking__is_instant AS booking__is_instant
         , subq_8.bookings_offset_once AS bookings_offset_once
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine'
         SELECT
           subq_10.ds AS metric_time__day
         FROM ***************************.mf_time_spine subq_10
@@ -155,7 +155,7 @@ FROM (
                   , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                   , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
                 FROM (
-                  -- Time Spine
+                  -- Read From Time Spine 'mf_time_spine'
                   SELECT
                     subq_3.ds AS metric_time__day
                   FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0.sql
@@ -18,7 +18,7 @@ FROM (
       subq_6.metric_time__day AS metric_time__day
       , subq_5.booking_fees_start_of_month AS booking_fees_start_of_month
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         subq_7.ds AS metric_time__day
       FROM ***************************.mf_time_spine subq_7

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_offsets__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_offsets__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_9.metric_time__day AS metric_time__day
     , subq_8.bookings_offset_once AS bookings_offset_once
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       subq_10.ds AS metric_time__day
     FROM ***************************.mf_time_spine subq_10
@@ -139,7 +139,7 @@ FROM (
               , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
               , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             FROM (
-              -- Time Spine
+              -- Read From Time Spine 'mf_time_spine'
               SELECT
                 subq_3.ds AS metric_time__day
               FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_offsets_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_offsets_with_time_constraint__plan0.sql
@@ -17,7 +17,7 @@ FROM (
       subq_9.metric_time__day AS metric_time__day
       , subq_8.bookings_offset_once AS bookings_offset_once
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         subq_10.ds AS metric_time__day
       FROM ***************************.mf_time_spine subq_10
@@ -144,7 +144,7 @@ FROM (
                 , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                 , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
               FROM (
-                -- Time Spine
+                -- Read From Time Spine 'mf_time_spine'
                 SELECT
                   subq_3.ds AS metric_time__day
                 FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_offsets_with_where_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_offsets_with_where_constraint__plan0.sql
@@ -17,7 +17,7 @@ FROM (
       subq_9.metric_time__day AS metric_time__day
       , subq_8.bookings_offset_once AS bookings_offset_once
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         subq_10.ds AS metric_time__day
       FROM ***************************.mf_time_spine subq_10
@@ -144,7 +144,7 @@ FROM (
                 , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                 , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
               FROM (
-                -- Time Spine
+                -- Read From Time Spine 'mf_time_spine'
                 SELECT
                   subq_3.ds AS metric_time__day
                 FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0.sql
@@ -226,7 +226,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
               , DATE_TRUNC('month', subq_3.ds) AS metric_time__month

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_offset_to_grain_metric_multiple_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_offset_to_grain_metric_multiple_granularities__plan0.sql
@@ -133,7 +133,7 @@ FROM (
           , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
           , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
         FROM (
-          -- Time Spine
+          -- Read From Time Spine 'mf_time_spine'
           SELECT
             subq_3.ds AS metric_time__day
             , DATE_TRUNC('month', subq_3.ds) AS metric_time__month

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_offset_to_grain_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_offset_to_grain_with_agg_time_dim__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_8.ds AS booking__ds__day
             FROM ***************************.mf_time_spine subq_8

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_offset_window_metric_filter_and_query_have_different_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_offset_window_metric_filter_and_query_have_different_granularities__plan0.sql
@@ -232,7 +232,7 @@ FROM (
               , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
               , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             FROM (
-              -- Time Spine
+              -- Read From Time Spine 'mf_time_spine'
               SELECT
                 subq_3.ds AS metric_time__day
                 , DATE_TRUNC('month', subq_3.ds) AS metric_time__month

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_offset_window_metric_multiple_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_offset_window_metric_multiple_granularities__plan0.sql
@@ -141,7 +141,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
               , DATE_TRUNC('month', subq_3.ds) AS metric_time__month

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_offset_window_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_offset_window_with_agg_time_dim__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_8.ds AS booking__ds__day
             FROM ***************************.mf_time_spine subq_8

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_time_offset_metric_with_time_constraint__plan0.sql
@@ -224,7 +224,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
@@ -224,7 +224,7 @@ FROM (
             , subq_4.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_4.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_6.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_6
@@ -331,7 +331,7 @@ FROM (
               , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
               , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             FROM (
-              -- Time Spine
+              -- Read From Time Spine 'mf_time_spine'
               SELECT
                 subq_3.ds AS metric_time__day
               FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
@@ -46,7 +46,7 @@ FROM (
           , subq_1.booking_monthly__listing AS booking_monthly__listing
           , subq_1.bookings_monthly AS bookings_monthly
         FROM (
-          -- Time Spine
+          -- Read From Time Spine 'mf_time_spine'
           SELECT
             DATE_TRUNC('month', subq_3.ds) AS metric_time__month
           FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_metric_with_month_dimension_and_offset_window__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_metric_with_month_dimension_and_offset_window__plan0_optimized.sql
@@ -15,7 +15,7 @@ FROM (
     subq_10.metric_time__month AS metric_time__month
     , SUM(monthly_bookings_source_src_16000.bookings_monthly) AS bookings_last_month
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       DATE_TRUNC('month', ds) AS metric_time__month
     FROM ***************************.mf_time_spine subq_11

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_to_grain__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_8.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_8

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_to_grain_and_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_to_grain_and_granularity__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_8.ds AS metric_time__day
               , DATE_TRUNC('week', subq_8.ds) AS metric_time__week

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_window__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_8.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_8

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_window_and_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_window_and_granularity__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_8.ds AS metric_time__day
               , DATE_TRUNC('quarter', subq_8.ds) AS metric_time__quarter

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
@@ -129,7 +129,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_3
@@ -454,7 +454,7 @@ FROM (
             , subq_9.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_9.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_11.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_11

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0.sql
@@ -129,7 +129,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
               , DATE_TRUNC('year', subq_3.ds) AS metric_time__year
@@ -456,7 +456,7 @@ FROM (
             , subq_9.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_9.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_11.ds AS metric_time__day
               , DATE_TRUNC('year', subq_11.ds) AS metric_time__year

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
@@ -548,7 +548,7 @@ FROM (
               , subq_7.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
               , subq_7.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             FROM (
-              -- Time Spine
+              -- Read From Time Spine 'mf_time_spine'
               SELECT
                 subq_9.ds AS metric_time__day
               FROM ***************************.mf_time_spine subq_9

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_offset_cumulative_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_offset_cumulative_metric__plan0.sql
@@ -123,7 +123,7 @@ FROM (
           , subq_4.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
           , subq_4.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
         FROM (
-          -- Time Spine
+          -- Read From Time Spine 'mf_time_spine'
           SELECT
             subq_6.ds AS metric_time__day
           FROM ***************************.mf_time_spine subq_6
@@ -230,7 +230,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_offset_metric_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_offset_metric_with_agg_time_dim__plan0.sql
@@ -129,7 +129,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS booking__ds__day
             FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_offset_metric_with_one_input_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_offset_metric_with_one_input_metric__plan0.sql
@@ -123,7 +123,7 @@ FROM (
           , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
           , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
         FROM (
-          -- Time Spine
+          -- Read From Time Spine 'mf_time_spine'
           SELECT
             subq_3.ds AS metric_time__day
           FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0.sql
@@ -24,7 +24,7 @@ FROM (
         , subq_8.booking__is_instant AS booking__is_instant
         , subq_8.bookings_offset_once AS bookings_offset_once
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine'
         SELECT
           subq_10.ds AS metric_time__day
         FROM ***************************.mf_time_spine subq_10
@@ -155,7 +155,7 @@ FROM (
                   , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                   , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
                 FROM (
-                  -- Time Spine
+                  -- Read From Time Spine 'mf_time_spine'
                   SELECT
                     subq_3.ds AS metric_time__day
                   FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0.sql
@@ -18,7 +18,7 @@ FROM (
       subq_6.metric_time__day AS metric_time__day
       , subq_5.booking_fees_start_of_month AS booking_fees_start_of_month
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         subq_7.ds AS metric_time__day
       FROM ***************************.mf_time_spine subq_7

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_nested_offsets__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_nested_offsets__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_9.metric_time__day AS metric_time__day
     , subq_8.bookings_offset_once AS bookings_offset_once
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       subq_10.ds AS metric_time__day
     FROM ***************************.mf_time_spine subq_10
@@ -139,7 +139,7 @@ FROM (
               , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
               , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             FROM (
-              -- Time Spine
+              -- Read From Time Spine 'mf_time_spine'
               SELECT
                 subq_3.ds AS metric_time__day
               FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_nested_offsets_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_nested_offsets_with_time_constraint__plan0.sql
@@ -17,7 +17,7 @@ FROM (
       subq_9.metric_time__day AS metric_time__day
       , subq_8.bookings_offset_once AS bookings_offset_once
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         subq_10.ds AS metric_time__day
       FROM ***************************.mf_time_spine subq_10
@@ -144,7 +144,7 @@ FROM (
                 , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                 , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
               FROM (
-                -- Time Spine
+                -- Read From Time Spine 'mf_time_spine'
                 SELECT
                   subq_3.ds AS metric_time__day
                 FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_nested_offsets_with_where_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_nested_offsets_with_where_constraint__plan0.sql
@@ -17,7 +17,7 @@ FROM (
       subq_9.metric_time__day AS metric_time__day
       , subq_8.bookings_offset_once AS bookings_offset_once
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         subq_10.ds AS metric_time__day
       FROM ***************************.mf_time_spine subq_10
@@ -144,7 +144,7 @@ FROM (
                 , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                 , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
               FROM (
-                -- Time Spine
+                -- Read From Time Spine 'mf_time_spine'
                 SELECT
                   subq_3.ds AS metric_time__day
                 FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0.sql
@@ -226,7 +226,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
               , DATE_TRUNC('month', subq_3.ds) AS metric_time__month

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_offset_to_grain_metric_multiple_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_offset_to_grain_metric_multiple_granularities__plan0.sql
@@ -133,7 +133,7 @@ FROM (
           , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
           , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
         FROM (
-          -- Time Spine
+          -- Read From Time Spine 'mf_time_spine'
           SELECT
             subq_3.ds AS metric_time__day
             , DATE_TRUNC('month', subq_3.ds) AS metric_time__month

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_offset_to_grain_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_offset_to_grain_with_agg_time_dim__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_8.ds AS booking__ds__day
             FROM ***************************.mf_time_spine subq_8

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_offset_window_metric_filter_and_query_have_different_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_offset_window_metric_filter_and_query_have_different_granularities__plan0.sql
@@ -232,7 +232,7 @@ FROM (
               , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
               , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             FROM (
-              -- Time Spine
+              -- Read From Time Spine 'mf_time_spine'
               SELECT
                 subq_3.ds AS metric_time__day
                 , DATE_TRUNC('month', subq_3.ds) AS metric_time__month

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_offset_window_metric_multiple_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_offset_window_metric_multiple_granularities__plan0.sql
@@ -141,7 +141,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
               , DATE_TRUNC('month', subq_3.ds) AS metric_time__month

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_offset_window_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_offset_window_with_agg_time_dim__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_8.ds AS booking__ds__day
             FROM ***************************.mf_time_spine subq_8

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_time_offset_metric_with_time_constraint__plan0.sql
@@ -224,7 +224,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
@@ -224,7 +224,7 @@ FROM (
             , subq_4.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_4.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_6.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_6
@@ -331,7 +331,7 @@ FROM (
               , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
               , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             FROM (
-              -- Time Spine
+              -- Read From Time Spine 'mf_time_spine'
               SELECT
                 subq_3.ds AS metric_time__day
               FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
@@ -46,7 +46,7 @@ FROM (
           , subq_1.booking_monthly__listing AS booking_monthly__listing
           , subq_1.bookings_monthly AS bookings_monthly
         FROM (
-          -- Time Spine
+          -- Read From Time Spine 'mf_time_spine'
           SELECT
             DATE_TRUNC('month', subq_3.ds) AS metric_time__month
           FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_metric_with_month_dimension_and_offset_window__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_metric_with_month_dimension_and_offset_window__plan0_optimized.sql
@@ -15,7 +15,7 @@ FROM (
     subq_10.metric_time__month AS metric_time__month
     , SUM(monthly_bookings_source_src_16000.bookings_monthly) AS bookings_last_month
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       DATE_TRUNC('month', ds) AS metric_time__month
     FROM ***************************.mf_time_spine subq_11

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_to_grain__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_8.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_8

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_to_grain_and_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_to_grain_and_granularity__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_8.ds AS metric_time__day
               , DATE_TRUNC('week', subq_8.ds) AS metric_time__week

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_window__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_8.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_8

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_window_and_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_window_and_granularity__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_8.ds AS metric_time__day
               , DATE_TRUNC('quarter', subq_8.ds) AS metric_time__quarter

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
@@ -129,7 +129,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_3
@@ -454,7 +454,7 @@ FROM (
             , subq_9.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_9.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_11.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_11

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0.sql
@@ -129,7 +129,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
               , DATE_TRUNC('year', subq_3.ds) AS metric_time__year
@@ -456,7 +456,7 @@ FROM (
             , subq_9.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_9.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_11.ds AS metric_time__day
               , DATE_TRUNC('year', subq_11.ds) AS metric_time__year

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
@@ -548,7 +548,7 @@ FROM (
               , subq_7.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
               , subq_7.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             FROM (
-              -- Time Spine
+              -- Read From Time Spine 'mf_time_spine'
               SELECT
                 subq_9.ds AS metric_time__day
               FROM ***************************.mf_time_spine subq_9

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_offset_cumulative_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_offset_cumulative_metric__plan0.sql
@@ -123,7 +123,7 @@ FROM (
           , subq_4.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
           , subq_4.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
         FROM (
-          -- Time Spine
+          -- Read From Time Spine 'mf_time_spine'
           SELECT
             subq_6.ds AS metric_time__day
           FROM ***************************.mf_time_spine subq_6
@@ -230,7 +230,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_offset_metric_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_offset_metric_with_agg_time_dim__plan0.sql
@@ -129,7 +129,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS booking__ds__day
             FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_offset_metric_with_one_input_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_offset_metric_with_one_input_metric__plan0.sql
@@ -123,7 +123,7 @@ FROM (
           , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
           , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
         FROM (
-          -- Time Spine
+          -- Read From Time Spine 'mf_time_spine'
           SELECT
             subq_3.ds AS metric_time__day
           FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0.sql
@@ -24,7 +24,7 @@ FROM (
         , subq_8.booking__is_instant AS booking__is_instant
         , subq_8.bookings_offset_once AS bookings_offset_once
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine'
         SELECT
           subq_10.ds AS metric_time__day
         FROM ***************************.mf_time_spine subq_10
@@ -155,7 +155,7 @@ FROM (
                   , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                   , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
                 FROM (
-                  -- Time Spine
+                  -- Read From Time Spine 'mf_time_spine'
                   SELECT
                     subq_3.ds AS metric_time__day
                   FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0.sql
@@ -18,7 +18,7 @@ FROM (
       subq_6.metric_time__day AS metric_time__day
       , subq_5.booking_fees_start_of_month AS booking_fees_start_of_month
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         subq_7.ds AS metric_time__day
       FROM ***************************.mf_time_spine subq_7

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_nested_offsets__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_nested_offsets__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_9.metric_time__day AS metric_time__day
     , subq_8.bookings_offset_once AS bookings_offset_once
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       subq_10.ds AS metric_time__day
     FROM ***************************.mf_time_spine subq_10
@@ -139,7 +139,7 @@ FROM (
               , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
               , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             FROM (
-              -- Time Spine
+              -- Read From Time Spine 'mf_time_spine'
               SELECT
                 subq_3.ds AS metric_time__day
               FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_nested_offsets_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_nested_offsets_with_time_constraint__plan0.sql
@@ -17,7 +17,7 @@ FROM (
       subq_9.metric_time__day AS metric_time__day
       , subq_8.bookings_offset_once AS bookings_offset_once
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         subq_10.ds AS metric_time__day
       FROM ***************************.mf_time_spine subq_10
@@ -144,7 +144,7 @@ FROM (
                 , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                 , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
               FROM (
-                -- Time Spine
+                -- Read From Time Spine 'mf_time_spine'
                 SELECT
                   subq_3.ds AS metric_time__day
                 FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_nested_offsets_with_where_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_nested_offsets_with_where_constraint__plan0.sql
@@ -17,7 +17,7 @@ FROM (
       subq_9.metric_time__day AS metric_time__day
       , subq_8.bookings_offset_once AS bookings_offset_once
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         subq_10.ds AS metric_time__day
       FROM ***************************.mf_time_spine subq_10
@@ -144,7 +144,7 @@ FROM (
                 , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                 , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
               FROM (
-                -- Time Spine
+                -- Read From Time Spine 'mf_time_spine'
                 SELECT
                   subq_3.ds AS metric_time__day
                 FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0.sql
@@ -226,7 +226,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
               , DATE_TRUNC('month', subq_3.ds) AS metric_time__month

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_offset_to_grain_metric_multiple_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_offset_to_grain_metric_multiple_granularities__plan0.sql
@@ -133,7 +133,7 @@ FROM (
           , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
           , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
         FROM (
-          -- Time Spine
+          -- Read From Time Spine 'mf_time_spine'
           SELECT
             subq_3.ds AS metric_time__day
             , DATE_TRUNC('month', subq_3.ds) AS metric_time__month

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_offset_to_grain_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_offset_to_grain_with_agg_time_dim__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_8.ds AS booking__ds__day
             FROM ***************************.mf_time_spine subq_8

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_offset_window_metric_filter_and_query_have_different_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_offset_window_metric_filter_and_query_have_different_granularities__plan0.sql
@@ -232,7 +232,7 @@ FROM (
               , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
               , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             FROM (
-              -- Time Spine
+              -- Read From Time Spine 'mf_time_spine'
               SELECT
                 subq_3.ds AS metric_time__day
                 , DATE_TRUNC('month', subq_3.ds) AS metric_time__month

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_offset_window_metric_multiple_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_offset_window_metric_multiple_granularities__plan0.sql
@@ -141,7 +141,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
               , DATE_TRUNC('month', subq_3.ds) AS metric_time__month

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_offset_window_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_offset_window_with_agg_time_dim__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_8.ds AS booking__ds__day
             FROM ***************************.mf_time_spine subq_8

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_time_offset_metric_with_time_constraint__plan0.sql
@@ -224,7 +224,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
@@ -224,7 +224,7 @@ FROM (
             , subq_4.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_4.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_6.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_6
@@ -331,7 +331,7 @@ FROM (
               , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
               , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             FROM (
-              -- Time Spine
+              -- Read From Time Spine 'mf_time_spine'
               SELECT
                 subq_3.ds AS metric_time__day
               FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
@@ -46,7 +46,7 @@ FROM (
           , subq_1.booking_monthly__listing AS booking_monthly__listing
           , subq_1.bookings_monthly AS bookings_monthly
         FROM (
-          -- Time Spine
+          -- Read From Time Spine 'mf_time_spine'
           SELECT
             DATE_TRUNC('month', subq_3.ds) AS metric_time__month
           FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_metric_with_month_dimension_and_offset_window__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_metric_with_month_dimension_and_offset_window__plan0_optimized.sql
@@ -15,7 +15,7 @@ FROM (
     subq_10.metric_time__month AS metric_time__month
     , SUM(monthly_bookings_source_src_16000.bookings_monthly) AS bookings_last_month
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       DATE_TRUNC('month', ds) AS metric_time__month
     FROM ***************************.mf_time_spine subq_11

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_metric_with_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_metric_with_offset_to_grain__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_8.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_8

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_metric_with_offset_to_grain_and_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_metric_with_offset_to_grain_and_granularity__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_8.ds AS metric_time__day
               , DATE_TRUNC('week', subq_8.ds) AS metric_time__week

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_metric_with_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_metric_with_offset_window__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_8.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_8

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_metric_with_offset_window_and_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_metric_with_offset_window_and_granularity__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_8.ds AS metric_time__day
               , DATE_TRUNC('quarter', subq_8.ds) AS metric_time__quarter

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
@@ -129,7 +129,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_3
@@ -454,7 +454,7 @@ FROM (
             , subq_9.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_9.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_11.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_11

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0.sql
@@ -129,7 +129,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
               , DATE_TRUNC('year', subq_3.ds) AS metric_time__year
@@ -456,7 +456,7 @@ FROM (
             , subq_9.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_9.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_11.ds AS metric_time__day
               , DATE_TRUNC('year', subq_11.ds) AS metric_time__year

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
@@ -548,7 +548,7 @@ FROM (
               , subq_7.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
               , subq_7.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             FROM (
-              -- Time Spine
+              -- Read From Time Spine 'mf_time_spine'
               SELECT
                 subq_9.ds AS metric_time__day
               FROM ***************************.mf_time_spine subq_9

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_offset_cumulative_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_offset_cumulative_metric__plan0.sql
@@ -123,7 +123,7 @@ FROM (
           , subq_4.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
           , subq_4.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
         FROM (
-          -- Time Spine
+          -- Read From Time Spine 'mf_time_spine'
           SELECT
             subq_6.ds AS metric_time__day
           FROM ***************************.mf_time_spine subq_6
@@ -230,7 +230,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_offset_metric_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_offset_metric_with_agg_time_dim__plan0.sql
@@ -129,7 +129,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS booking__ds__day
             FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_offset_metric_with_one_input_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_offset_metric_with_one_input_metric__plan0.sql
@@ -123,7 +123,7 @@ FROM (
           , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
           , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
         FROM (
-          -- Time Spine
+          -- Read From Time Spine 'mf_time_spine'
           SELECT
             subq_3.ds AS metric_time__day
           FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0.sql
@@ -24,7 +24,7 @@ FROM (
         , subq_8.booking__is_instant AS booking__is_instant
         , subq_8.bookings_offset_once AS bookings_offset_once
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine'
         SELECT
           subq_10.ds AS metric_time__day
         FROM ***************************.mf_time_spine subq_10
@@ -155,7 +155,7 @@ FROM (
                   , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                   , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
                 FROM (
-                  -- Time Spine
+                  -- Read From Time Spine 'mf_time_spine'
                   SELECT
                     subq_3.ds AS metric_time__day
                   FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0.sql
@@ -18,7 +18,7 @@ FROM (
       subq_6.metric_time__day AS metric_time__day
       , subq_5.booking_fees_start_of_month AS booking_fees_start_of_month
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         subq_7.ds AS metric_time__day
       FROM ***************************.mf_time_spine subq_7

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_nested_offsets__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_nested_offsets__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_9.metric_time__day AS metric_time__day
     , subq_8.bookings_offset_once AS bookings_offset_once
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       subq_10.ds AS metric_time__day
     FROM ***************************.mf_time_spine subq_10
@@ -139,7 +139,7 @@ FROM (
               , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
               , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             FROM (
-              -- Time Spine
+              -- Read From Time Spine 'mf_time_spine'
               SELECT
                 subq_3.ds AS metric_time__day
               FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_nested_offsets_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_nested_offsets_with_time_constraint__plan0.sql
@@ -17,7 +17,7 @@ FROM (
       subq_9.metric_time__day AS metric_time__day
       , subq_8.bookings_offset_once AS bookings_offset_once
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         subq_10.ds AS metric_time__day
       FROM ***************************.mf_time_spine subq_10
@@ -144,7 +144,7 @@ FROM (
                 , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                 , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
               FROM (
-                -- Time Spine
+                -- Read From Time Spine 'mf_time_spine'
                 SELECT
                   subq_3.ds AS metric_time__day
                 FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_nested_offsets_with_where_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_nested_offsets_with_where_constraint__plan0.sql
@@ -17,7 +17,7 @@ FROM (
       subq_9.metric_time__day AS metric_time__day
       , subq_8.bookings_offset_once AS bookings_offset_once
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         subq_10.ds AS metric_time__day
       FROM ***************************.mf_time_spine subq_10
@@ -144,7 +144,7 @@ FROM (
                 , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                 , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
               FROM (
-                -- Time Spine
+                -- Read From Time Spine 'mf_time_spine'
                 SELECT
                   subq_3.ds AS metric_time__day
                 FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0.sql
@@ -226,7 +226,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
               , DATE_TRUNC('month', subq_3.ds) AS metric_time__month

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_offset_to_grain_metric_multiple_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_offset_to_grain_metric_multiple_granularities__plan0.sql
@@ -133,7 +133,7 @@ FROM (
           , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
           , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
         FROM (
-          -- Time Spine
+          -- Read From Time Spine 'mf_time_spine'
           SELECT
             subq_3.ds AS metric_time__day
             , DATE_TRUNC('month', subq_3.ds) AS metric_time__month

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_offset_to_grain_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_offset_to_grain_with_agg_time_dim__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_8.ds AS booking__ds__day
             FROM ***************************.mf_time_spine subq_8

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_offset_window_metric_filter_and_query_have_different_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_offset_window_metric_filter_and_query_have_different_granularities__plan0.sql
@@ -232,7 +232,7 @@ FROM (
               , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
               , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             FROM (
-              -- Time Spine
+              -- Read From Time Spine 'mf_time_spine'
               SELECT
                 subq_3.ds AS metric_time__day
                 , DATE_TRUNC('month', subq_3.ds) AS metric_time__month

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_offset_window_metric_multiple_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_offset_window_metric_multiple_granularities__plan0.sql
@@ -141,7 +141,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
               , DATE_TRUNC('month', subq_3.ds) AS metric_time__month

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_offset_window_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_offset_window_with_agg_time_dim__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_8.ds AS booking__ds__day
             FROM ***************************.mf_time_spine subq_8

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_time_offset_metric_with_time_constraint__plan0.sql
@@ -224,7 +224,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_fill_nulls__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_fill_nulls__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_7.metric_time__day AS metric_time__day
     , subq_6.bookers AS bookers
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       subq_8.ds AS metric_time__day
     FROM ***************************.mf_time_spine subq_8
@@ -129,7 +129,7 @@ FROM (
           , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
           , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
         FROM (
-          -- Time Spine
+          -- Read From Time Spine 'mf_time_spine'
           SELECT
             subq_3.ds AS metric_time__day
           FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/BigQuery/test_derived_fill_nulls_for_one_input_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/BigQuery/test_derived_fill_nulls_for_one_input_metric__plan0.sql
@@ -23,7 +23,7 @@ FROM (
         subq_4.metric_time__day AS metric_time__day
         , subq_3.bookings AS bookings
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine'
         SELECT
           subq_5.ds AS metric_time__day
         FROM ***************************.mf_time_spine subq_5
@@ -358,7 +358,7 @@ FROM (
             , subq_9.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_9.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_11.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_11

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_with_filter_not_in_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_with_filter_not_in_group_by__plan0.sql
@@ -16,7 +16,7 @@ FROM (
     SELECT
       subq_7.metric_time__day
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         subq_6.ds AS metric_time__day
         , DATETIME_TRUNC(subq_6.ds, month) AS metric_time__month

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_with_filter_not_in_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_with_filter_not_in_group_by__plan0_optimized.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     metric_time__day
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       ds AS metric_time__day
       , DATETIME_TRUNC(ds, month) AS metric_time__month

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time__plan0.sql
@@ -16,7 +16,7 @@ FROM (
     SELECT
       subq_7.booking__ds__day
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         subq_6.ds AS booking__ds__day
         , subq_6.ds AS metric_time__day

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time__plan0_optimized.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     booking__ds__day
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       ds AS booking__ds__day
       , ds AS metric_time__day

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time_and_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time_and_metric_time__plan0.sql
@@ -16,7 +16,7 @@ FROM (
     SELECT
       subq_7.metric_time__day
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         subq_6.ds AS metric_time__day
         , DATETIME_TRUNC(subq_6.ds, month) AS booking__ds__month

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time_and_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time_and_metric_time__plan0_optimized.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     metric_time__day
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       ds AS metric_time__day
       , DATETIME_TRUNC(ds, month) AS booking__ds__month

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_with_filter_smaller_than_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_with_filter_smaller_than_group_by__plan0.sql
@@ -16,7 +16,7 @@ FROM (
     SELECT
       subq_7.metric_time__day
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine_hour'
       SELECT
         DATETIME_TRUNC(subq_6.ts, day) AS metric_time__day
         , subq_6.ts AS metric_time__hour

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_with_filter_smaller_than_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_with_filter_smaller_than_group_by__plan0_optimized.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     metric_time__day
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine_hour'
     SELECT
       DATETIME_TRUNC(ts, day) AS metric_time__day
       , ts AS metric_time__hour

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_with_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_with_filters__plan0.sql
@@ -21,7 +21,7 @@ FROM (
       SELECT
         subq_8.metric_time__day
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine'
         SELECT
           subq_7.ds AS metric_time__day
           , DATETIME_TRUNC(subq_7.ds, isoweek) AS metric_time__week

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_with_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_with_filters__plan0_optimized.sql
@@ -17,7 +17,7 @@ FROM (
     SELECT
       metric_time__day
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         ds AS metric_time__day
         , DATETIME_TRUNC(ds, isoweek) AS metric_time__week

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/BigQuery/test_simple_fill_nulls_with_0_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/BigQuery/test_simple_fill_nulls_with_0_metric_time__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_4.metric_time__day AS metric_time__day
     , subq_3.bookings AS bookings
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       subq_5.ds AS metric_time__day
     FROM ***************************.mf_time_spine subq_5

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/BigQuery/test_simple_fill_nulls_with_0_month__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/BigQuery/test_simple_fill_nulls_with_0_month__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_4.metric_time__month AS metric_time__month
     , subq_3.bookings AS bookings
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       DATETIME_TRUNC(subq_5.ds, month) AS metric_time__month
     FROM ***************************.mf_time_spine subq_5

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/BigQuery/test_simple_fill_nulls_with_0_month__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/BigQuery/test_simple_fill_nulls_with_0_month__plan0_optimized.sql
@@ -12,7 +12,7 @@ FROM (
     subq_11.metric_time__month AS metric_time__month
     , subq_10.bookings AS bookings
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       DATETIME_TRUNC(ds, month) AS metric_time__month
     FROM ***************************.mf_time_spine subq_12

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Databricks/test_cumulative_fill_nulls__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Databricks/test_cumulative_fill_nulls__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_7.metric_time__day AS metric_time__day
     , subq_6.bookers AS bookers
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       subq_8.ds AS metric_time__day
     FROM ***************************.mf_time_spine subq_8
@@ -129,7 +129,7 @@ FROM (
           , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
           , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
         FROM (
-          -- Time Spine
+          -- Read From Time Spine 'mf_time_spine'
           SELECT
             subq_3.ds AS metric_time__day
           FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Databricks/test_derived_fill_nulls_for_one_input_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Databricks/test_derived_fill_nulls_for_one_input_metric__plan0.sql
@@ -23,7 +23,7 @@ FROM (
         subq_4.metric_time__day AS metric_time__day
         , subq_3.bookings AS bookings
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine'
         SELECT
           subq_5.ds AS metric_time__day
         FROM ***************************.mf_time_spine subq_5
@@ -358,7 +358,7 @@ FROM (
             , subq_9.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_9.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_11.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_11

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Databricks/test_join_to_time_spine_with_filter_not_in_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Databricks/test_join_to_time_spine_with_filter_not_in_group_by__plan0.sql
@@ -16,7 +16,7 @@ FROM (
     SELECT
       subq_7.metric_time__day
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         subq_6.ds AS metric_time__day
         , DATE_TRUNC('month', subq_6.ds) AS metric_time__month

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Databricks/test_join_to_time_spine_with_filter_not_in_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Databricks/test_join_to_time_spine_with_filter_not_in_group_by__plan0_optimized.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     metric_time__day
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       ds AS metric_time__day
       , DATE_TRUNC('month', ds) AS metric_time__month

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Databricks/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Databricks/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time__plan0.sql
@@ -16,7 +16,7 @@ FROM (
     SELECT
       subq_7.booking__ds__day
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         subq_6.ds AS booking__ds__day
         , subq_6.ds AS metric_time__day

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Databricks/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Databricks/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time__plan0_optimized.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     booking__ds__day
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       ds AS booking__ds__day
       , ds AS metric_time__day

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Databricks/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time_and_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Databricks/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time_and_metric_time__plan0.sql
@@ -16,7 +16,7 @@ FROM (
     SELECT
       subq_7.metric_time__day
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         subq_6.ds AS metric_time__day
         , DATE_TRUNC('month', subq_6.ds) AS booking__ds__month

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Databricks/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time_and_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Databricks/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time_and_metric_time__plan0_optimized.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     metric_time__day
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       ds AS metric_time__day
       , DATE_TRUNC('month', ds) AS booking__ds__month

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Databricks/test_join_to_time_spine_with_filter_smaller_than_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Databricks/test_join_to_time_spine_with_filter_smaller_than_group_by__plan0.sql
@@ -16,7 +16,7 @@ FROM (
     SELECT
       subq_7.metric_time__day
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine_hour'
       SELECT
         DATE_TRUNC('day', subq_6.ts) AS metric_time__day
         , subq_6.ts AS metric_time__hour

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Databricks/test_join_to_time_spine_with_filter_smaller_than_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Databricks/test_join_to_time_spine_with_filter_smaller_than_group_by__plan0_optimized.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     metric_time__day
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine_hour'
     SELECT
       DATE_TRUNC('day', ts) AS metric_time__day
       , ts AS metric_time__hour

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Databricks/test_join_to_time_spine_with_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Databricks/test_join_to_time_spine_with_filters__plan0.sql
@@ -21,7 +21,7 @@ FROM (
       SELECT
         subq_8.metric_time__day
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine'
         SELECT
           subq_7.ds AS metric_time__day
           , DATE_TRUNC('week', subq_7.ds) AS metric_time__week

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Databricks/test_join_to_time_spine_with_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Databricks/test_join_to_time_spine_with_filters__plan0_optimized.sql
@@ -17,7 +17,7 @@ FROM (
     SELECT
       metric_time__day
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         ds AS metric_time__day
         , DATE_TRUNC('week', ds) AS metric_time__week

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Databricks/test_simple_fill_nulls_with_0_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Databricks/test_simple_fill_nulls_with_0_metric_time__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_4.metric_time__day AS metric_time__day
     , subq_3.bookings AS bookings
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       subq_5.ds AS metric_time__day
     FROM ***************************.mf_time_spine subq_5

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Databricks/test_simple_fill_nulls_with_0_month__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Databricks/test_simple_fill_nulls_with_0_month__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_4.metric_time__month AS metric_time__month
     , subq_3.bookings AS bookings
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       DATE_TRUNC('month', subq_5.ds) AS metric_time__month
     FROM ***************************.mf_time_spine subq_5

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Databricks/test_simple_fill_nulls_with_0_month__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Databricks/test_simple_fill_nulls_with_0_month__plan0_optimized.sql
@@ -12,7 +12,7 @@ FROM (
     subq_11.metric_time__month AS metric_time__month
     , subq_10.bookings AS bookings
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       DATE_TRUNC('month', ds) AS metric_time__month
     FROM ***************************.mf_time_spine subq_12

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_fill_nulls__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_fill_nulls__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_7.metric_time__day AS metric_time__day
     , subq_6.bookers AS bookers
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       subq_8.ds AS metric_time__day
     FROM ***************************.mf_time_spine subq_8
@@ -129,7 +129,7 @@ FROM (
           , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
           , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
         FROM (
-          -- Time Spine
+          -- Read From Time Spine 'mf_time_spine'
           SELECT
             subq_3.ds AS metric_time__day
           FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/DuckDB/test_derived_fill_nulls_for_one_input_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/DuckDB/test_derived_fill_nulls_for_one_input_metric__plan0.sql
@@ -23,7 +23,7 @@ FROM (
         subq_4.metric_time__day AS metric_time__day
         , subq_3.bookings AS bookings
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine'
         SELECT
           subq_5.ds AS metric_time__day
         FROM ***************************.mf_time_spine subq_5
@@ -358,7 +358,7 @@ FROM (
             , subq_9.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_9.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_11.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_11

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_with_filter_not_in_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_with_filter_not_in_group_by__plan0.sql
@@ -16,7 +16,7 @@ FROM (
     SELECT
       subq_7.metric_time__day
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         subq_6.ds AS metric_time__day
         , DATE_TRUNC('month', subq_6.ds) AS metric_time__month

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_with_filter_not_in_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_with_filter_not_in_group_by__plan0_optimized.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     metric_time__day
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       ds AS metric_time__day
       , DATE_TRUNC('month', ds) AS metric_time__month

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time__plan0.sql
@@ -16,7 +16,7 @@ FROM (
     SELECT
       subq_7.booking__ds__day
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         subq_6.ds AS booking__ds__day
         , subq_6.ds AS metric_time__day

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time__plan0_optimized.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     booking__ds__day
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       ds AS booking__ds__day
       , ds AS metric_time__day

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time_and_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time_and_metric_time__plan0.sql
@@ -16,7 +16,7 @@ FROM (
     SELECT
       subq_7.metric_time__day
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         subq_6.ds AS metric_time__day
         , DATE_TRUNC('month', subq_6.ds) AS booking__ds__month

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time_and_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time_and_metric_time__plan0_optimized.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     metric_time__day
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       ds AS metric_time__day
       , DATE_TRUNC('month', ds) AS booking__ds__month

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_with_filter_smaller_than_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_with_filter_smaller_than_group_by__plan0.sql
@@ -16,7 +16,7 @@ FROM (
     SELECT
       subq_7.metric_time__day
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine_hour'
       SELECT
         DATE_TRUNC('day', subq_6.ts) AS metric_time__day
         , subq_6.ts AS metric_time__hour

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_with_filter_smaller_than_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_with_filter_smaller_than_group_by__plan0_optimized.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     metric_time__day
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine_hour'
     SELECT
       DATE_TRUNC('day', ts) AS metric_time__day
       , ts AS metric_time__hour

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_with_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_with_filters__plan0.sql
@@ -21,7 +21,7 @@ FROM (
       SELECT
         subq_8.metric_time__day
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine'
         SELECT
           subq_7.ds AS metric_time__day
           , DATE_TRUNC('week', subq_7.ds) AS metric_time__week

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_with_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_with_filters__plan0_optimized.sql
@@ -17,7 +17,7 @@ FROM (
     SELECT
       metric_time__day
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         ds AS metric_time__day
         , DATE_TRUNC('week', ds) AS metric_time__week

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/DuckDB/test_simple_fill_nulls_with_0_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/DuckDB/test_simple_fill_nulls_with_0_metric_time__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_4.metric_time__day AS metric_time__day
     , subq_3.bookings AS bookings
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       subq_5.ds AS metric_time__day
     FROM ***************************.mf_time_spine subq_5

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/DuckDB/test_simple_fill_nulls_with_0_month__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/DuckDB/test_simple_fill_nulls_with_0_month__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_4.metric_time__month AS metric_time__month
     , subq_3.bookings AS bookings
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       DATE_TRUNC('month', subq_5.ds) AS metric_time__month
     FROM ***************************.mf_time_spine subq_5

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/DuckDB/test_simple_fill_nulls_with_0_month__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/DuckDB/test_simple_fill_nulls_with_0_month__plan0_optimized.sql
@@ -12,7 +12,7 @@ FROM (
     subq_11.metric_time__month AS metric_time__month
     , subq_10.bookings AS bookings
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       DATE_TRUNC('month', ds) AS metric_time__month
     FROM ***************************.mf_time_spine subq_12

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Postgres/test_cumulative_fill_nulls__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Postgres/test_cumulative_fill_nulls__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_7.metric_time__day AS metric_time__day
     , subq_6.bookers AS bookers
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       subq_8.ds AS metric_time__day
     FROM ***************************.mf_time_spine subq_8
@@ -129,7 +129,7 @@ FROM (
           , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
           , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
         FROM (
-          -- Time Spine
+          -- Read From Time Spine 'mf_time_spine'
           SELECT
             subq_3.ds AS metric_time__day
           FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Postgres/test_derived_fill_nulls_for_one_input_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Postgres/test_derived_fill_nulls_for_one_input_metric__plan0.sql
@@ -23,7 +23,7 @@ FROM (
         subq_4.metric_time__day AS metric_time__day
         , subq_3.bookings AS bookings
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine'
         SELECT
           subq_5.ds AS metric_time__day
         FROM ***************************.mf_time_spine subq_5
@@ -358,7 +358,7 @@ FROM (
             , subq_9.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_9.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_11.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_11

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Postgres/test_join_to_time_spine_with_filter_not_in_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Postgres/test_join_to_time_spine_with_filter_not_in_group_by__plan0.sql
@@ -16,7 +16,7 @@ FROM (
     SELECT
       subq_7.metric_time__day
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         subq_6.ds AS metric_time__day
         , DATE_TRUNC('month', subq_6.ds) AS metric_time__month

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Postgres/test_join_to_time_spine_with_filter_not_in_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Postgres/test_join_to_time_spine_with_filter_not_in_group_by__plan0_optimized.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     metric_time__day
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       ds AS metric_time__day
       , DATE_TRUNC('month', ds) AS metric_time__month

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Postgres/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Postgres/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time__plan0.sql
@@ -16,7 +16,7 @@ FROM (
     SELECT
       subq_7.booking__ds__day
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         subq_6.ds AS booking__ds__day
         , subq_6.ds AS metric_time__day

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Postgres/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Postgres/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time__plan0_optimized.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     booking__ds__day
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       ds AS booking__ds__day
       , ds AS metric_time__day

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Postgres/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time_and_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Postgres/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time_and_metric_time__plan0.sql
@@ -16,7 +16,7 @@ FROM (
     SELECT
       subq_7.metric_time__day
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         subq_6.ds AS metric_time__day
         , DATE_TRUNC('month', subq_6.ds) AS booking__ds__month

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Postgres/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time_and_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Postgres/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time_and_metric_time__plan0_optimized.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     metric_time__day
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       ds AS metric_time__day
       , DATE_TRUNC('month', ds) AS booking__ds__month

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Postgres/test_join_to_time_spine_with_filter_smaller_than_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Postgres/test_join_to_time_spine_with_filter_smaller_than_group_by__plan0.sql
@@ -16,7 +16,7 @@ FROM (
     SELECT
       subq_7.metric_time__day
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine_hour'
       SELECT
         DATE_TRUNC('day', subq_6.ts) AS metric_time__day
         , subq_6.ts AS metric_time__hour

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Postgres/test_join_to_time_spine_with_filter_smaller_than_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Postgres/test_join_to_time_spine_with_filter_smaller_than_group_by__plan0_optimized.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     metric_time__day
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine_hour'
     SELECT
       DATE_TRUNC('day', ts) AS metric_time__day
       , ts AS metric_time__hour

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Postgres/test_join_to_time_spine_with_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Postgres/test_join_to_time_spine_with_filters__plan0.sql
@@ -21,7 +21,7 @@ FROM (
       SELECT
         subq_8.metric_time__day
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine'
         SELECT
           subq_7.ds AS metric_time__day
           , DATE_TRUNC('week', subq_7.ds) AS metric_time__week

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Postgres/test_join_to_time_spine_with_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Postgres/test_join_to_time_spine_with_filters__plan0_optimized.sql
@@ -17,7 +17,7 @@ FROM (
     SELECT
       metric_time__day
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         ds AS metric_time__day
         , DATE_TRUNC('week', ds) AS metric_time__week

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Postgres/test_simple_fill_nulls_with_0_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Postgres/test_simple_fill_nulls_with_0_metric_time__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_4.metric_time__day AS metric_time__day
     , subq_3.bookings AS bookings
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       subq_5.ds AS metric_time__day
     FROM ***************************.mf_time_spine subq_5

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Postgres/test_simple_fill_nulls_with_0_month__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Postgres/test_simple_fill_nulls_with_0_month__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_4.metric_time__month AS metric_time__month
     , subq_3.bookings AS bookings
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       DATE_TRUNC('month', subq_5.ds) AS metric_time__month
     FROM ***************************.mf_time_spine subq_5

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Postgres/test_simple_fill_nulls_with_0_month__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Postgres/test_simple_fill_nulls_with_0_month__plan0_optimized.sql
@@ -12,7 +12,7 @@ FROM (
     subq_11.metric_time__month AS metric_time__month
     , subq_10.bookings AS bookings
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       DATE_TRUNC('month', ds) AS metric_time__month
     FROM ***************************.mf_time_spine subq_12

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Redshift/test_cumulative_fill_nulls__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Redshift/test_cumulative_fill_nulls__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_7.metric_time__day AS metric_time__day
     , subq_6.bookers AS bookers
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       subq_8.ds AS metric_time__day
     FROM ***************************.mf_time_spine subq_8
@@ -129,7 +129,7 @@ FROM (
           , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
           , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
         FROM (
-          -- Time Spine
+          -- Read From Time Spine 'mf_time_spine'
           SELECT
             subq_3.ds AS metric_time__day
           FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Redshift/test_derived_fill_nulls_for_one_input_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Redshift/test_derived_fill_nulls_for_one_input_metric__plan0.sql
@@ -23,7 +23,7 @@ FROM (
         subq_4.metric_time__day AS metric_time__day
         , subq_3.bookings AS bookings
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine'
         SELECT
           subq_5.ds AS metric_time__day
         FROM ***************************.mf_time_spine subq_5
@@ -358,7 +358,7 @@ FROM (
             , subq_9.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_9.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_11.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_11

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Redshift/test_join_to_time_spine_with_filter_not_in_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Redshift/test_join_to_time_spine_with_filter_not_in_group_by__plan0.sql
@@ -16,7 +16,7 @@ FROM (
     SELECT
       subq_7.metric_time__day
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         subq_6.ds AS metric_time__day
         , DATE_TRUNC('month', subq_6.ds) AS metric_time__month

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Redshift/test_join_to_time_spine_with_filter_not_in_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Redshift/test_join_to_time_spine_with_filter_not_in_group_by__plan0_optimized.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     metric_time__day
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       ds AS metric_time__day
       , DATE_TRUNC('month', ds) AS metric_time__month

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Redshift/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Redshift/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time__plan0.sql
@@ -16,7 +16,7 @@ FROM (
     SELECT
       subq_7.booking__ds__day
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         subq_6.ds AS booking__ds__day
         , subq_6.ds AS metric_time__day

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Redshift/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Redshift/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time__plan0_optimized.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     booking__ds__day
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       ds AS booking__ds__day
       , ds AS metric_time__day

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Redshift/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time_and_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Redshift/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time_and_metric_time__plan0.sql
@@ -16,7 +16,7 @@ FROM (
     SELECT
       subq_7.metric_time__day
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         subq_6.ds AS metric_time__day
         , DATE_TRUNC('month', subq_6.ds) AS booking__ds__month

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Redshift/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time_and_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Redshift/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time_and_metric_time__plan0_optimized.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     metric_time__day
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       ds AS metric_time__day
       , DATE_TRUNC('month', ds) AS booking__ds__month

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Redshift/test_join_to_time_spine_with_filter_smaller_than_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Redshift/test_join_to_time_spine_with_filter_smaller_than_group_by__plan0.sql
@@ -16,7 +16,7 @@ FROM (
     SELECT
       subq_7.metric_time__day
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine_hour'
       SELECT
         DATE_TRUNC('day', subq_6.ts) AS metric_time__day
         , subq_6.ts AS metric_time__hour

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Redshift/test_join_to_time_spine_with_filter_smaller_than_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Redshift/test_join_to_time_spine_with_filter_smaller_than_group_by__plan0_optimized.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     metric_time__day
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine_hour'
     SELECT
       DATE_TRUNC('day', ts) AS metric_time__day
       , ts AS metric_time__hour

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Redshift/test_join_to_time_spine_with_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Redshift/test_join_to_time_spine_with_filters__plan0.sql
@@ -21,7 +21,7 @@ FROM (
       SELECT
         subq_8.metric_time__day
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine'
         SELECT
           subq_7.ds AS metric_time__day
           , DATE_TRUNC('week', subq_7.ds) AS metric_time__week

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Redshift/test_join_to_time_spine_with_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Redshift/test_join_to_time_spine_with_filters__plan0_optimized.sql
@@ -17,7 +17,7 @@ FROM (
     SELECT
       metric_time__day
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         ds AS metric_time__day
         , DATE_TRUNC('week', ds) AS metric_time__week

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Redshift/test_simple_fill_nulls_with_0_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Redshift/test_simple_fill_nulls_with_0_metric_time__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_4.metric_time__day AS metric_time__day
     , subq_3.bookings AS bookings
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       subq_5.ds AS metric_time__day
     FROM ***************************.mf_time_spine subq_5

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Redshift/test_simple_fill_nulls_with_0_month__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Redshift/test_simple_fill_nulls_with_0_month__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_4.metric_time__month AS metric_time__month
     , subq_3.bookings AS bookings
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       DATE_TRUNC('month', subq_5.ds) AS metric_time__month
     FROM ***************************.mf_time_spine subq_5

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Redshift/test_simple_fill_nulls_with_0_month__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Redshift/test_simple_fill_nulls_with_0_month__plan0_optimized.sql
@@ -12,7 +12,7 @@ FROM (
     subq_11.metric_time__month AS metric_time__month
     , subq_10.bookings AS bookings
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       DATE_TRUNC('month', ds) AS metric_time__month
     FROM ***************************.mf_time_spine subq_12

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_fill_nulls__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_fill_nulls__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_7.metric_time__day AS metric_time__day
     , subq_6.bookers AS bookers
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       subq_8.ds AS metric_time__day
     FROM ***************************.mf_time_spine subq_8
@@ -129,7 +129,7 @@ FROM (
           , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
           , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
         FROM (
-          -- Time Spine
+          -- Read From Time Spine 'mf_time_spine'
           SELECT
             subq_3.ds AS metric_time__day
           FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Snowflake/test_derived_fill_nulls_for_one_input_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Snowflake/test_derived_fill_nulls_for_one_input_metric__plan0.sql
@@ -23,7 +23,7 @@ FROM (
         subq_4.metric_time__day AS metric_time__day
         , subq_3.bookings AS bookings
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine'
         SELECT
           subq_5.ds AS metric_time__day
         FROM ***************************.mf_time_spine subq_5
@@ -358,7 +358,7 @@ FROM (
             , subq_9.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_9.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_11.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_11

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_with_filter_not_in_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_with_filter_not_in_group_by__plan0.sql
@@ -16,7 +16,7 @@ FROM (
     SELECT
       subq_7.metric_time__day
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         subq_6.ds AS metric_time__day
         , DATE_TRUNC('month', subq_6.ds) AS metric_time__month

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_with_filter_not_in_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_with_filter_not_in_group_by__plan0_optimized.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     metric_time__day
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       ds AS metric_time__day
       , DATE_TRUNC('month', ds) AS metric_time__month

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time__plan0.sql
@@ -16,7 +16,7 @@ FROM (
     SELECT
       subq_7.booking__ds__day
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         subq_6.ds AS booking__ds__day
         , subq_6.ds AS metric_time__day

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time__plan0_optimized.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     booking__ds__day
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       ds AS booking__ds__day
       , ds AS metric_time__day

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time_and_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time_and_metric_time__plan0.sql
@@ -16,7 +16,7 @@ FROM (
     SELECT
       subq_7.metric_time__day
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         subq_6.ds AS metric_time__day
         , DATE_TRUNC('month', subq_6.ds) AS booking__ds__month

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time_and_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time_and_metric_time__plan0_optimized.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     metric_time__day
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       ds AS metric_time__day
       , DATE_TRUNC('month', ds) AS booking__ds__month

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_with_filter_smaller_than_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_with_filter_smaller_than_group_by__plan0.sql
@@ -16,7 +16,7 @@ FROM (
     SELECT
       subq_7.metric_time__day
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine_hour'
       SELECT
         DATE_TRUNC('day', subq_6.ts) AS metric_time__day
         , subq_6.ts AS metric_time__hour

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_with_filter_smaller_than_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_with_filter_smaller_than_group_by__plan0_optimized.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     metric_time__day
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine_hour'
     SELECT
       DATE_TRUNC('day', ts) AS metric_time__day
       , ts AS metric_time__hour

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_with_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_with_filters__plan0.sql
@@ -21,7 +21,7 @@ FROM (
       SELECT
         subq_8.metric_time__day
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine'
         SELECT
           subq_7.ds AS metric_time__day
           , DATE_TRUNC('week', subq_7.ds) AS metric_time__week

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_with_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_with_filters__plan0_optimized.sql
@@ -17,7 +17,7 @@ FROM (
     SELECT
       metric_time__day
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         ds AS metric_time__day
         , DATE_TRUNC('week', ds) AS metric_time__week

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Snowflake/test_simple_fill_nulls_with_0_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Snowflake/test_simple_fill_nulls_with_0_metric_time__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_4.metric_time__day AS metric_time__day
     , subq_3.bookings AS bookings
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       subq_5.ds AS metric_time__day
     FROM ***************************.mf_time_spine subq_5

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Snowflake/test_simple_fill_nulls_with_0_month__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Snowflake/test_simple_fill_nulls_with_0_month__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_4.metric_time__month AS metric_time__month
     , subq_3.bookings AS bookings
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       DATE_TRUNC('month', subq_5.ds) AS metric_time__month
     FROM ***************************.mf_time_spine subq_5

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Snowflake/test_simple_fill_nulls_with_0_month__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Snowflake/test_simple_fill_nulls_with_0_month__plan0_optimized.sql
@@ -12,7 +12,7 @@ FROM (
     subq_11.metric_time__month AS metric_time__month
     , subq_10.bookings AS bookings
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       DATE_TRUNC('month', ds) AS metric_time__month
     FROM ***************************.mf_time_spine subq_12

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Trino/test_cumulative_fill_nulls__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Trino/test_cumulative_fill_nulls__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_7.metric_time__day AS metric_time__day
     , subq_6.bookers AS bookers
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       subq_8.ds AS metric_time__day
     FROM ***************************.mf_time_spine subq_8
@@ -129,7 +129,7 @@ FROM (
           , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
           , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
         FROM (
-          -- Time Spine
+          -- Read From Time Spine 'mf_time_spine'
           SELECT
             subq_3.ds AS metric_time__day
           FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Trino/test_derived_fill_nulls_for_one_input_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Trino/test_derived_fill_nulls_for_one_input_metric__plan0.sql
@@ -23,7 +23,7 @@ FROM (
         subq_4.metric_time__day AS metric_time__day
         , subq_3.bookings AS bookings
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine'
         SELECT
           subq_5.ds AS metric_time__day
         FROM ***************************.mf_time_spine subq_5
@@ -358,7 +358,7 @@ FROM (
             , subq_9.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_9.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_11.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_11

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Trino/test_join_to_time_spine_with_filter_not_in_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Trino/test_join_to_time_spine_with_filter_not_in_group_by__plan0.sql
@@ -16,7 +16,7 @@ FROM (
     SELECT
       subq_7.metric_time__day
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         subq_6.ds AS metric_time__day
         , DATE_TRUNC('month', subq_6.ds) AS metric_time__month

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Trino/test_join_to_time_spine_with_filter_not_in_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Trino/test_join_to_time_spine_with_filter_not_in_group_by__plan0_optimized.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     metric_time__day
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       ds AS metric_time__day
       , DATE_TRUNC('month', ds) AS metric_time__month

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Trino/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Trino/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time__plan0.sql
@@ -16,7 +16,7 @@ FROM (
     SELECT
       subq_7.booking__ds__day
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         subq_6.ds AS booking__ds__day
         , subq_6.ds AS metric_time__day

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Trino/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Trino/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time__plan0_optimized.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     booking__ds__day
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       ds AS booking__ds__day
       , ds AS metric_time__day

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Trino/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time_and_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Trino/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time_and_metric_time__plan0.sql
@@ -16,7 +16,7 @@ FROM (
     SELECT
       subq_7.metric_time__day
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         subq_6.ds AS metric_time__day
         , DATE_TRUNC('month', subq_6.ds) AS booking__ds__month

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Trino/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time_and_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Trino/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time_and_metric_time__plan0_optimized.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     metric_time__day
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       ds AS metric_time__day
       , DATE_TRUNC('month', ds) AS booking__ds__month

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Trino/test_join_to_time_spine_with_filter_smaller_than_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Trino/test_join_to_time_spine_with_filter_smaller_than_group_by__plan0.sql
@@ -16,7 +16,7 @@ FROM (
     SELECT
       subq_7.metric_time__day
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine_hour'
       SELECT
         DATE_TRUNC('day', subq_6.ts) AS metric_time__day
         , subq_6.ts AS metric_time__hour

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Trino/test_join_to_time_spine_with_filter_smaller_than_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Trino/test_join_to_time_spine_with_filter_smaller_than_group_by__plan0_optimized.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     metric_time__day
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine_hour'
     SELECT
       DATE_TRUNC('day', ts) AS metric_time__day
       , ts AS metric_time__hour

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Trino/test_join_to_time_spine_with_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Trino/test_join_to_time_spine_with_filters__plan0.sql
@@ -21,7 +21,7 @@ FROM (
       SELECT
         subq_8.metric_time__day
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine'
         SELECT
           subq_7.ds AS metric_time__day
           , DATE_TRUNC('week', subq_7.ds) AS metric_time__week

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Trino/test_join_to_time_spine_with_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Trino/test_join_to_time_spine_with_filters__plan0_optimized.sql
@@ -17,7 +17,7 @@ FROM (
     SELECT
       metric_time__day
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         ds AS metric_time__day
         , DATE_TRUNC('week', ds) AS metric_time__week

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Trino/test_simple_fill_nulls_with_0_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Trino/test_simple_fill_nulls_with_0_metric_time__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_4.metric_time__day AS metric_time__day
     , subq_3.bookings AS bookings
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       subq_5.ds AS metric_time__day
     FROM ***************************.mf_time_spine subq_5

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Trino/test_simple_fill_nulls_with_0_month__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Trino/test_simple_fill_nulls_with_0_month__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_4.metric_time__month AS metric_time__month
     , subq_3.bookings AS bookings
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       DATE_TRUNC('month', subq_5.ds) AS metric_time__month
     FROM ***************************.mf_time_spine subq_5

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Trino/test_simple_fill_nulls_with_0_month__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Trino/test_simple_fill_nulls_with_0_month__plan0_optimized.sql
@@ -12,7 +12,7 @@ FROM (
     subq_11.metric_time__month AS metric_time__month
     , subq_10.bookings AS bookings
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       DATE_TRUNC('month', ds) AS metric_time__month
     FROM ***************************.mf_time_spine subq_12

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/BigQuery/test_offset_window_with_date_part__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/BigQuery/test_offset_window_with_date_part__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_8.ds AS metric_time__day
               , IF(EXTRACT(dayofweek FROM subq_8.ds) = 1, 7, EXTRACT(dayofweek FROM subq_8.ds) - 1) AS metric_time__extract_dow

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/BigQuery/test_sub_daily_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/BigQuery/test_sub_daily_metric_time__plan0.sql
@@ -39,7 +39,7 @@ FROM (
     , subq_0.ts__extract_dow AS metric_time__extract_dow
     , subq_0.ts__extract_doy AS metric_time__extract_doy
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine_millisecond'
     SELECT
       DATETIME_TRUNC(time_spine_src_28002.ts, millisecond) AS ts__millisecond
       , DATETIME_TRUNC(time_spine_src_28002.ts, second) AS ts__second

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/BigQuery/test_sub_daily_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/BigQuery/test_sub_daily_metric_time__plan0_optimized.sql
@@ -2,7 +2,7 @@ test_name: test_sub_daily_metric_time
 test_filename: test_granularity_date_part_rendering.py
 sql_engine: BigQuery
 ---
--- Time Spine
+-- Read From Time Spine 'mf_time_spine_millisecond'
 -- Metric Time Dimension 'ts'
 -- Pass Only Elements: ['metric_time__millisecond',]
 SELECT

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/BigQuery/test_subdaily_cumulative_grain_to_date_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/BigQuery/test_subdaily_cumulative_grain_to_date_metric__plan0.sql
@@ -210,7 +210,7 @@ FROM (
         , subq_1.user__home_state AS user__home_state
         , subq_1.archived_users AS archived_users
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine_hour'
         SELECT
           subq_3.ts AS metric_time__hour
         FROM ***************************.mf_time_spine_hour subq_3

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/BigQuery/test_subdaily_cumulative_window_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/BigQuery/test_subdaily_cumulative_window_metric__plan0.sql
@@ -210,7 +210,7 @@ FROM (
         , subq_1.user__home_state AS user__home_state
         , subq_1.archived_users AS archived_users
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine_hour'
         SELECT
           subq_3.ts AS metric_time__hour
         FROM ***************************.mf_time_spine_hour subq_3

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/BigQuery/test_subdaily_granularity_overrides_metric_default_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/BigQuery/test_subdaily_granularity_overrides_metric_default_granularity__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_4.metric_time__hour AS metric_time__hour
     , subq_3.archived_users AS archived_users
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine_hour'
     SELECT
       subq_5.ts AS metric_time__hour
     FROM ***************************.mf_time_spine_hour subq_5

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/BigQuery/test_subdaily_join_to_time_spine_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/BigQuery/test_subdaily_join_to_time_spine_metric__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_4.metric_time__hour AS metric_time__hour
     , subq_3.archived_users AS archived_users
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine_hour'
     SELECT
       subq_5.ts AS metric_time__hour
     FROM ***************************.mf_time_spine_hour subq_5

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/BigQuery/test_subdaily_offset_to_grain_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/BigQuery/test_subdaily_offset_to_grain_metric__plan0.sql
@@ -215,7 +215,7 @@ FROM (
           , subq_1.user__home_state AS user__home_state
           , subq_1.archived_users AS archived_users
         FROM (
-          -- Time Spine
+          -- Read From Time Spine 'mf_time_spine_hour'
           SELECT
             subq_3.ts AS metric_time__hour
           FROM ***************************.mf_time_spine_hour subq_3

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/BigQuery/test_subdaily_offset_window_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/BigQuery/test_subdaily_offset_window_metric__plan0.sql
@@ -215,7 +215,7 @@ FROM (
           , subq_1.user__home_state AS user__home_state
           , subq_1.archived_users AS archived_users
         FROM (
-          -- Time Spine
+          -- Read From Time Spine 'mf_time_spine_hour'
           SELECT
             subq_3.ts AS metric_time__hour
           FROM ***************************.mf_time_spine_hour subq_3

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/BigQuery/test_subdaily_time_constraint_with_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/BigQuery/test_subdaily_time_constraint_with_metric__plan0.sql
@@ -17,7 +17,7 @@ FROM (
       subq_5.metric_time__hour AS metric_time__hour
       , subq_4.archived_users AS archived_users
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine_hour'
       SELECT
         subq_6.ts AS metric_time__hour
       FROM ***************************.mf_time_spine_hour subq_6

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/BigQuery/test_subdaily_time_constraint_with_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/BigQuery/test_subdaily_time_constraint_with_metric__plan0_optimized.sql
@@ -9,7 +9,7 @@ SELECT
   subq_14.metric_time__hour AS metric_time__hour
   , subq_13.archived_users AS subdaily_join_to_time_spine_metric
 FROM (
-  -- Time Spine
+  -- Read From Time Spine 'mf_time_spine_hour'
   SELECT
     ts AS metric_time__hour
   FROM ***************************.mf_time_spine_hour subq_15

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/BigQuery/test_subdaily_time_constraint_without_metrics__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/BigQuery/test_subdaily_time_constraint_without_metrics__plan0.sql
@@ -68,7 +68,7 @@ FROM (
       , subq_0.ts__extract_dow AS metric_time__extract_dow
       , subq_0.ts__extract_doy AS metric_time__extract_doy
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine_second'
       SELECT
         DATETIME_TRUNC(time_spine_src_28003.ts, second) AS ts__second
         , DATETIME_TRUNC(time_spine_src_28003.ts, minute) AS ts__minute

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/BigQuery/test_subdaily_time_constraint_without_metrics__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/BigQuery/test_subdaily_time_constraint_without_metrics__plan0_optimized.sql
@@ -2,7 +2,7 @@ test_name: test_subdaily_time_constraint_without_metrics
 test_filename: test_granularity_date_part_rendering.py
 sql_engine: BigQuery
 ---
--- Time Spine
+-- Read From Time Spine 'mf_time_spine_second'
 -- Metric Time Dimension 'ts'
 -- Constrain Time Range to [2020-01-01T00:00:02, 2020-01-01T00:00:08]
 -- Pass Only Elements: ['metric_time__second',]

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Databricks/test_offset_window_with_date_part__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Databricks/test_offset_window_with_date_part__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_8.ds AS metric_time__day
               , EXTRACT(DAYOFWEEK_ISO FROM subq_8.ds) AS metric_time__extract_dow

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Databricks/test_sub_daily_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Databricks/test_sub_daily_metric_time__plan0.sql
@@ -39,7 +39,7 @@ FROM (
     , subq_0.ts__extract_dow AS metric_time__extract_dow
     , subq_0.ts__extract_doy AS metric_time__extract_doy
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine_millisecond'
     SELECT
       DATE_TRUNC('millisecond', time_spine_src_28002.ts) AS ts__millisecond
       , DATE_TRUNC('second', time_spine_src_28002.ts) AS ts__second

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Databricks/test_sub_daily_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Databricks/test_sub_daily_metric_time__plan0_optimized.sql
@@ -2,7 +2,7 @@ test_name: test_sub_daily_metric_time
 test_filename: test_granularity_date_part_rendering.py
 sql_engine: Databricks
 ---
--- Time Spine
+-- Read From Time Spine 'mf_time_spine_millisecond'
 -- Metric Time Dimension 'ts'
 -- Pass Only Elements: ['metric_time__millisecond',]
 SELECT

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Databricks/test_subdaily_cumulative_grain_to_date_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Databricks/test_subdaily_cumulative_grain_to_date_metric__plan0.sql
@@ -210,7 +210,7 @@ FROM (
         , subq_1.user__home_state AS user__home_state
         , subq_1.archived_users AS archived_users
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine_hour'
         SELECT
           subq_3.ts AS metric_time__hour
         FROM ***************************.mf_time_spine_hour subq_3

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Databricks/test_subdaily_cumulative_window_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Databricks/test_subdaily_cumulative_window_metric__plan0.sql
@@ -210,7 +210,7 @@ FROM (
         , subq_1.user__home_state AS user__home_state
         , subq_1.archived_users AS archived_users
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine_hour'
         SELECT
           subq_3.ts AS metric_time__hour
         FROM ***************************.mf_time_spine_hour subq_3

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Databricks/test_subdaily_granularity_overrides_metric_default_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Databricks/test_subdaily_granularity_overrides_metric_default_granularity__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_4.metric_time__hour AS metric_time__hour
     , subq_3.archived_users AS archived_users
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine_hour'
     SELECT
       subq_5.ts AS metric_time__hour
     FROM ***************************.mf_time_spine_hour subq_5

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Databricks/test_subdaily_join_to_time_spine_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Databricks/test_subdaily_join_to_time_spine_metric__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_4.metric_time__hour AS metric_time__hour
     , subq_3.archived_users AS archived_users
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine_hour'
     SELECT
       subq_5.ts AS metric_time__hour
     FROM ***************************.mf_time_spine_hour subq_5

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Databricks/test_subdaily_offset_to_grain_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Databricks/test_subdaily_offset_to_grain_metric__plan0.sql
@@ -215,7 +215,7 @@ FROM (
           , subq_1.user__home_state AS user__home_state
           , subq_1.archived_users AS archived_users
         FROM (
-          -- Time Spine
+          -- Read From Time Spine 'mf_time_spine_hour'
           SELECT
             subq_3.ts AS metric_time__hour
           FROM ***************************.mf_time_spine_hour subq_3

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Databricks/test_subdaily_offset_window_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Databricks/test_subdaily_offset_window_metric__plan0.sql
@@ -215,7 +215,7 @@ FROM (
           , subq_1.user__home_state AS user__home_state
           , subq_1.archived_users AS archived_users
         FROM (
-          -- Time Spine
+          -- Read From Time Spine 'mf_time_spine_hour'
           SELECT
             subq_3.ts AS metric_time__hour
           FROM ***************************.mf_time_spine_hour subq_3

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Databricks/test_subdaily_time_constraint_with_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Databricks/test_subdaily_time_constraint_with_metric__plan0.sql
@@ -17,7 +17,7 @@ FROM (
       subq_5.metric_time__hour AS metric_time__hour
       , subq_4.archived_users AS archived_users
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine_hour'
       SELECT
         subq_6.ts AS metric_time__hour
       FROM ***************************.mf_time_spine_hour subq_6

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Databricks/test_subdaily_time_constraint_with_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Databricks/test_subdaily_time_constraint_with_metric__plan0_optimized.sql
@@ -9,7 +9,7 @@ SELECT
   subq_14.metric_time__hour AS metric_time__hour
   , subq_13.archived_users AS subdaily_join_to_time_spine_metric
 FROM (
-  -- Time Spine
+  -- Read From Time Spine 'mf_time_spine_hour'
   SELECT
     ts AS metric_time__hour
   FROM ***************************.mf_time_spine_hour subq_15

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Databricks/test_subdaily_time_constraint_without_metrics__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Databricks/test_subdaily_time_constraint_without_metrics__plan0.sql
@@ -68,7 +68,7 @@ FROM (
       , subq_0.ts__extract_dow AS metric_time__extract_dow
       , subq_0.ts__extract_doy AS metric_time__extract_doy
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine_second'
       SELECT
         DATE_TRUNC('second', time_spine_src_28003.ts) AS ts__second
         , DATE_TRUNC('minute', time_spine_src_28003.ts) AS ts__minute

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Databricks/test_subdaily_time_constraint_without_metrics__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Databricks/test_subdaily_time_constraint_without_metrics__plan0_optimized.sql
@@ -2,7 +2,7 @@ test_name: test_subdaily_time_constraint_without_metrics
 test_filename: test_granularity_date_part_rendering.py
 sql_engine: Databricks
 ---
--- Time Spine
+-- Read From Time Spine 'mf_time_spine_second'
 -- Metric Time Dimension 'ts'
 -- Constrain Time Range to [2020-01-01T00:00:02, 2020-01-01T00:00:08]
 -- Pass Only Elements: ['metric_time__second',]

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/DuckDB/test_offset_window_with_date_part__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/DuckDB/test_offset_window_with_date_part__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_8.ds AS metric_time__day
               , EXTRACT(isodow FROM subq_8.ds) AS metric_time__extract_dow

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/DuckDB/test_sub_daily_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/DuckDB/test_sub_daily_metric_time__plan0.sql
@@ -39,7 +39,7 @@ FROM (
     , subq_0.ts__extract_dow AS metric_time__extract_dow
     , subq_0.ts__extract_doy AS metric_time__extract_doy
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine_millisecond'
     SELECT
       DATE_TRUNC('millisecond', time_spine_src_28002.ts) AS ts__millisecond
       , DATE_TRUNC('second', time_spine_src_28002.ts) AS ts__second

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/DuckDB/test_sub_daily_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/DuckDB/test_sub_daily_metric_time__plan0_optimized.sql
@@ -2,7 +2,7 @@ test_name: test_sub_daily_metric_time
 test_filename: test_granularity_date_part_rendering.py
 sql_engine: DuckDB
 ---
--- Time Spine
+-- Read From Time Spine 'mf_time_spine_millisecond'
 -- Metric Time Dimension 'ts'
 -- Pass Only Elements: ['metric_time__millisecond',]
 SELECT

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/DuckDB/test_subdaily_cumulative_grain_to_date_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/DuckDB/test_subdaily_cumulative_grain_to_date_metric__plan0.sql
@@ -210,7 +210,7 @@ FROM (
         , subq_1.user__home_state AS user__home_state
         , subq_1.archived_users AS archived_users
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine_hour'
         SELECT
           subq_3.ts AS metric_time__hour
         FROM ***************************.mf_time_spine_hour subq_3

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/DuckDB/test_subdaily_cumulative_window_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/DuckDB/test_subdaily_cumulative_window_metric__plan0.sql
@@ -210,7 +210,7 @@ FROM (
         , subq_1.user__home_state AS user__home_state
         , subq_1.archived_users AS archived_users
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine_hour'
         SELECT
           subq_3.ts AS metric_time__hour
         FROM ***************************.mf_time_spine_hour subq_3

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/DuckDB/test_subdaily_granularity_overrides_metric_default_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/DuckDB/test_subdaily_granularity_overrides_metric_default_granularity__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_4.metric_time__hour AS metric_time__hour
     , subq_3.archived_users AS archived_users
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine_hour'
     SELECT
       subq_5.ts AS metric_time__hour
     FROM ***************************.mf_time_spine_hour subq_5

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/DuckDB/test_subdaily_join_to_time_spine_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/DuckDB/test_subdaily_join_to_time_spine_metric__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_4.metric_time__hour AS metric_time__hour
     , subq_3.archived_users AS archived_users
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine_hour'
     SELECT
       subq_5.ts AS metric_time__hour
     FROM ***************************.mf_time_spine_hour subq_5

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/DuckDB/test_subdaily_offset_to_grain_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/DuckDB/test_subdaily_offset_to_grain_metric__plan0.sql
@@ -215,7 +215,7 @@ FROM (
           , subq_1.user__home_state AS user__home_state
           , subq_1.archived_users AS archived_users
         FROM (
-          -- Time Spine
+          -- Read From Time Spine 'mf_time_spine_hour'
           SELECT
             subq_3.ts AS metric_time__hour
           FROM ***************************.mf_time_spine_hour subq_3

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/DuckDB/test_subdaily_offset_window_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/DuckDB/test_subdaily_offset_window_metric__plan0.sql
@@ -215,7 +215,7 @@ FROM (
           , subq_1.user__home_state AS user__home_state
           , subq_1.archived_users AS archived_users
         FROM (
-          -- Time Spine
+          -- Read From Time Spine 'mf_time_spine_hour'
           SELECT
             subq_3.ts AS metric_time__hour
           FROM ***************************.mf_time_spine_hour subq_3

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/DuckDB/test_subdaily_time_constraint_with_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/DuckDB/test_subdaily_time_constraint_with_metric__plan0.sql
@@ -17,7 +17,7 @@ FROM (
       subq_5.metric_time__hour AS metric_time__hour
       , subq_4.archived_users AS archived_users
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine_hour'
       SELECT
         subq_6.ts AS metric_time__hour
       FROM ***************************.mf_time_spine_hour subq_6

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/DuckDB/test_subdaily_time_constraint_with_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/DuckDB/test_subdaily_time_constraint_with_metric__plan0_optimized.sql
@@ -9,7 +9,7 @@ SELECT
   subq_14.metric_time__hour AS metric_time__hour
   , subq_13.archived_users AS subdaily_join_to_time_spine_metric
 FROM (
-  -- Time Spine
+  -- Read From Time Spine 'mf_time_spine_hour'
   SELECT
     ts AS metric_time__hour
   FROM ***************************.mf_time_spine_hour subq_15

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/DuckDB/test_subdaily_time_constraint_without_metrics__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/DuckDB/test_subdaily_time_constraint_without_metrics__plan0.sql
@@ -68,7 +68,7 @@ FROM (
       , subq_0.ts__extract_dow AS metric_time__extract_dow
       , subq_0.ts__extract_doy AS metric_time__extract_doy
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine_second'
       SELECT
         DATE_TRUNC('second', time_spine_src_28003.ts) AS ts__second
         , DATE_TRUNC('minute', time_spine_src_28003.ts) AS ts__minute

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/DuckDB/test_subdaily_time_constraint_without_metrics__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/DuckDB/test_subdaily_time_constraint_without_metrics__plan0_optimized.sql
@@ -2,7 +2,7 @@ test_name: test_subdaily_time_constraint_without_metrics
 test_filename: test_granularity_date_part_rendering.py
 sql_engine: DuckDB
 ---
--- Time Spine
+-- Read From Time Spine 'mf_time_spine_second'
 -- Metric Time Dimension 'ts'
 -- Constrain Time Range to [2020-01-01T00:00:02, 2020-01-01T00:00:08]
 -- Pass Only Elements: ['metric_time__second',]

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Postgres/test_offset_window_with_date_part__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Postgres/test_offset_window_with_date_part__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_8.ds AS metric_time__day
               , EXTRACT(isodow FROM subq_8.ds) AS metric_time__extract_dow

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Postgres/test_sub_daily_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Postgres/test_sub_daily_metric_time__plan0.sql
@@ -39,7 +39,7 @@ FROM (
     , subq_0.ts__extract_dow AS metric_time__extract_dow
     , subq_0.ts__extract_doy AS metric_time__extract_doy
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine_millisecond'
     SELECT
       DATE_TRUNC('millisecond', time_spine_src_28002.ts) AS ts__millisecond
       , DATE_TRUNC('second', time_spine_src_28002.ts) AS ts__second

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Postgres/test_sub_daily_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Postgres/test_sub_daily_metric_time__plan0_optimized.sql
@@ -2,7 +2,7 @@ test_name: test_sub_daily_metric_time
 test_filename: test_granularity_date_part_rendering.py
 sql_engine: Postgres
 ---
--- Time Spine
+-- Read From Time Spine 'mf_time_spine_millisecond'
 -- Metric Time Dimension 'ts'
 -- Pass Only Elements: ['metric_time__millisecond',]
 SELECT

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Postgres/test_subdaily_cumulative_grain_to_date_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Postgres/test_subdaily_cumulative_grain_to_date_metric__plan0.sql
@@ -210,7 +210,7 @@ FROM (
         , subq_1.user__home_state AS user__home_state
         , subq_1.archived_users AS archived_users
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine_hour'
         SELECT
           subq_3.ts AS metric_time__hour
         FROM ***************************.mf_time_spine_hour subq_3

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Postgres/test_subdaily_cumulative_window_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Postgres/test_subdaily_cumulative_window_metric__plan0.sql
@@ -210,7 +210,7 @@ FROM (
         , subq_1.user__home_state AS user__home_state
         , subq_1.archived_users AS archived_users
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine_hour'
         SELECT
           subq_3.ts AS metric_time__hour
         FROM ***************************.mf_time_spine_hour subq_3

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Postgres/test_subdaily_granularity_overrides_metric_default_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Postgres/test_subdaily_granularity_overrides_metric_default_granularity__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_4.metric_time__hour AS metric_time__hour
     , subq_3.archived_users AS archived_users
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine_hour'
     SELECT
       subq_5.ts AS metric_time__hour
     FROM ***************************.mf_time_spine_hour subq_5

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Postgres/test_subdaily_join_to_time_spine_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Postgres/test_subdaily_join_to_time_spine_metric__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_4.metric_time__hour AS metric_time__hour
     , subq_3.archived_users AS archived_users
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine_hour'
     SELECT
       subq_5.ts AS metric_time__hour
     FROM ***************************.mf_time_spine_hour subq_5

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Postgres/test_subdaily_offset_to_grain_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Postgres/test_subdaily_offset_to_grain_metric__plan0.sql
@@ -215,7 +215,7 @@ FROM (
           , subq_1.user__home_state AS user__home_state
           , subq_1.archived_users AS archived_users
         FROM (
-          -- Time Spine
+          -- Read From Time Spine 'mf_time_spine_hour'
           SELECT
             subq_3.ts AS metric_time__hour
           FROM ***************************.mf_time_spine_hour subq_3

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Postgres/test_subdaily_offset_window_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Postgres/test_subdaily_offset_window_metric__plan0.sql
@@ -215,7 +215,7 @@ FROM (
           , subq_1.user__home_state AS user__home_state
           , subq_1.archived_users AS archived_users
         FROM (
-          -- Time Spine
+          -- Read From Time Spine 'mf_time_spine_hour'
           SELECT
             subq_3.ts AS metric_time__hour
           FROM ***************************.mf_time_spine_hour subq_3

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Postgres/test_subdaily_time_constraint_with_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Postgres/test_subdaily_time_constraint_with_metric__plan0.sql
@@ -17,7 +17,7 @@ FROM (
       subq_5.metric_time__hour AS metric_time__hour
       , subq_4.archived_users AS archived_users
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine_hour'
       SELECT
         subq_6.ts AS metric_time__hour
       FROM ***************************.mf_time_spine_hour subq_6

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Postgres/test_subdaily_time_constraint_with_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Postgres/test_subdaily_time_constraint_with_metric__plan0_optimized.sql
@@ -9,7 +9,7 @@ SELECT
   subq_14.metric_time__hour AS metric_time__hour
   , subq_13.archived_users AS subdaily_join_to_time_spine_metric
 FROM (
-  -- Time Spine
+  -- Read From Time Spine 'mf_time_spine_hour'
   SELECT
     ts AS metric_time__hour
   FROM ***************************.mf_time_spine_hour subq_15

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Postgres/test_subdaily_time_constraint_without_metrics__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Postgres/test_subdaily_time_constraint_without_metrics__plan0.sql
@@ -68,7 +68,7 @@ FROM (
       , subq_0.ts__extract_dow AS metric_time__extract_dow
       , subq_0.ts__extract_doy AS metric_time__extract_doy
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine_second'
       SELECT
         DATE_TRUNC('second', time_spine_src_28003.ts) AS ts__second
         , DATE_TRUNC('minute', time_spine_src_28003.ts) AS ts__minute

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Postgres/test_subdaily_time_constraint_without_metrics__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Postgres/test_subdaily_time_constraint_without_metrics__plan0_optimized.sql
@@ -2,7 +2,7 @@ test_name: test_subdaily_time_constraint_without_metrics
 test_filename: test_granularity_date_part_rendering.py
 sql_engine: Postgres
 ---
--- Time Spine
+-- Read From Time Spine 'mf_time_spine_second'
 -- Metric Time Dimension 'ts'
 -- Constrain Time Range to [2020-01-01T00:00:02, 2020-01-01T00:00:08]
 -- Pass Only Elements: ['metric_time__second',]

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Redshift/test_offset_window_with_date_part__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Redshift/test_offset_window_with_date_part__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_8.ds AS metric_time__day
               , CASE WHEN EXTRACT(dow FROM subq_8.ds) = 0 THEN EXTRACT(dow FROM subq_8.ds) + 7 ELSE EXTRACT(dow FROM subq_8.ds) END AS metric_time__extract_dow

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Redshift/test_sub_daily_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Redshift/test_sub_daily_metric_time__plan0.sql
@@ -39,7 +39,7 @@ FROM (
     , subq_0.ts__extract_dow AS metric_time__extract_dow
     , subq_0.ts__extract_doy AS metric_time__extract_doy
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine_millisecond'
     SELECT
       DATE_TRUNC('millisecond', time_spine_src_28002.ts) AS ts__millisecond
       , DATE_TRUNC('second', time_spine_src_28002.ts) AS ts__second

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Redshift/test_sub_daily_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Redshift/test_sub_daily_metric_time__plan0_optimized.sql
@@ -2,7 +2,7 @@ test_name: test_sub_daily_metric_time
 test_filename: test_granularity_date_part_rendering.py
 sql_engine: Redshift
 ---
--- Time Spine
+-- Read From Time Spine 'mf_time_spine_millisecond'
 -- Metric Time Dimension 'ts'
 -- Pass Only Elements: ['metric_time__millisecond',]
 SELECT

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Redshift/test_subdaily_cumulative_grain_to_date_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Redshift/test_subdaily_cumulative_grain_to_date_metric__plan0.sql
@@ -210,7 +210,7 @@ FROM (
         , subq_1.user__home_state AS user__home_state
         , subq_1.archived_users AS archived_users
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine_hour'
         SELECT
           subq_3.ts AS metric_time__hour
         FROM ***************************.mf_time_spine_hour subq_3

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Redshift/test_subdaily_cumulative_window_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Redshift/test_subdaily_cumulative_window_metric__plan0.sql
@@ -210,7 +210,7 @@ FROM (
         , subq_1.user__home_state AS user__home_state
         , subq_1.archived_users AS archived_users
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine_hour'
         SELECT
           subq_3.ts AS metric_time__hour
         FROM ***************************.mf_time_spine_hour subq_3

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Redshift/test_subdaily_granularity_overrides_metric_default_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Redshift/test_subdaily_granularity_overrides_metric_default_granularity__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_4.metric_time__hour AS metric_time__hour
     , subq_3.archived_users AS archived_users
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine_hour'
     SELECT
       subq_5.ts AS metric_time__hour
     FROM ***************************.mf_time_spine_hour subq_5

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Redshift/test_subdaily_join_to_time_spine_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Redshift/test_subdaily_join_to_time_spine_metric__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_4.metric_time__hour AS metric_time__hour
     , subq_3.archived_users AS archived_users
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine_hour'
     SELECT
       subq_5.ts AS metric_time__hour
     FROM ***************************.mf_time_spine_hour subq_5

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Redshift/test_subdaily_offset_to_grain_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Redshift/test_subdaily_offset_to_grain_metric__plan0.sql
@@ -215,7 +215,7 @@ FROM (
           , subq_1.user__home_state AS user__home_state
           , subq_1.archived_users AS archived_users
         FROM (
-          -- Time Spine
+          -- Read From Time Spine 'mf_time_spine_hour'
           SELECT
             subq_3.ts AS metric_time__hour
           FROM ***************************.mf_time_spine_hour subq_3

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Redshift/test_subdaily_offset_window_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Redshift/test_subdaily_offset_window_metric__plan0.sql
@@ -215,7 +215,7 @@ FROM (
           , subq_1.user__home_state AS user__home_state
           , subq_1.archived_users AS archived_users
         FROM (
-          -- Time Spine
+          -- Read From Time Spine 'mf_time_spine_hour'
           SELECT
             subq_3.ts AS metric_time__hour
           FROM ***************************.mf_time_spine_hour subq_3

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Redshift/test_subdaily_time_constraint_with_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Redshift/test_subdaily_time_constraint_with_metric__plan0.sql
@@ -17,7 +17,7 @@ FROM (
       subq_5.metric_time__hour AS metric_time__hour
       , subq_4.archived_users AS archived_users
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine_hour'
       SELECT
         subq_6.ts AS metric_time__hour
       FROM ***************************.mf_time_spine_hour subq_6

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Redshift/test_subdaily_time_constraint_with_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Redshift/test_subdaily_time_constraint_with_metric__plan0_optimized.sql
@@ -9,7 +9,7 @@ SELECT
   subq_14.metric_time__hour AS metric_time__hour
   , subq_13.archived_users AS subdaily_join_to_time_spine_metric
 FROM (
-  -- Time Spine
+  -- Read From Time Spine 'mf_time_spine_hour'
   SELECT
     ts AS metric_time__hour
   FROM ***************************.mf_time_spine_hour subq_15

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Redshift/test_subdaily_time_constraint_without_metrics__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Redshift/test_subdaily_time_constraint_without_metrics__plan0.sql
@@ -68,7 +68,7 @@ FROM (
       , subq_0.ts__extract_dow AS metric_time__extract_dow
       , subq_0.ts__extract_doy AS metric_time__extract_doy
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine_second'
       SELECT
         DATE_TRUNC('second', time_spine_src_28003.ts) AS ts__second
         , DATE_TRUNC('minute', time_spine_src_28003.ts) AS ts__minute

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Redshift/test_subdaily_time_constraint_without_metrics__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Redshift/test_subdaily_time_constraint_without_metrics__plan0_optimized.sql
@@ -2,7 +2,7 @@ test_name: test_subdaily_time_constraint_without_metrics
 test_filename: test_granularity_date_part_rendering.py
 sql_engine: Redshift
 ---
--- Time Spine
+-- Read From Time Spine 'mf_time_spine_second'
 -- Metric Time Dimension 'ts'
 -- Constrain Time Range to [2020-01-01T00:00:02, 2020-01-01T00:00:08]
 -- Pass Only Elements: ['metric_time__second',]

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Snowflake/test_offset_window_with_date_part__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Snowflake/test_offset_window_with_date_part__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_8.ds AS metric_time__day
               , EXTRACT(dayofweekiso FROM subq_8.ds) AS metric_time__extract_dow

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Snowflake/test_sub_daily_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Snowflake/test_sub_daily_metric_time__plan0.sql
@@ -39,7 +39,7 @@ FROM (
     , subq_0.ts__extract_dow AS metric_time__extract_dow
     , subq_0.ts__extract_doy AS metric_time__extract_doy
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine_millisecond'
     SELECT
       DATE_TRUNC('millisecond', time_spine_src_28002.ts) AS ts__millisecond
       , DATE_TRUNC('second', time_spine_src_28002.ts) AS ts__second

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Snowflake/test_sub_daily_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Snowflake/test_sub_daily_metric_time__plan0_optimized.sql
@@ -2,7 +2,7 @@ test_name: test_sub_daily_metric_time
 test_filename: test_granularity_date_part_rendering.py
 sql_engine: Snowflake
 ---
--- Time Spine
+-- Read From Time Spine 'mf_time_spine_millisecond'
 -- Metric Time Dimension 'ts'
 -- Pass Only Elements: ['metric_time__millisecond',]
 SELECT

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Snowflake/test_subdaily_cumulative_grain_to_date_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Snowflake/test_subdaily_cumulative_grain_to_date_metric__plan0.sql
@@ -210,7 +210,7 @@ FROM (
         , subq_1.user__home_state AS user__home_state
         , subq_1.archived_users AS archived_users
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine_hour'
         SELECT
           subq_3.ts AS metric_time__hour
         FROM ***************************.mf_time_spine_hour subq_3

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Snowflake/test_subdaily_cumulative_window_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Snowflake/test_subdaily_cumulative_window_metric__plan0.sql
@@ -210,7 +210,7 @@ FROM (
         , subq_1.user__home_state AS user__home_state
         , subq_1.archived_users AS archived_users
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine_hour'
         SELECT
           subq_3.ts AS metric_time__hour
         FROM ***************************.mf_time_spine_hour subq_3

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Snowflake/test_subdaily_granularity_overrides_metric_default_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Snowflake/test_subdaily_granularity_overrides_metric_default_granularity__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_4.metric_time__hour AS metric_time__hour
     , subq_3.archived_users AS archived_users
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine_hour'
     SELECT
       subq_5.ts AS metric_time__hour
     FROM ***************************.mf_time_spine_hour subq_5

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Snowflake/test_subdaily_join_to_time_spine_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Snowflake/test_subdaily_join_to_time_spine_metric__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_4.metric_time__hour AS metric_time__hour
     , subq_3.archived_users AS archived_users
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine_hour'
     SELECT
       subq_5.ts AS metric_time__hour
     FROM ***************************.mf_time_spine_hour subq_5

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Snowflake/test_subdaily_offset_to_grain_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Snowflake/test_subdaily_offset_to_grain_metric__plan0.sql
@@ -215,7 +215,7 @@ FROM (
           , subq_1.user__home_state AS user__home_state
           , subq_1.archived_users AS archived_users
         FROM (
-          -- Time Spine
+          -- Read From Time Spine 'mf_time_spine_hour'
           SELECT
             subq_3.ts AS metric_time__hour
           FROM ***************************.mf_time_spine_hour subq_3

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Snowflake/test_subdaily_offset_window_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Snowflake/test_subdaily_offset_window_metric__plan0.sql
@@ -215,7 +215,7 @@ FROM (
           , subq_1.user__home_state AS user__home_state
           , subq_1.archived_users AS archived_users
         FROM (
-          -- Time Spine
+          -- Read From Time Spine 'mf_time_spine_hour'
           SELECT
             subq_3.ts AS metric_time__hour
           FROM ***************************.mf_time_spine_hour subq_3

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Snowflake/test_subdaily_time_constraint_with_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Snowflake/test_subdaily_time_constraint_with_metric__plan0.sql
@@ -17,7 +17,7 @@ FROM (
       subq_5.metric_time__hour AS metric_time__hour
       , subq_4.archived_users AS archived_users
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine_hour'
       SELECT
         subq_6.ts AS metric_time__hour
       FROM ***************************.mf_time_spine_hour subq_6

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Snowflake/test_subdaily_time_constraint_with_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Snowflake/test_subdaily_time_constraint_with_metric__plan0_optimized.sql
@@ -9,7 +9,7 @@ SELECT
   subq_14.metric_time__hour AS metric_time__hour
   , subq_13.archived_users AS subdaily_join_to_time_spine_metric
 FROM (
-  -- Time Spine
+  -- Read From Time Spine 'mf_time_spine_hour'
   SELECT
     ts AS metric_time__hour
   FROM ***************************.mf_time_spine_hour subq_15

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Snowflake/test_subdaily_time_constraint_without_metrics__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Snowflake/test_subdaily_time_constraint_without_metrics__plan0.sql
@@ -68,7 +68,7 @@ FROM (
       , subq_0.ts__extract_dow AS metric_time__extract_dow
       , subq_0.ts__extract_doy AS metric_time__extract_doy
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine_second'
       SELECT
         DATE_TRUNC('second', time_spine_src_28003.ts) AS ts__second
         , DATE_TRUNC('minute', time_spine_src_28003.ts) AS ts__minute

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Snowflake/test_subdaily_time_constraint_without_metrics__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Snowflake/test_subdaily_time_constraint_without_metrics__plan0_optimized.sql
@@ -2,7 +2,7 @@ test_name: test_subdaily_time_constraint_without_metrics
 test_filename: test_granularity_date_part_rendering.py
 sql_engine: Snowflake
 ---
--- Time Spine
+-- Read From Time Spine 'mf_time_spine_second'
 -- Metric Time Dimension 'ts'
 -- Constrain Time Range to [2020-01-01T00:00:02, 2020-01-01T00:00:08]
 -- Pass Only Elements: ['metric_time__second',]

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Trino/test_offset_window_with_date_part__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Trino/test_offset_window_with_date_part__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_8.ds AS metric_time__day
               , EXTRACT(DAY_OF_WEEK FROM subq_8.ds) AS metric_time__extract_dow

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Trino/test_sub_daily_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Trino/test_sub_daily_metric_time__plan0.sql
@@ -39,7 +39,7 @@ FROM (
     , subq_0.ts__extract_dow AS metric_time__extract_dow
     , subq_0.ts__extract_doy AS metric_time__extract_doy
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine_millisecond'
     SELECT
       DATE_TRUNC('millisecond', time_spine_src_28002.ts) AS ts__millisecond
       , DATE_TRUNC('second', time_spine_src_28002.ts) AS ts__second

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Trino/test_sub_daily_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Trino/test_sub_daily_metric_time__plan0_optimized.sql
@@ -2,7 +2,7 @@ test_name: test_sub_daily_metric_time
 test_filename: test_granularity_date_part_rendering.py
 sql_engine: Trino
 ---
--- Time Spine
+-- Read From Time Spine 'mf_time_spine_millisecond'
 -- Metric Time Dimension 'ts'
 -- Pass Only Elements: ['metric_time__millisecond',]
 SELECT

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Trino/test_subdaily_cumulative_grain_to_date_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Trino/test_subdaily_cumulative_grain_to_date_metric__plan0.sql
@@ -210,7 +210,7 @@ FROM (
         , subq_1.user__home_state AS user__home_state
         , subq_1.archived_users AS archived_users
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine_hour'
         SELECT
           subq_3.ts AS metric_time__hour
         FROM ***************************.mf_time_spine_hour subq_3

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Trino/test_subdaily_cumulative_window_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Trino/test_subdaily_cumulative_window_metric__plan0.sql
@@ -210,7 +210,7 @@ FROM (
         , subq_1.user__home_state AS user__home_state
         , subq_1.archived_users AS archived_users
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine_hour'
         SELECT
           subq_3.ts AS metric_time__hour
         FROM ***************************.mf_time_spine_hour subq_3

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Trino/test_subdaily_granularity_overrides_metric_default_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Trino/test_subdaily_granularity_overrides_metric_default_granularity__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_4.metric_time__hour AS metric_time__hour
     , subq_3.archived_users AS archived_users
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine_hour'
     SELECT
       subq_5.ts AS metric_time__hour
     FROM ***************************.mf_time_spine_hour subq_5

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Trino/test_subdaily_join_to_time_spine_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Trino/test_subdaily_join_to_time_spine_metric__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_4.metric_time__hour AS metric_time__hour
     , subq_3.archived_users AS archived_users
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine_hour'
     SELECT
       subq_5.ts AS metric_time__hour
     FROM ***************************.mf_time_spine_hour subq_5

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Trino/test_subdaily_offset_to_grain_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Trino/test_subdaily_offset_to_grain_metric__plan0.sql
@@ -215,7 +215,7 @@ FROM (
           , subq_1.user__home_state AS user__home_state
           , subq_1.archived_users AS archived_users
         FROM (
-          -- Time Spine
+          -- Read From Time Spine 'mf_time_spine_hour'
           SELECT
             subq_3.ts AS metric_time__hour
           FROM ***************************.mf_time_spine_hour subq_3

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Trino/test_subdaily_offset_window_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Trino/test_subdaily_offset_window_metric__plan0.sql
@@ -215,7 +215,7 @@ FROM (
           , subq_1.user__home_state AS user__home_state
           , subq_1.archived_users AS archived_users
         FROM (
-          -- Time Spine
+          -- Read From Time Spine 'mf_time_spine_hour'
           SELECT
             subq_3.ts AS metric_time__hour
           FROM ***************************.mf_time_spine_hour subq_3

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Trino/test_subdaily_time_constraint_with_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Trino/test_subdaily_time_constraint_with_metric__plan0.sql
@@ -17,7 +17,7 @@ FROM (
       subq_5.metric_time__hour AS metric_time__hour
       , subq_4.archived_users AS archived_users
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine_hour'
       SELECT
         subq_6.ts AS metric_time__hour
       FROM ***************************.mf_time_spine_hour subq_6

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Trino/test_subdaily_time_constraint_with_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Trino/test_subdaily_time_constraint_with_metric__plan0_optimized.sql
@@ -9,7 +9,7 @@ SELECT
   subq_14.metric_time__hour AS metric_time__hour
   , subq_13.archived_users AS subdaily_join_to_time_spine_metric
 FROM (
-  -- Time Spine
+  -- Read From Time Spine 'mf_time_spine_hour'
   SELECT
     ts AS metric_time__hour
   FROM ***************************.mf_time_spine_hour subq_15

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Trino/test_subdaily_time_constraint_without_metrics__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Trino/test_subdaily_time_constraint_without_metrics__plan0.sql
@@ -68,7 +68,7 @@ FROM (
       , subq_0.ts__extract_dow AS metric_time__extract_dow
       , subq_0.ts__extract_doy AS metric_time__extract_doy
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine_second'
       SELECT
         DATE_TRUNC('second', time_spine_src_28003.ts) AS ts__second
         , DATE_TRUNC('minute', time_spine_src_28003.ts) AS ts__minute

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Trino/test_subdaily_time_constraint_without_metrics__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Trino/test_subdaily_time_constraint_without_metrics__plan0_optimized.sql
@@ -2,7 +2,7 @@ test_name: test_subdaily_time_constraint_without_metrics
 test_filename: test_granularity_date_part_rendering.py
 sql_engine: Trino
 ---
--- Time Spine
+-- Read From Time Spine 'mf_time_spine_second'
 -- Metric Time Dimension 'ts'
 -- Constrain Time Range to [2020-01-01T00:00:02, 2020-01-01T00:00:08]
 -- Pass Only Elements: ['metric_time__second',]

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/BigQuery/test_dimensions_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/BigQuery/test_dimensions_with_time_constraint__plan0.sql
@@ -222,7 +222,7 @@ FROM (
           , subq_1.ds__extract_doy AS metric_time__extract_doy
           , subq_1.ds__martian_day AS metric_time__martian_day
         FROM (
-          -- Time Spine
+          -- Read From Time Spine 'mf_time_spine'
           SELECT
             DATETIME_TRUNC(time_spine_src_28006.ds, day) AS ds__day
             , DATETIME_TRUNC(time_spine_src_28006.ds, isoweek) AS ds__week

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/BigQuery/test_metric_time_only__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/BigQuery/test_metric_time_only__plan0.sql
@@ -35,7 +35,7 @@ FROM (
     , subq_0.ds__extract_doy AS metric_time__extract_doy
     , subq_0.ds__martian_day AS metric_time__martian_day
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       DATETIME_TRUNC(time_spine_src_28006.ds, day) AS ds__day
       , DATETIME_TRUNC(time_spine_src_28006.ds, isoweek) AS ds__week

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/BigQuery/test_metric_time_only__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/BigQuery/test_metric_time_only__plan0_optimized.sql
@@ -4,7 +4,7 @@ docstring:
   Tests querying only metric time.
 sql_engine: BigQuery
 ---
--- Time Spine
+-- Read From Time Spine 'mf_time_spine'
 -- Metric Time Dimension 'ds'
 -- Pass Only Elements: ['metric_time__day',]
 SELECT

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/BigQuery/test_metric_time_quarter_alone__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/BigQuery/test_metric_time_quarter_alone__plan0.sql
@@ -33,7 +33,7 @@ FROM (
     , subq_0.ds__extract_doy AS metric_time__extract_doy
     , subq_0.ds__martian_day AS metric_time__martian_day
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       DATETIME_TRUNC(time_spine_src_28006.ds, day) AS ds__day
       , DATETIME_TRUNC(time_spine_src_28006.ds, isoweek) AS ds__week

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/BigQuery/test_metric_time_quarter_alone__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/BigQuery/test_metric_time_quarter_alone__plan0_optimized.sql
@@ -2,7 +2,7 @@ test_name: test_metric_time_quarter_alone
 test_filename: test_metric_time_without_metrics.py
 sql_engine: BigQuery
 ---
--- Time Spine
+-- Read From Time Spine 'mf_time_spine'
 -- Metric Time Dimension 'ds'
 -- Pass Only Elements: ['metric_time__quarter',]
 SELECT

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/BigQuery/test_metric_time_with_other_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/BigQuery/test_metric_time_with_other_dimensions__plan0.sql
@@ -161,7 +161,7 @@ FROM (
         , subq_1.ds__extract_doy AS metric_time__extract_doy
         , subq_1.ds__martian_day AS metric_time__martian_day
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine'
         SELECT
           DATETIME_TRUNC(time_spine_src_28006.ds, day) AS ds__day
           , DATETIME_TRUNC(time_spine_src_28006.ds, isoweek) AS ds__week

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Databricks/test_dimensions_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Databricks/test_dimensions_with_time_constraint__plan0.sql
@@ -222,7 +222,7 @@ FROM (
           , subq_1.ds__extract_doy AS metric_time__extract_doy
           , subq_1.ds__martian_day AS metric_time__martian_day
         FROM (
-          -- Time Spine
+          -- Read From Time Spine 'mf_time_spine'
           SELECT
             DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
             , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Databricks/test_metric_time_only__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Databricks/test_metric_time_only__plan0.sql
@@ -35,7 +35,7 @@ FROM (
     , subq_0.ds__extract_doy AS metric_time__extract_doy
     , subq_0.ds__martian_day AS metric_time__martian_day
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
       , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Databricks/test_metric_time_only__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Databricks/test_metric_time_only__plan0_optimized.sql
@@ -4,7 +4,7 @@ docstring:
   Tests querying only metric time.
 sql_engine: Databricks
 ---
--- Time Spine
+-- Read From Time Spine 'mf_time_spine'
 -- Metric Time Dimension 'ds'
 -- Pass Only Elements: ['metric_time__day',]
 SELECT

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Databricks/test_metric_time_quarter_alone__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Databricks/test_metric_time_quarter_alone__plan0.sql
@@ -33,7 +33,7 @@ FROM (
     , subq_0.ds__extract_doy AS metric_time__extract_doy
     , subq_0.ds__martian_day AS metric_time__martian_day
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
       , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Databricks/test_metric_time_quarter_alone__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Databricks/test_metric_time_quarter_alone__plan0_optimized.sql
@@ -2,7 +2,7 @@ test_name: test_metric_time_quarter_alone
 test_filename: test_metric_time_without_metrics.py
 sql_engine: Databricks
 ---
--- Time Spine
+-- Read From Time Spine 'mf_time_spine'
 -- Metric Time Dimension 'ds'
 -- Pass Only Elements: ['metric_time__quarter',]
 SELECT

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Databricks/test_metric_time_with_other_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Databricks/test_metric_time_with_other_dimensions__plan0.sql
@@ -161,7 +161,7 @@ FROM (
         , subq_1.ds__extract_doy AS metric_time__extract_doy
         , subq_1.ds__martian_day AS metric_time__martian_day
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine'
         SELECT
           DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
           , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/DuckDB/test_dimensions_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/DuckDB/test_dimensions_with_time_constraint__plan0.sql
@@ -222,7 +222,7 @@ FROM (
           , subq_1.ds__extract_doy AS metric_time__extract_doy
           , subq_1.ds__martian_day AS metric_time__martian_day
         FROM (
-          -- Time Spine
+          -- Read From Time Spine 'mf_time_spine'
           SELECT
             DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
             , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/DuckDB/test_metric_time_only__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/DuckDB/test_metric_time_only__plan0.sql
@@ -35,7 +35,7 @@ FROM (
     , subq_0.ds__extract_doy AS metric_time__extract_doy
     , subq_0.ds__martian_day AS metric_time__martian_day
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
       , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/DuckDB/test_metric_time_only__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/DuckDB/test_metric_time_only__plan0_optimized.sql
@@ -4,7 +4,7 @@ docstring:
   Tests querying only metric time.
 sql_engine: DuckDB
 ---
--- Time Spine
+-- Read From Time Spine 'mf_time_spine'
 -- Metric Time Dimension 'ds'
 -- Pass Only Elements: ['metric_time__day',]
 SELECT

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/DuckDB/test_metric_time_quarter_alone__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/DuckDB/test_metric_time_quarter_alone__plan0.sql
@@ -33,7 +33,7 @@ FROM (
     , subq_0.ds__extract_doy AS metric_time__extract_doy
     , subq_0.ds__martian_day AS metric_time__martian_day
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
       , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/DuckDB/test_metric_time_quarter_alone__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/DuckDB/test_metric_time_quarter_alone__plan0_optimized.sql
@@ -2,7 +2,7 @@ test_name: test_metric_time_quarter_alone
 test_filename: test_metric_time_without_metrics.py
 sql_engine: DuckDB
 ---
--- Time Spine
+-- Read From Time Spine 'mf_time_spine'
 -- Metric Time Dimension 'ds'
 -- Pass Only Elements: ['metric_time__quarter',]
 SELECT

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/DuckDB/test_metric_time_with_other_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/DuckDB/test_metric_time_with_other_dimensions__plan0.sql
@@ -161,7 +161,7 @@ FROM (
         , subq_1.ds__extract_doy AS metric_time__extract_doy
         , subq_1.ds__martian_day AS metric_time__martian_day
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine'
         SELECT
           DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
           , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Postgres/test_dimensions_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Postgres/test_dimensions_with_time_constraint__plan0.sql
@@ -222,7 +222,7 @@ FROM (
           , subq_1.ds__extract_doy AS metric_time__extract_doy
           , subq_1.ds__martian_day AS metric_time__martian_day
         FROM (
-          -- Time Spine
+          -- Read From Time Spine 'mf_time_spine'
           SELECT
             DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
             , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Postgres/test_metric_time_only__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Postgres/test_metric_time_only__plan0.sql
@@ -35,7 +35,7 @@ FROM (
     , subq_0.ds__extract_doy AS metric_time__extract_doy
     , subq_0.ds__martian_day AS metric_time__martian_day
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
       , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Postgres/test_metric_time_only__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Postgres/test_metric_time_only__plan0_optimized.sql
@@ -4,7 +4,7 @@ docstring:
   Tests querying only metric time.
 sql_engine: Postgres
 ---
--- Time Spine
+-- Read From Time Spine 'mf_time_spine'
 -- Metric Time Dimension 'ds'
 -- Pass Only Elements: ['metric_time__day',]
 SELECT

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Postgres/test_metric_time_quarter_alone__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Postgres/test_metric_time_quarter_alone__plan0.sql
@@ -33,7 +33,7 @@ FROM (
     , subq_0.ds__extract_doy AS metric_time__extract_doy
     , subq_0.ds__martian_day AS metric_time__martian_day
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
       , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Postgres/test_metric_time_quarter_alone__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Postgres/test_metric_time_quarter_alone__plan0_optimized.sql
@@ -2,7 +2,7 @@ test_name: test_metric_time_quarter_alone
 test_filename: test_metric_time_without_metrics.py
 sql_engine: Postgres
 ---
--- Time Spine
+-- Read From Time Spine 'mf_time_spine'
 -- Metric Time Dimension 'ds'
 -- Pass Only Elements: ['metric_time__quarter',]
 SELECT

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Postgres/test_metric_time_with_other_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Postgres/test_metric_time_with_other_dimensions__plan0.sql
@@ -161,7 +161,7 @@ FROM (
         , subq_1.ds__extract_doy AS metric_time__extract_doy
         , subq_1.ds__martian_day AS metric_time__martian_day
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine'
         SELECT
           DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
           , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Redshift/test_dimensions_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Redshift/test_dimensions_with_time_constraint__plan0.sql
@@ -222,7 +222,7 @@ FROM (
           , subq_1.ds__extract_doy AS metric_time__extract_doy
           , subq_1.ds__martian_day AS metric_time__martian_day
         FROM (
-          -- Time Spine
+          -- Read From Time Spine 'mf_time_spine'
           SELECT
             DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
             , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Redshift/test_metric_time_only__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Redshift/test_metric_time_only__plan0.sql
@@ -35,7 +35,7 @@ FROM (
     , subq_0.ds__extract_doy AS metric_time__extract_doy
     , subq_0.ds__martian_day AS metric_time__martian_day
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
       , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Redshift/test_metric_time_only__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Redshift/test_metric_time_only__plan0_optimized.sql
@@ -4,7 +4,7 @@ docstring:
   Tests querying only metric time.
 sql_engine: Redshift
 ---
--- Time Spine
+-- Read From Time Spine 'mf_time_spine'
 -- Metric Time Dimension 'ds'
 -- Pass Only Elements: ['metric_time__day',]
 SELECT

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Redshift/test_metric_time_quarter_alone__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Redshift/test_metric_time_quarter_alone__plan0.sql
@@ -33,7 +33,7 @@ FROM (
     , subq_0.ds__extract_doy AS metric_time__extract_doy
     , subq_0.ds__martian_day AS metric_time__martian_day
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
       , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Redshift/test_metric_time_quarter_alone__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Redshift/test_metric_time_quarter_alone__plan0_optimized.sql
@@ -2,7 +2,7 @@ test_name: test_metric_time_quarter_alone
 test_filename: test_metric_time_without_metrics.py
 sql_engine: Redshift
 ---
--- Time Spine
+-- Read From Time Spine 'mf_time_spine'
 -- Metric Time Dimension 'ds'
 -- Pass Only Elements: ['metric_time__quarter',]
 SELECT

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Redshift/test_metric_time_with_other_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Redshift/test_metric_time_with_other_dimensions__plan0.sql
@@ -161,7 +161,7 @@ FROM (
         , subq_1.ds__extract_doy AS metric_time__extract_doy
         , subq_1.ds__martian_day AS metric_time__martian_day
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine'
         SELECT
           DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
           , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Snowflake/test_dimensions_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Snowflake/test_dimensions_with_time_constraint__plan0.sql
@@ -222,7 +222,7 @@ FROM (
           , subq_1.ds__extract_doy AS metric_time__extract_doy
           , subq_1.ds__martian_day AS metric_time__martian_day
         FROM (
-          -- Time Spine
+          -- Read From Time Spine 'mf_time_spine'
           SELECT
             DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
             , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Snowflake/test_metric_time_only__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Snowflake/test_metric_time_only__plan0.sql
@@ -35,7 +35,7 @@ FROM (
     , subq_0.ds__extract_doy AS metric_time__extract_doy
     , subq_0.ds__martian_day AS metric_time__martian_day
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
       , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Snowflake/test_metric_time_only__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Snowflake/test_metric_time_only__plan0_optimized.sql
@@ -4,7 +4,7 @@ docstring:
   Tests querying only metric time.
 sql_engine: Snowflake
 ---
--- Time Spine
+-- Read From Time Spine 'mf_time_spine'
 -- Metric Time Dimension 'ds'
 -- Pass Only Elements: ['metric_time__day',]
 SELECT

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Snowflake/test_metric_time_quarter_alone__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Snowflake/test_metric_time_quarter_alone__plan0.sql
@@ -33,7 +33,7 @@ FROM (
     , subq_0.ds__extract_doy AS metric_time__extract_doy
     , subq_0.ds__martian_day AS metric_time__martian_day
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
       , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Snowflake/test_metric_time_quarter_alone__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Snowflake/test_metric_time_quarter_alone__plan0_optimized.sql
@@ -2,7 +2,7 @@ test_name: test_metric_time_quarter_alone
 test_filename: test_metric_time_without_metrics.py
 sql_engine: Snowflake
 ---
--- Time Spine
+-- Read From Time Spine 'mf_time_spine'
 -- Metric Time Dimension 'ds'
 -- Pass Only Elements: ['metric_time__quarter',]
 SELECT

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Snowflake/test_metric_time_with_other_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Snowflake/test_metric_time_with_other_dimensions__plan0.sql
@@ -161,7 +161,7 @@ FROM (
         , subq_1.ds__extract_doy AS metric_time__extract_doy
         , subq_1.ds__martian_day AS metric_time__martian_day
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine'
         SELECT
           DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
           , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Trino/test_dimensions_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Trino/test_dimensions_with_time_constraint__plan0.sql
@@ -222,7 +222,7 @@ FROM (
           , subq_1.ds__extract_doy AS metric_time__extract_doy
           , subq_1.ds__martian_day AS metric_time__martian_day
         FROM (
-          -- Time Spine
+          -- Read From Time Spine 'mf_time_spine'
           SELECT
             DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
             , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Trino/test_metric_time_only__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Trino/test_metric_time_only__plan0.sql
@@ -35,7 +35,7 @@ FROM (
     , subq_0.ds__extract_doy AS metric_time__extract_doy
     , subq_0.ds__martian_day AS metric_time__martian_day
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
       , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Trino/test_metric_time_only__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Trino/test_metric_time_only__plan0_optimized.sql
@@ -4,7 +4,7 @@ docstring:
   Tests querying only metric time.
 sql_engine: Trino
 ---
--- Time Spine
+-- Read From Time Spine 'mf_time_spine'
 -- Metric Time Dimension 'ds'
 -- Pass Only Elements: ['metric_time__day',]
 SELECT

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Trino/test_metric_time_quarter_alone__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Trino/test_metric_time_quarter_alone__plan0.sql
@@ -33,7 +33,7 @@ FROM (
     , subq_0.ds__extract_doy AS metric_time__extract_doy
     , subq_0.ds__martian_day AS metric_time__martian_day
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
       , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Trino/test_metric_time_quarter_alone__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Trino/test_metric_time_quarter_alone__plan0_optimized.sql
@@ -2,7 +2,7 @@ test_name: test_metric_time_quarter_alone
 test_filename: test_metric_time_without_metrics.py
 sql_engine: Trino
 ---
--- Time Spine
+-- Read From Time Spine 'mf_time_spine'
 -- Metric Time Dimension 'ds'
 -- Pass Only Elements: ['metric_time__quarter',]
 SELECT

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Trino/test_metric_time_with_other_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Trino/test_metric_time_with_other_dimensions__plan0.sql
@@ -161,7 +161,7 @@ FROM (
         , subq_1.ds__extract_doy AS metric_time__extract_doy
         , subq_1.ds__martian_day AS metric_time__martian_day
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine'
         SELECT
           DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
           , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/test_dimensions_with_time_constraint__plan0.xml
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/test_dimensions_with_time_constraint__plan0.xml
@@ -801,7 +801,7 @@ test_filename: test_metric_time_without_metrics.py
                         <!-- where = None -->
                         <!-- distinct = False -->
                         <SqlSelectStatementNode>
-                            <!-- description = 'Time Spine' -->
+                            <!-- description = "Read From Time Spine 'mf_time_spine'" -->
                             <!-- node_id = NodeId(id_str='ss_1') -->
                             <!-- col0 =                                                                                   -->
                             <!--   SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_28293), column_alias='ds__day') -->

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/test_metric_time_only__plan0.xml
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/test_metric_time_only__plan0.xml
@@ -82,7 +82,7 @@ docstring:
             <!-- where = None -->
             <!-- distinct = False -->
             <SqlSelectStatementNode>
-                <!-- description = 'Time Spine' -->
+                <!-- description = "Read From Time Spine 'mf_time_spine'" -->
                 <!-- node_id = NodeId(id_str='ss_0') -->
                 <!-- col0 = SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_28293), column_alias='ds__day') -->
                 <!-- col1 = SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_28294), column_alias='ds__week') -->

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/test_metric_time_quarter_alone__plan0.xml
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/test_metric_time_quarter_alone__plan0.xml
@@ -81,7 +81,7 @@ test_filename: test_metric_time_without_metrics.py
             <!-- where = None -->
             <!-- distinct = False -->
             <SqlSelectStatementNode>
-                <!-- description = 'Time Spine' -->
+                <!-- description = "Read From Time Spine 'mf_time_spine'" -->
                 <!-- node_id = NodeId(id_str='ss_0') -->
                 <!-- col0 = SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_28293), column_alias='ds__day') -->
                 <!-- col1 = SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_28294), column_alias='ds__week') -->

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/test_metric_time_with_other_dimensions__plan0.xml
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/test_metric_time_with_other_dimensions__plan0.xml
@@ -550,7 +550,7 @@ test_filename: test_metric_time_without_metrics.py
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
-                        <!-- description = 'Time Spine' -->
+                        <!-- description = "Read From Time Spine 'mf_time_spine'" -->
                         <!-- node_id = NodeId(id_str='ss_1') -->
                         <!-- col0 =                                                                                   -->
                         <!--   SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_28293), column_alias='ds__day') -->

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_query_time_filters__plan0.sql
@@ -329,7 +329,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
@@ -31,7 +31,7 @@ FROM (
         , subq_8.listing__country_latest AS listing__country_latest
         , subq_8.bookings AS bookings
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine'
         SELECT
           subq_10.ds AS metric_time__day
         FROM ***************************.mf_time_spine subq_10
@@ -612,7 +612,7 @@ FROM (
         , subq_24.listing__country_latest AS listing__country_latest
         , subq_24.bookings AS bookings
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine'
         SELECT
           subq_26.ds AS metric_time__day
         FROM ***************************.mf_time_spine subq_26
@@ -935,7 +935,7 @@ FROM (
                   , subq_14.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                   , subq_14.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
                 FROM (
-                  -- Time Spine
+                  -- Read From Time Spine 'mf_time_spine'
                   SELECT
                     subq_16.ds AS metric_time__day
                   FROM ***************************.mf_time_spine subq_16

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_offset_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_offset_metric_with_query_time_filters__plan0.sql
@@ -908,7 +908,7 @@ FROM (
                 , subq_11.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                 , subq_11.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
               FROM (
-                -- Time Spine
+                -- Read From Time Spine 'mf_time_spine'
                 SELECT
                   subq_13.ds AS metric_time__day
                 FROM ***************************.mf_time_spine subq_13

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_simple_join_to_time_spine_pushdown_filter_application__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_simple_join_to_time_spine_pushdown_filter_application__plan0.sql
@@ -24,7 +24,7 @@ FROM (
       , subq_4.booking__is_instant AS booking__is_instant
       , subq_4.bookings AS bookings
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         subq_6.ds AS metric_time__day
       FROM ***************************.mf_time_spine subq_6

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_with_query_time_filters__plan0.sql
@@ -329,7 +329,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
@@ -31,7 +31,7 @@ FROM (
         , subq_8.listing__country_latest AS listing__country_latest
         , subq_8.bookings AS bookings
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine'
         SELECT
           subq_10.ds AS metric_time__day
         FROM ***************************.mf_time_spine subq_10
@@ -612,7 +612,7 @@ FROM (
         , subq_24.listing__country_latest AS listing__country_latest
         , subq_24.bookings AS bookings
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine'
         SELECT
           subq_26.ds AS metric_time__day
         FROM ***************************.mf_time_spine subq_26
@@ -935,7 +935,7 @@ FROM (
                   , subq_14.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                   , subq_14.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
                 FROM (
-                  -- Time Spine
+                  -- Read From Time Spine 'mf_time_spine'
                   SELECT
                     subq_16.ds AS metric_time__day
                   FROM ***************************.mf_time_spine subq_16

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_offset_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_offset_metric_with_query_time_filters__plan0.sql
@@ -908,7 +908,7 @@ FROM (
                 , subq_11.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                 , subq_11.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
               FROM (
-                -- Time Spine
+                -- Read From Time Spine 'mf_time_spine'
                 SELECT
                   subq_13.ds AS metric_time__day
                 FROM ***************************.mf_time_spine subq_13

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_simple_join_to_time_spine_pushdown_filter_application__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_simple_join_to_time_spine_pushdown_filter_application__plan0.sql
@@ -24,7 +24,7 @@ FROM (
       , subq_4.booking__is_instant AS booking__is_instant
       , subq_4.bookings AS bookings
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         subq_6.ds AS metric_time__day
       FROM ***************************.mf_time_spine subq_6

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_query_time_filters__plan0.sql
@@ -329,7 +329,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
@@ -31,7 +31,7 @@ FROM (
         , subq_8.listing__country_latest AS listing__country_latest
         , subq_8.bookings AS bookings
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine'
         SELECT
           subq_10.ds AS metric_time__day
         FROM ***************************.mf_time_spine subq_10
@@ -612,7 +612,7 @@ FROM (
         , subq_24.listing__country_latest AS listing__country_latest
         , subq_24.bookings AS bookings
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine'
         SELECT
           subq_26.ds AS metric_time__day
         FROM ***************************.mf_time_spine subq_26
@@ -935,7 +935,7 @@ FROM (
                   , subq_14.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                   , subq_14.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
                 FROM (
-                  -- Time Spine
+                  -- Read From Time Spine 'mf_time_spine'
                   SELECT
                     subq_16.ds AS metric_time__day
                   FROM ***************************.mf_time_spine subq_16

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_offset_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_offset_metric_with_query_time_filters__plan0.sql
@@ -908,7 +908,7 @@ FROM (
                 , subq_11.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                 , subq_11.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
               FROM (
-                -- Time Spine
+                -- Read From Time Spine 'mf_time_spine'
                 SELECT
                   subq_13.ds AS metric_time__day
                 FROM ***************************.mf_time_spine subq_13

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_simple_join_to_time_spine_pushdown_filter_application__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_simple_join_to_time_spine_pushdown_filter_application__plan0.sql
@@ -24,7 +24,7 @@ FROM (
       , subq_4.booking__is_instant AS booking__is_instant
       , subq_4.bookings AS bookings
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         subq_6.ds AS metric_time__day
       FROM ***************************.mf_time_spine subq_6

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_with_query_time_filters__plan0.sql
@@ -329,7 +329,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
@@ -31,7 +31,7 @@ FROM (
         , subq_8.listing__country_latest AS listing__country_latest
         , subq_8.bookings AS bookings
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine'
         SELECT
           subq_10.ds AS metric_time__day
         FROM ***************************.mf_time_spine subq_10
@@ -612,7 +612,7 @@ FROM (
         , subq_24.listing__country_latest AS listing__country_latest
         , subq_24.bookings AS bookings
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine'
         SELECT
           subq_26.ds AS metric_time__day
         FROM ***************************.mf_time_spine subq_26
@@ -935,7 +935,7 @@ FROM (
                   , subq_14.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                   , subq_14.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
                 FROM (
-                  -- Time Spine
+                  -- Read From Time Spine 'mf_time_spine'
                   SELECT
                     subq_16.ds AS metric_time__day
                   FROM ***************************.mf_time_spine subq_16

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_offset_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_offset_metric_with_query_time_filters__plan0.sql
@@ -908,7 +908,7 @@ FROM (
                 , subq_11.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                 , subq_11.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
               FROM (
-                -- Time Spine
+                -- Read From Time Spine 'mf_time_spine'
                 SELECT
                   subq_13.ds AS metric_time__day
                 FROM ***************************.mf_time_spine subq_13

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_simple_join_to_time_spine_pushdown_filter_application__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_simple_join_to_time_spine_pushdown_filter_application__plan0.sql
@@ -24,7 +24,7 @@ FROM (
       , subq_4.booking__is_instant AS booking__is_instant
       , subq_4.bookings AS bookings
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         subq_6.ds AS metric_time__day
       FROM ***************************.mf_time_spine subq_6

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_with_query_time_filters__plan0.sql
@@ -329,7 +329,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
@@ -31,7 +31,7 @@ FROM (
         , subq_8.listing__country_latest AS listing__country_latest
         , subq_8.bookings AS bookings
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine'
         SELECT
           subq_10.ds AS metric_time__day
         FROM ***************************.mf_time_spine subq_10
@@ -612,7 +612,7 @@ FROM (
         , subq_24.listing__country_latest AS listing__country_latest
         , subq_24.bookings AS bookings
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine'
         SELECT
           subq_26.ds AS metric_time__day
         FROM ***************************.mf_time_spine subq_26
@@ -935,7 +935,7 @@ FROM (
                   , subq_14.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                   , subq_14.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
                 FROM (
-                  -- Time Spine
+                  -- Read From Time Spine 'mf_time_spine'
                   SELECT
                     subq_16.ds AS metric_time__day
                   FROM ***************************.mf_time_spine subq_16

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_offset_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_offset_metric_with_query_time_filters__plan0.sql
@@ -908,7 +908,7 @@ FROM (
                 , subq_11.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                 , subq_11.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
               FROM (
-                -- Time Spine
+                -- Read From Time Spine 'mf_time_spine'
                 SELECT
                   subq_13.ds AS metric_time__day
                 FROM ***************************.mf_time_spine subq_13

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_simple_join_to_time_spine_pushdown_filter_application__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_simple_join_to_time_spine_pushdown_filter_application__plan0.sql
@@ -24,7 +24,7 @@ FROM (
       , subq_4.booking__is_instant AS booking__is_instant
       , subq_4.bookings AS bookings
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         subq_6.ds AS metric_time__day
       FROM ***************************.mf_time_spine subq_6

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_with_query_time_filters__plan0.sql
@@ -329,7 +329,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
@@ -31,7 +31,7 @@ FROM (
         , subq_8.listing__country_latest AS listing__country_latest
         , subq_8.bookings AS bookings
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine'
         SELECT
           subq_10.ds AS metric_time__day
         FROM ***************************.mf_time_spine subq_10
@@ -612,7 +612,7 @@ FROM (
         , subq_24.listing__country_latest AS listing__country_latest
         , subq_24.bookings AS bookings
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine'
         SELECT
           subq_26.ds AS metric_time__day
         FROM ***************************.mf_time_spine subq_26
@@ -935,7 +935,7 @@ FROM (
                   , subq_14.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                   , subq_14.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
                 FROM (
-                  -- Time Spine
+                  -- Read From Time Spine 'mf_time_spine'
                   SELECT
                     subq_16.ds AS metric_time__day
                   FROM ***************************.mf_time_spine subq_16

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_offset_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_offset_metric_with_query_time_filters__plan0.sql
@@ -908,7 +908,7 @@ FROM (
                 , subq_11.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                 , subq_11.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
               FROM (
-                -- Time Spine
+                -- Read From Time Spine 'mf_time_spine'
                 SELECT
                   subq_13.ds AS metric_time__day
                 FROM ***************************.mf_time_spine subq_13

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_simple_join_to_time_spine_pushdown_filter_application__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_simple_join_to_time_spine_pushdown_filter_application__plan0.sql
@@ -24,7 +24,7 @@ FROM (
       , subq_4.booking__is_instant AS booking__is_instant
       , subq_4.bookings AS bookings
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         subq_6.ds AS metric_time__day
       FROM ***************************.mf_time_spine subq_6

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_with_query_time_filters__plan0.sql
@@ -329,7 +329,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Time Spine
+            -- Read From Time Spine 'mf_time_spine'
             SELECT
               subq_3.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_3

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
@@ -31,7 +31,7 @@ FROM (
         , subq_8.listing__country_latest AS listing__country_latest
         , subq_8.bookings AS bookings
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine'
         SELECT
           subq_10.ds AS metric_time__day
         FROM ***************************.mf_time_spine subq_10
@@ -612,7 +612,7 @@ FROM (
         , subq_24.listing__country_latest AS listing__country_latest
         , subq_24.bookings AS bookings
       FROM (
-        -- Time Spine
+        -- Read From Time Spine 'mf_time_spine'
         SELECT
           subq_26.ds AS metric_time__day
         FROM ***************************.mf_time_spine subq_26
@@ -935,7 +935,7 @@ FROM (
                   , subq_14.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                   , subq_14.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
                 FROM (
-                  -- Time Spine
+                  -- Read From Time Spine 'mf_time_spine'
                   SELECT
                     subq_16.ds AS metric_time__day
                   FROM ***************************.mf_time_spine subq_16

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_offset_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_offset_metric_with_query_time_filters__plan0.sql
@@ -908,7 +908,7 @@ FROM (
                 , subq_11.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                 , subq_11.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
               FROM (
-                -- Time Spine
+                -- Read From Time Spine 'mf_time_spine'
                 SELECT
                   subq_13.ds AS metric_time__day
                 FROM ***************************.mf_time_spine subq_13

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_simple_join_to_time_spine_pushdown_filter_application__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_simple_join_to_time_spine_pushdown_filter_application__plan0.sql
@@ -24,7 +24,7 @@ FROM (
       , subq_4.booking__is_instant AS booking__is_instant
       , subq_4.bookings AS bookings
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         subq_6.ds AS metric_time__day
       FROM ***************************.mf_time_spine subq_6

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_min_max_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_min_max_metric_time__plan0.sql
@@ -40,7 +40,7 @@ FROM (
       , subq_0.ds__extract_doy AS metric_time__extract_doy
       , subq_0.ds__martian_day AS metric_time__martian_day
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         DATETIME_TRUNC(time_spine_src_28006.ds, day) AS ds__day
         , DATETIME_TRUNC(time_spine_src_28006.ds, isoweek) AS ds__week

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_min_max_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_min_max_metric_time__plan0_optimized.sql
@@ -9,7 +9,7 @@ SELECT
   MIN(metric_time__day) AS metric_time__day__min
   , MAX(metric_time__day) AS metric_time__day__max
 FROM (
-  -- Time Spine
+  -- Read From Time Spine 'mf_time_spine'
   -- Metric Time Dimension 'ds'
   -- Pass Only Elements: ['metric_time__day',]
   SELECT

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_min_max_metric_time_week__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_min_max_metric_time_week__plan0.sql
@@ -40,7 +40,7 @@ FROM (
       , subq_0.ds__extract_doy AS metric_time__extract_doy
       , subq_0.ds__martian_day AS metric_time__martian_day
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         DATETIME_TRUNC(time_spine_src_28006.ds, day) AS ds__day
         , DATETIME_TRUNC(time_spine_src_28006.ds, isoweek) AS ds__week

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_min_max_metric_time_week__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_min_max_metric_time_week__plan0_optimized.sql
@@ -9,7 +9,7 @@ SELECT
   MIN(metric_time__week) AS metric_time__week__min
   , MAX(metric_time__week) AS metric_time__week__max
 FROM (
-  -- Time Spine
+  -- Read From Time Spine 'mf_time_spine'
   -- Metric Time Dimension 'ds'
   -- Pass Only Elements: ['metric_time__week',]
   SELECT

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_min_max_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_min_max_metric_time__plan0.sql
@@ -40,7 +40,7 @@ FROM (
       , subq_0.ds__extract_doy AS metric_time__extract_doy
       , subq_0.ds__martian_day AS metric_time__martian_day
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
         , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_min_max_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_min_max_metric_time__plan0_optimized.sql
@@ -9,7 +9,7 @@ SELECT
   MIN(metric_time__day) AS metric_time__day__min
   , MAX(metric_time__day) AS metric_time__day__max
 FROM (
-  -- Time Spine
+  -- Read From Time Spine 'mf_time_spine'
   -- Metric Time Dimension 'ds'
   -- Pass Only Elements: ['metric_time__day',]
   SELECT

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_min_max_metric_time_week__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_min_max_metric_time_week__plan0.sql
@@ -40,7 +40,7 @@ FROM (
       , subq_0.ds__extract_doy AS metric_time__extract_doy
       , subq_0.ds__martian_day AS metric_time__martian_day
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
         , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_min_max_metric_time_week__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_min_max_metric_time_week__plan0_optimized.sql
@@ -9,7 +9,7 @@ SELECT
   MIN(metric_time__week) AS metric_time__week__min
   , MAX(metric_time__week) AS metric_time__week__max
 FROM (
-  -- Time Spine
+  -- Read From Time Spine 'mf_time_spine'
   -- Metric Time Dimension 'ds'
   -- Pass Only Elements: ['metric_time__week',]
   SELECT

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_min_max_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_min_max_metric_time__plan0.sql
@@ -40,7 +40,7 @@ FROM (
       , subq_0.ds__extract_doy AS metric_time__extract_doy
       , subq_0.ds__martian_day AS metric_time__martian_day
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
         , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_min_max_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_min_max_metric_time__plan0_optimized.sql
@@ -9,7 +9,7 @@ SELECT
   MIN(metric_time__day) AS metric_time__day__min
   , MAX(metric_time__day) AS metric_time__day__max
 FROM (
-  -- Time Spine
+  -- Read From Time Spine 'mf_time_spine'
   -- Metric Time Dimension 'ds'
   -- Pass Only Elements: ['metric_time__day',]
   SELECT

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_min_max_metric_time_week__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_min_max_metric_time_week__plan0.sql
@@ -40,7 +40,7 @@ FROM (
       , subq_0.ds__extract_doy AS metric_time__extract_doy
       , subq_0.ds__martian_day AS metric_time__martian_day
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
         , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_min_max_metric_time_week__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_min_max_metric_time_week__plan0_optimized.sql
@@ -9,7 +9,7 @@ SELECT
   MIN(metric_time__week) AS metric_time__week__min
   , MAX(metric_time__week) AS metric_time__week__max
 FROM (
-  -- Time Spine
+  -- Read From Time Spine 'mf_time_spine'
   -- Metric Time Dimension 'ds'
   -- Pass Only Elements: ['metric_time__week',]
   SELECT

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_min_max_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_min_max_metric_time__plan0.sql
@@ -40,7 +40,7 @@ FROM (
       , subq_0.ds__extract_doy AS metric_time__extract_doy
       , subq_0.ds__martian_day AS metric_time__martian_day
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
         , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_min_max_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_min_max_metric_time__plan0_optimized.sql
@@ -9,7 +9,7 @@ SELECT
   MIN(metric_time__day) AS metric_time__day__min
   , MAX(metric_time__day) AS metric_time__day__max
 FROM (
-  -- Time Spine
+  -- Read From Time Spine 'mf_time_spine'
   -- Metric Time Dimension 'ds'
   -- Pass Only Elements: ['metric_time__day',]
   SELECT

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_min_max_metric_time_week__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_min_max_metric_time_week__plan0.sql
@@ -40,7 +40,7 @@ FROM (
       , subq_0.ds__extract_doy AS metric_time__extract_doy
       , subq_0.ds__martian_day AS metric_time__martian_day
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
         , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_min_max_metric_time_week__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_min_max_metric_time_week__plan0_optimized.sql
@@ -9,7 +9,7 @@ SELECT
   MIN(metric_time__week) AS metric_time__week__min
   , MAX(metric_time__week) AS metric_time__week__max
 FROM (
-  -- Time Spine
+  -- Read From Time Spine 'mf_time_spine'
   -- Metric Time Dimension 'ds'
   -- Pass Only Elements: ['metric_time__week',]
   SELECT

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_min_max_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_min_max_metric_time__plan0.sql
@@ -40,7 +40,7 @@ FROM (
       , subq_0.ds__extract_doy AS metric_time__extract_doy
       , subq_0.ds__martian_day AS metric_time__martian_day
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
         , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_min_max_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_min_max_metric_time__plan0_optimized.sql
@@ -9,7 +9,7 @@ SELECT
   MIN(metric_time__day) AS metric_time__day__min
   , MAX(metric_time__day) AS metric_time__day__max
 FROM (
-  -- Time Spine
+  -- Read From Time Spine 'mf_time_spine'
   -- Metric Time Dimension 'ds'
   -- Pass Only Elements: ['metric_time__day',]
   SELECT

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_min_max_metric_time_week__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_min_max_metric_time_week__plan0.sql
@@ -40,7 +40,7 @@ FROM (
       , subq_0.ds__extract_doy AS metric_time__extract_doy
       , subq_0.ds__martian_day AS metric_time__martian_day
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
         , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_min_max_metric_time_week__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_min_max_metric_time_week__plan0_optimized.sql
@@ -9,7 +9,7 @@ SELECT
   MIN(metric_time__week) AS metric_time__week__min
   , MAX(metric_time__week) AS metric_time__week__max
 FROM (
-  -- Time Spine
+  -- Read From Time Spine 'mf_time_spine'
   -- Metric Time Dimension 'ds'
   -- Pass Only Elements: ['metric_time__week',]
   SELECT

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_min_max_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_min_max_metric_time__plan0.sql
@@ -40,7 +40,7 @@ FROM (
       , subq_0.ds__extract_doy AS metric_time__extract_doy
       , subq_0.ds__martian_day AS metric_time__martian_day
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
         , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_min_max_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_min_max_metric_time__plan0_optimized.sql
@@ -9,7 +9,7 @@ SELECT
   MIN(metric_time__day) AS metric_time__day__min
   , MAX(metric_time__day) AS metric_time__day__max
 FROM (
-  -- Time Spine
+  -- Read From Time Spine 'mf_time_spine'
   -- Metric Time Dimension 'ds'
   -- Pass Only Elements: ['metric_time__day',]
   SELECT

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_min_max_metric_time_week__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_min_max_metric_time_week__plan0.sql
@@ -40,7 +40,7 @@ FROM (
       , subq_0.ds__extract_doy AS metric_time__extract_doy
       , subq_0.ds__martian_day AS metric_time__martian_day
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
         , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_min_max_metric_time_week__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_min_max_metric_time_week__plan0_optimized.sql
@@ -9,7 +9,7 @@ SELECT
   MIN(metric_time__week) AS metric_time__week__min
   , MAX(metric_time__week) AS metric_time__week__max
 FROM (
-  -- Time Spine
+  -- Read From Time Spine 'mf_time_spine'
   -- Metric Time Dimension 'ds'
   -- Pass Only Elements: ['metric_time__week',]
   SELECT

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_min_max_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_min_max_metric_time__plan0.sql
@@ -40,7 +40,7 @@ FROM (
       , subq_0.ds__extract_doy AS metric_time__extract_doy
       , subq_0.ds__martian_day AS metric_time__martian_day
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
         , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_min_max_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_min_max_metric_time__plan0_optimized.sql
@@ -9,7 +9,7 @@ SELECT
   MIN(metric_time__day) AS metric_time__day__min
   , MAX(metric_time__day) AS metric_time__day__max
 FROM (
-  -- Time Spine
+  -- Read From Time Spine 'mf_time_spine'
   -- Metric Time Dimension 'ds'
   -- Pass Only Elements: ['metric_time__day',]
   SELECT

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_min_max_metric_time_week__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_min_max_metric_time_week__plan0.sql
@@ -40,7 +40,7 @@ FROM (
       , subq_0.ds__extract_doy AS metric_time__extract_doy
       , subq_0.ds__martian_day AS metric_time__martian_day
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
         , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_min_max_metric_time_week__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_min_max_metric_time_week__plan0_optimized.sql
@@ -9,7 +9,7 @@ SELECT
   MIN(metric_time__week) AS metric_time__week__min
   , MAX(metric_time__week) AS metric_time__week__max
 FROM (
-  -- Time Spine
+  -- Read From Time Spine 'mf_time_spine'
   -- Metric Time Dimension 'ds'
   -- Pass Only Elements: ['metric_time__week',]
   SELECT

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_with_input_measure_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_with_input_measure_constraint__plan0.sql
@@ -22,7 +22,7 @@ FROM (
     SELECT
       subq_7.metric_time__day
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         subq_6.ds AS metric_time__day
       FROM ***************************.mf_time_spine subq_6

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_with_input_measure_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_with_input_measure_constraint__plan0_optimized.sql
@@ -17,7 +17,7 @@ FROM (
   SELECT
     metric_time__day
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       ds AS metric_time__day
     FROM ***************************.mf_time_spine subq_15

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_with_queried_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_with_queried_time_constraint__plan0.sql
@@ -19,7 +19,7 @@ FROM (
       subq_5.metric_time__day AS metric_time__day
       , subq_4.bookings AS bookings
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         subq_6.ds AS metric_time__day
       FROM ***************************.mf_time_spine subq_6

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_with_queried_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_with_queried_time_constraint__plan0_optimized.sql
@@ -15,7 +15,7 @@ FROM (
     subq_14.metric_time__day AS metric_time__day
     , subq_13.bookings AS bookings
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       ds AS metric_time__day
     FROM ***************************.mf_time_spine subq_15

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/BigQuery/test_simple_join_to_time_spine__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/BigQuery/test_simple_join_to_time_spine__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_4.metric_time__day AS metric_time__day
     , subq_3.bookings AS bookings
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       subq_5.ds AS metric_time__day
     FROM ***************************.mf_time_spine subq_5

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/BigQuery/test_simple_join_to_time_spine_with_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/BigQuery/test_simple_join_to_time_spine_with_filter__plan0.sql
@@ -14,7 +14,7 @@ FROM (
     subq_5.metric_time__day AS metric_time__day
     , subq_4.bookings AS bookings
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       subq_6.ds AS metric_time__day
     FROM ***************************.mf_time_spine subq_6

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/BigQuery/test_simple_join_to_time_spine_with_queried_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/BigQuery/test_simple_join_to_time_spine_with_queried_filter__plan0.sql
@@ -22,7 +22,7 @@ FROM (
       , subq_4.booking__is_instant AS booking__is_instant
       , subq_4.bookings AS bookings
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         subq_6.ds AS metric_time__day
       FROM ***************************.mf_time_spine subq_6

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Databricks/test_join_to_time_spine_with_input_measure_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Databricks/test_join_to_time_spine_with_input_measure_constraint__plan0.sql
@@ -22,7 +22,7 @@ FROM (
     SELECT
       subq_7.metric_time__day
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         subq_6.ds AS metric_time__day
       FROM ***************************.mf_time_spine subq_6

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Databricks/test_join_to_time_spine_with_input_measure_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Databricks/test_join_to_time_spine_with_input_measure_constraint__plan0_optimized.sql
@@ -17,7 +17,7 @@ FROM (
   SELECT
     metric_time__day
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       ds AS metric_time__day
     FROM ***************************.mf_time_spine subq_15

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Databricks/test_join_to_time_spine_with_queried_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Databricks/test_join_to_time_spine_with_queried_time_constraint__plan0.sql
@@ -19,7 +19,7 @@ FROM (
       subq_5.metric_time__day AS metric_time__day
       , subq_4.bookings AS bookings
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         subq_6.ds AS metric_time__day
       FROM ***************************.mf_time_spine subq_6

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Databricks/test_join_to_time_spine_with_queried_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Databricks/test_join_to_time_spine_with_queried_time_constraint__plan0_optimized.sql
@@ -15,7 +15,7 @@ FROM (
     subq_14.metric_time__day AS metric_time__day
     , subq_13.bookings AS bookings
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       ds AS metric_time__day
     FROM ***************************.mf_time_spine subq_15

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Databricks/test_simple_join_to_time_spine__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Databricks/test_simple_join_to_time_spine__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_4.metric_time__day AS metric_time__day
     , subq_3.bookings AS bookings
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       subq_5.ds AS metric_time__day
     FROM ***************************.mf_time_spine subq_5

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Databricks/test_simple_join_to_time_spine_with_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Databricks/test_simple_join_to_time_spine_with_filter__plan0.sql
@@ -14,7 +14,7 @@ FROM (
     subq_5.metric_time__day AS metric_time__day
     , subq_4.bookings AS bookings
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       subq_6.ds AS metric_time__day
     FROM ***************************.mf_time_spine subq_6

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Databricks/test_simple_join_to_time_spine_with_queried_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Databricks/test_simple_join_to_time_spine_with_queried_filter__plan0.sql
@@ -22,7 +22,7 @@ FROM (
       , subq_4.booking__is_instant AS booking__is_instant
       , subq_4.bookings AS bookings
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         subq_6.ds AS metric_time__day
       FROM ***************************.mf_time_spine subq_6

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_with_input_measure_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_with_input_measure_constraint__plan0.sql
@@ -22,7 +22,7 @@ FROM (
     SELECT
       subq_7.metric_time__day
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         subq_6.ds AS metric_time__day
       FROM ***************************.mf_time_spine subq_6

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_with_input_measure_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_with_input_measure_constraint__plan0_optimized.sql
@@ -17,7 +17,7 @@ FROM (
   SELECT
     metric_time__day
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       ds AS metric_time__day
     FROM ***************************.mf_time_spine subq_15

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_with_queried_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_with_queried_time_constraint__plan0.sql
@@ -19,7 +19,7 @@ FROM (
       subq_5.metric_time__day AS metric_time__day
       , subq_4.bookings AS bookings
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         subq_6.ds AS metric_time__day
       FROM ***************************.mf_time_spine subq_6

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_with_queried_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_with_queried_time_constraint__plan0_optimized.sql
@@ -15,7 +15,7 @@ FROM (
     subq_14.metric_time__day AS metric_time__day
     , subq_13.bookings AS bookings
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       ds AS metric_time__day
     FROM ***************************.mf_time_spine subq_15

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/DuckDB/test_simple_join_to_time_spine__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/DuckDB/test_simple_join_to_time_spine__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_4.metric_time__day AS metric_time__day
     , subq_3.bookings AS bookings
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       subq_5.ds AS metric_time__day
     FROM ***************************.mf_time_spine subq_5

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/DuckDB/test_simple_join_to_time_spine_with_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/DuckDB/test_simple_join_to_time_spine_with_filter__plan0.sql
@@ -14,7 +14,7 @@ FROM (
     subq_5.metric_time__day AS metric_time__day
     , subq_4.bookings AS bookings
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       subq_6.ds AS metric_time__day
     FROM ***************************.mf_time_spine subq_6

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/DuckDB/test_simple_join_to_time_spine_with_queried_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/DuckDB/test_simple_join_to_time_spine_with_queried_filter__plan0.sql
@@ -22,7 +22,7 @@ FROM (
       , subq_4.booking__is_instant AS booking__is_instant
       , subq_4.bookings AS bookings
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         subq_6.ds AS metric_time__day
       FROM ***************************.mf_time_spine subq_6

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Postgres/test_join_to_time_spine_with_input_measure_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Postgres/test_join_to_time_spine_with_input_measure_constraint__plan0.sql
@@ -22,7 +22,7 @@ FROM (
     SELECT
       subq_7.metric_time__day
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         subq_6.ds AS metric_time__day
       FROM ***************************.mf_time_spine subq_6

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Postgres/test_join_to_time_spine_with_input_measure_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Postgres/test_join_to_time_spine_with_input_measure_constraint__plan0_optimized.sql
@@ -17,7 +17,7 @@ FROM (
   SELECT
     metric_time__day
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       ds AS metric_time__day
     FROM ***************************.mf_time_spine subq_15

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Postgres/test_join_to_time_spine_with_queried_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Postgres/test_join_to_time_spine_with_queried_time_constraint__plan0.sql
@@ -19,7 +19,7 @@ FROM (
       subq_5.metric_time__day AS metric_time__day
       , subq_4.bookings AS bookings
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         subq_6.ds AS metric_time__day
       FROM ***************************.mf_time_spine subq_6

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Postgres/test_join_to_time_spine_with_queried_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Postgres/test_join_to_time_spine_with_queried_time_constraint__plan0_optimized.sql
@@ -15,7 +15,7 @@ FROM (
     subq_14.metric_time__day AS metric_time__day
     , subq_13.bookings AS bookings
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       ds AS metric_time__day
     FROM ***************************.mf_time_spine subq_15

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Postgres/test_simple_join_to_time_spine__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Postgres/test_simple_join_to_time_spine__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_4.metric_time__day AS metric_time__day
     , subq_3.bookings AS bookings
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       subq_5.ds AS metric_time__day
     FROM ***************************.mf_time_spine subq_5

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Postgres/test_simple_join_to_time_spine_with_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Postgres/test_simple_join_to_time_spine_with_filter__plan0.sql
@@ -14,7 +14,7 @@ FROM (
     subq_5.metric_time__day AS metric_time__day
     , subq_4.bookings AS bookings
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       subq_6.ds AS metric_time__day
     FROM ***************************.mf_time_spine subq_6

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Postgres/test_simple_join_to_time_spine_with_queried_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Postgres/test_simple_join_to_time_spine_with_queried_filter__plan0.sql
@@ -22,7 +22,7 @@ FROM (
       , subq_4.booking__is_instant AS booking__is_instant
       , subq_4.bookings AS bookings
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         subq_6.ds AS metric_time__day
       FROM ***************************.mf_time_spine subq_6

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Redshift/test_join_to_time_spine_with_input_measure_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Redshift/test_join_to_time_spine_with_input_measure_constraint__plan0.sql
@@ -22,7 +22,7 @@ FROM (
     SELECT
       subq_7.metric_time__day
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         subq_6.ds AS metric_time__day
       FROM ***************************.mf_time_spine subq_6

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Redshift/test_join_to_time_spine_with_input_measure_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Redshift/test_join_to_time_spine_with_input_measure_constraint__plan0_optimized.sql
@@ -17,7 +17,7 @@ FROM (
   SELECT
     metric_time__day
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       ds AS metric_time__day
     FROM ***************************.mf_time_spine subq_15

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Redshift/test_join_to_time_spine_with_queried_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Redshift/test_join_to_time_spine_with_queried_time_constraint__plan0.sql
@@ -19,7 +19,7 @@ FROM (
       subq_5.metric_time__day AS metric_time__day
       , subq_4.bookings AS bookings
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         subq_6.ds AS metric_time__day
       FROM ***************************.mf_time_spine subq_6

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Redshift/test_join_to_time_spine_with_queried_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Redshift/test_join_to_time_spine_with_queried_time_constraint__plan0_optimized.sql
@@ -15,7 +15,7 @@ FROM (
     subq_14.metric_time__day AS metric_time__day
     , subq_13.bookings AS bookings
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       ds AS metric_time__day
     FROM ***************************.mf_time_spine subq_15

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Redshift/test_simple_join_to_time_spine__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Redshift/test_simple_join_to_time_spine__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_4.metric_time__day AS metric_time__day
     , subq_3.bookings AS bookings
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       subq_5.ds AS metric_time__day
     FROM ***************************.mf_time_spine subq_5

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Redshift/test_simple_join_to_time_spine_with_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Redshift/test_simple_join_to_time_spine_with_filter__plan0.sql
@@ -14,7 +14,7 @@ FROM (
     subq_5.metric_time__day AS metric_time__day
     , subq_4.bookings AS bookings
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       subq_6.ds AS metric_time__day
     FROM ***************************.mf_time_spine subq_6

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Redshift/test_simple_join_to_time_spine_with_queried_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Redshift/test_simple_join_to_time_spine_with_queried_filter__plan0.sql
@@ -22,7 +22,7 @@ FROM (
       , subq_4.booking__is_instant AS booking__is_instant
       , subq_4.bookings AS bookings
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         subq_6.ds AS metric_time__day
       FROM ***************************.mf_time_spine subq_6

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_with_input_measure_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_with_input_measure_constraint__plan0.sql
@@ -22,7 +22,7 @@ FROM (
     SELECT
       subq_7.metric_time__day
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         subq_6.ds AS metric_time__day
       FROM ***************************.mf_time_spine subq_6

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_with_input_measure_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_with_input_measure_constraint__plan0_optimized.sql
@@ -17,7 +17,7 @@ FROM (
   SELECT
     metric_time__day
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       ds AS metric_time__day
     FROM ***************************.mf_time_spine subq_15

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_with_queried_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_with_queried_time_constraint__plan0.sql
@@ -19,7 +19,7 @@ FROM (
       subq_5.metric_time__day AS metric_time__day
       , subq_4.bookings AS bookings
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         subq_6.ds AS metric_time__day
       FROM ***************************.mf_time_spine subq_6

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_with_queried_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_with_queried_time_constraint__plan0_optimized.sql
@@ -15,7 +15,7 @@ FROM (
     subq_14.metric_time__day AS metric_time__day
     , subq_13.bookings AS bookings
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       ds AS metric_time__day
     FROM ***************************.mf_time_spine subq_15

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Snowflake/test_simple_join_to_time_spine__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Snowflake/test_simple_join_to_time_spine__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_4.metric_time__day AS metric_time__day
     , subq_3.bookings AS bookings
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       subq_5.ds AS metric_time__day
     FROM ***************************.mf_time_spine subq_5

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Snowflake/test_simple_join_to_time_spine_with_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Snowflake/test_simple_join_to_time_spine_with_filter__plan0.sql
@@ -14,7 +14,7 @@ FROM (
     subq_5.metric_time__day AS metric_time__day
     , subq_4.bookings AS bookings
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       subq_6.ds AS metric_time__day
     FROM ***************************.mf_time_spine subq_6

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Snowflake/test_simple_join_to_time_spine_with_queried_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Snowflake/test_simple_join_to_time_spine_with_queried_filter__plan0.sql
@@ -22,7 +22,7 @@ FROM (
       , subq_4.booking__is_instant AS booking__is_instant
       , subq_4.bookings AS bookings
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         subq_6.ds AS metric_time__day
       FROM ***************************.mf_time_spine subq_6

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Trino/test_join_to_time_spine_with_input_measure_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Trino/test_join_to_time_spine_with_input_measure_constraint__plan0.sql
@@ -22,7 +22,7 @@ FROM (
     SELECT
       subq_7.metric_time__day
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         subq_6.ds AS metric_time__day
       FROM ***************************.mf_time_spine subq_6

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Trino/test_join_to_time_spine_with_input_measure_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Trino/test_join_to_time_spine_with_input_measure_constraint__plan0_optimized.sql
@@ -17,7 +17,7 @@ FROM (
   SELECT
     metric_time__day
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       ds AS metric_time__day
     FROM ***************************.mf_time_spine subq_15

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Trino/test_join_to_time_spine_with_queried_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Trino/test_join_to_time_spine_with_queried_time_constraint__plan0.sql
@@ -19,7 +19,7 @@ FROM (
       subq_5.metric_time__day AS metric_time__day
       , subq_4.bookings AS bookings
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         subq_6.ds AS metric_time__day
       FROM ***************************.mf_time_spine subq_6

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Trino/test_join_to_time_spine_with_queried_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Trino/test_join_to_time_spine_with_queried_time_constraint__plan0_optimized.sql
@@ -15,7 +15,7 @@ FROM (
     subq_14.metric_time__day AS metric_time__day
     , subq_13.bookings AS bookings
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       ds AS metric_time__day
     FROM ***************************.mf_time_spine subq_15

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Trino/test_simple_join_to_time_spine__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Trino/test_simple_join_to_time_spine__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_4.metric_time__day AS metric_time__day
     , subq_3.bookings AS bookings
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       subq_5.ds AS metric_time__day
     FROM ***************************.mf_time_spine subq_5

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Trino/test_simple_join_to_time_spine_with_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Trino/test_simple_join_to_time_spine_with_filter__plan0.sql
@@ -14,7 +14,7 @@ FROM (
     subq_5.metric_time__day AS metric_time__day
     , subq_4.bookings AS bookings
   FROM (
-    -- Time Spine
+    -- Read From Time Spine 'mf_time_spine'
     SELECT
       subq_6.ds AS metric_time__day
     FROM ***************************.mf_time_spine subq_6

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Trino/test_simple_join_to_time_spine_with_queried_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Trino/test_simple_join_to_time_spine_with_queried_filter__plan0.sql
@@ -22,7 +22,7 @@ FROM (
       , subq_4.booking__is_instant AS booking__is_instant
       , subq_4.bookings AS bookings
     FROM (
-      -- Time Spine
+      -- Read From Time Spine 'mf_time_spine'
       SELECT
         subq_6.ds AS metric_time__day
       FROM ***************************.mf_time_spine subq_6


### PR DESCRIPTION
This is a huge commit but it's all just snapshot description changes. There are only three files with minor changed logic.