### PR TITLE
Don't apply unnecessary `DATE_TRUNC` to base time spine column

### DIFF
--- a/metricflow/dataset/convert_semantic_model.py
+++ b/metricflow/dataset/convert_semantic_model.py
@@ -528,13 +528,11 @@ class SemanticModelToDataSetConverter:
             time_granularity=ExpandedTimeGranularity.from_time_granularity(base_granularity),
         )
         time_dimension_instances.append(base_time_dimension_instance)
-        base_dimension_select_expr = SemanticModelToDataSetConverter._make_element_sql_expr(
-            table_alias=from_source_alias, element_name=base_column_name
+        base_dimension_select_expr = SqlColumnReferenceExpression.from_table_and_column_names(
+            table_alias=from_source_alias, column_name=base_column_name
         )
-        base_select_column = self._build_column_for_standard_time_granularity(
-            time_granularity=base_granularity,
-            expr=base_dimension_select_expr,
-            column_alias=base_time_dimension_instance.associated_column.column_name,
+        base_select_column = SqlSelectColumn(
+            expr=base_dimension_select_expr, column_alias=base_time_dimension_instance.associated_column.column_name
         )
         select_columns.append(base_select_column)
         new_base_instances, new_base_columns = self._build_time_dimension_instances_and_columns(

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/BigQuery/test_no_metric_custom_granularity_joined_to_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/BigQuery/test_no_metric_custom_granularity_joined_to_non_default_grain__plan0.sql
@@ -413,7 +413,7 @@ FROM (
       FROM (
         -- Read From Time Spine 'mf_time_spine'
         SELECT
-          DATETIME_TRUNC(time_spine_src_28006.ds, day) AS ds__day
+          time_spine_src_28006.ds AS ds__day
           , DATETIME_TRUNC(time_spine_src_28006.ds, isoweek) AS ds__week
           , DATETIME_TRUNC(time_spine_src_28006.ds, month) AS ds__month
           , DATETIME_TRUNC(time_spine_src_28006.ds, quarter) AS ds__quarter

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/BigQuery/test_no_metric_custom_granularity_joined_to_non_default_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/BigQuery/test_no_metric_custom_granularity_joined_to_non_default_grain__plan0_optimized.sql
@@ -10,14 +10,14 @@ SELECT
   subq_12.martian_day AS user__bio_added_ts__martian_day
   , subq_11.martian_day AS metric_time__martian_day
   , DATETIME_TRUNC(users_ds_source_src_28000.bio_added_ts, month) AS user__bio_added_ts__month
-  , DATETIME_TRUNC(time_spine_src_28006.ds, day) AS metric_time__day
+  , time_spine_src_28006.ds AS metric_time__day
 FROM ***************************.dim_users users_ds_source_src_28000
 CROSS JOIN
   ***************************.mf_time_spine time_spine_src_28006
 LEFT OUTER JOIN
   ***************************.mf_time_spine subq_11
 ON
-  DATETIME_TRUNC(time_spine_src_28006.ds, day) = subq_11.ds
+  time_spine_src_28006.ds = subq_11.ds
 LEFT OUTER JOIN
   ***************************.mf_time_spine subq_12
 ON

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/BigQuery/test_no_metric_custom_granularity_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/BigQuery/test_no_metric_custom_granularity_metric_time__plan0.sql
@@ -37,7 +37,7 @@ FROM (
   FROM (
     -- Read From Time Spine 'mf_time_spine'
     SELECT
-      DATETIME_TRUNC(time_spine_src_28006.ds, day) AS ds__day
+      time_spine_src_28006.ds AS ds__day
       , DATETIME_TRUNC(time_spine_src_28006.ds, isoweek) AS ds__week
       , DATETIME_TRUNC(time_spine_src_28006.ds, month) AS ds__month
       , DATETIME_TRUNC(time_spine_src_28006.ds, quarter) AS ds__quarter

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/BigQuery/test_no_metric_custom_granularity_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/BigQuery/test_no_metric_custom_granularity_metric_time__plan0_optimized.sql
@@ -11,6 +11,6 @@ FROM ***************************.mf_time_spine time_spine_src_28006
 LEFT OUTER JOIN
   ***************************.mf_time_spine subq_4
 ON
-  DATETIME_TRUNC(time_spine_src_28006.ds, day) = subq_4.ds
+  time_spine_src_28006.ds = subq_4.ds
 GROUP BY
   metric_time__martian_day

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Databricks/test_no_metric_custom_granularity_joined_to_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Databricks/test_no_metric_custom_granularity_joined_to_non_default_grain__plan0.sql
@@ -413,7 +413,7 @@ FROM (
       FROM (
         -- Read From Time Spine 'mf_time_spine'
         SELECT
-          DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
+          time_spine_src_28006.ds AS ds__day
           , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week
           , DATE_TRUNC('month', time_spine_src_28006.ds) AS ds__month
           , DATE_TRUNC('quarter', time_spine_src_28006.ds) AS ds__quarter

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Databricks/test_no_metric_custom_granularity_joined_to_non_default_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Databricks/test_no_metric_custom_granularity_joined_to_non_default_grain__plan0_optimized.sql
@@ -10,14 +10,14 @@ SELECT
   subq_12.martian_day AS user__bio_added_ts__martian_day
   , subq_11.martian_day AS metric_time__martian_day
   , DATE_TRUNC('month', users_ds_source_src_28000.bio_added_ts) AS user__bio_added_ts__month
-  , DATE_TRUNC('day', time_spine_src_28006.ds) AS metric_time__day
+  , time_spine_src_28006.ds AS metric_time__day
 FROM ***************************.dim_users users_ds_source_src_28000
 CROSS JOIN
   ***************************.mf_time_spine time_spine_src_28006
 LEFT OUTER JOIN
   ***************************.mf_time_spine subq_11
 ON
-  DATE_TRUNC('day', time_spine_src_28006.ds) = subq_11.ds
+  time_spine_src_28006.ds = subq_11.ds
 LEFT OUTER JOIN
   ***************************.mf_time_spine subq_12
 ON
@@ -26,4 +26,4 @@ GROUP BY
   subq_12.martian_day
   , subq_11.martian_day
   , DATE_TRUNC('month', users_ds_source_src_28000.bio_added_ts)
-  , DATE_TRUNC('day', time_spine_src_28006.ds)
+  , time_spine_src_28006.ds

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Databricks/test_no_metric_custom_granularity_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Databricks/test_no_metric_custom_granularity_metric_time__plan0.sql
@@ -37,7 +37,7 @@ FROM (
   FROM (
     -- Read From Time Spine 'mf_time_spine'
     SELECT
-      DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
+      time_spine_src_28006.ds AS ds__day
       , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week
       , DATE_TRUNC('month', time_spine_src_28006.ds) AS ds__month
       , DATE_TRUNC('quarter', time_spine_src_28006.ds) AS ds__quarter

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Databricks/test_no_metric_custom_granularity_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Databricks/test_no_metric_custom_granularity_metric_time__plan0_optimized.sql
@@ -11,6 +11,6 @@ FROM ***************************.mf_time_spine time_spine_src_28006
 LEFT OUTER JOIN
   ***************************.mf_time_spine subq_4
 ON
-  DATE_TRUNC('day', time_spine_src_28006.ds) = subq_4.ds
+  time_spine_src_28006.ds = subq_4.ds
 GROUP BY
   subq_4.martian_day

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/DuckDB/test_no_metric_custom_granularity_joined_to_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/DuckDB/test_no_metric_custom_granularity_joined_to_non_default_grain__plan0.sql
@@ -413,7 +413,7 @@ FROM (
       FROM (
         -- Read From Time Spine 'mf_time_spine'
         SELECT
-          DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
+          time_spine_src_28006.ds AS ds__day
           , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week
           , DATE_TRUNC('month', time_spine_src_28006.ds) AS ds__month
           , DATE_TRUNC('quarter', time_spine_src_28006.ds) AS ds__quarter

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/DuckDB/test_no_metric_custom_granularity_joined_to_non_default_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/DuckDB/test_no_metric_custom_granularity_joined_to_non_default_grain__plan0_optimized.sql
@@ -10,14 +10,14 @@ SELECT
   subq_12.martian_day AS user__bio_added_ts__martian_day
   , subq_11.martian_day AS metric_time__martian_day
   , DATE_TRUNC('month', users_ds_source_src_28000.bio_added_ts) AS user__bio_added_ts__month
-  , DATE_TRUNC('day', time_spine_src_28006.ds) AS metric_time__day
+  , time_spine_src_28006.ds AS metric_time__day
 FROM ***************************.dim_users users_ds_source_src_28000
 CROSS JOIN
   ***************************.mf_time_spine time_spine_src_28006
 LEFT OUTER JOIN
   ***************************.mf_time_spine subq_11
 ON
-  DATE_TRUNC('day', time_spine_src_28006.ds) = subq_11.ds
+  time_spine_src_28006.ds = subq_11.ds
 LEFT OUTER JOIN
   ***************************.mf_time_spine subq_12
 ON
@@ -26,4 +26,4 @@ GROUP BY
   subq_12.martian_day
   , subq_11.martian_day
   , DATE_TRUNC('month', users_ds_source_src_28000.bio_added_ts)
-  , DATE_TRUNC('day', time_spine_src_28006.ds)
+  , time_spine_src_28006.ds

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/DuckDB/test_no_metric_custom_granularity_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/DuckDB/test_no_metric_custom_granularity_metric_time__plan0.sql
@@ -37,7 +37,7 @@ FROM (
   FROM (
     -- Read From Time Spine 'mf_time_spine'
     SELECT
-      DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
+      time_spine_src_28006.ds AS ds__day
       , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week
       , DATE_TRUNC('month', time_spine_src_28006.ds) AS ds__month
       , DATE_TRUNC('quarter', time_spine_src_28006.ds) AS ds__quarter

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/DuckDB/test_no_metric_custom_granularity_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/DuckDB/test_no_metric_custom_granularity_metric_time__plan0_optimized.sql
@@ -11,6 +11,6 @@ FROM ***************************.mf_time_spine time_spine_src_28006
 LEFT OUTER JOIN
   ***************************.mf_time_spine subq_4
 ON
-  DATE_TRUNC('day', time_spine_src_28006.ds) = subq_4.ds
+  time_spine_src_28006.ds = subq_4.ds
 GROUP BY
   subq_4.martian_day

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Postgres/test_no_metric_custom_granularity_joined_to_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Postgres/test_no_metric_custom_granularity_joined_to_non_default_grain__plan0.sql
@@ -413,7 +413,7 @@ FROM (
       FROM (
         -- Read From Time Spine 'mf_time_spine'
         SELECT
-          DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
+          time_spine_src_28006.ds AS ds__day
           , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week
           , DATE_TRUNC('month', time_spine_src_28006.ds) AS ds__month
           , DATE_TRUNC('quarter', time_spine_src_28006.ds) AS ds__quarter

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Postgres/test_no_metric_custom_granularity_joined_to_non_default_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Postgres/test_no_metric_custom_granularity_joined_to_non_default_grain__plan0_optimized.sql
@@ -10,14 +10,14 @@ SELECT
   subq_12.martian_day AS user__bio_added_ts__martian_day
   , subq_11.martian_day AS metric_time__martian_day
   , DATE_TRUNC('month', users_ds_source_src_28000.bio_added_ts) AS user__bio_added_ts__month
-  , DATE_TRUNC('day', time_spine_src_28006.ds) AS metric_time__day
+  , time_spine_src_28006.ds AS metric_time__day
 FROM ***************************.dim_users users_ds_source_src_28000
 CROSS JOIN
   ***************************.mf_time_spine time_spine_src_28006
 LEFT OUTER JOIN
   ***************************.mf_time_spine subq_11
 ON
-  DATE_TRUNC('day', time_spine_src_28006.ds) = subq_11.ds
+  time_spine_src_28006.ds = subq_11.ds
 LEFT OUTER JOIN
   ***************************.mf_time_spine subq_12
 ON
@@ -26,4 +26,4 @@ GROUP BY
   subq_12.martian_day
   , subq_11.martian_day
   , DATE_TRUNC('month', users_ds_source_src_28000.bio_added_ts)
-  , DATE_TRUNC('day', time_spine_src_28006.ds)
+  , time_spine_src_28006.ds

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Postgres/test_no_metric_custom_granularity_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Postgres/test_no_metric_custom_granularity_metric_time__plan0.sql
@@ -37,7 +37,7 @@ FROM (
   FROM (
     -- Read From Time Spine 'mf_time_spine'
     SELECT
-      DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
+      time_spine_src_28006.ds AS ds__day
       , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week
       , DATE_TRUNC('month', time_spine_src_28006.ds) AS ds__month
       , DATE_TRUNC('quarter', time_spine_src_28006.ds) AS ds__quarter

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Postgres/test_no_metric_custom_granularity_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Postgres/test_no_metric_custom_granularity_metric_time__plan0_optimized.sql
@@ -11,6 +11,6 @@ FROM ***************************.mf_time_spine time_spine_src_28006
 LEFT OUTER JOIN
   ***************************.mf_time_spine subq_4
 ON
-  DATE_TRUNC('day', time_spine_src_28006.ds) = subq_4.ds
+  time_spine_src_28006.ds = subq_4.ds
 GROUP BY
   subq_4.martian_day

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Redshift/test_no_metric_custom_granularity_joined_to_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Redshift/test_no_metric_custom_granularity_joined_to_non_default_grain__plan0.sql
@@ -413,7 +413,7 @@ FROM (
       FROM (
         -- Read From Time Spine 'mf_time_spine'
         SELECT
-          DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
+          time_spine_src_28006.ds AS ds__day
           , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week
           , DATE_TRUNC('month', time_spine_src_28006.ds) AS ds__month
           , DATE_TRUNC('quarter', time_spine_src_28006.ds) AS ds__quarter

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Redshift/test_no_metric_custom_granularity_joined_to_non_default_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Redshift/test_no_metric_custom_granularity_joined_to_non_default_grain__plan0_optimized.sql
@@ -10,14 +10,14 @@ SELECT
   subq_12.martian_day AS user__bio_added_ts__martian_day
   , subq_11.martian_day AS metric_time__martian_day
   , DATE_TRUNC('month', users_ds_source_src_28000.bio_added_ts) AS user__bio_added_ts__month
-  , DATE_TRUNC('day', time_spine_src_28006.ds) AS metric_time__day
+  , time_spine_src_28006.ds AS metric_time__day
 FROM ***************************.dim_users users_ds_source_src_28000
 CROSS JOIN
   ***************************.mf_time_spine time_spine_src_28006
 LEFT OUTER JOIN
   ***************************.mf_time_spine subq_11
 ON
-  DATE_TRUNC('day', time_spine_src_28006.ds) = subq_11.ds
+  time_spine_src_28006.ds = subq_11.ds
 LEFT OUTER JOIN
   ***************************.mf_time_spine subq_12
 ON
@@ -26,4 +26,4 @@ GROUP BY
   subq_12.martian_day
   , subq_11.martian_day
   , DATE_TRUNC('month', users_ds_source_src_28000.bio_added_ts)
-  , DATE_TRUNC('day', time_spine_src_28006.ds)
+  , time_spine_src_28006.ds

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Redshift/test_no_metric_custom_granularity_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Redshift/test_no_metric_custom_granularity_metric_time__plan0.sql
@@ -37,7 +37,7 @@ FROM (
   FROM (
     -- Read From Time Spine 'mf_time_spine'
     SELECT
-      DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
+      time_spine_src_28006.ds AS ds__day
       , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week
       , DATE_TRUNC('month', time_spine_src_28006.ds) AS ds__month
       , DATE_TRUNC('quarter', time_spine_src_28006.ds) AS ds__quarter

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Redshift/test_no_metric_custom_granularity_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Redshift/test_no_metric_custom_granularity_metric_time__plan0_optimized.sql
@@ -11,6 +11,6 @@ FROM ***************************.mf_time_spine time_spine_src_28006
 LEFT OUTER JOIN
   ***************************.mf_time_spine subq_4
 ON
-  DATE_TRUNC('day', time_spine_src_28006.ds) = subq_4.ds
+  time_spine_src_28006.ds = subq_4.ds
 GROUP BY
   subq_4.martian_day

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Snowflake/test_no_metric_custom_granularity_joined_to_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Snowflake/test_no_metric_custom_granularity_joined_to_non_default_grain__plan0.sql
@@ -413,7 +413,7 @@ FROM (
       FROM (
         -- Read From Time Spine 'mf_time_spine'
         SELECT
-          DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
+          time_spine_src_28006.ds AS ds__day
           , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week
           , DATE_TRUNC('month', time_spine_src_28006.ds) AS ds__month
           , DATE_TRUNC('quarter', time_spine_src_28006.ds) AS ds__quarter

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Snowflake/test_no_metric_custom_granularity_joined_to_non_default_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Snowflake/test_no_metric_custom_granularity_joined_to_non_default_grain__plan0_optimized.sql
@@ -10,14 +10,14 @@ SELECT
   subq_12.martian_day AS user__bio_added_ts__martian_day
   , subq_11.martian_day AS metric_time__martian_day
   , DATE_TRUNC('month', users_ds_source_src_28000.bio_added_ts) AS user__bio_added_ts__month
-  , DATE_TRUNC('day', time_spine_src_28006.ds) AS metric_time__day
+  , time_spine_src_28006.ds AS metric_time__day
 FROM ***************************.dim_users users_ds_source_src_28000
 CROSS JOIN
   ***************************.mf_time_spine time_spine_src_28006
 LEFT OUTER JOIN
   ***************************.mf_time_spine subq_11
 ON
-  DATE_TRUNC('day', time_spine_src_28006.ds) = subq_11.ds
+  time_spine_src_28006.ds = subq_11.ds
 LEFT OUTER JOIN
   ***************************.mf_time_spine subq_12
 ON
@@ -26,4 +26,4 @@ GROUP BY
   subq_12.martian_day
   , subq_11.martian_day
   , DATE_TRUNC('month', users_ds_source_src_28000.bio_added_ts)
-  , DATE_TRUNC('day', time_spine_src_28006.ds)
+  , time_spine_src_28006.ds

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Snowflake/test_no_metric_custom_granularity_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Snowflake/test_no_metric_custom_granularity_metric_time__plan0.sql
@@ -37,7 +37,7 @@ FROM (
   FROM (
     -- Read From Time Spine 'mf_time_spine'
     SELECT
-      DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
+      time_spine_src_28006.ds AS ds__day
       , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week
       , DATE_TRUNC('month', time_spine_src_28006.ds) AS ds__month
       , DATE_TRUNC('quarter', time_spine_src_28006.ds) AS ds__quarter

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Snowflake/test_no_metric_custom_granularity_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Snowflake/test_no_metric_custom_granularity_metric_time__plan0_optimized.sql
@@ -11,6 +11,6 @@ FROM ***************************.mf_time_spine time_spine_src_28006
 LEFT OUTER JOIN
   ***************************.mf_time_spine subq_4
 ON
-  DATE_TRUNC('day', time_spine_src_28006.ds) = subq_4.ds
+  time_spine_src_28006.ds = subq_4.ds
 GROUP BY
   subq_4.martian_day

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Trino/test_no_metric_custom_granularity_joined_to_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Trino/test_no_metric_custom_granularity_joined_to_non_default_grain__plan0.sql
@@ -413,7 +413,7 @@ FROM (
       FROM (
         -- Read From Time Spine 'mf_time_spine'
         SELECT
-          DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
+          time_spine_src_28006.ds AS ds__day
           , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week
           , DATE_TRUNC('month', time_spine_src_28006.ds) AS ds__month
           , DATE_TRUNC('quarter', time_spine_src_28006.ds) AS ds__quarter

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Trino/test_no_metric_custom_granularity_joined_to_non_default_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Trino/test_no_metric_custom_granularity_joined_to_non_default_grain__plan0_optimized.sql
@@ -10,14 +10,14 @@ SELECT
   subq_12.martian_day AS user__bio_added_ts__martian_day
   , subq_11.martian_day AS metric_time__martian_day
   , DATE_TRUNC('month', users_ds_source_src_28000.bio_added_ts) AS user__bio_added_ts__month
-  , DATE_TRUNC('day', time_spine_src_28006.ds) AS metric_time__day
+  , time_spine_src_28006.ds AS metric_time__day
 FROM ***************************.dim_users users_ds_source_src_28000
 CROSS JOIN
   ***************************.mf_time_spine time_spine_src_28006
 LEFT OUTER JOIN
   ***************************.mf_time_spine subq_11
 ON
-  DATE_TRUNC('day', time_spine_src_28006.ds) = subq_11.ds
+  time_spine_src_28006.ds = subq_11.ds
 LEFT OUTER JOIN
   ***************************.mf_time_spine subq_12
 ON
@@ -26,4 +26,4 @@ GROUP BY
   subq_12.martian_day
   , subq_11.martian_day
   , DATE_TRUNC('month', users_ds_source_src_28000.bio_added_ts)
-  , DATE_TRUNC('day', time_spine_src_28006.ds)
+  , time_spine_src_28006.ds

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Trino/test_no_metric_custom_granularity_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Trino/test_no_metric_custom_granularity_metric_time__plan0.sql
@@ -37,7 +37,7 @@ FROM (
   FROM (
     -- Read From Time Spine 'mf_time_spine'
     SELECT
-      DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
+      time_spine_src_28006.ds AS ds__day
       , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week
       , DATE_TRUNC('month', time_spine_src_28006.ds) AS ds__month
       , DATE_TRUNC('quarter', time_spine_src_28006.ds) AS ds__quarter

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Trino/test_no_metric_custom_granularity_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Trino/test_no_metric_custom_granularity_metric_time__plan0_optimized.sql
@@ -11,6 +11,6 @@ FROM ***************************.mf_time_spine time_spine_src_28006
 LEFT OUTER JOIN
   ***************************.mf_time_spine subq_4
 ON
-  DATE_TRUNC('day', time_spine_src_28006.ds) = subq_4.ds
+  time_spine_src_28006.ds = subq_4.ds
 GROUP BY
   subq_4.martian_day

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/BigQuery/test_sub_daily_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/BigQuery/test_sub_daily_metric_time__plan0.sql
@@ -41,7 +41,7 @@ FROM (
   FROM (
     -- Read From Time Spine 'mf_time_spine_millisecond'
     SELECT
-      DATETIME_TRUNC(time_spine_src_28002.ts, millisecond) AS ts__millisecond
+      time_spine_src_28002.ts AS ts__millisecond
       , DATETIME_TRUNC(time_spine_src_28002.ts, second) AS ts__second
       , DATETIME_TRUNC(time_spine_src_28002.ts, minute) AS ts__minute
       , DATETIME_TRUNC(time_spine_src_28002.ts, hour) AS ts__hour

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/BigQuery/test_sub_daily_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/BigQuery/test_sub_daily_metric_time__plan0_optimized.sql
@@ -6,7 +6,7 @@ sql_engine: BigQuery
 -- Metric Time Dimension 'ts'
 -- Pass Only Elements: ['metric_time__millisecond',]
 SELECT
-  DATETIME_TRUNC(ts, millisecond) AS metric_time__millisecond
+  ts AS metric_time__millisecond
 FROM ***************************.mf_time_spine_millisecond time_spine_src_28002
 GROUP BY
   metric_time__millisecond

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/BigQuery/test_subdaily_time_constraint_without_metrics__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/BigQuery/test_subdaily_time_constraint_without_metrics__plan0.sql
@@ -70,7 +70,7 @@ FROM (
     FROM (
       -- Read From Time Spine 'mf_time_spine_second'
       SELECT
-        DATETIME_TRUNC(time_spine_src_28003.ts, second) AS ts__second
+        time_spine_src_28003.ts AS ts__second
         , DATETIME_TRUNC(time_spine_src_28003.ts, minute) AS ts__minute
         , DATETIME_TRUNC(time_spine_src_28003.ts, hour) AS ts__hour
         , DATETIME_TRUNC(time_spine_src_28003.ts, day) AS ts__day

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/BigQuery/test_subdaily_time_constraint_without_metrics__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/BigQuery/test_subdaily_time_constraint_without_metrics__plan0_optimized.sql
@@ -7,8 +7,8 @@ sql_engine: BigQuery
 -- Constrain Time Range to [2020-01-01T00:00:02, 2020-01-01T00:00:08]
 -- Pass Only Elements: ['metric_time__second',]
 SELECT
-  DATETIME_TRUNC(ts, second) AS metric_time__second
+  ts AS metric_time__second
 FROM ***************************.mf_time_spine_second time_spine_src_28003
-WHERE DATETIME_TRUNC(ts, second) BETWEEN '2020-01-01 00:00:02' AND '2020-01-01 00:00:08'
+WHERE ts BETWEEN '2020-01-01 00:00:02' AND '2020-01-01 00:00:08'
 GROUP BY
   metric_time__second

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Databricks/test_sub_daily_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Databricks/test_sub_daily_metric_time__plan0.sql
@@ -41,7 +41,7 @@ FROM (
   FROM (
     -- Read From Time Spine 'mf_time_spine_millisecond'
     SELECT
-      DATE_TRUNC('millisecond', time_spine_src_28002.ts) AS ts__millisecond
+      time_spine_src_28002.ts AS ts__millisecond
       , DATE_TRUNC('second', time_spine_src_28002.ts) AS ts__second
       , DATE_TRUNC('minute', time_spine_src_28002.ts) AS ts__minute
       , DATE_TRUNC('hour', time_spine_src_28002.ts) AS ts__hour

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Databricks/test_sub_daily_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Databricks/test_sub_daily_metric_time__plan0_optimized.sql
@@ -6,7 +6,7 @@ sql_engine: Databricks
 -- Metric Time Dimension 'ts'
 -- Pass Only Elements: ['metric_time__millisecond',]
 SELECT
-  DATE_TRUNC('millisecond', ts) AS metric_time__millisecond
+  ts AS metric_time__millisecond
 FROM ***************************.mf_time_spine_millisecond time_spine_src_28002
 GROUP BY
-  DATE_TRUNC('millisecond', ts)
+  ts

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Databricks/test_subdaily_time_constraint_without_metrics__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Databricks/test_subdaily_time_constraint_without_metrics__plan0.sql
@@ -70,7 +70,7 @@ FROM (
     FROM (
       -- Read From Time Spine 'mf_time_spine_second'
       SELECT
-        DATE_TRUNC('second', time_spine_src_28003.ts) AS ts__second
+        time_spine_src_28003.ts AS ts__second
         , DATE_TRUNC('minute', time_spine_src_28003.ts) AS ts__minute
         , DATE_TRUNC('hour', time_spine_src_28003.ts) AS ts__hour
         , DATE_TRUNC('day', time_spine_src_28003.ts) AS ts__day

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Databricks/test_subdaily_time_constraint_without_metrics__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Databricks/test_subdaily_time_constraint_without_metrics__plan0_optimized.sql
@@ -7,8 +7,8 @@ sql_engine: Databricks
 -- Constrain Time Range to [2020-01-01T00:00:02, 2020-01-01T00:00:08]
 -- Pass Only Elements: ['metric_time__second',]
 SELECT
-  DATE_TRUNC('second', ts) AS metric_time__second
+  ts AS metric_time__second
 FROM ***************************.mf_time_spine_second time_spine_src_28003
-WHERE DATE_TRUNC('second', ts) BETWEEN '2020-01-01 00:00:02' AND '2020-01-01 00:00:08'
+WHERE ts BETWEEN '2020-01-01 00:00:02' AND '2020-01-01 00:00:08'
 GROUP BY
-  DATE_TRUNC('second', ts)
+  ts

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/DuckDB/test_sub_daily_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/DuckDB/test_sub_daily_metric_time__plan0.sql
@@ -41,7 +41,7 @@ FROM (
   FROM (
     -- Read From Time Spine 'mf_time_spine_millisecond'
     SELECT
-      DATE_TRUNC('millisecond', time_spine_src_28002.ts) AS ts__millisecond
+      time_spine_src_28002.ts AS ts__millisecond
       , DATE_TRUNC('second', time_spine_src_28002.ts) AS ts__second
       , DATE_TRUNC('minute', time_spine_src_28002.ts) AS ts__minute
       , DATE_TRUNC('hour', time_spine_src_28002.ts) AS ts__hour

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/DuckDB/test_sub_daily_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/DuckDB/test_sub_daily_metric_time__plan0_optimized.sql
@@ -6,7 +6,7 @@ sql_engine: DuckDB
 -- Metric Time Dimension 'ts'
 -- Pass Only Elements: ['metric_time__millisecond',]
 SELECT
-  DATE_TRUNC('millisecond', ts) AS metric_time__millisecond
+  ts AS metric_time__millisecond
 FROM ***************************.mf_time_spine_millisecond time_spine_src_28002
 GROUP BY
-  DATE_TRUNC('millisecond', ts)
+  ts

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/DuckDB/test_subdaily_time_constraint_without_metrics__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/DuckDB/test_subdaily_time_constraint_without_metrics__plan0.sql
@@ -70,7 +70,7 @@ FROM (
     FROM (
       -- Read From Time Spine 'mf_time_spine_second'
       SELECT
-        DATE_TRUNC('second', time_spine_src_28003.ts) AS ts__second
+        time_spine_src_28003.ts AS ts__second
         , DATE_TRUNC('minute', time_spine_src_28003.ts) AS ts__minute
         , DATE_TRUNC('hour', time_spine_src_28003.ts) AS ts__hour
         , DATE_TRUNC('day', time_spine_src_28003.ts) AS ts__day

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/DuckDB/test_subdaily_time_constraint_without_metrics__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/DuckDB/test_subdaily_time_constraint_without_metrics__plan0_optimized.sql
@@ -7,8 +7,8 @@ sql_engine: DuckDB
 -- Constrain Time Range to [2020-01-01T00:00:02, 2020-01-01T00:00:08]
 -- Pass Only Elements: ['metric_time__second',]
 SELECT
-  DATE_TRUNC('second', ts) AS metric_time__second
+  ts AS metric_time__second
 FROM ***************************.mf_time_spine_second time_spine_src_28003
-WHERE DATE_TRUNC('second', ts) BETWEEN '2020-01-01 00:00:02' AND '2020-01-01 00:00:08'
+WHERE ts BETWEEN '2020-01-01 00:00:02' AND '2020-01-01 00:00:08'
 GROUP BY
-  DATE_TRUNC('second', ts)
+  ts

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Postgres/test_sub_daily_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Postgres/test_sub_daily_metric_time__plan0.sql
@@ -41,7 +41,7 @@ FROM (
   FROM (
     -- Read From Time Spine 'mf_time_spine_millisecond'
     SELECT
-      DATE_TRUNC('millisecond', time_spine_src_28002.ts) AS ts__millisecond
+      time_spine_src_28002.ts AS ts__millisecond
       , DATE_TRUNC('second', time_spine_src_28002.ts) AS ts__second
       , DATE_TRUNC('minute', time_spine_src_28002.ts) AS ts__minute
       , DATE_TRUNC('hour', time_spine_src_28002.ts) AS ts__hour

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Postgres/test_sub_daily_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Postgres/test_sub_daily_metric_time__plan0_optimized.sql
@@ -6,7 +6,7 @@ sql_engine: Postgres
 -- Metric Time Dimension 'ts'
 -- Pass Only Elements: ['metric_time__millisecond',]
 SELECT
-  DATE_TRUNC('millisecond', ts) AS metric_time__millisecond
+  ts AS metric_time__millisecond
 FROM ***************************.mf_time_spine_millisecond time_spine_src_28002
 GROUP BY
-  DATE_TRUNC('millisecond', ts)
+  ts

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Postgres/test_subdaily_time_constraint_without_metrics__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Postgres/test_subdaily_time_constraint_without_metrics__plan0.sql
@@ -70,7 +70,7 @@ FROM (
     FROM (
       -- Read From Time Spine 'mf_time_spine_second'
       SELECT
-        DATE_TRUNC('second', time_spine_src_28003.ts) AS ts__second
+        time_spine_src_28003.ts AS ts__second
         , DATE_TRUNC('minute', time_spine_src_28003.ts) AS ts__minute
         , DATE_TRUNC('hour', time_spine_src_28003.ts) AS ts__hour
         , DATE_TRUNC('day', time_spine_src_28003.ts) AS ts__day

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Postgres/test_subdaily_time_constraint_without_metrics__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Postgres/test_subdaily_time_constraint_without_metrics__plan0_optimized.sql
@@ -7,8 +7,8 @@ sql_engine: Postgres
 -- Constrain Time Range to [2020-01-01T00:00:02, 2020-01-01T00:00:08]
 -- Pass Only Elements: ['metric_time__second',]
 SELECT
-  DATE_TRUNC('second', ts) AS metric_time__second
+  ts AS metric_time__second
 FROM ***************************.mf_time_spine_second time_spine_src_28003
-WHERE DATE_TRUNC('second', ts) BETWEEN '2020-01-01 00:00:02' AND '2020-01-01 00:00:08'
+WHERE ts BETWEEN '2020-01-01 00:00:02' AND '2020-01-01 00:00:08'
 GROUP BY
-  DATE_TRUNC('second', ts)
+  ts

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Redshift/test_sub_daily_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Redshift/test_sub_daily_metric_time__plan0.sql
@@ -41,7 +41,7 @@ FROM (
   FROM (
     -- Read From Time Spine 'mf_time_spine_millisecond'
     SELECT
-      DATE_TRUNC('millisecond', time_spine_src_28002.ts) AS ts__millisecond
+      time_spine_src_28002.ts AS ts__millisecond
       , DATE_TRUNC('second', time_spine_src_28002.ts) AS ts__second
       , DATE_TRUNC('minute', time_spine_src_28002.ts) AS ts__minute
       , DATE_TRUNC('hour', time_spine_src_28002.ts) AS ts__hour

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Redshift/test_sub_daily_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Redshift/test_sub_daily_metric_time__plan0_optimized.sql
@@ -6,7 +6,7 @@ sql_engine: Redshift
 -- Metric Time Dimension 'ts'
 -- Pass Only Elements: ['metric_time__millisecond',]
 SELECT
-  DATE_TRUNC('millisecond', ts) AS metric_time__millisecond
+  ts AS metric_time__millisecond
 FROM ***************************.mf_time_spine_millisecond time_spine_src_28002
 GROUP BY
-  DATE_TRUNC('millisecond', ts)
+  ts

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Redshift/test_subdaily_time_constraint_without_metrics__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Redshift/test_subdaily_time_constraint_without_metrics__plan0.sql
@@ -70,7 +70,7 @@ FROM (
     FROM (
       -- Read From Time Spine 'mf_time_spine_second'
       SELECT
-        DATE_TRUNC('second', time_spine_src_28003.ts) AS ts__second
+        time_spine_src_28003.ts AS ts__second
         , DATE_TRUNC('minute', time_spine_src_28003.ts) AS ts__minute
         , DATE_TRUNC('hour', time_spine_src_28003.ts) AS ts__hour
         , DATE_TRUNC('day', time_spine_src_28003.ts) AS ts__day

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Redshift/test_subdaily_time_constraint_without_metrics__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Redshift/test_subdaily_time_constraint_without_metrics__plan0_optimized.sql
@@ -7,8 +7,8 @@ sql_engine: Redshift
 -- Constrain Time Range to [2020-01-01T00:00:02, 2020-01-01T00:00:08]
 -- Pass Only Elements: ['metric_time__second',]
 SELECT
-  DATE_TRUNC('second', ts) AS metric_time__second
+  ts AS metric_time__second
 FROM ***************************.mf_time_spine_second time_spine_src_28003
-WHERE DATE_TRUNC('second', ts) BETWEEN '2020-01-01 00:00:02' AND '2020-01-01 00:00:08'
+WHERE ts BETWEEN '2020-01-01 00:00:02' AND '2020-01-01 00:00:08'
 GROUP BY
-  DATE_TRUNC('second', ts)
+  ts

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Snowflake/test_sub_daily_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Snowflake/test_sub_daily_metric_time__plan0.sql
@@ -41,7 +41,7 @@ FROM (
   FROM (
     -- Read From Time Spine 'mf_time_spine_millisecond'
     SELECT
-      DATE_TRUNC('millisecond', time_spine_src_28002.ts) AS ts__millisecond
+      time_spine_src_28002.ts AS ts__millisecond
       , DATE_TRUNC('second', time_spine_src_28002.ts) AS ts__second
       , DATE_TRUNC('minute', time_spine_src_28002.ts) AS ts__minute
       , DATE_TRUNC('hour', time_spine_src_28002.ts) AS ts__hour

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Snowflake/test_sub_daily_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Snowflake/test_sub_daily_metric_time__plan0_optimized.sql
@@ -6,7 +6,7 @@ sql_engine: Snowflake
 -- Metric Time Dimension 'ts'
 -- Pass Only Elements: ['metric_time__millisecond',]
 SELECT
-  DATE_TRUNC('millisecond', ts) AS metric_time__millisecond
+  ts AS metric_time__millisecond
 FROM ***************************.mf_time_spine_millisecond time_spine_src_28002
 GROUP BY
-  DATE_TRUNC('millisecond', ts)
+  ts

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Snowflake/test_subdaily_time_constraint_without_metrics__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Snowflake/test_subdaily_time_constraint_without_metrics__plan0.sql
@@ -70,7 +70,7 @@ FROM (
     FROM (
       -- Read From Time Spine 'mf_time_spine_second'
       SELECT
-        DATE_TRUNC('second', time_spine_src_28003.ts) AS ts__second
+        time_spine_src_28003.ts AS ts__second
         , DATE_TRUNC('minute', time_spine_src_28003.ts) AS ts__minute
         , DATE_TRUNC('hour', time_spine_src_28003.ts) AS ts__hour
         , DATE_TRUNC('day', time_spine_src_28003.ts) AS ts__day

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Snowflake/test_subdaily_time_constraint_without_metrics__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Snowflake/test_subdaily_time_constraint_without_metrics__plan0_optimized.sql
@@ -7,8 +7,8 @@ sql_engine: Snowflake
 -- Constrain Time Range to [2020-01-01T00:00:02, 2020-01-01T00:00:08]
 -- Pass Only Elements: ['metric_time__second',]
 SELECT
-  DATE_TRUNC('second', ts) AS metric_time__second
+  ts AS metric_time__second
 FROM ***************************.mf_time_spine_second time_spine_src_28003
-WHERE DATE_TRUNC('second', ts) BETWEEN '2020-01-01 00:00:02' AND '2020-01-01 00:00:08'
+WHERE ts BETWEEN '2020-01-01 00:00:02' AND '2020-01-01 00:00:08'
 GROUP BY
-  DATE_TRUNC('second', ts)
+  ts

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Trino/test_sub_daily_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Trino/test_sub_daily_metric_time__plan0.sql
@@ -41,7 +41,7 @@ FROM (
   FROM (
     -- Read From Time Spine 'mf_time_spine_millisecond'
     SELECT
-      DATE_TRUNC('millisecond', time_spine_src_28002.ts) AS ts__millisecond
+      time_spine_src_28002.ts AS ts__millisecond
       , DATE_TRUNC('second', time_spine_src_28002.ts) AS ts__second
       , DATE_TRUNC('minute', time_spine_src_28002.ts) AS ts__minute
       , DATE_TRUNC('hour', time_spine_src_28002.ts) AS ts__hour

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Trino/test_sub_daily_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Trino/test_sub_daily_metric_time__plan0_optimized.sql
@@ -6,7 +6,7 @@ sql_engine: Trino
 -- Metric Time Dimension 'ts'
 -- Pass Only Elements: ['metric_time__millisecond',]
 SELECT
-  DATE_TRUNC('millisecond', ts) AS metric_time__millisecond
+  ts AS metric_time__millisecond
 FROM ***************************.mf_time_spine_millisecond time_spine_src_28002
 GROUP BY
-  DATE_TRUNC('millisecond', ts)
+  ts

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Trino/test_subdaily_time_constraint_without_metrics__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Trino/test_subdaily_time_constraint_without_metrics__plan0.sql
@@ -70,7 +70,7 @@ FROM (
     FROM (
       -- Read From Time Spine 'mf_time_spine_second'
       SELECT
-        DATE_TRUNC('second', time_spine_src_28003.ts) AS ts__second
+        time_spine_src_28003.ts AS ts__second
         , DATE_TRUNC('minute', time_spine_src_28003.ts) AS ts__minute
         , DATE_TRUNC('hour', time_spine_src_28003.ts) AS ts__hour
         , DATE_TRUNC('day', time_spine_src_28003.ts) AS ts__day

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Trino/test_subdaily_time_constraint_without_metrics__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Trino/test_subdaily_time_constraint_without_metrics__plan0_optimized.sql
@@ -7,8 +7,8 @@ sql_engine: Trino
 -- Constrain Time Range to [2020-01-01T00:00:02, 2020-01-01T00:00:08]
 -- Pass Only Elements: ['metric_time__second',]
 SELECT
-  DATE_TRUNC('second', ts) AS metric_time__second
+  ts AS metric_time__second
 FROM ***************************.mf_time_spine_second time_spine_src_28003
-WHERE DATE_TRUNC('second', ts) BETWEEN timestamp '2020-01-01 00:00:02' AND timestamp '2020-01-01 00:00:08'
+WHERE ts BETWEEN timestamp '2020-01-01 00:00:02' AND timestamp '2020-01-01 00:00:08'
 GROUP BY
-  DATE_TRUNC('second', ts)
+  ts

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/BigQuery/test_dimensions_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/BigQuery/test_dimensions_with_time_constraint__plan0.sql
@@ -224,7 +224,7 @@ FROM (
         FROM (
           -- Read From Time Spine 'mf_time_spine'
           SELECT
-            DATETIME_TRUNC(time_spine_src_28006.ds, day) AS ds__day
+            time_spine_src_28006.ds AS ds__day
             , DATETIME_TRUNC(time_spine_src_28006.ds, isoweek) AS ds__week
             , DATETIME_TRUNC(time_spine_src_28006.ds, month) AS ds__month
             , DATETIME_TRUNC(time_spine_src_28006.ds, quarter) AS ds__quarter

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/BigQuery/test_dimensions_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/BigQuery/test_dimensions_with_time_constraint__plan0_optimized.sql
@@ -6,7 +6,7 @@ sql_engine: BigQuery
 -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-03T00:00:00]
 -- Pass Only Elements: ['user__home_state_latest', 'listing__is_lux_latest', 'metric_time__day']
 SELECT
-  DATETIME_TRUNC(time_spine_src_28006.ds, day) AS metric_time__day
+  time_spine_src_28006.ds AS metric_time__day
   , listings_latest_src_28000.is_lux AS listing__is_lux_latest
   , users_latest_src_28000.home_state_latest AS user__home_state_latest
 FROM ***************************.dim_listings_latest listings_latest_src_28000
@@ -16,7 +16,7 @@ FULL OUTER JOIN
   ***************************.dim_users_latest users_latest_src_28000
 ON
   listings_latest_src_28000.user_id = users_latest_src_28000.user_id
-WHERE DATETIME_TRUNC(time_spine_src_28006.ds, day) BETWEEN '2020-01-01' AND '2020-01-03'
+WHERE time_spine_src_28006.ds BETWEEN '2020-01-01' AND '2020-01-03'
 GROUP BY
   metric_time__day
   , listing__is_lux_latest

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/BigQuery/test_metric_time_only__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/BigQuery/test_metric_time_only__plan0.sql
@@ -37,7 +37,7 @@ FROM (
   FROM (
     -- Read From Time Spine 'mf_time_spine'
     SELECT
-      DATETIME_TRUNC(time_spine_src_28006.ds, day) AS ds__day
+      time_spine_src_28006.ds AS ds__day
       , DATETIME_TRUNC(time_spine_src_28006.ds, isoweek) AS ds__week
       , DATETIME_TRUNC(time_spine_src_28006.ds, month) AS ds__month
       , DATETIME_TRUNC(time_spine_src_28006.ds, quarter) AS ds__quarter

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/BigQuery/test_metric_time_only__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/BigQuery/test_metric_time_only__plan0_optimized.sql
@@ -8,7 +8,7 @@ sql_engine: BigQuery
 -- Metric Time Dimension 'ds'
 -- Pass Only Elements: ['metric_time__day',]
 SELECT
-  DATETIME_TRUNC(ds, day) AS metric_time__day
+  ds AS metric_time__day
 FROM ***************************.mf_time_spine time_spine_src_28006
 GROUP BY
   metric_time__day

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/BigQuery/test_metric_time_quarter_alone__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/BigQuery/test_metric_time_quarter_alone__plan0.sql
@@ -35,7 +35,7 @@ FROM (
   FROM (
     -- Read From Time Spine 'mf_time_spine'
     SELECT
-      DATETIME_TRUNC(time_spine_src_28006.ds, day) AS ds__day
+      time_spine_src_28006.ds AS ds__day
       , DATETIME_TRUNC(time_spine_src_28006.ds, isoweek) AS ds__week
       , DATETIME_TRUNC(time_spine_src_28006.ds, month) AS ds__month
       , DATETIME_TRUNC(time_spine_src_28006.ds, quarter) AS ds__quarter

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/BigQuery/test_metric_time_with_other_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/BigQuery/test_metric_time_with_other_dimensions__plan0.sql
@@ -163,7 +163,7 @@ FROM (
       FROM (
         -- Read From Time Spine 'mf_time_spine'
         SELECT
-          DATETIME_TRUNC(time_spine_src_28006.ds, day) AS ds__day
+          time_spine_src_28006.ds AS ds__day
           , DATETIME_TRUNC(time_spine_src_28006.ds, isoweek) AS ds__week
           , DATETIME_TRUNC(time_spine_src_28006.ds, month) AS ds__month
           , DATETIME_TRUNC(time_spine_src_28006.ds, quarter) AS ds__quarter

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/BigQuery/test_metric_time_with_other_dimensions__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/BigQuery/test_metric_time_with_other_dimensions__plan0_optimized.sql
@@ -5,7 +5,7 @@ sql_engine: BigQuery
 -- Join Standard Outputs
 -- Pass Only Elements: ['user__home_state_latest', 'listing__is_lux_latest', 'metric_time__day']
 SELECT
-  DATETIME_TRUNC(time_spine_src_28006.ds, day) AS metric_time__day
+  time_spine_src_28006.ds AS metric_time__day
   , listings_latest_src_28000.is_lux AS listing__is_lux_latest
   , users_latest_src_28000.home_state_latest AS user__home_state_latest
 FROM ***************************.dim_listings_latest listings_latest_src_28000

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Databricks/test_dimensions_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Databricks/test_dimensions_with_time_constraint__plan0.sql
@@ -224,7 +224,7 @@ FROM (
         FROM (
           -- Read From Time Spine 'mf_time_spine'
           SELECT
-            DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
+            time_spine_src_28006.ds AS ds__day
             , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week
             , DATE_TRUNC('month', time_spine_src_28006.ds) AS ds__month
             , DATE_TRUNC('quarter', time_spine_src_28006.ds) AS ds__quarter

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Databricks/test_dimensions_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Databricks/test_dimensions_with_time_constraint__plan0_optimized.sql
@@ -6,7 +6,7 @@ sql_engine: Databricks
 -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-03T00:00:00]
 -- Pass Only Elements: ['user__home_state_latest', 'listing__is_lux_latest', 'metric_time__day']
 SELECT
-  DATE_TRUNC('day', time_spine_src_28006.ds) AS metric_time__day
+  time_spine_src_28006.ds AS metric_time__day
   , listings_latest_src_28000.is_lux AS listing__is_lux_latest
   , users_latest_src_28000.home_state_latest AS user__home_state_latest
 FROM ***************************.dim_listings_latest listings_latest_src_28000
@@ -16,8 +16,8 @@ FULL OUTER JOIN
   ***************************.dim_users_latest users_latest_src_28000
 ON
   listings_latest_src_28000.user_id = users_latest_src_28000.user_id
-WHERE DATE_TRUNC('day', time_spine_src_28006.ds) BETWEEN '2020-01-01' AND '2020-01-03'
+WHERE time_spine_src_28006.ds BETWEEN '2020-01-01' AND '2020-01-03'
 GROUP BY
-  DATE_TRUNC('day', time_spine_src_28006.ds)
+  time_spine_src_28006.ds
   , listings_latest_src_28000.is_lux
   , users_latest_src_28000.home_state_latest

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Databricks/test_metric_time_only__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Databricks/test_metric_time_only__plan0.sql
@@ -37,7 +37,7 @@ FROM (
   FROM (
     -- Read From Time Spine 'mf_time_spine'
     SELECT
-      DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
+      time_spine_src_28006.ds AS ds__day
       , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week
       , DATE_TRUNC('month', time_spine_src_28006.ds) AS ds__month
       , DATE_TRUNC('quarter', time_spine_src_28006.ds) AS ds__quarter

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Databricks/test_metric_time_only__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Databricks/test_metric_time_only__plan0_optimized.sql
@@ -8,7 +8,7 @@ sql_engine: Databricks
 -- Metric Time Dimension 'ds'
 -- Pass Only Elements: ['metric_time__day',]
 SELECT
-  DATE_TRUNC('day', ds) AS metric_time__day
+  ds AS metric_time__day
 FROM ***************************.mf_time_spine time_spine_src_28006
 GROUP BY
-  DATE_TRUNC('day', ds)
+  ds

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Databricks/test_metric_time_quarter_alone__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Databricks/test_metric_time_quarter_alone__plan0.sql
@@ -35,7 +35,7 @@ FROM (
   FROM (
     -- Read From Time Spine 'mf_time_spine'
     SELECT
-      DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
+      time_spine_src_28006.ds AS ds__day
       , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week
       , DATE_TRUNC('month', time_spine_src_28006.ds) AS ds__month
       , DATE_TRUNC('quarter', time_spine_src_28006.ds) AS ds__quarter

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Databricks/test_metric_time_with_other_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Databricks/test_metric_time_with_other_dimensions__plan0.sql
@@ -163,7 +163,7 @@ FROM (
       FROM (
         -- Read From Time Spine 'mf_time_spine'
         SELECT
-          DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
+          time_spine_src_28006.ds AS ds__day
           , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week
           , DATE_TRUNC('month', time_spine_src_28006.ds) AS ds__month
           , DATE_TRUNC('quarter', time_spine_src_28006.ds) AS ds__quarter

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Databricks/test_metric_time_with_other_dimensions__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Databricks/test_metric_time_with_other_dimensions__plan0_optimized.sql
@@ -5,7 +5,7 @@ sql_engine: Databricks
 -- Join Standard Outputs
 -- Pass Only Elements: ['user__home_state_latest', 'listing__is_lux_latest', 'metric_time__day']
 SELECT
-  DATE_TRUNC('day', time_spine_src_28006.ds) AS metric_time__day
+  time_spine_src_28006.ds AS metric_time__day
   , listings_latest_src_28000.is_lux AS listing__is_lux_latest
   , users_latest_src_28000.home_state_latest AS user__home_state_latest
 FROM ***************************.dim_listings_latest listings_latest_src_28000
@@ -16,6 +16,6 @@ FULL OUTER JOIN
 ON
   listings_latest_src_28000.user_id = users_latest_src_28000.user_id
 GROUP BY
-  DATE_TRUNC('day', time_spine_src_28006.ds)
+  time_spine_src_28006.ds
   , listings_latest_src_28000.is_lux
   , users_latest_src_28000.home_state_latest

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/DuckDB/test_dimensions_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/DuckDB/test_dimensions_with_time_constraint__plan0.sql
@@ -224,7 +224,7 @@ FROM (
         FROM (
           -- Read From Time Spine 'mf_time_spine'
           SELECT
-            DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
+            time_spine_src_28006.ds AS ds__day
             , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week
             , DATE_TRUNC('month', time_spine_src_28006.ds) AS ds__month
             , DATE_TRUNC('quarter', time_spine_src_28006.ds) AS ds__quarter

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/DuckDB/test_dimensions_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/DuckDB/test_dimensions_with_time_constraint__plan0_optimized.sql
@@ -6,7 +6,7 @@ sql_engine: DuckDB
 -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-03T00:00:00]
 -- Pass Only Elements: ['user__home_state_latest', 'listing__is_lux_latest', 'metric_time__day']
 SELECT
-  DATE_TRUNC('day', time_spine_src_28006.ds) AS metric_time__day
+  time_spine_src_28006.ds AS metric_time__day
   , listings_latest_src_28000.is_lux AS listing__is_lux_latest
   , users_latest_src_28000.home_state_latest AS user__home_state_latest
 FROM ***************************.dim_listings_latest listings_latest_src_28000
@@ -16,8 +16,8 @@ FULL OUTER JOIN
   ***************************.dim_users_latest users_latest_src_28000
 ON
   listings_latest_src_28000.user_id = users_latest_src_28000.user_id
-WHERE DATE_TRUNC('day', time_spine_src_28006.ds) BETWEEN '2020-01-01' AND '2020-01-03'
+WHERE time_spine_src_28006.ds BETWEEN '2020-01-01' AND '2020-01-03'
 GROUP BY
-  DATE_TRUNC('day', time_spine_src_28006.ds)
+  time_spine_src_28006.ds
   , listings_latest_src_28000.is_lux
   , users_latest_src_28000.home_state_latest

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/DuckDB/test_metric_time_only__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/DuckDB/test_metric_time_only__plan0.sql
@@ -37,7 +37,7 @@ FROM (
   FROM (
     -- Read From Time Spine 'mf_time_spine'
     SELECT
-      DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
+      time_spine_src_28006.ds AS ds__day
       , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week
       , DATE_TRUNC('month', time_spine_src_28006.ds) AS ds__month
       , DATE_TRUNC('quarter', time_spine_src_28006.ds) AS ds__quarter

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/DuckDB/test_metric_time_only__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/DuckDB/test_metric_time_only__plan0_optimized.sql
@@ -8,7 +8,7 @@ sql_engine: DuckDB
 -- Metric Time Dimension 'ds'
 -- Pass Only Elements: ['metric_time__day',]
 SELECT
-  DATE_TRUNC('day', ds) AS metric_time__day
+  ds AS metric_time__day
 FROM ***************************.mf_time_spine time_spine_src_28006
 GROUP BY
-  DATE_TRUNC('day', ds)
+  ds

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/DuckDB/test_metric_time_quarter_alone__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/DuckDB/test_metric_time_quarter_alone__plan0.sql
@@ -35,7 +35,7 @@ FROM (
   FROM (
     -- Read From Time Spine 'mf_time_spine'
     SELECT
-      DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
+      time_spine_src_28006.ds AS ds__day
       , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week
       , DATE_TRUNC('month', time_spine_src_28006.ds) AS ds__month
       , DATE_TRUNC('quarter', time_spine_src_28006.ds) AS ds__quarter

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/DuckDB/test_metric_time_with_other_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/DuckDB/test_metric_time_with_other_dimensions__plan0.sql
@@ -163,7 +163,7 @@ FROM (
       FROM (
         -- Read From Time Spine 'mf_time_spine'
         SELECT
-          DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
+          time_spine_src_28006.ds AS ds__day
           , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week
           , DATE_TRUNC('month', time_spine_src_28006.ds) AS ds__month
           , DATE_TRUNC('quarter', time_spine_src_28006.ds) AS ds__quarter

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/DuckDB/test_metric_time_with_other_dimensions__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/DuckDB/test_metric_time_with_other_dimensions__plan0_optimized.sql
@@ -5,7 +5,7 @@ sql_engine: DuckDB
 -- Join Standard Outputs
 -- Pass Only Elements: ['user__home_state_latest', 'listing__is_lux_latest', 'metric_time__day']
 SELECT
-  DATE_TRUNC('day', time_spine_src_28006.ds) AS metric_time__day
+  time_spine_src_28006.ds AS metric_time__day
   , listings_latest_src_28000.is_lux AS listing__is_lux_latest
   , users_latest_src_28000.home_state_latest AS user__home_state_latest
 FROM ***************************.dim_listings_latest listings_latest_src_28000
@@ -16,6 +16,6 @@ FULL OUTER JOIN
 ON
   listings_latest_src_28000.user_id = users_latest_src_28000.user_id
 GROUP BY
-  DATE_TRUNC('day', time_spine_src_28006.ds)
+  time_spine_src_28006.ds
   , listings_latest_src_28000.is_lux
   , users_latest_src_28000.home_state_latest

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Postgres/test_dimensions_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Postgres/test_dimensions_with_time_constraint__plan0.sql
@@ -224,7 +224,7 @@ FROM (
         FROM (
           -- Read From Time Spine 'mf_time_spine'
           SELECT
-            DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
+            time_spine_src_28006.ds AS ds__day
             , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week
             , DATE_TRUNC('month', time_spine_src_28006.ds) AS ds__month
             , DATE_TRUNC('quarter', time_spine_src_28006.ds) AS ds__quarter

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Postgres/test_dimensions_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Postgres/test_dimensions_with_time_constraint__plan0_optimized.sql
@@ -6,7 +6,7 @@ sql_engine: Postgres
 -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-03T00:00:00]
 -- Pass Only Elements: ['user__home_state_latest', 'listing__is_lux_latest', 'metric_time__day']
 SELECT
-  DATE_TRUNC('day', time_spine_src_28006.ds) AS metric_time__day
+  time_spine_src_28006.ds AS metric_time__day
   , listings_latest_src_28000.is_lux AS listing__is_lux_latest
   , users_latest_src_28000.home_state_latest AS user__home_state_latest
 FROM ***************************.dim_listings_latest listings_latest_src_28000
@@ -16,8 +16,8 @@ FULL OUTER JOIN
   ***************************.dim_users_latest users_latest_src_28000
 ON
   listings_latest_src_28000.user_id = users_latest_src_28000.user_id
-WHERE DATE_TRUNC('day', time_spine_src_28006.ds) BETWEEN '2020-01-01' AND '2020-01-03'
+WHERE time_spine_src_28006.ds BETWEEN '2020-01-01' AND '2020-01-03'
 GROUP BY
-  DATE_TRUNC('day', time_spine_src_28006.ds)
+  time_spine_src_28006.ds
   , listings_latest_src_28000.is_lux
   , users_latest_src_28000.home_state_latest

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Postgres/test_metric_time_only__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Postgres/test_metric_time_only__plan0.sql
@@ -37,7 +37,7 @@ FROM (
   FROM (
     -- Read From Time Spine 'mf_time_spine'
     SELECT
-      DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
+      time_spine_src_28006.ds AS ds__day
       , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week
       , DATE_TRUNC('month', time_spine_src_28006.ds) AS ds__month
       , DATE_TRUNC('quarter', time_spine_src_28006.ds) AS ds__quarter

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Postgres/test_metric_time_only__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Postgres/test_metric_time_only__plan0_optimized.sql
@@ -8,7 +8,7 @@ sql_engine: Postgres
 -- Metric Time Dimension 'ds'
 -- Pass Only Elements: ['metric_time__day',]
 SELECT
-  DATE_TRUNC('day', ds) AS metric_time__day
+  ds AS metric_time__day
 FROM ***************************.mf_time_spine time_spine_src_28006
 GROUP BY
-  DATE_TRUNC('day', ds)
+  ds

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Postgres/test_metric_time_quarter_alone__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Postgres/test_metric_time_quarter_alone__plan0.sql
@@ -35,7 +35,7 @@ FROM (
   FROM (
     -- Read From Time Spine 'mf_time_spine'
     SELECT
-      DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
+      time_spine_src_28006.ds AS ds__day
       , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week
       , DATE_TRUNC('month', time_spine_src_28006.ds) AS ds__month
       , DATE_TRUNC('quarter', time_spine_src_28006.ds) AS ds__quarter

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Postgres/test_metric_time_with_other_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Postgres/test_metric_time_with_other_dimensions__plan0.sql
@@ -163,7 +163,7 @@ FROM (
       FROM (
         -- Read From Time Spine 'mf_time_spine'
         SELECT
-          DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
+          time_spine_src_28006.ds AS ds__day
           , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week
           , DATE_TRUNC('month', time_spine_src_28006.ds) AS ds__month
           , DATE_TRUNC('quarter', time_spine_src_28006.ds) AS ds__quarter

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Postgres/test_metric_time_with_other_dimensions__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Postgres/test_metric_time_with_other_dimensions__plan0_optimized.sql
@@ -5,7 +5,7 @@ sql_engine: Postgres
 -- Join Standard Outputs
 -- Pass Only Elements: ['user__home_state_latest', 'listing__is_lux_latest', 'metric_time__day']
 SELECT
-  DATE_TRUNC('day', time_spine_src_28006.ds) AS metric_time__day
+  time_spine_src_28006.ds AS metric_time__day
   , listings_latest_src_28000.is_lux AS listing__is_lux_latest
   , users_latest_src_28000.home_state_latest AS user__home_state_latest
 FROM ***************************.dim_listings_latest listings_latest_src_28000
@@ -16,6 +16,6 @@ FULL OUTER JOIN
 ON
   listings_latest_src_28000.user_id = users_latest_src_28000.user_id
 GROUP BY
-  DATE_TRUNC('day', time_spine_src_28006.ds)
+  time_spine_src_28006.ds
   , listings_latest_src_28000.is_lux
   , users_latest_src_28000.home_state_latest

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Redshift/test_dimensions_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Redshift/test_dimensions_with_time_constraint__plan0.sql
@@ -224,7 +224,7 @@ FROM (
         FROM (
           -- Read From Time Spine 'mf_time_spine'
           SELECT
-            DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
+            time_spine_src_28006.ds AS ds__day
             , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week
             , DATE_TRUNC('month', time_spine_src_28006.ds) AS ds__month
             , DATE_TRUNC('quarter', time_spine_src_28006.ds) AS ds__quarter

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Redshift/test_dimensions_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Redshift/test_dimensions_with_time_constraint__plan0_optimized.sql
@@ -6,7 +6,7 @@ sql_engine: Redshift
 -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-03T00:00:00]
 -- Pass Only Elements: ['user__home_state_latest', 'listing__is_lux_latest', 'metric_time__day']
 SELECT
-  DATE_TRUNC('day', time_spine_src_28006.ds) AS metric_time__day
+  time_spine_src_28006.ds AS metric_time__day
   , listings_latest_src_28000.is_lux AS listing__is_lux_latest
   , users_latest_src_28000.home_state_latest AS user__home_state_latest
 FROM ***************************.dim_listings_latest listings_latest_src_28000
@@ -16,8 +16,8 @@ FULL OUTER JOIN
   ***************************.dim_users_latest users_latest_src_28000
 ON
   listings_latest_src_28000.user_id = users_latest_src_28000.user_id
-WHERE DATE_TRUNC('day', time_spine_src_28006.ds) BETWEEN '2020-01-01' AND '2020-01-03'
+WHERE time_spine_src_28006.ds BETWEEN '2020-01-01' AND '2020-01-03'
 GROUP BY
-  DATE_TRUNC('day', time_spine_src_28006.ds)
+  time_spine_src_28006.ds
   , listings_latest_src_28000.is_lux
   , users_latest_src_28000.home_state_latest

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Redshift/test_metric_time_only__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Redshift/test_metric_time_only__plan0.sql
@@ -37,7 +37,7 @@ FROM (
   FROM (
     -- Read From Time Spine 'mf_time_spine'
     SELECT
-      DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
+      time_spine_src_28006.ds AS ds__day
       , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week
       , DATE_TRUNC('month', time_spine_src_28006.ds) AS ds__month
       , DATE_TRUNC('quarter', time_spine_src_28006.ds) AS ds__quarter

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Redshift/test_metric_time_only__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Redshift/test_metric_time_only__plan0_optimized.sql
@@ -8,7 +8,7 @@ sql_engine: Redshift
 -- Metric Time Dimension 'ds'
 -- Pass Only Elements: ['metric_time__day',]
 SELECT
-  DATE_TRUNC('day', ds) AS metric_time__day
+  ds AS metric_time__day
 FROM ***************************.mf_time_spine time_spine_src_28006
 GROUP BY
-  DATE_TRUNC('day', ds)
+  ds

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Redshift/test_metric_time_quarter_alone__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Redshift/test_metric_time_quarter_alone__plan0.sql
@@ -35,7 +35,7 @@ FROM (
   FROM (
     -- Read From Time Spine 'mf_time_spine'
     SELECT
-      DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
+      time_spine_src_28006.ds AS ds__day
       , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week
       , DATE_TRUNC('month', time_spine_src_28006.ds) AS ds__month
       , DATE_TRUNC('quarter', time_spine_src_28006.ds) AS ds__quarter

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Redshift/test_metric_time_with_other_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Redshift/test_metric_time_with_other_dimensions__plan0.sql
@@ -163,7 +163,7 @@ FROM (
       FROM (
         -- Read From Time Spine 'mf_time_spine'
         SELECT
-          DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
+          time_spine_src_28006.ds AS ds__day
           , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week
           , DATE_TRUNC('month', time_spine_src_28006.ds) AS ds__month
           , DATE_TRUNC('quarter', time_spine_src_28006.ds) AS ds__quarter

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Redshift/test_metric_time_with_other_dimensions__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Redshift/test_metric_time_with_other_dimensions__plan0_optimized.sql
@@ -5,7 +5,7 @@ sql_engine: Redshift
 -- Join Standard Outputs
 -- Pass Only Elements: ['user__home_state_latest', 'listing__is_lux_latest', 'metric_time__day']
 SELECT
-  DATE_TRUNC('day', time_spine_src_28006.ds) AS metric_time__day
+  time_spine_src_28006.ds AS metric_time__day
   , listings_latest_src_28000.is_lux AS listing__is_lux_latest
   , users_latest_src_28000.home_state_latest AS user__home_state_latest
 FROM ***************************.dim_listings_latest listings_latest_src_28000
@@ -16,6 +16,6 @@ FULL OUTER JOIN
 ON
   listings_latest_src_28000.user_id = users_latest_src_28000.user_id
 GROUP BY
-  DATE_TRUNC('day', time_spine_src_28006.ds)
+  time_spine_src_28006.ds
   , listings_latest_src_28000.is_lux
   , users_latest_src_28000.home_state_latest

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Snowflake/test_dimensions_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Snowflake/test_dimensions_with_time_constraint__plan0.sql
@@ -224,7 +224,7 @@ FROM (
         FROM (
           -- Read From Time Spine 'mf_time_spine'
           SELECT
-            DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
+            time_spine_src_28006.ds AS ds__day
             , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week
             , DATE_TRUNC('month', time_spine_src_28006.ds) AS ds__month
             , DATE_TRUNC('quarter', time_spine_src_28006.ds) AS ds__quarter

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Snowflake/test_dimensions_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Snowflake/test_dimensions_with_time_constraint__plan0_optimized.sql
@@ -6,7 +6,7 @@ sql_engine: Snowflake
 -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-03T00:00:00]
 -- Pass Only Elements: ['user__home_state_latest', 'listing__is_lux_latest', 'metric_time__day']
 SELECT
-  DATE_TRUNC('day', time_spine_src_28006.ds) AS metric_time__day
+  time_spine_src_28006.ds AS metric_time__day
   , listings_latest_src_28000.is_lux AS listing__is_lux_latest
   , users_latest_src_28000.home_state_latest AS user__home_state_latest
 FROM ***************************.dim_listings_latest listings_latest_src_28000
@@ -16,8 +16,8 @@ FULL OUTER JOIN
   ***************************.dim_users_latest users_latest_src_28000
 ON
   listings_latest_src_28000.user_id = users_latest_src_28000.user_id
-WHERE DATE_TRUNC('day', time_spine_src_28006.ds) BETWEEN '2020-01-01' AND '2020-01-03'
+WHERE time_spine_src_28006.ds BETWEEN '2020-01-01' AND '2020-01-03'
 GROUP BY
-  DATE_TRUNC('day', time_spine_src_28006.ds)
+  time_spine_src_28006.ds
   , listings_latest_src_28000.is_lux
   , users_latest_src_28000.home_state_latest

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Snowflake/test_metric_time_only__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Snowflake/test_metric_time_only__plan0.sql
@@ -37,7 +37,7 @@ FROM (
   FROM (
     -- Read From Time Spine 'mf_time_spine'
     SELECT
-      DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
+      time_spine_src_28006.ds AS ds__day
       , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week
       , DATE_TRUNC('month', time_spine_src_28006.ds) AS ds__month
       , DATE_TRUNC('quarter', time_spine_src_28006.ds) AS ds__quarter

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Snowflake/test_metric_time_only__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Snowflake/test_metric_time_only__plan0_optimized.sql
@@ -8,7 +8,7 @@ sql_engine: Snowflake
 -- Metric Time Dimension 'ds'
 -- Pass Only Elements: ['metric_time__day',]
 SELECT
-  DATE_TRUNC('day', ds) AS metric_time__day
+  ds AS metric_time__day
 FROM ***************************.mf_time_spine time_spine_src_28006
 GROUP BY
-  DATE_TRUNC('day', ds)
+  ds

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Snowflake/test_metric_time_quarter_alone__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Snowflake/test_metric_time_quarter_alone__plan0.sql
@@ -35,7 +35,7 @@ FROM (
   FROM (
     -- Read From Time Spine 'mf_time_spine'
     SELECT
-      DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
+      time_spine_src_28006.ds AS ds__day
       , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week
       , DATE_TRUNC('month', time_spine_src_28006.ds) AS ds__month
       , DATE_TRUNC('quarter', time_spine_src_28006.ds) AS ds__quarter

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Snowflake/test_metric_time_with_other_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Snowflake/test_metric_time_with_other_dimensions__plan0.sql
@@ -163,7 +163,7 @@ FROM (
       FROM (
         -- Read From Time Spine 'mf_time_spine'
         SELECT
-          DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
+          time_spine_src_28006.ds AS ds__day
           , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week
           , DATE_TRUNC('month', time_spine_src_28006.ds) AS ds__month
           , DATE_TRUNC('quarter', time_spine_src_28006.ds) AS ds__quarter

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Snowflake/test_metric_time_with_other_dimensions__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Snowflake/test_metric_time_with_other_dimensions__plan0_optimized.sql
@@ -5,7 +5,7 @@ sql_engine: Snowflake
 -- Join Standard Outputs
 -- Pass Only Elements: ['user__home_state_latest', 'listing__is_lux_latest', 'metric_time__day']
 SELECT
-  DATE_TRUNC('day', time_spine_src_28006.ds) AS metric_time__day
+  time_spine_src_28006.ds AS metric_time__day
   , listings_latest_src_28000.is_lux AS listing__is_lux_latest
   , users_latest_src_28000.home_state_latest AS user__home_state_latest
 FROM ***************************.dim_listings_latest listings_latest_src_28000
@@ -16,6 +16,6 @@ FULL OUTER JOIN
 ON
   listings_latest_src_28000.user_id = users_latest_src_28000.user_id
 GROUP BY
-  DATE_TRUNC('day', time_spine_src_28006.ds)
+  time_spine_src_28006.ds
   , listings_latest_src_28000.is_lux
   , users_latest_src_28000.home_state_latest

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Trino/test_dimensions_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Trino/test_dimensions_with_time_constraint__plan0.sql
@@ -224,7 +224,7 @@ FROM (
         FROM (
           -- Read From Time Spine 'mf_time_spine'
           SELECT
-            DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
+            time_spine_src_28006.ds AS ds__day
             , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week
             , DATE_TRUNC('month', time_spine_src_28006.ds) AS ds__month
             , DATE_TRUNC('quarter', time_spine_src_28006.ds) AS ds__quarter

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Trino/test_dimensions_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Trino/test_dimensions_with_time_constraint__plan0_optimized.sql
@@ -6,7 +6,7 @@ sql_engine: Trino
 -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-03T00:00:00]
 -- Pass Only Elements: ['user__home_state_latest', 'listing__is_lux_latest', 'metric_time__day']
 SELECT
-  DATE_TRUNC('day', time_spine_src_28006.ds) AS metric_time__day
+  time_spine_src_28006.ds AS metric_time__day
   , listings_latest_src_28000.is_lux AS listing__is_lux_latest
   , users_latest_src_28000.home_state_latest AS user__home_state_latest
 FROM ***************************.dim_listings_latest listings_latest_src_28000
@@ -16,8 +16,8 @@ FULL OUTER JOIN
   ***************************.dim_users_latest users_latest_src_28000
 ON
   listings_latest_src_28000.user_id = users_latest_src_28000.user_id
-WHERE DATE_TRUNC('day', time_spine_src_28006.ds) BETWEEN timestamp '2020-01-01' AND timestamp '2020-01-03'
+WHERE time_spine_src_28006.ds BETWEEN timestamp '2020-01-01' AND timestamp '2020-01-03'
 GROUP BY
-  DATE_TRUNC('day', time_spine_src_28006.ds)
+  time_spine_src_28006.ds
   , listings_latest_src_28000.is_lux
   , users_latest_src_28000.home_state_latest

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Trino/test_metric_time_only__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Trino/test_metric_time_only__plan0.sql
@@ -37,7 +37,7 @@ FROM (
   FROM (
     -- Read From Time Spine 'mf_time_spine'
     SELECT
-      DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
+      time_spine_src_28006.ds AS ds__day
       , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week
       , DATE_TRUNC('month', time_spine_src_28006.ds) AS ds__month
       , DATE_TRUNC('quarter', time_spine_src_28006.ds) AS ds__quarter

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Trino/test_metric_time_only__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Trino/test_metric_time_only__plan0_optimized.sql
@@ -8,7 +8,7 @@ sql_engine: Trino
 -- Metric Time Dimension 'ds'
 -- Pass Only Elements: ['metric_time__day',]
 SELECT
-  DATE_TRUNC('day', ds) AS metric_time__day
+  ds AS metric_time__day
 FROM ***************************.mf_time_spine time_spine_src_28006
 GROUP BY
-  DATE_TRUNC('day', ds)
+  ds

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Trino/test_metric_time_quarter_alone__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Trino/test_metric_time_quarter_alone__plan0.sql
@@ -35,7 +35,7 @@ FROM (
   FROM (
     -- Read From Time Spine 'mf_time_spine'
     SELECT
-      DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
+      time_spine_src_28006.ds AS ds__day
       , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week
       , DATE_TRUNC('month', time_spine_src_28006.ds) AS ds__month
       , DATE_TRUNC('quarter', time_spine_src_28006.ds) AS ds__quarter

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Trino/test_metric_time_with_other_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Trino/test_metric_time_with_other_dimensions__plan0.sql
@@ -163,7 +163,7 @@ FROM (
       FROM (
         -- Read From Time Spine 'mf_time_spine'
         SELECT
-          DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
+          time_spine_src_28006.ds AS ds__day
           , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week
           , DATE_TRUNC('month', time_spine_src_28006.ds) AS ds__month
           , DATE_TRUNC('quarter', time_spine_src_28006.ds) AS ds__quarter

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Trino/test_metric_time_with_other_dimensions__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Trino/test_metric_time_with_other_dimensions__plan0_optimized.sql
@@ -5,7 +5,7 @@ sql_engine: Trino
 -- Join Standard Outputs
 -- Pass Only Elements: ['user__home_state_latest', 'listing__is_lux_latest', 'metric_time__day']
 SELECT
-  DATE_TRUNC('day', time_spine_src_28006.ds) AS metric_time__day
+  time_spine_src_28006.ds AS metric_time__day
   , listings_latest_src_28000.is_lux AS listing__is_lux_latest
   , users_latest_src_28000.home_state_latest AS user__home_state_latest
 FROM ***************************.dim_listings_latest listings_latest_src_28000
@@ -16,6 +16,6 @@ FULL OUTER JOIN
 ON
   listings_latest_src_28000.user_id = users_latest_src_28000.user_id
 GROUP BY
-  DATE_TRUNC('day', time_spine_src_28006.ds)
+  time_spine_src_28006.ds
   , listings_latest_src_28000.is_lux
   , users_latest_src_28000.home_state_latest

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/test_dimensions_with_time_constraint__plan0.xml
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/test_dimensions_with_time_constraint__plan0.xml
@@ -803,22 +803,25 @@ test_filename: test_metric_time_without_metrics.py
                         <SqlSelectStatementNode>
                             <!-- description = "Read From Time Spine 'mf_time_spine'" -->
                             <!-- node_id = NodeId(id_str='ss_1') -->
-                            <!-- col0 =                                                                                   -->
-                            <!--   SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_28293), column_alias='ds__day') -->
+                            <!-- col0 =                                                   -->
+                            <!--   SqlSelectColumn(                                       -->
+                            <!--     expr=SqlColumnReferenceExpression(node_id=cr_28130), -->
+                            <!--     column_alias='ds__day',                              -->
+                            <!--   )                                                      -->
                             <!-- col1 =                                                                                    -->
-                            <!--   SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_28294), column_alias='ds__week') -->
+                            <!--   SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_28287), column_alias='ds__week') -->
                             <!-- col2 =                                             -->
                             <!--   SqlSelectColumn(                                 -->
-                            <!--     expr=SqlDateTruncExpression(node_id=dt_28295), -->
+                            <!--     expr=SqlDateTruncExpression(node_id=dt_28288), -->
                             <!--     column_alias='ds__month',                      -->
                             <!--   )                                                -->
                             <!-- col3 =                                             -->
                             <!--   SqlSelectColumn(                                 -->
-                            <!--     expr=SqlDateTruncExpression(node_id=dt_28296), -->
+                            <!--     expr=SqlDateTruncExpression(node_id=dt_28289), -->
                             <!--     column_alias='ds__quarter',                    -->
                             <!--   )                                                -->
                             <!-- col4 =                                                                                    -->
-                            <!--   SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_28297), column_alias='ds__year') -->
+                            <!--   SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_28290), column_alias='ds__year') -->
                             <!-- col5 =                                           -->
                             <!--   SqlSelectColumn(                               -->
                             <!--     expr=SqlExtractExpression(node_id=ex_28300), -->

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/test_metric_time_only__plan0.xml
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/test_metric_time_only__plan0.xml
@@ -84,11 +84,11 @@ docstring:
             <SqlSelectStatementNode>
                 <!-- description = "Read From Time Spine 'mf_time_spine'" -->
                 <!-- node_id = NodeId(id_str='ss_0') -->
-                <!-- col0 = SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_28293), column_alias='ds__day') -->
-                <!-- col1 = SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_28294), column_alias='ds__week') -->
-                <!-- col2 = SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_28295), column_alias='ds__month') -->
-                <!-- col3 = SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_28296), column_alias='ds__quarter') -->
-                <!-- col4 = SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_28297), column_alias='ds__year') -->
+                <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28130), column_alias='ds__day') -->
+                <!-- col1 = SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_28287), column_alias='ds__week') -->
+                <!-- col2 = SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_28288), column_alias='ds__month') -->
+                <!-- col3 = SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_28289), column_alias='ds__quarter') -->
+                <!-- col4 = SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_28290), column_alias='ds__year') -->
                 <!-- col5 =                                                                                          -->
                 <!--   SqlSelectColumn(expr=SqlExtractExpression(node_id=ex_28300), column_alias='ds__extract_year') -->
                 <!-- col6 =                                                                                             -->

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/test_metric_time_quarter_alone__plan0.xml
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/test_metric_time_quarter_alone__plan0.xml
@@ -83,11 +83,11 @@ test_filename: test_metric_time_without_metrics.py
             <SqlSelectStatementNode>
                 <!-- description = "Read From Time Spine 'mf_time_spine'" -->
                 <!-- node_id = NodeId(id_str='ss_0') -->
-                <!-- col0 = SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_28293), column_alias='ds__day') -->
-                <!-- col1 = SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_28294), column_alias='ds__week') -->
-                <!-- col2 = SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_28295), column_alias='ds__month') -->
-                <!-- col3 = SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_28296), column_alias='ds__quarter') -->
-                <!-- col4 = SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_28297), column_alias='ds__year') -->
+                <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28130), column_alias='ds__day') -->
+                <!-- col1 = SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_28287), column_alias='ds__week') -->
+                <!-- col2 = SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_28288), column_alias='ds__month') -->
+                <!-- col3 = SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_28289), column_alias='ds__quarter') -->
+                <!-- col4 = SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_28290), column_alias='ds__year') -->
                 <!-- col5 =                                                                                          -->
                 <!--   SqlSelectColumn(expr=SqlExtractExpression(node_id=ex_28300), column_alias='ds__extract_year') -->
                 <!-- col6 =                                                                                             -->

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/test_metric_time_with_other_dimensions__plan0.xml
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/test_metric_time_with_other_dimensions__plan0.xml
@@ -552,16 +552,19 @@ test_filename: test_metric_time_without_metrics.py
                     <SqlSelectStatementNode>
                         <!-- description = "Read From Time Spine 'mf_time_spine'" -->
                         <!-- node_id = NodeId(id_str='ss_1') -->
-                        <!-- col0 =                                                                                   -->
-                        <!--   SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_28293), column_alias='ds__day') -->
+                        <!-- col0 =                                                   -->
+                        <!--   SqlSelectColumn(                                       -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_28130), -->
+                        <!--     column_alias='ds__day',                              -->
+                        <!--   )                                                      -->
                         <!-- col1 =                                                                                    -->
-                        <!--   SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_28294), column_alias='ds__week') -->
+                        <!--   SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_28287), column_alias='ds__week') -->
                         <!-- col2 =                                                                                     -->
-                        <!--   SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_28295), column_alias='ds__month') -->
+                        <!--   SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_28288), column_alias='ds__month') -->
                         <!-- col3 =                                                                                       -->
-                        <!--   SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_28296), column_alias='ds__quarter') -->
+                        <!--   SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_28289), column_alias='ds__quarter') -->
                         <!-- col4 =                                                                                    -->
-                        <!--   SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_28297), column_alias='ds__year') -->
+                        <!--   SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_28290), column_alias='ds__year') -->
                         <!-- col5 =                                           -->
                         <!--   SqlSelectColumn(                               -->
                         <!--     expr=SqlExtractExpression(node_id=ex_28300), -->

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_min_max_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_min_max_metric_time__plan0.sql
@@ -42,7 +42,7 @@ FROM (
     FROM (
       -- Read From Time Spine 'mf_time_spine'
       SELECT
-        DATETIME_TRUNC(time_spine_src_28006.ds, day) AS ds__day
+        time_spine_src_28006.ds AS ds__day
         , DATETIME_TRUNC(time_spine_src_28006.ds, isoweek) AS ds__week
         , DATETIME_TRUNC(time_spine_src_28006.ds, month) AS ds__month
         , DATETIME_TRUNC(time_spine_src_28006.ds, quarter) AS ds__quarter

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_min_max_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_min_max_metric_time__plan0_optimized.sql
@@ -13,7 +13,7 @@ FROM (
   -- Metric Time Dimension 'ds'
   -- Pass Only Elements: ['metric_time__day',]
   SELECT
-    DATETIME_TRUNC(ds, day) AS metric_time__day
+    ds AS metric_time__day
   FROM ***************************.mf_time_spine time_spine_src_28006
   GROUP BY
     metric_time__day

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_min_max_metric_time_week__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_min_max_metric_time_week__plan0.sql
@@ -42,7 +42,7 @@ FROM (
     FROM (
       -- Read From Time Spine 'mf_time_spine'
       SELECT
-        DATETIME_TRUNC(time_spine_src_28006.ds, day) AS ds__day
+        time_spine_src_28006.ds AS ds__day
         , DATETIME_TRUNC(time_spine_src_28006.ds, isoweek) AS ds__week
         , DATETIME_TRUNC(time_spine_src_28006.ds, month) AS ds__month
         , DATETIME_TRUNC(time_spine_src_28006.ds, quarter) AS ds__quarter

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_min_max_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_min_max_metric_time__plan0.sql
@@ -42,7 +42,7 @@ FROM (
     FROM (
       -- Read From Time Spine 'mf_time_spine'
       SELECT
-        DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
+        time_spine_src_28006.ds AS ds__day
         , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week
         , DATE_TRUNC('month', time_spine_src_28006.ds) AS ds__month
         , DATE_TRUNC('quarter', time_spine_src_28006.ds) AS ds__quarter

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_min_max_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_min_max_metric_time__plan0_optimized.sql
@@ -13,8 +13,8 @@ FROM (
   -- Metric Time Dimension 'ds'
   -- Pass Only Elements: ['metric_time__day',]
   SELECT
-    DATE_TRUNC('day', ds) AS metric_time__day
+    ds AS metric_time__day
   FROM ***************************.mf_time_spine time_spine_src_28006
   GROUP BY
-    DATE_TRUNC('day', ds)
+    ds
 ) subq_5

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_min_max_metric_time_week__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_min_max_metric_time_week__plan0.sql
@@ -42,7 +42,7 @@ FROM (
     FROM (
       -- Read From Time Spine 'mf_time_spine'
       SELECT
-        DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
+        time_spine_src_28006.ds AS ds__day
         , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week
         , DATE_TRUNC('month', time_spine_src_28006.ds) AS ds__month
         , DATE_TRUNC('quarter', time_spine_src_28006.ds) AS ds__quarter

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_min_max_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_min_max_metric_time__plan0.sql
@@ -42,7 +42,7 @@ FROM (
     FROM (
       -- Read From Time Spine 'mf_time_spine'
       SELECT
-        DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
+        time_spine_src_28006.ds AS ds__day
         , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week
         , DATE_TRUNC('month', time_spine_src_28006.ds) AS ds__month
         , DATE_TRUNC('quarter', time_spine_src_28006.ds) AS ds__quarter

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_min_max_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_min_max_metric_time__plan0_optimized.sql
@@ -13,8 +13,8 @@ FROM (
   -- Metric Time Dimension 'ds'
   -- Pass Only Elements: ['metric_time__day',]
   SELECT
-    DATE_TRUNC('day', ds) AS metric_time__day
+    ds AS metric_time__day
   FROM ***************************.mf_time_spine time_spine_src_28006
   GROUP BY
-    DATE_TRUNC('day', ds)
+    ds
 ) subq_5

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_min_max_metric_time_week__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_min_max_metric_time_week__plan0.sql
@@ -42,7 +42,7 @@ FROM (
     FROM (
       -- Read From Time Spine 'mf_time_spine'
       SELECT
-        DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
+        time_spine_src_28006.ds AS ds__day
         , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week
         , DATE_TRUNC('month', time_spine_src_28006.ds) AS ds__month
         , DATE_TRUNC('quarter', time_spine_src_28006.ds) AS ds__quarter

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_min_max_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_min_max_metric_time__plan0.sql
@@ -42,7 +42,7 @@ FROM (
     FROM (
       -- Read From Time Spine 'mf_time_spine'
       SELECT
-        DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
+        time_spine_src_28006.ds AS ds__day
         , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week
         , DATE_TRUNC('month', time_spine_src_28006.ds) AS ds__month
         , DATE_TRUNC('quarter', time_spine_src_28006.ds) AS ds__quarter

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_min_max_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_min_max_metric_time__plan0_optimized.sql
@@ -13,8 +13,8 @@ FROM (
   -- Metric Time Dimension 'ds'
   -- Pass Only Elements: ['metric_time__day',]
   SELECT
-    DATE_TRUNC('day', ds) AS metric_time__day
+    ds AS metric_time__day
   FROM ***************************.mf_time_spine time_spine_src_28006
   GROUP BY
-    DATE_TRUNC('day', ds)
+    ds
 ) subq_5

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_min_max_metric_time_week__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_min_max_metric_time_week__plan0.sql
@@ -42,7 +42,7 @@ FROM (
     FROM (
       -- Read From Time Spine 'mf_time_spine'
       SELECT
-        DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
+        time_spine_src_28006.ds AS ds__day
         , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week
         , DATE_TRUNC('month', time_spine_src_28006.ds) AS ds__month
         , DATE_TRUNC('quarter', time_spine_src_28006.ds) AS ds__quarter

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_min_max_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_min_max_metric_time__plan0.sql
@@ -42,7 +42,7 @@ FROM (
     FROM (
       -- Read From Time Spine 'mf_time_spine'
       SELECT
-        DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
+        time_spine_src_28006.ds AS ds__day
         , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week
         , DATE_TRUNC('month', time_spine_src_28006.ds) AS ds__month
         , DATE_TRUNC('quarter', time_spine_src_28006.ds) AS ds__quarter

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_min_max_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_min_max_metric_time__plan0_optimized.sql
@@ -13,8 +13,8 @@ FROM (
   -- Metric Time Dimension 'ds'
   -- Pass Only Elements: ['metric_time__day',]
   SELECT
-    DATE_TRUNC('day', ds) AS metric_time__day
+    ds AS metric_time__day
   FROM ***************************.mf_time_spine time_spine_src_28006
   GROUP BY
-    DATE_TRUNC('day', ds)
+    ds
 ) subq_5

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_min_max_metric_time_week__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_min_max_metric_time_week__plan0.sql
@@ -42,7 +42,7 @@ FROM (
     FROM (
       -- Read From Time Spine 'mf_time_spine'
       SELECT
-        DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
+        time_spine_src_28006.ds AS ds__day
         , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week
         , DATE_TRUNC('month', time_spine_src_28006.ds) AS ds__month
         , DATE_TRUNC('quarter', time_spine_src_28006.ds) AS ds__quarter

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_min_max_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_min_max_metric_time__plan0.sql
@@ -42,7 +42,7 @@ FROM (
     FROM (
       -- Read From Time Spine 'mf_time_spine'
       SELECT
-        DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
+        time_spine_src_28006.ds AS ds__day
         , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week
         , DATE_TRUNC('month', time_spine_src_28006.ds) AS ds__month
         , DATE_TRUNC('quarter', time_spine_src_28006.ds) AS ds__quarter

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_min_max_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_min_max_metric_time__plan0_optimized.sql
@@ -13,8 +13,8 @@ FROM (
   -- Metric Time Dimension 'ds'
   -- Pass Only Elements: ['metric_time__day',]
   SELECT
-    DATE_TRUNC('day', ds) AS metric_time__day
+    ds AS metric_time__day
   FROM ***************************.mf_time_spine time_spine_src_28006
   GROUP BY
-    DATE_TRUNC('day', ds)
+    ds
 ) subq_5

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_min_max_metric_time_week__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_min_max_metric_time_week__plan0.sql
@@ -42,7 +42,7 @@ FROM (
     FROM (
       -- Read From Time Spine 'mf_time_spine'
       SELECT
-        DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
+        time_spine_src_28006.ds AS ds__day
         , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week
         , DATE_TRUNC('month', time_spine_src_28006.ds) AS ds__month
         , DATE_TRUNC('quarter', time_spine_src_28006.ds) AS ds__quarter

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_min_max_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_min_max_metric_time__plan0.sql
@@ -42,7 +42,7 @@ FROM (
     FROM (
       -- Read From Time Spine 'mf_time_spine'
       SELECT
-        DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
+        time_spine_src_28006.ds AS ds__day
         , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week
         , DATE_TRUNC('month', time_spine_src_28006.ds) AS ds__month
         , DATE_TRUNC('quarter', time_spine_src_28006.ds) AS ds__quarter

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_min_max_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_min_max_metric_time__plan0_optimized.sql
@@ -13,8 +13,8 @@ FROM (
   -- Metric Time Dimension 'ds'
   -- Pass Only Elements: ['metric_time__day',]
   SELECT
-    DATE_TRUNC('day', ds) AS metric_time__day
+    ds AS metric_time__day
   FROM ***************************.mf_time_spine time_spine_src_28006
   GROUP BY
-    DATE_TRUNC('day', ds)
+    ds
 ) subq_5

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_min_max_metric_time_week__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_min_max_metric_time_week__plan0.sql
@@ -42,7 +42,7 @@ FROM (
     FROM (
       -- Read From Time Spine 'mf_time_spine'
       SELECT
-        DATE_TRUNC('day', time_spine_src_28006.ds) AS ds__day
+        time_spine_src_28006.ds AS ds__day
         , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week
         , DATE_TRUNC('month', time_spine_src_28006.ds) AS ds__month
         , DATE_TRUNC('quarter', time_spine_src_28006.ds) AS ds__quarter


### PR DESCRIPTION
This will enable more efficient queries. We require the described grain to be accurate to the grain of the column, so this `DATE_TRUNC` is unnecessary.