### PR TITLE
Create `SqlAddTimeExpression`

### DIFF
--- a/metricflow-semantics/metricflow_semantics/dag/id_prefix.py
+++ b/metricflow-semantics/metricflow_semantics/dag/id_prefix.py
@@ -69,6 +69,7 @@ class StaticIdPrefix(IdPrefix, Enum, metaclass=EnumMetaClassHelper):
     SQL_EXPR_CAST_TO_TIMESTAMP_PREFIX = "ctt"
     SQL_EXPR_DATE_TRUNC = "dt"
     SQL_EXPR_SUBTRACT_TIME_INTERVAL_PREFIX = "sti"
+    SQL_EXPR_ADD_TIME_PREFIX = "ati"
     SQL_EXPR_EXTRACT = "ex"
     SQL_EXPR_RATIO_COMPUTATION = "rc"
     SQL_EXPR_BETWEEN_PREFIX = "betw"

--- a/metricflow/sql/render/big_query.py
+++ b/metricflow/sql/render/big_query.py
@@ -167,7 +167,7 @@ class BigQuerySqlExpressionRenderer(DefaultSqlExpressionRenderer):
         )
 
     @override
-    def visit_time_delta_expr(self, node: SqlSubtractTimeIntervalExpression) -> SqlExpressionRenderResult:
+    def visit_subtract_time_interval_expr(self, node: SqlSubtractTimeIntervalExpression) -> SqlExpressionRenderResult:
         """Render time delta for BigQuery, which requires ISO prefixing for the WEEK granularity value."""
         column = node.arg.accept(self)
 

--- a/metricflow/sql/render/duckdb_renderer.py
+++ b/metricflow/sql/render/duckdb_renderer.py
@@ -37,7 +37,7 @@ class DuckDbSqlExpressionRenderer(DefaultSqlExpressionRenderer):
         }
 
     @override
-    def visit_time_delta_expr(self, node: SqlSubtractTimeIntervalExpression) -> SqlExpressionRenderResult:
+    def visit_subtract_time_interval_expr(self, node: SqlSubtractTimeIntervalExpression) -> SqlExpressionRenderResult:
         """Render time delta expression for DuckDB, which requires slightly different syntax from other engines."""
         arg_rendered = node.arg.accept(self)
 

--- a/metricflow/sql/render/duckdb_renderer.py
+++ b/metricflow/sql/render/duckdb_renderer.py
@@ -15,6 +15,7 @@ from metricflow.sql.render.expr_renderer import (
 )
 from metricflow.sql.render.sql_plan_renderer import DefaultSqlQueryPlanRenderer
 from metricflow.sql.sql_exprs import (
+    SqlAddTimeExpression,
     SqlGenerateUuidExpression,
     SqlPercentileExpression,
     SqlPercentileFunctionType,
@@ -49,6 +50,22 @@ class DuckDbSqlExpressionRenderer(DefaultSqlExpressionRenderer):
 
         return SqlExpressionRenderResult(
             sql=f"{arg_rendered.sql} - INTERVAL {count} {granularity.value}",
+            bind_parameter_set=arg_rendered.bind_parameter_set,
+        )
+
+    @override
+    def visit_add_time_expr(self, node: SqlAddTimeExpression) -> SqlExpressionRenderResult:
+        """Render time delta expression for DuckDB, which requires slightly different syntax from other engines."""
+        arg_rendered = node.arg.accept(self)
+        count_rendered = node.count_expr.accept(self).sql
+
+        granularity = node.granularity
+        if granularity == TimeGranularity.QUARTER:
+            granularity = TimeGranularity.MONTH
+            count_rendered = f"{count_rendered} * 3"
+
+        return SqlExpressionRenderResult(
+            sql=f"{arg_rendered.sql} + INTERVAL {count_rendered} {granularity.value}",
             bind_parameter_set=arg_rendered.bind_parameter_set,
         )
 

--- a/metricflow/sql/render/duckdb_renderer.py
+++ b/metricflow/sql/render/duckdb_renderer.py
@@ -44,7 +44,7 @@ class DuckDbSqlExpressionRenderer(DefaultSqlExpressionRenderer):
 
         count = node.count
         granularity = node.granularity
-        if granularity == TimeGranularity.QUARTER:
+        if granularity is TimeGranularity.QUARTER:
             granularity = TimeGranularity.MONTH
             count *= 3
 
@@ -60,9 +60,9 @@ class DuckDbSqlExpressionRenderer(DefaultSqlExpressionRenderer):
         count_rendered = node.count_expr.accept(self).sql
 
         granularity = node.granularity
-        if granularity == TimeGranularity.QUARTER:
+        if granularity is TimeGranularity.QUARTER:
             granularity = TimeGranularity.MONTH
-            count_rendered = f"{count_rendered} * 3"
+            count_rendered = f"({count_rendered} * 3)"
 
         return SqlExpressionRenderResult(
             sql=f"{arg_rendered.sql} + INTERVAL {count_rendered} {granularity.value}",

--- a/metricflow/sql/render/expr_renderer.py
+++ b/metricflow/sql/render/expr_renderer.py
@@ -311,7 +311,7 @@ class DefaultSqlExpressionRenderer(SqlExpressionRenderer):
 
         count = node.count
         granularity = node.granularity
-        if granularity == TimeGranularity.QUARTER:
+        if granularity is TimeGranularity.QUARTER:
             granularity = TimeGranularity.MONTH
             count *= 3
         return SqlExpressionRenderResult(
@@ -324,9 +324,9 @@ class DefaultSqlExpressionRenderer(SqlExpressionRenderer):
         count_rendered = node.count_expr.accept(self).sql
 
         granularity = node.granularity
-        if granularity == TimeGranularity.QUARTER:
+        if granularity is TimeGranularity.QUARTER:
             granularity = TimeGranularity.MONTH
-            count_rendered = f"{count_rendered} * 3"
+            count_rendered = f"({count_rendered} * 3)"
 
         return SqlExpressionRenderResult(
             sql=f"DATEADD({granularity.value}, {count_rendered}, {arg_rendered.sql})",

--- a/metricflow/sql/render/expr_renderer.py
+++ b/metricflow/sql/render/expr_renderer.py
@@ -303,7 +303,9 @@ class DefaultSqlExpressionRenderer(SqlExpressionRenderer):
 
         return date_part.value
 
-    def visit_time_delta_expr(self, node: SqlSubtractTimeIntervalExpression) -> SqlExpressionRenderResult:  # noqa: D102
+    def visit_subtract_time_interval_expr(
+        self, node: SqlSubtractTimeIntervalExpression
+    ) -> SqlExpressionRenderResult:  # noqa: D102
         arg_rendered = node.arg.accept(self)
 
         count = node.count

--- a/metricflow/sql/render/postgres.py
+++ b/metricflow/sql/render/postgres.py
@@ -40,7 +40,7 @@ class PostgresSqlExpressionRenderer(DefaultSqlExpressionRenderer):
         return {SqlPercentileFunctionType.CONTINUOUS, SqlPercentileFunctionType.DISCRETE}
 
     @override
-    def visit_time_delta_expr(self, node: SqlSubtractTimeIntervalExpression) -> SqlExpressionRenderResult:
+    def visit_subtract_time_interval_expr(self, node: SqlSubtractTimeIntervalExpression) -> SqlExpressionRenderResult:
         """Render time delta operations for PostgreSQL, which needs custom support for quarterly granularity."""
         arg_rendered = node.arg.accept(self)
 

--- a/metricflow/sql/render/postgres.py
+++ b/metricflow/sql/render/postgres.py
@@ -47,7 +47,7 @@ class PostgresSqlExpressionRenderer(DefaultSqlExpressionRenderer):
 
         count = node.count
         granularity = node.granularity
-        if granularity == TimeGranularity.QUARTER:
+        if granularity is TimeGranularity.QUARTER:
             granularity = TimeGranularity.MONTH
             count *= 3
         return SqlExpressionRenderResult(
@@ -62,9 +62,9 @@ class PostgresSqlExpressionRenderer(DefaultSqlExpressionRenderer):
         count_rendered = node.count_expr.accept(self).sql
 
         granularity = node.granularity
-        if granularity == TimeGranularity.QUARTER:
+        if granularity is TimeGranularity.QUARTER:
             granularity = TimeGranularity.MONTH
-            count_rendered = f"{count_rendered} * 3"
+            count_rendered = f"({count_rendered} * 3)"
 
         return SqlExpressionRenderResult(
             sql=f"{arg_rendered.sql} + MAKE_INTERVAL({granularity.value}s => {count_rendered})",

--- a/metricflow/sql/render/postgres.py
+++ b/metricflow/sql/render/postgres.py
@@ -16,6 +16,7 @@ from metricflow.sql.render.expr_renderer import (
 )
 from metricflow.sql.render.sql_plan_renderer import DefaultSqlQueryPlanRenderer
 from metricflow.sql.sql_exprs import (
+    SqlAddTimeExpression,
     SqlGenerateUuidExpression,
     SqlPercentileExpression,
     SqlPercentileFunctionType,
@@ -51,6 +52,22 @@ class PostgresSqlExpressionRenderer(DefaultSqlExpressionRenderer):
             count *= 3
         return SqlExpressionRenderResult(
             sql=f"{arg_rendered.sql} - MAKE_INTERVAL({granularity.value}s => {count})",
+            bind_parameter_set=arg_rendered.bind_parameter_set,
+        )
+
+    @override
+    def visit_add_time_expr(self, node: SqlAddTimeExpression) -> SqlExpressionRenderResult:
+        """Render time delta operations for PostgreSQL, which needs custom support for quarterly granularity."""
+        arg_rendered = node.arg.accept(self)
+        count_rendered = node.count_expr.accept(self).sql
+
+        granularity = node.granularity
+        if granularity == TimeGranularity.QUARTER:
+            granularity = TimeGranularity.MONTH
+            count_rendered = f"{count_rendered} * 3"
+
+        return SqlExpressionRenderResult(
+            sql=f"{arg_rendered.sql} + MAKE_INTERVAL({granularity.value}s => {count_rendered})",
             bind_parameter_set=arg_rendered.bind_parameter_set,
         )
 

--- a/metricflow/sql/render/trino.py
+++ b/metricflow/sql/render/trino.py
@@ -52,7 +52,7 @@ class TrinoSqlExpressionRenderer(DefaultSqlExpressionRenderer):
 
         count = node.count
         granularity = node.granularity
-        if granularity == TimeGranularity.QUARTER:
+        if granularity is TimeGranularity.QUARTER:
             granularity = TimeGranularity.MONTH
             count *= 3
         return SqlExpressionRenderResult(
@@ -67,9 +67,9 @@ class TrinoSqlExpressionRenderer(DefaultSqlExpressionRenderer):
         count_rendered = node.count_expr.accept(self).sql
 
         granularity = node.granularity
-        if granularity == TimeGranularity.QUARTER:
+        if granularity is TimeGranularity.QUARTER:
             granularity = TimeGranularity.MONTH
-            count_rendered = f"{count_rendered} * 3"
+            count_rendered = f"({count_rendered} * 3)"
 
         return SqlExpressionRenderResult(
             sql=f"DATE_ADD('{granularity.value}', {count_rendered}, {arg_rendered.sql})",

--- a/metricflow/sql/render/trino.py
+++ b/metricflow/sql/render/trino.py
@@ -45,7 +45,7 @@ class TrinoSqlExpressionRenderer(DefaultSqlExpressionRenderer):
         )
 
     @override
-    def visit_time_delta_expr(self, node: SqlSubtractTimeIntervalExpression) -> SqlExpressionRenderResult:
+    def visit_subtract_time_interval_expr(self, node: SqlSubtractTimeIntervalExpression) -> SqlExpressionRenderResult:
         """Render time delta for Trino, require granularity in quotes and function name change."""
         arg_rendered = node.arg.accept(self)
 

--- a/metricflow/sql/render/trino.py
+++ b/metricflow/sql/render/trino.py
@@ -17,6 +17,7 @@ from metricflow.sql.render.expr_renderer import (
 )
 from metricflow.sql.render.sql_plan_renderer import DefaultSqlQueryPlanRenderer
 from metricflow.sql.sql_exprs import (
+    SqlAddTimeExpression,
     SqlBetweenExpression,
     SqlGenerateUuidExpression,
     SqlPercentileExpression,
@@ -56,6 +57,22 @@ class TrinoSqlExpressionRenderer(DefaultSqlExpressionRenderer):
             count *= 3
         return SqlExpressionRenderResult(
             sql=f"DATE_ADD('{granularity.value}', -{count}, {arg_rendered.sql})",
+            bind_parameter_set=arg_rendered.bind_parameter_set,
+        )
+
+    @override
+    def visit_add_time_expr(self, node: SqlAddTimeExpression) -> SqlExpressionRenderResult:
+        """Render time delta for Trino, require granularity in quotes and function name change."""
+        arg_rendered = node.arg.accept(self)
+        count_rendered = node.count_expr.accept(self).sql
+
+        granularity = node.granularity
+        if granularity == TimeGranularity.QUARTER:
+            granularity = TimeGranularity.MONTH
+            count_rendered = f"{count_rendered} * 3"
+
+        return SqlExpressionRenderResult(
+            sql=f"DATE_ADD('{granularity.value}', {count_rendered}, {arg_rendered.sql})",
             bind_parameter_set=arg_rendered.bind_parameter_set,
         )
 

--- a/metricflow/sql/sql_exprs.py
+++ b/metricflow/sql/sql_exprs.py
@@ -212,7 +212,9 @@ class SqlExpressionNodeVisitor(Generic[VisitorOutputT], ABC):
         pass
 
     @abstractmethod
-    def visit_time_delta_expr(self, node: SqlSubtractTimeIntervalExpression) -> VisitorOutputT:  # noqa: D102
+    def visit_subtract_time_interval_expr(
+        self, node: SqlSubtractTimeIntervalExpression
+    ) -> VisitorOutputT:  # noqa: D102
         pass
 
     @abstractmethod
@@ -1289,11 +1291,11 @@ class SqlSubtractTimeIntervalExpression(SqlExpressionNode):
         return False
 
     def accept(self, visitor: SqlExpressionNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D102
-        return visitor.visit_time_delta_expr(self)
+        return visitor.visit_subtract_time_interval_expr(self)
 
     @property
     def description(self) -> str:  # noqa: D102
-        return "Time delta"
+        return "Subtract time interval"
 
     def rewrite(  # noqa: D102
         self,

--- a/metricflow/sql/sql_exprs.py
+++ b/metricflow/sql/sql_exprs.py
@@ -212,9 +212,13 @@ class SqlExpressionNodeVisitor(Generic[VisitorOutputT], ABC):
         pass
 
     @abstractmethod
-    def visit_subtract_time_interval_expr(
+    def visit_subtract_time_interval_expr(  # noqa: D102
         self, node: SqlSubtractTimeIntervalExpression
-    ) -> VisitorOutputT:  # noqa: D102
+    ) -> VisitorOutputT:
+        pass
+
+    @abstractmethod
+    def visit_add_time_expr(self, node: SqlAddTimeExpression) -> VisitorOutputT:  # noqa: D102
         pass
 
     @abstractmethod
@@ -1318,6 +1322,65 @@ class SqlSubtractTimeIntervalExpression(SqlExpressionNode):
         if not isinstance(other, SqlSubtractTimeIntervalExpression):
             return False
         return self.count == other.count and self.granularity == other.granularity and self._parents_match(other)
+
+
+@dataclass(frozen=True, eq=False)
+class SqlAddTimeExpression(SqlExpressionNode):
+    """Add a time interval expr to a timestamp."""
+
+    arg: SqlExpressionNode
+    count_expr: SqlExpressionNode
+    granularity: TimeGranularity
+
+    @staticmethod
+    def create(  # noqa: D102
+        arg: SqlExpressionNode,
+        count_expr: SqlExpressionNode,
+        granularity: TimeGranularity,
+    ) -> SqlAddTimeExpression:
+        return SqlAddTimeExpression(
+            parent_nodes=(arg, count_expr),
+            arg=arg,
+            count_expr=count_expr,
+            granularity=granularity,
+        )
+
+    @classmethod
+    def id_prefix(cls) -> IdPrefix:  # noqa: D102
+        return StaticIdPrefix.SQL_EXPR_ADD_TIME_PREFIX
+
+    @property
+    def requires_parenthesis(self) -> bool:  # noqa: D102
+        return False
+
+    def accept(self, visitor: SqlExpressionNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D102
+        return visitor.visit_add_time_expr(self)
+
+    @property
+    def description(self) -> str:  # noqa: D102
+        return "Add time interval"
+
+    def rewrite(  # noqa: D102
+        self,
+        column_replacements: Optional[SqlColumnReplacements] = None,
+        should_render_table_alias: Optional[bool] = None,
+    ) -> SqlExpressionNode:
+        return SqlAddTimeExpression.create(
+            arg=self.arg.rewrite(column_replacements, should_render_table_alias),
+            count_expr=self.count_expr,
+            granularity=self.granularity,
+        )
+
+    @property
+    def lineage(self) -> SqlExpressionTreeLineage:  # noqa: D102
+        return SqlExpressionTreeLineage.combine(
+            tuple(x.lineage for x in self.parent_nodes) + (SqlExpressionTreeLineage(other_exprs=(self,)),)
+        )
+
+    def matches(self, other: SqlExpressionNode) -> bool:  # noqa: D102
+        if not isinstance(other, SqlAddTimeExpression):
+            return False
+        return self.count_expr == other.count_expr and self.granularity == other.granularity and self.arg == other.arg
 
 
 @dataclass(frozen=True, eq=False)

--- a/metricflow/sql/sql_exprs.py
+++ b/metricflow/sql/sql_exprs.py
@@ -1373,7 +1373,7 @@ class SqlAddTimeExpression(SqlExpressionNode):
 
     @property
     def lineage(self) -> SqlExpressionTreeLineage:  # noqa: D102
-        return SqlExpressionTreeLineage.combine(
+        return SqlExpressionTreeLineage.merge_iterable(
             tuple(x.lineage for x in self.parent_nodes) + (SqlExpressionTreeLineage(other_exprs=(self,)),)
         )
 

--- a/tests_metricflow/snapshots/test_engine_specific_rendering.py/SqlQueryPlan/BigQuery/test_add_time_expr__plan0.sql
+++ b/tests_metricflow/snapshots/test_engine_specific_rendering.py/SqlQueryPlan/BigQuery/test_add_time_expr__plan0.sql
@@ -2,9 +2,9 @@ test_name: test_add_time_expr
 test_filename: test_engine_specific_rendering.py
 docstring:
   Tests rendering of the SqlAddTimeExpr in a query.
-sql_engine: Redshift
+sql_engine: BigQuery
 ---
 -- Test Add Time Expression
 SELECT
-  DATEADD(month, (1 * 3), '2020-01-01') AS add_time
+  DATE_ADD(CAST('2020-01-01' AS DATETIME), INTERVAL SqlExpressionRenderResult(sql='1', bind_parameter_set=SqlBindParameterSet(param_items=())) quarter) AS add_time
 FROM foo.bar a

--- a/tests_metricflow/snapshots/test_engine_specific_rendering.py/SqlQueryPlan/Databricks/test_add_time_expr__plan0.sql
+++ b/tests_metricflow/snapshots/test_engine_specific_rendering.py/SqlQueryPlan/Databricks/test_add_time_expr__plan0.sql
@@ -2,7 +2,7 @@ test_name: test_add_time_expr
 test_filename: test_engine_specific_rendering.py
 docstring:
   Tests rendering of the SqlAddTimeExpr in a query.
-sql_engine: Redshift
+sql_engine: Databricks
 ---
 -- Test Add Time Expression
 SELECT

--- a/tests_metricflow/snapshots/test_engine_specific_rendering.py/SqlQueryPlan/DuckDB/test_add_time_expr__plan0.sql
+++ b/tests_metricflow/snapshots/test_engine_specific_rendering.py/SqlQueryPlan/DuckDB/test_add_time_expr__plan0.sql
@@ -1,0 +1,10 @@
+test_name: test_add_time_expr
+test_filename: test_engine_specific_rendering.py
+docstring:
+  Tests rendering of the SqlAddTimeExpr in a query.
+sql_engine: DuckDB
+---
+-- Test Add Time Expression
+SELECT
+  '2020-01-01' + INTERVAL (1 * 3) month AS add_time
+FROM foo.bar a

--- a/tests_metricflow/snapshots/test_engine_specific_rendering.py/SqlQueryPlan/Postgres/test_add_time_expr__plan0.sql
+++ b/tests_metricflow/snapshots/test_engine_specific_rendering.py/SqlQueryPlan/Postgres/test_add_time_expr__plan0.sql
@@ -2,9 +2,9 @@ test_name: test_add_time_expr
 test_filename: test_engine_specific_rendering.py
 docstring:
   Tests rendering of the SqlAddTimeExpr in a query.
-sql_engine: Redshift
+sql_engine: Postgres
 ---
 -- Test Add Time Expression
 SELECT
-  DATEADD(month, (1 * 3), '2020-01-01') AS add_time
+  '2020-01-01' + MAKE_INTERVAL(months => (1 * 3)) AS add_time
 FROM foo.bar a

--- a/tests_metricflow/snapshots/test_engine_specific_rendering.py/SqlQueryPlan/Redshift/test_add_time_expr__plan0.sql
+++ b/tests_metricflow/snapshots/test_engine_specific_rendering.py/SqlQueryPlan/Redshift/test_add_time_expr__plan0.sql
@@ -1,0 +1,10 @@
+test_name: test_add_time_expr
+test_filename: test_engine_specific_rendering.py
+docstring:
+  Tests rendering of the SqlAddTimeExpr in a query.
+sql_engine: Redshift
+---
+-- Test Approximate Discrete Percentile Expression
+SELECT
+  DATEADD(month, (1 * 3), '2020-01-01') AS add_time
+FROM foo.bar a

--- a/tests_metricflow/snapshots/test_engine_specific_rendering.py/SqlQueryPlan/Snowflake/test_add_time_expr__plan0.sql
+++ b/tests_metricflow/snapshots/test_engine_specific_rendering.py/SqlQueryPlan/Snowflake/test_add_time_expr__plan0.sql
@@ -2,7 +2,7 @@ test_name: test_add_time_expr
 test_filename: test_engine_specific_rendering.py
 docstring:
   Tests rendering of the SqlAddTimeExpr in a query.
-sql_engine: Redshift
+sql_engine: Snowflake
 ---
 -- Test Add Time Expression
 SELECT

--- a/tests_metricflow/snapshots/test_engine_specific_rendering.py/SqlQueryPlan/Trino/test_add_time_expr__plan0.sql
+++ b/tests_metricflow/snapshots/test_engine_specific_rendering.py/SqlQueryPlan/Trino/test_add_time_expr__plan0.sql
@@ -2,9 +2,9 @@ test_name: test_add_time_expr
 test_filename: test_engine_specific_rendering.py
 docstring:
   Tests rendering of the SqlAddTimeExpr in a query.
-sql_engine: Redshift
+sql_engine: Trino
 ---
 -- Test Add Time Expression
 SELECT
-  DATEADD(month, (1 * 3), '2020-01-01') AS add_time
+  DATE_ADD('month', (1 * 3), '2020-01-01') AS add_time
 FROM foo.bar a


### PR DESCRIPTION
Adds a new SQL expression that adds a time interval to a date/time expression. This differs from the existing time delta expression because it 1) adds instead of subtracts, and 2) accepts a SQL expression for the count instead of an integer. This will be used to build the SQL for custom granularity offset windows.