### PR TITLE
Memoize results in `SourceScanOptimizer` for better CTE generation

### DIFF
--- a/metricflow/dataflow/dataflow_plan_analyzer.py
+++ b/metricflow/dataflow/dataflow_plan_analyzer.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from collections import defaultdict
 from typing import Dict, FrozenSet, Mapping, Sequence, Set
 
@@ -7,6 +8,8 @@ from typing_extensions import override
 
 from metricflow.dataflow.dataflow_plan import DataflowPlan, DataflowPlanNode
 from metricflow.dataflow.dataflow_plan_visitor import DataflowPlanNodeVisitorWithDefaultHandler
+
+logger = logging.getLogger(__name__)
 
 
 class DataflowPlanAnalyzer:

--- a/metricflow/dataflow/optimizer/source_scan/cm_branch_combiner.py
+++ b/metricflow/dataflow/optimizer/source_scan/cm_branch_combiner.py
@@ -132,7 +132,7 @@ class ComputeMetricsBranchCombiner(DataflowPlanNodeVisitor[ComputeMetricsBranchC
         self._current_left_node: DataflowPlanNode = left_branch_node
 
     def _log_visit_node_type(self, node: DataflowPlanNode) -> None:
-        logger.debug(LazyFormat(lambda: f"Visiting {node}"))
+        logger.debug(lambda: f"Visiting {node.node_id}")
 
     def _log_combine_failure(
         self,
@@ -142,8 +142,10 @@ class ComputeMetricsBranchCombiner(DataflowPlanNodeVisitor[ComputeMetricsBranchC
     ) -> None:
         logger.debug(
             LazyFormat(
-                lambda: f"Because {combine_failure_reason}, unable to combine nodes "
-                f"left_node={left_node} right_node={right_node}",
+                "Unable to combine nodes",
+                combine_failure_reason=combine_failure_reason,
+                left_node=left_node.node_id,
+                right_node=right_node.node_id,
             )
         )
 
@@ -154,7 +156,12 @@ class ComputeMetricsBranchCombiner(DataflowPlanNodeVisitor[ComputeMetricsBranchC
         combined_node: DataflowPlanNode,
     ) -> None:
         logger.debug(
-            LazyFormat(lambda: f"Combined left_node={left_node} right_node={right_node} combined_node: {combined_node}")
+            LazyFormat(
+                "Successfully combined nodes",
+                left_node=left_node.node_id,
+                right_node=right_node.node_id,
+                combined_node=combined_node.node_id,
+            )
         )
 
     def _combine_parent_branches(self, current_right_node: DataflowPlanNode) -> Optional[Sequence[DataflowPlanNode]]:

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/BigQuery/test_conversion_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/BigQuery/test_conversion_metric__plan0_optimized.sql
@@ -5,15 +5,25 @@ docstring:
 sql_engine: BigQuery
 ---
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATETIME_TRUNC(ds, day) AS metric_time__day
+    , user_id AS user
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
-  metric_time__day
+  metric_time__day AS metric_time__day
   , CAST(buys AS FLOAT64) / CAST(NULLIF(visits, 0) AS FLOAT64) AS visit_buy_conversion_rate
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_21.metric_time__day, subq_32.metric_time__day) AS metric_time__day
+    COALESCE(subq_21.metric_time__day, subq_31.metric_time__day) AS metric_time__day
     , MAX(subq_21.visits) AS visits
-    , MAX(subq_32.buys) AS buys
+    , MAX(subq_31.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['visits', 'metric_time__day']
@@ -22,12 +32,12 @@ FROM (
       metric_time__day
       , SUM(visits) AS visits
     FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
+      -- Read From CTE For node_id=sma_28019
       SELECT
-        DATETIME_TRUNC(ds, day) AS metric_time__day
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
+        metric_time__day
+        , sma_28019_cte.user
+        , visits
+      FROM sma_28019_cte sma_28019_cte
     ) subq_18
     WHERE metric_time__day = '2020-01-01'
     GROUP BY
@@ -43,50 +53,49 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_25.visits) OVER (
+        FIRST_VALUE(subq_24.visits) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_25.metric_time__day) OVER (
+        , FIRST_VALUE(subq_24.metric_time__day) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_25.user) OVER (
+        , FIRST_VALUE(subq_24.user) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_28.mf_internal_uuid AS mf_internal_uuid
-        , subq_28.buys AS buys
+        , subq_27.mf_internal_uuid AS mf_internal_uuid
+        , subq_27.buys AS buys
       FROM (
         -- Constrain Output with WHERE
         -- Pass Only Elements: ['visits', 'metric_time__day', 'user']
         SELECT
           metric_time__day
-          , subq_23.user
+          , subq_22.user
           , visits
         FROM (
-          -- Read Elements From Semantic Model 'visits_source'
-          -- Metric Time Dimension 'ds'
+          -- Read From CTE For node_id=sma_28019
           SELECT
-            DATETIME_TRUNC(ds, day) AS metric_time__day
-            , user_id AS user
-            , 1 AS visits
-          FROM ***************************.fct_visits visits_source_src_28000
-        ) subq_23
+            metric_time__day
+            , sma_28019_cte.user
+            , visits
+          FROM sma_28019_cte sma_28019_cte
+        ) subq_22
         WHERE metric_time__day = '2020-01-01'
-      ) subq_25
+      ) subq_24
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -97,19 +106,19 @@ FROM (
           , 1 AS buys
           , GENERATE_UUID() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_28
+      ) subq_27
       ON
         (
-          subq_25.user = subq_28.user
+          subq_24.user = subq_27.user
         ) AND (
-          (subq_25.metric_time__day <= subq_28.metric_time__day)
+          (subq_24.metric_time__day <= subq_27.metric_time__day)
         )
-    ) subq_29
+    ) subq_28
     GROUP BY
       metric_time__day
-  ) subq_32
+  ) subq_31
   ON
-    subq_21.metric_time__day = subq_32.metric_time__day
+    subq_21.metric_time__day = subq_31.metric_time__day
   GROUP BY
     metric_time__day
-) subq_33
+) subq_32

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/BigQuery/test_conversion_metric_with_categorical_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/BigQuery/test_conversion_metric_with_categorical_filter__plan0_optimized.sql
@@ -5,17 +5,28 @@ docstring:
 sql_engine: BigQuery
 ---
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATETIME_TRUNC(ds, day) AS metric_time__day
+    , user_id AS user
+    , referrer_id AS visit__referrer_id
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
-  metric_time__day
-  , visit__referrer_id
+  metric_time__day AS metric_time__day
+  , visit__referrer_id AS visit__referrer_id
   , CAST(buys AS FLOAT64) / CAST(NULLIF(visits, 0) AS FLOAT64) AS visit_buy_conversion_rate
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_21.metric_time__day, subq_32.metric_time__day) AS metric_time__day
-    , COALESCE(subq_21.visit__referrer_id, subq_32.visit__referrer_id) AS visit__referrer_id
+    COALESCE(subq_21.metric_time__day, subq_31.metric_time__day) AS metric_time__day
+    , COALESCE(subq_21.visit__referrer_id, subq_31.visit__referrer_id) AS visit__referrer_id
     , MAX(subq_21.visits) AS visits
-    , MAX(subq_32.buys) AS buys
+    , MAX(subq_31.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
@@ -25,13 +36,13 @@ FROM (
       , visit__referrer_id
       , SUM(visits) AS visits
     FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
+      -- Read From CTE For node_id=sma_28019
       SELECT
-        DATETIME_TRUNC(ds, day) AS metric_time__day
-        , referrer_id AS visit__referrer_id
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
+        metric_time__day
+        , sma_28019_cte.user
+        , visit__referrer_id
+        , visits
+      FROM sma_28019_cte sma_28019_cte
     ) subq_18
     WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
@@ -49,60 +60,59 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_25.visits) OVER (
+        FIRST_VALUE(subq_24.visits) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_25.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_24.visit__referrer_id) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_25.metric_time__day) OVER (
+        , FIRST_VALUE(subq_24.metric_time__day) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_25.user) OVER (
+        , FIRST_VALUE(subq_24.user) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_28.mf_internal_uuid AS mf_internal_uuid
-        , subq_28.buys AS buys
+        , subq_27.mf_internal_uuid AS mf_internal_uuid
+        , subq_27.buys AS buys
       FROM (
         -- Constrain Output with WHERE
         -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user']
         SELECT
           metric_time__day
-          , subq_23.user
+          , subq_22.user
           , visit__referrer_id
           , visits
         FROM (
-          -- Read Elements From Semantic Model 'visits_source'
-          -- Metric Time Dimension 'ds'
+          -- Read From CTE For node_id=sma_28019
           SELECT
-            DATETIME_TRUNC(ds, day) AS metric_time__day
-            , user_id AS user
-            , referrer_id AS visit__referrer_id
-            , 1 AS visits
-          FROM ***************************.fct_visits visits_source_src_28000
-        ) subq_23
+            metric_time__day
+            , sma_28019_cte.user
+            , visit__referrer_id
+            , visits
+          FROM sma_28019_cte sma_28019_cte
+        ) subq_22
         WHERE visit__referrer_id = 'ref_id_01'
-      ) subq_25
+      ) subq_24
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -113,25 +123,25 @@ FROM (
           , 1 AS buys
           , GENERATE_UUID() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_28
+      ) subq_27
       ON
         (
-          subq_25.user = subq_28.user
+          subq_24.user = subq_27.user
         ) AND (
-          (subq_25.metric_time__day <= subq_28.metric_time__day)
+          (subq_24.metric_time__day <= subq_27.metric_time__day)
         )
-    ) subq_29
+    ) subq_28
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_32
+  ) subq_31
   ON
     (
-      subq_21.visit__referrer_id = subq_32.visit__referrer_id
+      subq_21.visit__referrer_id = subq_31.visit__referrer_id
     ) AND (
-      subq_21.metric_time__day = subq_32.metric_time__day
+      subq_21.metric_time__day = subq_31.metric_time__day
     )
   GROUP BY
     metric_time__day
     , visit__referrer_id
-) subq_33
+) subq_32

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/BigQuery/test_conversion_metric_with_different_time_dimension_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/BigQuery/test_conversion_metric_with_different_time_dimension_grains__plan0_optimized.sql
@@ -6,16 +6,25 @@ sql_engine: BigQuery
 ---
 -- Combine Aggregated Outputs
 -- Compute Metrics via Expressions
-SELECT
-  CAST(MAX(subq_28.buys_month) AS FLOAT64) / CAST(NULLIF(MAX(subq_18.visits), 0) AS FLOAT64) AS visit_buy_conversion_rate_with_monthly_conversion
-FROM (
+WITH sma_28019_cte AS (
   -- Read Elements From Semantic Model 'visits_source'
   -- Metric Time Dimension 'ds'
+  SELECT
+    DATETIME_TRUNC(ds, month) AS metric_time__month
+    , user_id AS user
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
+SELECT
+  CAST(MAX(subq_27.buys_month) AS FLOAT64) / CAST(NULLIF(MAX(subq_18.visits), 0) AS FLOAT64) AS visit_buy_conversion_rate_with_monthly_conversion
+FROM (
+  -- Read From CTE For node_id=sma_28019
   -- Pass Only Elements: ['visits',]
   -- Aggregate Measures
   SELECT
-    SUM(1) AS visits
-  FROM ***************************.fct_visits visits_source_src_28000
+    SUM(visits) AS visits
+  FROM sma_28019_cte sma_28019_cte
 ) subq_18
 CROSS JOIN (
   -- Find conversions for user within the range of 1 month
@@ -26,42 +35,33 @@ CROSS JOIN (
   FROM (
     -- Dedupe the fanout with mf_internal_uuid in the conversion data set
     SELECT DISTINCT
-      FIRST_VALUE(subq_21.visits) OVER (
+      FIRST_VALUE(sma_28019_cte.visits) OVER (
         PARTITION BY
-          subq_24.user
-          , subq_24.metric_time__month
-          , subq_24.mf_internal_uuid
-        ORDER BY subq_21.metric_time__month DESC
+          subq_23.user
+          , subq_23.metric_time__month
+          , subq_23.mf_internal_uuid
+        ORDER BY sma_28019_cte.metric_time__month DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS visits
-      , FIRST_VALUE(subq_21.metric_time__month) OVER (
+      , FIRST_VALUE(sma_28019_cte.metric_time__month) OVER (
         PARTITION BY
-          subq_24.user
-          , subq_24.metric_time__month
-          , subq_24.mf_internal_uuid
-        ORDER BY subq_21.metric_time__month DESC
+          subq_23.user
+          , subq_23.metric_time__month
+          , subq_23.mf_internal_uuid
+        ORDER BY sma_28019_cte.metric_time__month DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS metric_time__month
-      , FIRST_VALUE(subq_21.user) OVER (
+      , FIRST_VALUE(sma_28019_cte.user) OVER (
         PARTITION BY
-          subq_24.user
-          , subq_24.metric_time__month
-          , subq_24.mf_internal_uuid
-        ORDER BY subq_21.metric_time__month DESC
+          subq_23.user
+          , subq_23.metric_time__month
+          , subq_23.mf_internal_uuid
+        ORDER BY sma_28019_cte.metric_time__month DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS user
-      , subq_24.mf_internal_uuid AS mf_internal_uuid
-      , subq_24.buys_month AS buys_month
-    FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['visits', 'metric_time__month', 'user']
-      SELECT
-        DATETIME_TRUNC(ds, month) AS metric_time__month
-        , user_id AS user
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
-    ) subq_21
+      , subq_23.mf_internal_uuid AS mf_internal_uuid
+      , subq_23.buys_month AS buys_month
+    FROM sma_28019_cte sma_28019_cte
     INNER JOIN (
       -- Read Elements From Semantic Model 'buys_source'
       -- Metric Time Dimension 'ds_month'
@@ -72,16 +72,16 @@ CROSS JOIN (
         , 1 AS buys_month
         , GENERATE_UUID() AS mf_internal_uuid
       FROM ***************************.fct_buys buys_source_src_28000
-    ) subq_24
+    ) subq_23
     ON
       (
-        subq_21.user = subq_24.user
+        sma_28019_cte.user = subq_23.user
       ) AND (
         (
-          subq_21.metric_time__month <= subq_24.metric_time__month
+          sma_28019_cte.metric_time__month <= subq_23.metric_time__month
         ) AND (
-          subq_21.metric_time__month > DATE_SUB(CAST(subq_24.metric_time__month AS DATETIME), INTERVAL 1 month)
+          sma_28019_cte.metric_time__month > DATE_SUB(CAST(subq_23.metric_time__month AS DATETIME), INTERVAL 1 month)
         )
       )
-  ) subq_25
-) subq_28
+  ) subq_24
+) subq_27

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/BigQuery/test_conversion_metric_with_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/BigQuery/test_conversion_metric_with_filter__plan0_optimized.sql
@@ -6,8 +6,18 @@ sql_engine: BigQuery
 ---
 -- Combine Aggregated Outputs
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATETIME_TRUNC(ds, day) AS metric_time__day
+    , user_id AS user
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
-  CAST(MAX(subq_32.buys) AS FLOAT64) / CAST(NULLIF(MAX(subq_21.visits), 0) AS FLOAT64) AS visit_buy_conversion_rate
+  CAST(MAX(subq_31.buys) AS FLOAT64) / CAST(NULLIF(MAX(subq_21.visits), 0) AS FLOAT64) AS visit_buy_conversion_rate
 FROM (
   -- Constrain Output with WHERE
   -- Pass Only Elements: ['visits',]
@@ -15,12 +25,12 @@ FROM (
   SELECT
     SUM(visits) AS visits
   FROM (
-    -- Read Elements From Semantic Model 'visits_source'
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28019
     SELECT
-      DATETIME_TRUNC(ds, day) AS metric_time__day
-      , 1 AS visits
-    FROM ***************************.fct_visits visits_source_src_28000
+      metric_time__day
+      , sma_28019_cte.user
+      , visits
+    FROM sma_28019_cte sma_28019_cte
   ) subq_18
   WHERE metric_time__day = '2020-01-01'
 ) subq_21
@@ -33,50 +43,49 @@ CROSS JOIN (
   FROM (
     -- Dedupe the fanout with mf_internal_uuid in the conversion data set
     SELECT DISTINCT
-      FIRST_VALUE(subq_25.visits) OVER (
+      FIRST_VALUE(subq_24.visits) OVER (
         PARTITION BY
-          subq_28.user
-          , subq_28.metric_time__day
-          , subq_28.mf_internal_uuid
-        ORDER BY subq_25.metric_time__day DESC
+          subq_27.user
+          , subq_27.metric_time__day
+          , subq_27.mf_internal_uuid
+        ORDER BY subq_24.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS visits
-      , FIRST_VALUE(subq_25.metric_time__day) OVER (
+      , FIRST_VALUE(subq_24.metric_time__day) OVER (
         PARTITION BY
-          subq_28.user
-          , subq_28.metric_time__day
-          , subq_28.mf_internal_uuid
-        ORDER BY subq_25.metric_time__day DESC
+          subq_27.user
+          , subq_27.metric_time__day
+          , subq_27.mf_internal_uuid
+        ORDER BY subq_24.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS metric_time__day
-      , FIRST_VALUE(subq_25.user) OVER (
+      , FIRST_VALUE(subq_24.user) OVER (
         PARTITION BY
-          subq_28.user
-          , subq_28.metric_time__day
-          , subq_28.mf_internal_uuid
-        ORDER BY subq_25.metric_time__day DESC
+          subq_27.user
+          , subq_27.metric_time__day
+          , subq_27.mf_internal_uuid
+        ORDER BY subq_24.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS user
-      , subq_28.mf_internal_uuid AS mf_internal_uuid
-      , subq_28.buys AS buys
+      , subq_27.mf_internal_uuid AS mf_internal_uuid
+      , subq_27.buys AS buys
     FROM (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['visits', 'metric_time__day', 'user']
       SELECT
         metric_time__day
-        , subq_23.user
+        , subq_22.user
         , visits
       FROM (
-        -- Read Elements From Semantic Model 'visits_source'
-        -- Metric Time Dimension 'ds'
+        -- Read From CTE For node_id=sma_28019
         SELECT
-          DATETIME_TRUNC(ds, day) AS metric_time__day
-          , user_id AS user
-          , 1 AS visits
-        FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_23
+          metric_time__day
+          , sma_28019_cte.user
+          , visits
+        FROM sma_28019_cte sma_28019_cte
+      ) subq_22
       WHERE metric_time__day = '2020-01-01'
-    ) subq_25
+    ) subq_24
     INNER JOIN (
       -- Read Elements From Semantic Model 'buys_source'
       -- Metric Time Dimension 'ds'
@@ -87,12 +96,12 @@ CROSS JOIN (
         , 1 AS buys
         , GENERATE_UUID() AS mf_internal_uuid
       FROM ***************************.fct_buys buys_source_src_28000
-    ) subq_28
+    ) subq_27
     ON
       (
-        subq_25.user = subq_28.user
+        subq_24.user = subq_27.user
       ) AND (
-        (subq_25.metric_time__day <= subq_28.metric_time__day)
+        (subq_24.metric_time__day <= subq_27.metric_time__day)
       )
-  ) subq_29
-) subq_32
+  ) subq_28
+) subq_31

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/BigQuery/test_conversion_metric_with_filter_not_in_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/BigQuery/test_conversion_metric_with_filter_not_in_group_by__plan0_optimized.sql
@@ -6,8 +6,19 @@ sql_engine: BigQuery
 ---
 -- Combine Aggregated Outputs
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATETIME_TRUNC(ds, day) AS metric_time__day
+    , user_id AS user
+    , referrer_id AS visit__referrer_id
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
-  COALESCE(MAX(subq_32.buys), 0) AS visit_buy_conversions
+  COALESCE(MAX(subq_31.buys), 0) AS visit_buy_conversions
 FROM (
   -- Constrain Output with WHERE
   -- Pass Only Elements: ['visits',]
@@ -15,12 +26,13 @@ FROM (
   SELECT
     SUM(visits) AS visits
   FROM (
-    -- Read Elements From Semantic Model 'visits_source'
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28019
     SELECT
-      referrer_id AS visit__referrer_id
-      , 1 AS visits
-    FROM ***************************.fct_visits visits_source_src_28000
+      metric_time__day
+      , sma_28019_cte.user
+      , visit__referrer_id
+      , visits
+    FROM sma_28019_cte sma_28019_cte
   ) subq_18
   WHERE visit__referrer_id = 'ref_id_01'
 ) subq_21
@@ -33,60 +45,59 @@ CROSS JOIN (
   FROM (
     -- Dedupe the fanout with mf_internal_uuid in the conversion data set
     SELECT DISTINCT
-      FIRST_VALUE(subq_25.visits) OVER (
+      FIRST_VALUE(subq_24.visits) OVER (
         PARTITION BY
-          subq_28.user
-          , subq_28.metric_time__day
-          , subq_28.mf_internal_uuid
-        ORDER BY subq_25.metric_time__day DESC
+          subq_27.user
+          , subq_27.metric_time__day
+          , subq_27.mf_internal_uuid
+        ORDER BY subq_24.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS visits
-      , FIRST_VALUE(subq_25.visit__referrer_id) OVER (
+      , FIRST_VALUE(subq_24.visit__referrer_id) OVER (
         PARTITION BY
-          subq_28.user
-          , subq_28.metric_time__day
-          , subq_28.mf_internal_uuid
-        ORDER BY subq_25.metric_time__day DESC
+          subq_27.user
+          , subq_27.metric_time__day
+          , subq_27.mf_internal_uuid
+        ORDER BY subq_24.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS visit__referrer_id
-      , FIRST_VALUE(subq_25.metric_time__day) OVER (
+      , FIRST_VALUE(subq_24.metric_time__day) OVER (
         PARTITION BY
-          subq_28.user
-          , subq_28.metric_time__day
-          , subq_28.mf_internal_uuid
-        ORDER BY subq_25.metric_time__day DESC
+          subq_27.user
+          , subq_27.metric_time__day
+          , subq_27.mf_internal_uuid
+        ORDER BY subq_24.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS metric_time__day
-      , FIRST_VALUE(subq_25.user) OVER (
+      , FIRST_VALUE(subq_24.user) OVER (
         PARTITION BY
-          subq_28.user
-          , subq_28.metric_time__day
-          , subq_28.mf_internal_uuid
-        ORDER BY subq_25.metric_time__day DESC
+          subq_27.user
+          , subq_27.metric_time__day
+          , subq_27.mf_internal_uuid
+        ORDER BY subq_24.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS user
-      , subq_28.mf_internal_uuid AS mf_internal_uuid
-      , subq_28.buys AS buys
+      , subq_27.mf_internal_uuid AS mf_internal_uuid
+      , subq_27.buys AS buys
     FROM (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user']
       SELECT
         metric_time__day
-        , subq_23.user
+        , subq_22.user
         , visit__referrer_id
         , visits
       FROM (
-        -- Read Elements From Semantic Model 'visits_source'
-        -- Metric Time Dimension 'ds'
+        -- Read From CTE For node_id=sma_28019
         SELECT
-          DATETIME_TRUNC(ds, day) AS metric_time__day
-          , user_id AS user
-          , referrer_id AS visit__referrer_id
-          , 1 AS visits
-        FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_23
+          metric_time__day
+          , sma_28019_cte.user
+          , visit__referrer_id
+          , visits
+        FROM sma_28019_cte sma_28019_cte
+      ) subq_22
       WHERE visit__referrer_id = 'ref_id_01'
-    ) subq_25
+    ) subq_24
     INNER JOIN (
       -- Read Elements From Semantic Model 'buys_source'
       -- Metric Time Dimension 'ds'
@@ -97,16 +108,16 @@ CROSS JOIN (
         , 1 AS buys
         , GENERATE_UUID() AS mf_internal_uuid
       FROM ***************************.fct_buys buys_source_src_28000
-    ) subq_28
+    ) subq_27
     ON
       (
-        subq_25.user = subq_28.user
+        subq_24.user = subq_27.user
       ) AND (
         (
-          subq_25.metric_time__day <= subq_28.metric_time__day
+          subq_24.metric_time__day <= subq_27.metric_time__day
         ) AND (
-          subq_25.metric_time__day > DATE_SUB(CAST(subq_28.metric_time__day AS DATETIME), INTERVAL 7 day)
+          subq_24.metric_time__day > DATE_SUB(CAST(subq_27.metric_time__day AS DATETIME), INTERVAL 7 day)
         )
       )
-  ) subq_29
-) subq_32
+  ) subq_28
+) subq_31

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/BigQuery/test_conversion_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/BigQuery/test_conversion_metric_with_time_constraint__plan0_optimized.sql
@@ -5,15 +5,28 @@ docstring:
 sql_engine: BigQuery
 ---
 -- Compute Metrics via Expressions
+WITH ctr_0_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
+  SELECT
+    DATETIME_TRUNC(ds, day) AS metric_time__day
+    , user_id AS user
+    , referrer_id AS visit__referrer_id
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+  WHERE DATETIME_TRUNC(ds, day) BETWEEN '2020-01-01' AND '2020-01-02'
+)
+
 SELECT
-  visit__referrer_id
+  visit__referrer_id AS visit__referrer_id
   , CAST(buys AS FLOAT64) / CAST(NULLIF(visits, 0) AS FLOAT64) AS visit_buy_conversion_rate
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_24.visit__referrer_id, subq_36.visit__referrer_id) AS visit__referrer_id
+    COALESCE(subq_24.visit__referrer_id, subq_34.visit__referrer_id) AS visit__referrer_id
     , MAX(subq_24.visits) AS visits
-    , MAX(subq_36.buys) AS buys
+    , MAX(subq_34.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['visits', 'visit__referrer_id']
@@ -22,14 +35,13 @@ FROM (
       visit__referrer_id
       , SUM(visits) AS visits
     FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
-      -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
+      -- Read From CTE For node_id=ctr_0
       SELECT
-        referrer_id AS visit__referrer_id
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
-      WHERE DATETIME_TRUNC(ds, day) BETWEEN '2020-01-01' AND '2020-01-02'
+        metric_time__day
+        , ctr_0_cte.user
+        , visit__referrer_id
+        , visits
+      FROM ctr_0_cte ctr_0_cte
     ) subq_21
     WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
@@ -45,62 +57,59 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_29.visits) OVER (
+        FIRST_VALUE(subq_27.visits) OVER (
           PARTITION BY
-            subq_32.user
-            , subq_32.metric_time__day
-            , subq_32.mf_internal_uuid
-          ORDER BY subq_29.metric_time__day DESC
+            subq_30.user
+            , subq_30.metric_time__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_29.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_27.visit__referrer_id) OVER (
           PARTITION BY
-            subq_32.user
-            , subq_32.metric_time__day
-            , subq_32.mf_internal_uuid
-          ORDER BY subq_29.metric_time__day DESC
+            subq_30.user
+            , subq_30.metric_time__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_29.metric_time__day) OVER (
+        , FIRST_VALUE(subq_27.metric_time__day) OVER (
           PARTITION BY
-            subq_32.user
-            , subq_32.metric_time__day
-            , subq_32.mf_internal_uuid
-          ORDER BY subq_29.metric_time__day DESC
+            subq_30.user
+            , subq_30.metric_time__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_29.user) OVER (
+        , FIRST_VALUE(subq_27.user) OVER (
           PARTITION BY
-            subq_32.user
-            , subq_32.metric_time__day
-            , subq_32.mf_internal_uuid
-          ORDER BY subq_29.metric_time__day DESC
+            subq_30.user
+            , subq_30.metric_time__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_32.mf_internal_uuid AS mf_internal_uuid
-        , subq_32.buys AS buys
+        , subq_30.mf_internal_uuid AS mf_internal_uuid
+        , subq_30.buys AS buys
       FROM (
         -- Constrain Output with WHERE
         -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user']
         SELECT
           metric_time__day
-          , subq_27.user
+          , subq_25.user
           , visit__referrer_id
           , visits
         FROM (
-          -- Read Elements From Semantic Model 'visits_source'
-          -- Metric Time Dimension 'ds'
-          -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
+          -- Read From CTE For node_id=ctr_0
           SELECT
-            DATETIME_TRUNC(ds, day) AS metric_time__day
-            , user_id AS user
-            , referrer_id AS visit__referrer_id
-            , 1 AS visits
-          FROM ***************************.fct_visits visits_source_src_28000
-          WHERE DATETIME_TRUNC(ds, day) BETWEEN '2020-01-01' AND '2020-01-02'
-        ) subq_27
+            metric_time__day
+            , ctr_0_cte.user
+            , visit__referrer_id
+            , visits
+          FROM ctr_0_cte ctr_0_cte
+        ) subq_25
         WHERE visit__referrer_id = 'ref_id_01'
-      ) subq_29
+      ) subq_27
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -111,19 +120,19 @@ FROM (
           , 1 AS buys
           , GENERATE_UUID() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_32
+      ) subq_30
       ON
         (
-          subq_29.user = subq_32.user
+          subq_27.user = subq_30.user
         ) AND (
-          (subq_29.metric_time__day <= subq_32.metric_time__day)
+          (subq_27.metric_time__day <= subq_30.metric_time__day)
         )
-    ) subq_33
+    ) subq_31
     GROUP BY
       visit__referrer_id
-  ) subq_36
+  ) subq_34
   ON
-    subq_24.visit__referrer_id = subq_36.visit__referrer_id
+    subq_24.visit__referrer_id = subq_34.visit__referrer_id
   GROUP BY
     visit__referrer_id
-) subq_37
+) subq_35

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/BigQuery/test_conversion_metric_with_window__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/BigQuery/test_conversion_metric_with_window__plan0_optimized.sql
@@ -5,15 +5,25 @@ docstring:
 sql_engine: BigQuery
 ---
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATETIME_TRUNC(ds, day) AS metric_time__day
+    , user_id AS user
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
-  metric_time__day
+  metric_time__day AS metric_time__day
   , CAST(buys AS FLOAT64) / CAST(NULLIF(visits, 0) AS FLOAT64) AS visit_buy_conversion_rate_7days
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_21.metric_time__day, subq_32.metric_time__day) AS metric_time__day
+    COALESCE(subq_21.metric_time__day, subq_31.metric_time__day) AS metric_time__day
     , MAX(subq_21.visits) AS visits
-    , MAX(subq_32.buys) AS buys
+    , MAX(subq_31.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['visits', 'metric_time__day']
@@ -22,12 +32,12 @@ FROM (
       metric_time__day
       , SUM(visits) AS visits
     FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
+      -- Read From CTE For node_id=sma_28019
       SELECT
-        DATETIME_TRUNC(ds, day) AS metric_time__day
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
+        metric_time__day
+        , sma_28019_cte.user
+        , visits
+      FROM sma_28019_cte sma_28019_cte
     ) subq_18
     WHERE metric_time__day = '2020-01-01'
     GROUP BY
@@ -43,50 +53,49 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_25.visits) OVER (
+        FIRST_VALUE(subq_24.visits) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_25.metric_time__day) OVER (
+        , FIRST_VALUE(subq_24.metric_time__day) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_25.user) OVER (
+        , FIRST_VALUE(subq_24.user) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_28.mf_internal_uuid AS mf_internal_uuid
-        , subq_28.buys AS buys
+        , subq_27.mf_internal_uuid AS mf_internal_uuid
+        , subq_27.buys AS buys
       FROM (
         -- Constrain Output with WHERE
         -- Pass Only Elements: ['visits', 'metric_time__day', 'user']
         SELECT
           metric_time__day
-          , subq_23.user
+          , subq_22.user
           , visits
         FROM (
-          -- Read Elements From Semantic Model 'visits_source'
-          -- Metric Time Dimension 'ds'
+          -- Read From CTE For node_id=sma_28019
           SELECT
-            DATETIME_TRUNC(ds, day) AS metric_time__day
-            , user_id AS user
-            , 1 AS visits
-          FROM ***************************.fct_visits visits_source_src_28000
-        ) subq_23
+            metric_time__day
+            , sma_28019_cte.user
+            , visits
+          FROM sma_28019_cte sma_28019_cte
+        ) subq_22
         WHERE metric_time__day = '2020-01-01'
-      ) subq_25
+      ) subq_24
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -97,23 +106,23 @@ FROM (
           , 1 AS buys
           , GENERATE_UUID() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_28
+      ) subq_27
       ON
         (
-          subq_25.user = subq_28.user
+          subq_24.user = subq_27.user
         ) AND (
           (
-            subq_25.metric_time__day <= subq_28.metric_time__day
+            subq_24.metric_time__day <= subq_27.metric_time__day
           ) AND (
-            subq_25.metric_time__day > DATE_SUB(CAST(subq_28.metric_time__day AS DATETIME), INTERVAL 7 day)
+            subq_24.metric_time__day > DATE_SUB(CAST(subq_27.metric_time__day AS DATETIME), INTERVAL 7 day)
           )
         )
-    ) subq_29
+    ) subq_28
     GROUP BY
       metric_time__day
-  ) subq_32
+  ) subq_31
   ON
-    subq_21.metric_time__day = subq_32.metric_time__day
+    subq_21.metric_time__day = subq_31.metric_time__day
   GROUP BY
     metric_time__day
-) subq_33
+) subq_32

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/BigQuery/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/BigQuery/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
@@ -5,17 +5,30 @@ docstring:
 sql_engine: BigQuery
 ---
 -- Compute Metrics via Expressions
+WITH ctr_0_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
+  SELECT
+    DATETIME_TRUNC(ds, day) AS metric_time__day
+    , user_id AS user
+    , referrer_id AS visit__referrer_id
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+  WHERE DATETIME_TRUNC(ds, day) BETWEEN '2020-01-01' AND '2020-01-02'
+)
+
 SELECT
-  metric_time__day
-  , visit__referrer_id
+  metric_time__day AS metric_time__day
+  , visit__referrer_id AS visit__referrer_id
   , CAST(buys AS FLOAT64) / CAST(NULLIF(visits, 0) AS FLOAT64) AS visit_buy_conversion_rate_7days
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_24.metric_time__day, subq_36.metric_time__day) AS metric_time__day
-    , COALESCE(subq_24.visit__referrer_id, subq_36.visit__referrer_id) AS visit__referrer_id
+    COALESCE(subq_24.metric_time__day, subq_34.metric_time__day) AS metric_time__day
+    , COALESCE(subq_24.visit__referrer_id, subq_34.visit__referrer_id) AS visit__referrer_id
     , MAX(subq_24.visits) AS visits
-    , MAX(subq_36.buys) AS buys
+    , MAX(subq_34.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
@@ -25,15 +38,13 @@ FROM (
       , visit__referrer_id
       , SUM(visits) AS visits
     FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
-      -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
+      -- Read From CTE For node_id=ctr_0
       SELECT
-        DATETIME_TRUNC(ds, day) AS metric_time__day
-        , referrer_id AS visit__referrer_id
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
-      WHERE DATETIME_TRUNC(ds, day) BETWEEN '2020-01-01' AND '2020-01-02'
+        metric_time__day
+        , ctr_0_cte.user
+        , visit__referrer_id
+        , visits
+      FROM ctr_0_cte ctr_0_cte
     ) subq_21
     WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
@@ -51,62 +62,59 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_29.visits) OVER (
+        FIRST_VALUE(subq_27.visits) OVER (
           PARTITION BY
-            subq_32.user
-            , subq_32.metric_time__day
-            , subq_32.mf_internal_uuid
-          ORDER BY subq_29.metric_time__day DESC
+            subq_30.user
+            , subq_30.metric_time__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_29.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_27.visit__referrer_id) OVER (
           PARTITION BY
-            subq_32.user
-            , subq_32.metric_time__day
-            , subq_32.mf_internal_uuid
-          ORDER BY subq_29.metric_time__day DESC
+            subq_30.user
+            , subq_30.metric_time__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_29.metric_time__day) OVER (
+        , FIRST_VALUE(subq_27.metric_time__day) OVER (
           PARTITION BY
-            subq_32.user
-            , subq_32.metric_time__day
-            , subq_32.mf_internal_uuid
-          ORDER BY subq_29.metric_time__day DESC
+            subq_30.user
+            , subq_30.metric_time__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_29.user) OVER (
+        , FIRST_VALUE(subq_27.user) OVER (
           PARTITION BY
-            subq_32.user
-            , subq_32.metric_time__day
-            , subq_32.mf_internal_uuid
-          ORDER BY subq_29.metric_time__day DESC
+            subq_30.user
+            , subq_30.metric_time__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_32.mf_internal_uuid AS mf_internal_uuid
-        , subq_32.buys AS buys
+        , subq_30.mf_internal_uuid AS mf_internal_uuid
+        , subq_30.buys AS buys
       FROM (
         -- Constrain Output with WHERE
         -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user']
         SELECT
           metric_time__day
-          , subq_27.user
+          , subq_25.user
           , visit__referrer_id
           , visits
         FROM (
-          -- Read Elements From Semantic Model 'visits_source'
-          -- Metric Time Dimension 'ds'
-          -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
+          -- Read From CTE For node_id=ctr_0
           SELECT
-            DATETIME_TRUNC(ds, day) AS metric_time__day
-            , user_id AS user
-            , referrer_id AS visit__referrer_id
-            , 1 AS visits
-          FROM ***************************.fct_visits visits_source_src_28000
-          WHERE DATETIME_TRUNC(ds, day) BETWEEN '2020-01-01' AND '2020-01-02'
-        ) subq_27
+            metric_time__day
+            , ctr_0_cte.user
+            , visit__referrer_id
+            , visits
+          FROM ctr_0_cte ctr_0_cte
+        ) subq_25
         WHERE visit__referrer_id = 'ref_id_01'
-      ) subq_29
+      ) subq_27
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -117,29 +125,29 @@ FROM (
           , 1 AS buys
           , GENERATE_UUID() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_32
+      ) subq_30
       ON
         (
-          subq_29.user = subq_32.user
+          subq_27.user = subq_30.user
         ) AND (
           (
-            subq_29.metric_time__day <= subq_32.metric_time__day
+            subq_27.metric_time__day <= subq_30.metric_time__day
           ) AND (
-            subq_29.metric_time__day > DATE_SUB(CAST(subq_32.metric_time__day AS DATETIME), INTERVAL 7 day)
+            subq_27.metric_time__day > DATE_SUB(CAST(subq_30.metric_time__day AS DATETIME), INTERVAL 7 day)
           )
         )
-    ) subq_33
+    ) subq_31
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_36
+  ) subq_34
   ON
     (
-      subq_24.visit__referrer_id = subq_36.visit__referrer_id
+      subq_24.visit__referrer_id = subq_34.visit__referrer_id
     ) AND (
-      subq_24.metric_time__day = subq_36.metric_time__day
+      subq_24.metric_time__day = subq_34.metric_time__day
     )
   GROUP BY
     metric_time__day
     , visit__referrer_id
-) subq_37
+) subq_35

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Databricks/test_conversion_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Databricks/test_conversion_metric__plan0_optimized.sql
@@ -5,15 +5,25 @@ docstring:
 sql_engine: Databricks
 ---
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
-  metric_time__day
+  metric_time__day AS metric_time__day
   , CAST(buys AS DOUBLE) / CAST(NULLIF(visits, 0) AS DOUBLE) AS visit_buy_conversion_rate
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_21.metric_time__day, subq_32.metric_time__day) AS metric_time__day
+    COALESCE(subq_21.metric_time__day, subq_31.metric_time__day) AS metric_time__day
     , MAX(subq_21.visits) AS visits
-    , MAX(subq_32.buys) AS buys
+    , MAX(subq_31.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['visits', 'metric_time__day']
@@ -22,12 +32,12 @@ FROM (
       metric_time__day
       , SUM(visits) AS visits
     FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
+      -- Read From CTE For node_id=sma_28019
       SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
+        metric_time__day
+        , sma_28019_cte.user
+        , visits
+      FROM sma_28019_cte sma_28019_cte
     ) subq_18
     WHERE metric_time__day = '2020-01-01'
     GROUP BY
@@ -43,50 +53,49 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_25.visits) OVER (
+        FIRST_VALUE(subq_24.visits) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_25.metric_time__day) OVER (
+        , FIRST_VALUE(subq_24.metric_time__day) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_25.user) OVER (
+        , FIRST_VALUE(subq_24.user) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_28.mf_internal_uuid AS mf_internal_uuid
-        , subq_28.buys AS buys
+        , subq_27.mf_internal_uuid AS mf_internal_uuid
+        , subq_27.buys AS buys
       FROM (
         -- Constrain Output with WHERE
         -- Pass Only Elements: ['visits', 'metric_time__day', 'user']
         SELECT
           metric_time__day
-          , subq_23.user
+          , subq_22.user
           , visits
         FROM (
-          -- Read Elements From Semantic Model 'visits_source'
-          -- Metric Time Dimension 'ds'
+          -- Read From CTE For node_id=sma_28019
           SELECT
-            DATE_TRUNC('day', ds) AS metric_time__day
-            , user_id AS user
-            , 1 AS visits
-          FROM ***************************.fct_visits visits_source_src_28000
-        ) subq_23
+            metric_time__day
+            , sma_28019_cte.user
+            , visits
+          FROM sma_28019_cte sma_28019_cte
+        ) subq_22
         WHERE metric_time__day = '2020-01-01'
-      ) subq_25
+      ) subq_24
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -97,19 +106,19 @@ FROM (
           , 1 AS buys
           , UUID() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_28
+      ) subq_27
       ON
         (
-          subq_25.user = subq_28.user
+          subq_24.user = subq_27.user
         ) AND (
-          (subq_25.metric_time__day <= subq_28.metric_time__day)
+          (subq_24.metric_time__day <= subq_27.metric_time__day)
         )
-    ) subq_29
+    ) subq_28
     GROUP BY
       metric_time__day
-  ) subq_32
+  ) subq_31
   ON
-    subq_21.metric_time__day = subq_32.metric_time__day
+    subq_21.metric_time__day = subq_31.metric_time__day
   GROUP BY
-    COALESCE(subq_21.metric_time__day, subq_32.metric_time__day)
-) subq_33
+    COALESCE(subq_21.metric_time__day, subq_31.metric_time__day)
+) subq_32

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Databricks/test_conversion_metric_with_categorical_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Databricks/test_conversion_metric_with_categorical_filter__plan0_optimized.sql
@@ -5,17 +5,28 @@ docstring:
 sql_engine: Databricks
 ---
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , referrer_id AS visit__referrer_id
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
-  metric_time__day
-  , visit__referrer_id
+  metric_time__day AS metric_time__day
+  , visit__referrer_id AS visit__referrer_id
   , CAST(buys AS DOUBLE) / CAST(NULLIF(visits, 0) AS DOUBLE) AS visit_buy_conversion_rate
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_21.metric_time__day, subq_32.metric_time__day) AS metric_time__day
-    , COALESCE(subq_21.visit__referrer_id, subq_32.visit__referrer_id) AS visit__referrer_id
+    COALESCE(subq_21.metric_time__day, subq_31.metric_time__day) AS metric_time__day
+    , COALESCE(subq_21.visit__referrer_id, subq_31.visit__referrer_id) AS visit__referrer_id
     , MAX(subq_21.visits) AS visits
-    , MAX(subq_32.buys) AS buys
+    , MAX(subq_31.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
@@ -25,13 +36,13 @@ FROM (
       , visit__referrer_id
       , SUM(visits) AS visits
     FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
+      -- Read From CTE For node_id=sma_28019
       SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , referrer_id AS visit__referrer_id
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
+        metric_time__day
+        , sma_28019_cte.user
+        , visit__referrer_id
+        , visits
+      FROM sma_28019_cte sma_28019_cte
     ) subq_18
     WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
@@ -49,60 +60,59 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_25.visits) OVER (
+        FIRST_VALUE(subq_24.visits) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_25.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_24.visit__referrer_id) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_25.metric_time__day) OVER (
+        , FIRST_VALUE(subq_24.metric_time__day) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_25.user) OVER (
+        , FIRST_VALUE(subq_24.user) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_28.mf_internal_uuid AS mf_internal_uuid
-        , subq_28.buys AS buys
+        , subq_27.mf_internal_uuid AS mf_internal_uuid
+        , subq_27.buys AS buys
       FROM (
         -- Constrain Output with WHERE
         -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user']
         SELECT
           metric_time__day
-          , subq_23.user
+          , subq_22.user
           , visit__referrer_id
           , visits
         FROM (
-          -- Read Elements From Semantic Model 'visits_source'
-          -- Metric Time Dimension 'ds'
+          -- Read From CTE For node_id=sma_28019
           SELECT
-            DATE_TRUNC('day', ds) AS metric_time__day
-            , user_id AS user
-            , referrer_id AS visit__referrer_id
-            , 1 AS visits
-          FROM ***************************.fct_visits visits_source_src_28000
-        ) subq_23
+            metric_time__day
+            , sma_28019_cte.user
+            , visit__referrer_id
+            , visits
+          FROM sma_28019_cte sma_28019_cte
+        ) subq_22
         WHERE visit__referrer_id = 'ref_id_01'
-      ) subq_25
+      ) subq_24
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -113,25 +123,25 @@ FROM (
           , 1 AS buys
           , UUID() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_28
+      ) subq_27
       ON
         (
-          subq_25.user = subq_28.user
+          subq_24.user = subq_27.user
         ) AND (
-          (subq_25.metric_time__day <= subq_28.metric_time__day)
+          (subq_24.metric_time__day <= subq_27.metric_time__day)
         )
-    ) subq_29
+    ) subq_28
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_32
+  ) subq_31
   ON
     (
-      subq_21.visit__referrer_id = subq_32.visit__referrer_id
+      subq_21.visit__referrer_id = subq_31.visit__referrer_id
     ) AND (
-      subq_21.metric_time__day = subq_32.metric_time__day
+      subq_21.metric_time__day = subq_31.metric_time__day
     )
   GROUP BY
-    COALESCE(subq_21.metric_time__day, subq_32.metric_time__day)
-    , COALESCE(subq_21.visit__referrer_id, subq_32.visit__referrer_id)
-) subq_33
+    COALESCE(subq_21.metric_time__day, subq_31.metric_time__day)
+    , COALESCE(subq_21.visit__referrer_id, subq_31.visit__referrer_id)
+) subq_32

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Databricks/test_conversion_metric_with_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Databricks/test_conversion_metric_with_filter__plan0_optimized.sql
@@ -6,8 +6,18 @@ sql_engine: Databricks
 ---
 -- Combine Aggregated Outputs
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
-  CAST(MAX(subq_32.buys) AS DOUBLE) / CAST(NULLIF(MAX(subq_21.visits), 0) AS DOUBLE) AS visit_buy_conversion_rate
+  CAST(MAX(subq_31.buys) AS DOUBLE) / CAST(NULLIF(MAX(subq_21.visits), 0) AS DOUBLE) AS visit_buy_conversion_rate
 FROM (
   -- Constrain Output with WHERE
   -- Pass Only Elements: ['visits',]
@@ -15,12 +25,12 @@ FROM (
   SELECT
     SUM(visits) AS visits
   FROM (
-    -- Read Elements From Semantic Model 'visits_source'
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28019
     SELECT
-      DATE_TRUNC('day', ds) AS metric_time__day
-      , 1 AS visits
-    FROM ***************************.fct_visits visits_source_src_28000
+      metric_time__day
+      , sma_28019_cte.user
+      , visits
+    FROM sma_28019_cte sma_28019_cte
   ) subq_18
   WHERE metric_time__day = '2020-01-01'
 ) subq_21
@@ -33,50 +43,49 @@ CROSS JOIN (
   FROM (
     -- Dedupe the fanout with mf_internal_uuid in the conversion data set
     SELECT DISTINCT
-      FIRST_VALUE(subq_25.visits) OVER (
+      FIRST_VALUE(subq_24.visits) OVER (
         PARTITION BY
-          subq_28.user
-          , subq_28.metric_time__day
-          , subq_28.mf_internal_uuid
-        ORDER BY subq_25.metric_time__day DESC
+          subq_27.user
+          , subq_27.metric_time__day
+          , subq_27.mf_internal_uuid
+        ORDER BY subq_24.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS visits
-      , FIRST_VALUE(subq_25.metric_time__day) OVER (
+      , FIRST_VALUE(subq_24.metric_time__day) OVER (
         PARTITION BY
-          subq_28.user
-          , subq_28.metric_time__day
-          , subq_28.mf_internal_uuid
-        ORDER BY subq_25.metric_time__day DESC
+          subq_27.user
+          , subq_27.metric_time__day
+          , subq_27.mf_internal_uuid
+        ORDER BY subq_24.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS metric_time__day
-      , FIRST_VALUE(subq_25.user) OVER (
+      , FIRST_VALUE(subq_24.user) OVER (
         PARTITION BY
-          subq_28.user
-          , subq_28.metric_time__day
-          , subq_28.mf_internal_uuid
-        ORDER BY subq_25.metric_time__day DESC
+          subq_27.user
+          , subq_27.metric_time__day
+          , subq_27.mf_internal_uuid
+        ORDER BY subq_24.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS user
-      , subq_28.mf_internal_uuid AS mf_internal_uuid
-      , subq_28.buys AS buys
+      , subq_27.mf_internal_uuid AS mf_internal_uuid
+      , subq_27.buys AS buys
     FROM (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['visits', 'metric_time__day', 'user']
       SELECT
         metric_time__day
-        , subq_23.user
+        , subq_22.user
         , visits
       FROM (
-        -- Read Elements From Semantic Model 'visits_source'
-        -- Metric Time Dimension 'ds'
+        -- Read From CTE For node_id=sma_28019
         SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , user_id AS user
-          , 1 AS visits
-        FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_23
+          metric_time__day
+          , sma_28019_cte.user
+          , visits
+        FROM sma_28019_cte sma_28019_cte
+      ) subq_22
       WHERE metric_time__day = '2020-01-01'
-    ) subq_25
+    ) subq_24
     INNER JOIN (
       -- Read Elements From Semantic Model 'buys_source'
       -- Metric Time Dimension 'ds'
@@ -87,12 +96,12 @@ CROSS JOIN (
         , 1 AS buys
         , UUID() AS mf_internal_uuid
       FROM ***************************.fct_buys buys_source_src_28000
-    ) subq_28
+    ) subq_27
     ON
       (
-        subq_25.user = subq_28.user
+        subq_24.user = subq_27.user
       ) AND (
-        (subq_25.metric_time__day <= subq_28.metric_time__day)
+        (subq_24.metric_time__day <= subq_27.metric_time__day)
       )
-  ) subq_29
-) subq_32
+  ) subq_28
+) subq_31

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Databricks/test_conversion_metric_with_filter_not_in_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Databricks/test_conversion_metric_with_filter_not_in_group_by__plan0_optimized.sql
@@ -6,8 +6,19 @@ sql_engine: Databricks
 ---
 -- Combine Aggregated Outputs
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , referrer_id AS visit__referrer_id
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
-  COALESCE(MAX(subq_32.buys), 0) AS visit_buy_conversions
+  COALESCE(MAX(subq_31.buys), 0) AS visit_buy_conversions
 FROM (
   -- Constrain Output with WHERE
   -- Pass Only Elements: ['visits',]
@@ -15,12 +26,13 @@ FROM (
   SELECT
     SUM(visits) AS visits
   FROM (
-    -- Read Elements From Semantic Model 'visits_source'
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28019
     SELECT
-      referrer_id AS visit__referrer_id
-      , 1 AS visits
-    FROM ***************************.fct_visits visits_source_src_28000
+      metric_time__day
+      , sma_28019_cte.user
+      , visit__referrer_id
+      , visits
+    FROM sma_28019_cte sma_28019_cte
   ) subq_18
   WHERE visit__referrer_id = 'ref_id_01'
 ) subq_21
@@ -33,60 +45,59 @@ CROSS JOIN (
   FROM (
     -- Dedupe the fanout with mf_internal_uuid in the conversion data set
     SELECT DISTINCT
-      FIRST_VALUE(subq_25.visits) OVER (
+      FIRST_VALUE(subq_24.visits) OVER (
         PARTITION BY
-          subq_28.user
-          , subq_28.metric_time__day
-          , subq_28.mf_internal_uuid
-        ORDER BY subq_25.metric_time__day DESC
+          subq_27.user
+          , subq_27.metric_time__day
+          , subq_27.mf_internal_uuid
+        ORDER BY subq_24.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS visits
-      , FIRST_VALUE(subq_25.visit__referrer_id) OVER (
+      , FIRST_VALUE(subq_24.visit__referrer_id) OVER (
         PARTITION BY
-          subq_28.user
-          , subq_28.metric_time__day
-          , subq_28.mf_internal_uuid
-        ORDER BY subq_25.metric_time__day DESC
+          subq_27.user
+          , subq_27.metric_time__day
+          , subq_27.mf_internal_uuid
+        ORDER BY subq_24.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS visit__referrer_id
-      , FIRST_VALUE(subq_25.metric_time__day) OVER (
+      , FIRST_VALUE(subq_24.metric_time__day) OVER (
         PARTITION BY
-          subq_28.user
-          , subq_28.metric_time__day
-          , subq_28.mf_internal_uuid
-        ORDER BY subq_25.metric_time__day DESC
+          subq_27.user
+          , subq_27.metric_time__day
+          , subq_27.mf_internal_uuid
+        ORDER BY subq_24.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS metric_time__day
-      , FIRST_VALUE(subq_25.user) OVER (
+      , FIRST_VALUE(subq_24.user) OVER (
         PARTITION BY
-          subq_28.user
-          , subq_28.metric_time__day
-          , subq_28.mf_internal_uuid
-        ORDER BY subq_25.metric_time__day DESC
+          subq_27.user
+          , subq_27.metric_time__day
+          , subq_27.mf_internal_uuid
+        ORDER BY subq_24.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS user
-      , subq_28.mf_internal_uuid AS mf_internal_uuid
-      , subq_28.buys AS buys
+      , subq_27.mf_internal_uuid AS mf_internal_uuid
+      , subq_27.buys AS buys
     FROM (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user']
       SELECT
         metric_time__day
-        , subq_23.user
+        , subq_22.user
         , visit__referrer_id
         , visits
       FROM (
-        -- Read Elements From Semantic Model 'visits_source'
-        -- Metric Time Dimension 'ds'
+        -- Read From CTE For node_id=sma_28019
         SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , user_id AS user
-          , referrer_id AS visit__referrer_id
-          , 1 AS visits
-        FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_23
+          metric_time__day
+          , sma_28019_cte.user
+          , visit__referrer_id
+          , visits
+        FROM sma_28019_cte sma_28019_cte
+      ) subq_22
       WHERE visit__referrer_id = 'ref_id_01'
-    ) subq_25
+    ) subq_24
     INNER JOIN (
       -- Read Elements From Semantic Model 'buys_source'
       -- Metric Time Dimension 'ds'
@@ -97,16 +108,16 @@ CROSS JOIN (
         , 1 AS buys
         , UUID() AS mf_internal_uuid
       FROM ***************************.fct_buys buys_source_src_28000
-    ) subq_28
+    ) subq_27
     ON
       (
-        subq_25.user = subq_28.user
+        subq_24.user = subq_27.user
       ) AND (
         (
-          subq_25.metric_time__day <= subq_28.metric_time__day
+          subq_24.metric_time__day <= subq_27.metric_time__day
         ) AND (
-          subq_25.metric_time__day > DATEADD(day, -7, subq_28.metric_time__day)
+          subq_24.metric_time__day > DATEADD(day, -7, subq_27.metric_time__day)
         )
       )
-  ) subq_29
-) subq_32
+  ) subq_28
+) subq_31

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Databricks/test_conversion_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Databricks/test_conversion_metric_with_time_constraint__plan0_optimized.sql
@@ -5,15 +5,28 @@ docstring:
 sql_engine: Databricks
 ---
 -- Compute Metrics via Expressions
+WITH ctr_0_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , referrer_id AS visit__referrer_id
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+  WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
+)
+
 SELECT
-  visit__referrer_id
+  visit__referrer_id AS visit__referrer_id
   , CAST(buys AS DOUBLE) / CAST(NULLIF(visits, 0) AS DOUBLE) AS visit_buy_conversion_rate
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_24.visit__referrer_id, subq_36.visit__referrer_id) AS visit__referrer_id
+    COALESCE(subq_24.visit__referrer_id, subq_34.visit__referrer_id) AS visit__referrer_id
     , MAX(subq_24.visits) AS visits
-    , MAX(subq_36.buys) AS buys
+    , MAX(subq_34.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['visits', 'visit__referrer_id']
@@ -22,14 +35,13 @@ FROM (
       visit__referrer_id
       , SUM(visits) AS visits
     FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
-      -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
+      -- Read From CTE For node_id=ctr_0
       SELECT
-        referrer_id AS visit__referrer_id
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
-      WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
+        metric_time__day
+        , ctr_0_cte.user
+        , visit__referrer_id
+        , visits
+      FROM ctr_0_cte ctr_0_cte
     ) subq_21
     WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
@@ -45,62 +57,59 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_29.visits) OVER (
+        FIRST_VALUE(subq_27.visits) OVER (
           PARTITION BY
-            subq_32.user
-            , subq_32.metric_time__day
-            , subq_32.mf_internal_uuid
-          ORDER BY subq_29.metric_time__day DESC
+            subq_30.user
+            , subq_30.metric_time__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_29.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_27.visit__referrer_id) OVER (
           PARTITION BY
-            subq_32.user
-            , subq_32.metric_time__day
-            , subq_32.mf_internal_uuid
-          ORDER BY subq_29.metric_time__day DESC
+            subq_30.user
+            , subq_30.metric_time__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_29.metric_time__day) OVER (
+        , FIRST_VALUE(subq_27.metric_time__day) OVER (
           PARTITION BY
-            subq_32.user
-            , subq_32.metric_time__day
-            , subq_32.mf_internal_uuid
-          ORDER BY subq_29.metric_time__day DESC
+            subq_30.user
+            , subq_30.metric_time__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_29.user) OVER (
+        , FIRST_VALUE(subq_27.user) OVER (
           PARTITION BY
-            subq_32.user
-            , subq_32.metric_time__day
-            , subq_32.mf_internal_uuid
-          ORDER BY subq_29.metric_time__day DESC
+            subq_30.user
+            , subq_30.metric_time__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_32.mf_internal_uuid AS mf_internal_uuid
-        , subq_32.buys AS buys
+        , subq_30.mf_internal_uuid AS mf_internal_uuid
+        , subq_30.buys AS buys
       FROM (
         -- Constrain Output with WHERE
         -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user']
         SELECT
           metric_time__day
-          , subq_27.user
+          , subq_25.user
           , visit__referrer_id
           , visits
         FROM (
-          -- Read Elements From Semantic Model 'visits_source'
-          -- Metric Time Dimension 'ds'
-          -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
+          -- Read From CTE For node_id=ctr_0
           SELECT
-            DATE_TRUNC('day', ds) AS metric_time__day
-            , user_id AS user
-            , referrer_id AS visit__referrer_id
-            , 1 AS visits
-          FROM ***************************.fct_visits visits_source_src_28000
-          WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
-        ) subq_27
+            metric_time__day
+            , ctr_0_cte.user
+            , visit__referrer_id
+            , visits
+          FROM ctr_0_cte ctr_0_cte
+        ) subq_25
         WHERE visit__referrer_id = 'ref_id_01'
-      ) subq_29
+      ) subq_27
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -111,19 +120,19 @@ FROM (
           , 1 AS buys
           , UUID() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_32
+      ) subq_30
       ON
         (
-          subq_29.user = subq_32.user
+          subq_27.user = subq_30.user
         ) AND (
-          (subq_29.metric_time__day <= subq_32.metric_time__day)
+          (subq_27.metric_time__day <= subq_30.metric_time__day)
         )
-    ) subq_33
+    ) subq_31
     GROUP BY
       visit__referrer_id
-  ) subq_36
+  ) subq_34
   ON
-    subq_24.visit__referrer_id = subq_36.visit__referrer_id
+    subq_24.visit__referrer_id = subq_34.visit__referrer_id
   GROUP BY
-    COALESCE(subq_24.visit__referrer_id, subq_36.visit__referrer_id)
-) subq_37
+    COALESCE(subq_24.visit__referrer_id, subq_34.visit__referrer_id)
+) subq_35

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Databricks/test_conversion_metric_with_window__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Databricks/test_conversion_metric_with_window__plan0_optimized.sql
@@ -5,15 +5,25 @@ docstring:
 sql_engine: Databricks
 ---
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
-  metric_time__day
+  metric_time__day AS metric_time__day
   , CAST(buys AS DOUBLE) / CAST(NULLIF(visits, 0) AS DOUBLE) AS visit_buy_conversion_rate_7days
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_21.metric_time__day, subq_32.metric_time__day) AS metric_time__day
+    COALESCE(subq_21.metric_time__day, subq_31.metric_time__day) AS metric_time__day
     , MAX(subq_21.visits) AS visits
-    , MAX(subq_32.buys) AS buys
+    , MAX(subq_31.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['visits', 'metric_time__day']
@@ -22,12 +32,12 @@ FROM (
       metric_time__day
       , SUM(visits) AS visits
     FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
+      -- Read From CTE For node_id=sma_28019
       SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
+        metric_time__day
+        , sma_28019_cte.user
+        , visits
+      FROM sma_28019_cte sma_28019_cte
     ) subq_18
     WHERE metric_time__day = '2020-01-01'
     GROUP BY
@@ -43,50 +53,49 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_25.visits) OVER (
+        FIRST_VALUE(subq_24.visits) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_25.metric_time__day) OVER (
+        , FIRST_VALUE(subq_24.metric_time__day) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_25.user) OVER (
+        , FIRST_VALUE(subq_24.user) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_28.mf_internal_uuid AS mf_internal_uuid
-        , subq_28.buys AS buys
+        , subq_27.mf_internal_uuid AS mf_internal_uuid
+        , subq_27.buys AS buys
       FROM (
         -- Constrain Output with WHERE
         -- Pass Only Elements: ['visits', 'metric_time__day', 'user']
         SELECT
           metric_time__day
-          , subq_23.user
+          , subq_22.user
           , visits
         FROM (
-          -- Read Elements From Semantic Model 'visits_source'
-          -- Metric Time Dimension 'ds'
+          -- Read From CTE For node_id=sma_28019
           SELECT
-            DATE_TRUNC('day', ds) AS metric_time__day
-            , user_id AS user
-            , 1 AS visits
-          FROM ***************************.fct_visits visits_source_src_28000
-        ) subq_23
+            metric_time__day
+            , sma_28019_cte.user
+            , visits
+          FROM sma_28019_cte sma_28019_cte
+        ) subq_22
         WHERE metric_time__day = '2020-01-01'
-      ) subq_25
+      ) subq_24
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -97,23 +106,23 @@ FROM (
           , 1 AS buys
           , UUID() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_28
+      ) subq_27
       ON
         (
-          subq_25.user = subq_28.user
+          subq_24.user = subq_27.user
         ) AND (
           (
-            subq_25.metric_time__day <= subq_28.metric_time__day
+            subq_24.metric_time__day <= subq_27.metric_time__day
           ) AND (
-            subq_25.metric_time__day > DATEADD(day, -7, subq_28.metric_time__day)
+            subq_24.metric_time__day > DATEADD(day, -7, subq_27.metric_time__day)
           )
         )
-    ) subq_29
+    ) subq_28
     GROUP BY
       metric_time__day
-  ) subq_32
+  ) subq_31
   ON
-    subq_21.metric_time__day = subq_32.metric_time__day
+    subq_21.metric_time__day = subq_31.metric_time__day
   GROUP BY
-    COALESCE(subq_21.metric_time__day, subq_32.metric_time__day)
-) subq_33
+    COALESCE(subq_21.metric_time__day, subq_31.metric_time__day)
+) subq_32

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Databricks/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Databricks/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
@@ -5,17 +5,30 @@ docstring:
 sql_engine: Databricks
 ---
 -- Compute Metrics via Expressions
+WITH ctr_0_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , referrer_id AS visit__referrer_id
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+  WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
+)
+
 SELECT
-  metric_time__day
-  , visit__referrer_id
+  metric_time__day AS metric_time__day
+  , visit__referrer_id AS visit__referrer_id
   , CAST(buys AS DOUBLE) / CAST(NULLIF(visits, 0) AS DOUBLE) AS visit_buy_conversion_rate_7days
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_24.metric_time__day, subq_36.metric_time__day) AS metric_time__day
-    , COALESCE(subq_24.visit__referrer_id, subq_36.visit__referrer_id) AS visit__referrer_id
+    COALESCE(subq_24.metric_time__day, subq_34.metric_time__day) AS metric_time__day
+    , COALESCE(subq_24.visit__referrer_id, subq_34.visit__referrer_id) AS visit__referrer_id
     , MAX(subq_24.visits) AS visits
-    , MAX(subq_36.buys) AS buys
+    , MAX(subq_34.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
@@ -25,15 +38,13 @@ FROM (
       , visit__referrer_id
       , SUM(visits) AS visits
     FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
-      -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
+      -- Read From CTE For node_id=ctr_0
       SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , referrer_id AS visit__referrer_id
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
-      WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
+        metric_time__day
+        , ctr_0_cte.user
+        , visit__referrer_id
+        , visits
+      FROM ctr_0_cte ctr_0_cte
     ) subq_21
     WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
@@ -51,62 +62,59 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_29.visits) OVER (
+        FIRST_VALUE(subq_27.visits) OVER (
           PARTITION BY
-            subq_32.user
-            , subq_32.metric_time__day
-            , subq_32.mf_internal_uuid
-          ORDER BY subq_29.metric_time__day DESC
+            subq_30.user
+            , subq_30.metric_time__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_29.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_27.visit__referrer_id) OVER (
           PARTITION BY
-            subq_32.user
-            , subq_32.metric_time__day
-            , subq_32.mf_internal_uuid
-          ORDER BY subq_29.metric_time__day DESC
+            subq_30.user
+            , subq_30.metric_time__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_29.metric_time__day) OVER (
+        , FIRST_VALUE(subq_27.metric_time__day) OVER (
           PARTITION BY
-            subq_32.user
-            , subq_32.metric_time__day
-            , subq_32.mf_internal_uuid
-          ORDER BY subq_29.metric_time__day DESC
+            subq_30.user
+            , subq_30.metric_time__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_29.user) OVER (
+        , FIRST_VALUE(subq_27.user) OVER (
           PARTITION BY
-            subq_32.user
-            , subq_32.metric_time__day
-            , subq_32.mf_internal_uuid
-          ORDER BY subq_29.metric_time__day DESC
+            subq_30.user
+            , subq_30.metric_time__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_32.mf_internal_uuid AS mf_internal_uuid
-        , subq_32.buys AS buys
+        , subq_30.mf_internal_uuid AS mf_internal_uuid
+        , subq_30.buys AS buys
       FROM (
         -- Constrain Output with WHERE
         -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user']
         SELECT
           metric_time__day
-          , subq_27.user
+          , subq_25.user
           , visit__referrer_id
           , visits
         FROM (
-          -- Read Elements From Semantic Model 'visits_source'
-          -- Metric Time Dimension 'ds'
-          -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
+          -- Read From CTE For node_id=ctr_0
           SELECT
-            DATE_TRUNC('day', ds) AS metric_time__day
-            , user_id AS user
-            , referrer_id AS visit__referrer_id
-            , 1 AS visits
-          FROM ***************************.fct_visits visits_source_src_28000
-          WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
-        ) subq_27
+            metric_time__day
+            , ctr_0_cte.user
+            , visit__referrer_id
+            , visits
+          FROM ctr_0_cte ctr_0_cte
+        ) subq_25
         WHERE visit__referrer_id = 'ref_id_01'
-      ) subq_29
+      ) subq_27
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -117,29 +125,29 @@ FROM (
           , 1 AS buys
           , UUID() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_32
+      ) subq_30
       ON
         (
-          subq_29.user = subq_32.user
+          subq_27.user = subq_30.user
         ) AND (
           (
-            subq_29.metric_time__day <= subq_32.metric_time__day
+            subq_27.metric_time__day <= subq_30.metric_time__day
           ) AND (
-            subq_29.metric_time__day > DATEADD(day, -7, subq_32.metric_time__day)
+            subq_27.metric_time__day > DATEADD(day, -7, subq_30.metric_time__day)
           )
         )
-    ) subq_33
+    ) subq_31
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_36
+  ) subq_34
   ON
     (
-      subq_24.visit__referrer_id = subq_36.visit__referrer_id
+      subq_24.visit__referrer_id = subq_34.visit__referrer_id
     ) AND (
-      subq_24.metric_time__day = subq_36.metric_time__day
+      subq_24.metric_time__day = subq_34.metric_time__day
     )
   GROUP BY
-    COALESCE(subq_24.metric_time__day, subq_36.metric_time__day)
-    , COALESCE(subq_24.visit__referrer_id, subq_36.visit__referrer_id)
-) subq_37
+    COALESCE(subq_24.metric_time__day, subq_34.metric_time__day)
+    , COALESCE(subq_24.visit__referrer_id, subq_34.visit__referrer_id)
+) subq_35

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/DuckDB/test_conversion_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/DuckDB/test_conversion_metric__plan0_optimized.sql
@@ -5,15 +5,25 @@ docstring:
 sql_engine: DuckDB
 ---
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
-  metric_time__day
+  metric_time__day AS metric_time__day
   , CAST(buys AS DOUBLE) / CAST(NULLIF(visits, 0) AS DOUBLE) AS visit_buy_conversion_rate
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_21.metric_time__day, subq_32.metric_time__day) AS metric_time__day
+    COALESCE(subq_21.metric_time__day, subq_31.metric_time__day) AS metric_time__day
     , MAX(subq_21.visits) AS visits
-    , MAX(subq_32.buys) AS buys
+    , MAX(subq_31.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['visits', 'metric_time__day']
@@ -22,12 +32,12 @@ FROM (
       metric_time__day
       , SUM(visits) AS visits
     FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
+      -- Read From CTE For node_id=sma_28019
       SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
+        metric_time__day
+        , sma_28019_cte.user
+        , visits
+      FROM sma_28019_cte sma_28019_cte
     ) subq_18
     WHERE metric_time__day = '2020-01-01'
     GROUP BY
@@ -43,50 +53,49 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_25.visits) OVER (
+        FIRST_VALUE(subq_24.visits) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_25.metric_time__day) OVER (
+        , FIRST_VALUE(subq_24.metric_time__day) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_25.user) OVER (
+        , FIRST_VALUE(subq_24.user) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_28.mf_internal_uuid AS mf_internal_uuid
-        , subq_28.buys AS buys
+        , subq_27.mf_internal_uuid AS mf_internal_uuid
+        , subq_27.buys AS buys
       FROM (
         -- Constrain Output with WHERE
         -- Pass Only Elements: ['visits', 'metric_time__day', 'user']
         SELECT
           metric_time__day
-          , subq_23.user
+          , subq_22.user
           , visits
         FROM (
-          -- Read Elements From Semantic Model 'visits_source'
-          -- Metric Time Dimension 'ds'
+          -- Read From CTE For node_id=sma_28019
           SELECT
-            DATE_TRUNC('day', ds) AS metric_time__day
-            , user_id AS user
-            , 1 AS visits
-          FROM ***************************.fct_visits visits_source_src_28000
-        ) subq_23
+            metric_time__day
+            , sma_28019_cte.user
+            , visits
+          FROM sma_28019_cte sma_28019_cte
+        ) subq_22
         WHERE metric_time__day = '2020-01-01'
-      ) subq_25
+      ) subq_24
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -97,19 +106,19 @@ FROM (
           , 1 AS buys
           , GEN_RANDOM_UUID() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_28
+      ) subq_27
       ON
         (
-          subq_25.user = subq_28.user
+          subq_24.user = subq_27.user
         ) AND (
-          (subq_25.metric_time__day <= subq_28.metric_time__day)
+          (subq_24.metric_time__day <= subq_27.metric_time__day)
         )
-    ) subq_29
+    ) subq_28
     GROUP BY
       metric_time__day
-  ) subq_32
+  ) subq_31
   ON
-    subq_21.metric_time__day = subq_32.metric_time__day
+    subq_21.metric_time__day = subq_31.metric_time__day
   GROUP BY
-    COALESCE(subq_21.metric_time__day, subq_32.metric_time__day)
-) subq_33
+    COALESCE(subq_21.metric_time__day, subq_31.metric_time__day)
+) subq_32

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/DuckDB/test_conversion_metric_with_categorical_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/DuckDB/test_conversion_metric_with_categorical_filter__plan0_optimized.sql
@@ -5,17 +5,28 @@ docstring:
 sql_engine: DuckDB
 ---
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , referrer_id AS visit__referrer_id
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
-  metric_time__day
-  , visit__referrer_id
+  metric_time__day AS metric_time__day
+  , visit__referrer_id AS visit__referrer_id
   , CAST(buys AS DOUBLE) / CAST(NULLIF(visits, 0) AS DOUBLE) AS visit_buy_conversion_rate
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_21.metric_time__day, subq_32.metric_time__day) AS metric_time__day
-    , COALESCE(subq_21.visit__referrer_id, subq_32.visit__referrer_id) AS visit__referrer_id
+    COALESCE(subq_21.metric_time__day, subq_31.metric_time__day) AS metric_time__day
+    , COALESCE(subq_21.visit__referrer_id, subq_31.visit__referrer_id) AS visit__referrer_id
     , MAX(subq_21.visits) AS visits
-    , MAX(subq_32.buys) AS buys
+    , MAX(subq_31.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
@@ -25,13 +36,13 @@ FROM (
       , visit__referrer_id
       , SUM(visits) AS visits
     FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
+      -- Read From CTE For node_id=sma_28019
       SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , referrer_id AS visit__referrer_id
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
+        metric_time__day
+        , sma_28019_cte.user
+        , visit__referrer_id
+        , visits
+      FROM sma_28019_cte sma_28019_cte
     ) subq_18
     WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
@@ -49,60 +60,59 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_25.visits) OVER (
+        FIRST_VALUE(subq_24.visits) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_25.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_24.visit__referrer_id) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_25.metric_time__day) OVER (
+        , FIRST_VALUE(subq_24.metric_time__day) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_25.user) OVER (
+        , FIRST_VALUE(subq_24.user) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_28.mf_internal_uuid AS mf_internal_uuid
-        , subq_28.buys AS buys
+        , subq_27.mf_internal_uuid AS mf_internal_uuid
+        , subq_27.buys AS buys
       FROM (
         -- Constrain Output with WHERE
         -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user']
         SELECT
           metric_time__day
-          , subq_23.user
+          , subq_22.user
           , visit__referrer_id
           , visits
         FROM (
-          -- Read Elements From Semantic Model 'visits_source'
-          -- Metric Time Dimension 'ds'
+          -- Read From CTE For node_id=sma_28019
           SELECT
-            DATE_TRUNC('day', ds) AS metric_time__day
-            , user_id AS user
-            , referrer_id AS visit__referrer_id
-            , 1 AS visits
-          FROM ***************************.fct_visits visits_source_src_28000
-        ) subq_23
+            metric_time__day
+            , sma_28019_cte.user
+            , visit__referrer_id
+            , visits
+          FROM sma_28019_cte sma_28019_cte
+        ) subq_22
         WHERE visit__referrer_id = 'ref_id_01'
-      ) subq_25
+      ) subq_24
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -113,25 +123,25 @@ FROM (
           , 1 AS buys
           , GEN_RANDOM_UUID() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_28
+      ) subq_27
       ON
         (
-          subq_25.user = subq_28.user
+          subq_24.user = subq_27.user
         ) AND (
-          (subq_25.metric_time__day <= subq_28.metric_time__day)
+          (subq_24.metric_time__day <= subq_27.metric_time__day)
         )
-    ) subq_29
+    ) subq_28
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_32
+  ) subq_31
   ON
     (
-      subq_21.visit__referrer_id = subq_32.visit__referrer_id
+      subq_21.visit__referrer_id = subq_31.visit__referrer_id
     ) AND (
-      subq_21.metric_time__day = subq_32.metric_time__day
+      subq_21.metric_time__day = subq_31.metric_time__day
     )
   GROUP BY
-    COALESCE(subq_21.metric_time__day, subq_32.metric_time__day)
-    , COALESCE(subq_21.visit__referrer_id, subq_32.visit__referrer_id)
-) subq_33
+    COALESCE(subq_21.metric_time__day, subq_31.metric_time__day)
+    , COALESCE(subq_21.visit__referrer_id, subq_31.visit__referrer_id)
+) subq_32

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/DuckDB/test_conversion_metric_with_different_time_dimension_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/DuckDB/test_conversion_metric_with_different_time_dimension_grains__plan0_optimized.sql
@@ -6,16 +6,25 @@ sql_engine: DuckDB
 ---
 -- Combine Aggregated Outputs
 -- Compute Metrics via Expressions
-SELECT
-  CAST(MAX(subq_28.buys_month) AS DOUBLE) / CAST(NULLIF(MAX(subq_18.visits), 0) AS DOUBLE) AS visit_buy_conversion_rate_with_monthly_conversion
-FROM (
+WITH sma_28019_cte AS (
   -- Read Elements From Semantic Model 'visits_source'
   -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('month', ds) AS metric_time__month
+    , user_id AS user
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
+SELECT
+  CAST(MAX(subq_27.buys_month) AS DOUBLE) / CAST(NULLIF(MAX(subq_18.visits), 0) AS DOUBLE) AS visit_buy_conversion_rate_with_monthly_conversion
+FROM (
+  -- Read From CTE For node_id=sma_28019
   -- Pass Only Elements: ['visits',]
   -- Aggregate Measures
   SELECT
-    SUM(1) AS visits
-  FROM ***************************.fct_visits visits_source_src_28000
+    SUM(visits) AS visits
+  FROM sma_28019_cte sma_28019_cte
 ) subq_18
 CROSS JOIN (
   -- Find conversions for user within the range of 1 month
@@ -26,42 +35,33 @@ CROSS JOIN (
   FROM (
     -- Dedupe the fanout with mf_internal_uuid in the conversion data set
     SELECT DISTINCT
-      FIRST_VALUE(subq_21.visits) OVER (
+      FIRST_VALUE(sma_28019_cte.visits) OVER (
         PARTITION BY
-          subq_24.user
-          , subq_24.metric_time__month
-          , subq_24.mf_internal_uuid
-        ORDER BY subq_21.metric_time__month DESC
+          subq_23.user
+          , subq_23.metric_time__month
+          , subq_23.mf_internal_uuid
+        ORDER BY sma_28019_cte.metric_time__month DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS visits
-      , FIRST_VALUE(subq_21.metric_time__month) OVER (
+      , FIRST_VALUE(sma_28019_cte.metric_time__month) OVER (
         PARTITION BY
-          subq_24.user
-          , subq_24.metric_time__month
-          , subq_24.mf_internal_uuid
-        ORDER BY subq_21.metric_time__month DESC
+          subq_23.user
+          , subq_23.metric_time__month
+          , subq_23.mf_internal_uuid
+        ORDER BY sma_28019_cte.metric_time__month DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS metric_time__month
-      , FIRST_VALUE(subq_21.user) OVER (
+      , FIRST_VALUE(sma_28019_cte.user) OVER (
         PARTITION BY
-          subq_24.user
-          , subq_24.metric_time__month
-          , subq_24.mf_internal_uuid
-        ORDER BY subq_21.metric_time__month DESC
+          subq_23.user
+          , subq_23.metric_time__month
+          , subq_23.mf_internal_uuid
+        ORDER BY sma_28019_cte.metric_time__month DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS user
-      , subq_24.mf_internal_uuid AS mf_internal_uuid
-      , subq_24.buys_month AS buys_month
-    FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['visits', 'metric_time__month', 'user']
-      SELECT
-        DATE_TRUNC('month', ds) AS metric_time__month
-        , user_id AS user
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
-    ) subq_21
+      , subq_23.mf_internal_uuid AS mf_internal_uuid
+      , subq_23.buys_month AS buys_month
+    FROM sma_28019_cte sma_28019_cte
     INNER JOIN (
       -- Read Elements From Semantic Model 'buys_source'
       -- Metric Time Dimension 'ds_month'
@@ -72,16 +72,16 @@ CROSS JOIN (
         , 1 AS buys_month
         , GEN_RANDOM_UUID() AS mf_internal_uuid
       FROM ***************************.fct_buys buys_source_src_28000
-    ) subq_24
+    ) subq_23
     ON
       (
-        subq_21.user = subq_24.user
+        sma_28019_cte.user = subq_23.user
       ) AND (
         (
-          subq_21.metric_time__month <= subq_24.metric_time__month
+          sma_28019_cte.metric_time__month <= subq_23.metric_time__month
         ) AND (
-          subq_21.metric_time__month > subq_24.metric_time__month - INTERVAL 1 month
+          sma_28019_cte.metric_time__month > subq_23.metric_time__month - INTERVAL 1 month
         )
       )
-  ) subq_25
-) subq_28
+  ) subq_24
+) subq_27

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/DuckDB/test_conversion_metric_with_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/DuckDB/test_conversion_metric_with_filter__plan0_optimized.sql
@@ -6,8 +6,18 @@ sql_engine: DuckDB
 ---
 -- Combine Aggregated Outputs
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
-  CAST(MAX(subq_32.buys) AS DOUBLE) / CAST(NULLIF(MAX(subq_21.visits), 0) AS DOUBLE) AS visit_buy_conversion_rate
+  CAST(MAX(subq_31.buys) AS DOUBLE) / CAST(NULLIF(MAX(subq_21.visits), 0) AS DOUBLE) AS visit_buy_conversion_rate
 FROM (
   -- Constrain Output with WHERE
   -- Pass Only Elements: ['visits',]
@@ -15,12 +25,12 @@ FROM (
   SELECT
     SUM(visits) AS visits
   FROM (
-    -- Read Elements From Semantic Model 'visits_source'
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28019
     SELECT
-      DATE_TRUNC('day', ds) AS metric_time__day
-      , 1 AS visits
-    FROM ***************************.fct_visits visits_source_src_28000
+      metric_time__day
+      , sma_28019_cte.user
+      , visits
+    FROM sma_28019_cte sma_28019_cte
   ) subq_18
   WHERE metric_time__day = '2020-01-01'
 ) subq_21
@@ -33,50 +43,49 @@ CROSS JOIN (
   FROM (
     -- Dedupe the fanout with mf_internal_uuid in the conversion data set
     SELECT DISTINCT
-      FIRST_VALUE(subq_25.visits) OVER (
+      FIRST_VALUE(subq_24.visits) OVER (
         PARTITION BY
-          subq_28.user
-          , subq_28.metric_time__day
-          , subq_28.mf_internal_uuid
-        ORDER BY subq_25.metric_time__day DESC
+          subq_27.user
+          , subq_27.metric_time__day
+          , subq_27.mf_internal_uuid
+        ORDER BY subq_24.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS visits
-      , FIRST_VALUE(subq_25.metric_time__day) OVER (
+      , FIRST_VALUE(subq_24.metric_time__day) OVER (
         PARTITION BY
-          subq_28.user
-          , subq_28.metric_time__day
-          , subq_28.mf_internal_uuid
-        ORDER BY subq_25.metric_time__day DESC
+          subq_27.user
+          , subq_27.metric_time__day
+          , subq_27.mf_internal_uuid
+        ORDER BY subq_24.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS metric_time__day
-      , FIRST_VALUE(subq_25.user) OVER (
+      , FIRST_VALUE(subq_24.user) OVER (
         PARTITION BY
-          subq_28.user
-          , subq_28.metric_time__day
-          , subq_28.mf_internal_uuid
-        ORDER BY subq_25.metric_time__day DESC
+          subq_27.user
+          , subq_27.metric_time__day
+          , subq_27.mf_internal_uuid
+        ORDER BY subq_24.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS user
-      , subq_28.mf_internal_uuid AS mf_internal_uuid
-      , subq_28.buys AS buys
+      , subq_27.mf_internal_uuid AS mf_internal_uuid
+      , subq_27.buys AS buys
     FROM (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['visits', 'metric_time__day', 'user']
       SELECT
         metric_time__day
-        , subq_23.user
+        , subq_22.user
         , visits
       FROM (
-        -- Read Elements From Semantic Model 'visits_source'
-        -- Metric Time Dimension 'ds'
+        -- Read From CTE For node_id=sma_28019
         SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , user_id AS user
-          , 1 AS visits
-        FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_23
+          metric_time__day
+          , sma_28019_cte.user
+          , visits
+        FROM sma_28019_cte sma_28019_cte
+      ) subq_22
       WHERE metric_time__day = '2020-01-01'
-    ) subq_25
+    ) subq_24
     INNER JOIN (
       -- Read Elements From Semantic Model 'buys_source'
       -- Metric Time Dimension 'ds'
@@ -87,12 +96,12 @@ CROSS JOIN (
         , 1 AS buys
         , GEN_RANDOM_UUID() AS mf_internal_uuid
       FROM ***************************.fct_buys buys_source_src_28000
-    ) subq_28
+    ) subq_27
     ON
       (
-        subq_25.user = subq_28.user
+        subq_24.user = subq_27.user
       ) AND (
-        (subq_25.metric_time__day <= subq_28.metric_time__day)
+        (subq_24.metric_time__day <= subq_27.metric_time__day)
       )
-  ) subq_29
-) subq_32
+  ) subq_28
+) subq_31

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/DuckDB/test_conversion_metric_with_filter_not_in_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/DuckDB/test_conversion_metric_with_filter_not_in_group_by__plan0_optimized.sql
@@ -6,8 +6,19 @@ sql_engine: DuckDB
 ---
 -- Combine Aggregated Outputs
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , referrer_id AS visit__referrer_id
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
-  COALESCE(MAX(subq_32.buys), 0) AS visit_buy_conversions
+  COALESCE(MAX(subq_31.buys), 0) AS visit_buy_conversions
 FROM (
   -- Constrain Output with WHERE
   -- Pass Only Elements: ['visits',]
@@ -15,12 +26,13 @@ FROM (
   SELECT
     SUM(visits) AS visits
   FROM (
-    -- Read Elements From Semantic Model 'visits_source'
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28019
     SELECT
-      referrer_id AS visit__referrer_id
-      , 1 AS visits
-    FROM ***************************.fct_visits visits_source_src_28000
+      metric_time__day
+      , sma_28019_cte.user
+      , visit__referrer_id
+      , visits
+    FROM sma_28019_cte sma_28019_cte
   ) subq_18
   WHERE visit__referrer_id = 'ref_id_01'
 ) subq_21
@@ -33,60 +45,59 @@ CROSS JOIN (
   FROM (
     -- Dedupe the fanout with mf_internal_uuid in the conversion data set
     SELECT DISTINCT
-      FIRST_VALUE(subq_25.visits) OVER (
+      FIRST_VALUE(subq_24.visits) OVER (
         PARTITION BY
-          subq_28.user
-          , subq_28.metric_time__day
-          , subq_28.mf_internal_uuid
-        ORDER BY subq_25.metric_time__day DESC
+          subq_27.user
+          , subq_27.metric_time__day
+          , subq_27.mf_internal_uuid
+        ORDER BY subq_24.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS visits
-      , FIRST_VALUE(subq_25.visit__referrer_id) OVER (
+      , FIRST_VALUE(subq_24.visit__referrer_id) OVER (
         PARTITION BY
-          subq_28.user
-          , subq_28.metric_time__day
-          , subq_28.mf_internal_uuid
-        ORDER BY subq_25.metric_time__day DESC
+          subq_27.user
+          , subq_27.metric_time__day
+          , subq_27.mf_internal_uuid
+        ORDER BY subq_24.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS visit__referrer_id
-      , FIRST_VALUE(subq_25.metric_time__day) OVER (
+      , FIRST_VALUE(subq_24.metric_time__day) OVER (
         PARTITION BY
-          subq_28.user
-          , subq_28.metric_time__day
-          , subq_28.mf_internal_uuid
-        ORDER BY subq_25.metric_time__day DESC
+          subq_27.user
+          , subq_27.metric_time__day
+          , subq_27.mf_internal_uuid
+        ORDER BY subq_24.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS metric_time__day
-      , FIRST_VALUE(subq_25.user) OVER (
+      , FIRST_VALUE(subq_24.user) OVER (
         PARTITION BY
-          subq_28.user
-          , subq_28.metric_time__day
-          , subq_28.mf_internal_uuid
-        ORDER BY subq_25.metric_time__day DESC
+          subq_27.user
+          , subq_27.metric_time__day
+          , subq_27.mf_internal_uuid
+        ORDER BY subq_24.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS user
-      , subq_28.mf_internal_uuid AS mf_internal_uuid
-      , subq_28.buys AS buys
+      , subq_27.mf_internal_uuid AS mf_internal_uuid
+      , subq_27.buys AS buys
     FROM (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user']
       SELECT
         metric_time__day
-        , subq_23.user
+        , subq_22.user
         , visit__referrer_id
         , visits
       FROM (
-        -- Read Elements From Semantic Model 'visits_source'
-        -- Metric Time Dimension 'ds'
+        -- Read From CTE For node_id=sma_28019
         SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , user_id AS user
-          , referrer_id AS visit__referrer_id
-          , 1 AS visits
-        FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_23
+          metric_time__day
+          , sma_28019_cte.user
+          , visit__referrer_id
+          , visits
+        FROM sma_28019_cte sma_28019_cte
+      ) subq_22
       WHERE visit__referrer_id = 'ref_id_01'
-    ) subq_25
+    ) subq_24
     INNER JOIN (
       -- Read Elements From Semantic Model 'buys_source'
       -- Metric Time Dimension 'ds'
@@ -97,16 +108,16 @@ CROSS JOIN (
         , 1 AS buys
         , GEN_RANDOM_UUID() AS mf_internal_uuid
       FROM ***************************.fct_buys buys_source_src_28000
-    ) subq_28
+    ) subq_27
     ON
       (
-        subq_25.user = subq_28.user
+        subq_24.user = subq_27.user
       ) AND (
         (
-          subq_25.metric_time__day <= subq_28.metric_time__day
+          subq_24.metric_time__day <= subq_27.metric_time__day
         ) AND (
-          subq_25.metric_time__day > subq_28.metric_time__day - INTERVAL 7 day
+          subq_24.metric_time__day > subq_27.metric_time__day - INTERVAL 7 day
         )
       )
-  ) subq_29
-) subq_32
+  ) subq_28
+) subq_31

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/DuckDB/test_conversion_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/DuckDB/test_conversion_metric_with_time_constraint__plan0_optimized.sql
@@ -5,15 +5,28 @@ docstring:
 sql_engine: DuckDB
 ---
 -- Compute Metrics via Expressions
+WITH ctr_0_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , referrer_id AS visit__referrer_id
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+  WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
+)
+
 SELECT
-  visit__referrer_id
+  visit__referrer_id AS visit__referrer_id
   , CAST(buys AS DOUBLE) / CAST(NULLIF(visits, 0) AS DOUBLE) AS visit_buy_conversion_rate
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_24.visit__referrer_id, subq_36.visit__referrer_id) AS visit__referrer_id
+    COALESCE(subq_24.visit__referrer_id, subq_34.visit__referrer_id) AS visit__referrer_id
     , MAX(subq_24.visits) AS visits
-    , MAX(subq_36.buys) AS buys
+    , MAX(subq_34.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['visits', 'visit__referrer_id']
@@ -22,14 +35,13 @@ FROM (
       visit__referrer_id
       , SUM(visits) AS visits
     FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
-      -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
+      -- Read From CTE For node_id=ctr_0
       SELECT
-        referrer_id AS visit__referrer_id
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
-      WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
+        metric_time__day
+        , ctr_0_cte.user
+        , visit__referrer_id
+        , visits
+      FROM ctr_0_cte ctr_0_cte
     ) subq_21
     WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
@@ -45,62 +57,59 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_29.visits) OVER (
+        FIRST_VALUE(subq_27.visits) OVER (
           PARTITION BY
-            subq_32.user
-            , subq_32.metric_time__day
-            , subq_32.mf_internal_uuid
-          ORDER BY subq_29.metric_time__day DESC
+            subq_30.user
+            , subq_30.metric_time__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_29.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_27.visit__referrer_id) OVER (
           PARTITION BY
-            subq_32.user
-            , subq_32.metric_time__day
-            , subq_32.mf_internal_uuid
-          ORDER BY subq_29.metric_time__day DESC
+            subq_30.user
+            , subq_30.metric_time__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_29.metric_time__day) OVER (
+        , FIRST_VALUE(subq_27.metric_time__day) OVER (
           PARTITION BY
-            subq_32.user
-            , subq_32.metric_time__day
-            , subq_32.mf_internal_uuid
-          ORDER BY subq_29.metric_time__day DESC
+            subq_30.user
+            , subq_30.metric_time__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_29.user) OVER (
+        , FIRST_VALUE(subq_27.user) OVER (
           PARTITION BY
-            subq_32.user
-            , subq_32.metric_time__day
-            , subq_32.mf_internal_uuid
-          ORDER BY subq_29.metric_time__day DESC
+            subq_30.user
+            , subq_30.metric_time__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_32.mf_internal_uuid AS mf_internal_uuid
-        , subq_32.buys AS buys
+        , subq_30.mf_internal_uuid AS mf_internal_uuid
+        , subq_30.buys AS buys
       FROM (
         -- Constrain Output with WHERE
         -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user']
         SELECT
           metric_time__day
-          , subq_27.user
+          , subq_25.user
           , visit__referrer_id
           , visits
         FROM (
-          -- Read Elements From Semantic Model 'visits_source'
-          -- Metric Time Dimension 'ds'
-          -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
+          -- Read From CTE For node_id=ctr_0
           SELECT
-            DATE_TRUNC('day', ds) AS metric_time__day
-            , user_id AS user
-            , referrer_id AS visit__referrer_id
-            , 1 AS visits
-          FROM ***************************.fct_visits visits_source_src_28000
-          WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
-        ) subq_27
+            metric_time__day
+            , ctr_0_cte.user
+            , visit__referrer_id
+            , visits
+          FROM ctr_0_cte ctr_0_cte
+        ) subq_25
         WHERE visit__referrer_id = 'ref_id_01'
-      ) subq_29
+      ) subq_27
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -111,19 +120,19 @@ FROM (
           , 1 AS buys
           , GEN_RANDOM_UUID() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_32
+      ) subq_30
       ON
         (
-          subq_29.user = subq_32.user
+          subq_27.user = subq_30.user
         ) AND (
-          (subq_29.metric_time__day <= subq_32.metric_time__day)
+          (subq_27.metric_time__day <= subq_30.metric_time__day)
         )
-    ) subq_33
+    ) subq_31
     GROUP BY
       visit__referrer_id
-  ) subq_36
+  ) subq_34
   ON
-    subq_24.visit__referrer_id = subq_36.visit__referrer_id
+    subq_24.visit__referrer_id = subq_34.visit__referrer_id
   GROUP BY
-    COALESCE(subq_24.visit__referrer_id, subq_36.visit__referrer_id)
-) subq_37
+    COALESCE(subq_24.visit__referrer_id, subq_34.visit__referrer_id)
+) subq_35

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/DuckDB/test_conversion_metric_with_window__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/DuckDB/test_conversion_metric_with_window__plan0_optimized.sql
@@ -5,15 +5,25 @@ docstring:
 sql_engine: DuckDB
 ---
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
-  metric_time__day
+  metric_time__day AS metric_time__day
   , CAST(buys AS DOUBLE) / CAST(NULLIF(visits, 0) AS DOUBLE) AS visit_buy_conversion_rate_7days
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_21.metric_time__day, subq_32.metric_time__day) AS metric_time__day
+    COALESCE(subq_21.metric_time__day, subq_31.metric_time__day) AS metric_time__day
     , MAX(subq_21.visits) AS visits
-    , MAX(subq_32.buys) AS buys
+    , MAX(subq_31.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['visits', 'metric_time__day']
@@ -22,12 +32,12 @@ FROM (
       metric_time__day
       , SUM(visits) AS visits
     FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
+      -- Read From CTE For node_id=sma_28019
       SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
+        metric_time__day
+        , sma_28019_cte.user
+        , visits
+      FROM sma_28019_cte sma_28019_cte
     ) subq_18
     WHERE metric_time__day = '2020-01-01'
     GROUP BY
@@ -43,50 +53,49 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_25.visits) OVER (
+        FIRST_VALUE(subq_24.visits) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_25.metric_time__day) OVER (
+        , FIRST_VALUE(subq_24.metric_time__day) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_25.user) OVER (
+        , FIRST_VALUE(subq_24.user) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_28.mf_internal_uuid AS mf_internal_uuid
-        , subq_28.buys AS buys
+        , subq_27.mf_internal_uuid AS mf_internal_uuid
+        , subq_27.buys AS buys
       FROM (
         -- Constrain Output with WHERE
         -- Pass Only Elements: ['visits', 'metric_time__day', 'user']
         SELECT
           metric_time__day
-          , subq_23.user
+          , subq_22.user
           , visits
         FROM (
-          -- Read Elements From Semantic Model 'visits_source'
-          -- Metric Time Dimension 'ds'
+          -- Read From CTE For node_id=sma_28019
           SELECT
-            DATE_TRUNC('day', ds) AS metric_time__day
-            , user_id AS user
-            , 1 AS visits
-          FROM ***************************.fct_visits visits_source_src_28000
-        ) subq_23
+            metric_time__day
+            , sma_28019_cte.user
+            , visits
+          FROM sma_28019_cte sma_28019_cte
+        ) subq_22
         WHERE metric_time__day = '2020-01-01'
-      ) subq_25
+      ) subq_24
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -97,23 +106,23 @@ FROM (
           , 1 AS buys
           , GEN_RANDOM_UUID() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_28
+      ) subq_27
       ON
         (
-          subq_25.user = subq_28.user
+          subq_24.user = subq_27.user
         ) AND (
           (
-            subq_25.metric_time__day <= subq_28.metric_time__day
+            subq_24.metric_time__day <= subq_27.metric_time__day
           ) AND (
-            subq_25.metric_time__day > subq_28.metric_time__day - INTERVAL 7 day
+            subq_24.metric_time__day > subq_27.metric_time__day - INTERVAL 7 day
           )
         )
-    ) subq_29
+    ) subq_28
     GROUP BY
       metric_time__day
-  ) subq_32
+  ) subq_31
   ON
-    subq_21.metric_time__day = subq_32.metric_time__day
+    subq_21.metric_time__day = subq_31.metric_time__day
   GROUP BY
-    COALESCE(subq_21.metric_time__day, subq_32.metric_time__day)
-) subq_33
+    COALESCE(subq_21.metric_time__day, subq_31.metric_time__day)
+) subq_32

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/DuckDB/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/DuckDB/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
@@ -5,17 +5,30 @@ docstring:
 sql_engine: DuckDB
 ---
 -- Compute Metrics via Expressions
+WITH ctr_0_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , referrer_id AS visit__referrer_id
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+  WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
+)
+
 SELECT
-  metric_time__day
-  , visit__referrer_id
+  metric_time__day AS metric_time__day
+  , visit__referrer_id AS visit__referrer_id
   , CAST(buys AS DOUBLE) / CAST(NULLIF(visits, 0) AS DOUBLE) AS visit_buy_conversion_rate_7days
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_24.metric_time__day, subq_36.metric_time__day) AS metric_time__day
-    , COALESCE(subq_24.visit__referrer_id, subq_36.visit__referrer_id) AS visit__referrer_id
+    COALESCE(subq_24.metric_time__day, subq_34.metric_time__day) AS metric_time__day
+    , COALESCE(subq_24.visit__referrer_id, subq_34.visit__referrer_id) AS visit__referrer_id
     , MAX(subq_24.visits) AS visits
-    , MAX(subq_36.buys) AS buys
+    , MAX(subq_34.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
@@ -25,15 +38,13 @@ FROM (
       , visit__referrer_id
       , SUM(visits) AS visits
     FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
-      -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
+      -- Read From CTE For node_id=ctr_0
       SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , referrer_id AS visit__referrer_id
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
-      WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
+        metric_time__day
+        , ctr_0_cte.user
+        , visit__referrer_id
+        , visits
+      FROM ctr_0_cte ctr_0_cte
     ) subq_21
     WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
@@ -51,62 +62,59 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_29.visits) OVER (
+        FIRST_VALUE(subq_27.visits) OVER (
           PARTITION BY
-            subq_32.user
-            , subq_32.metric_time__day
-            , subq_32.mf_internal_uuid
-          ORDER BY subq_29.metric_time__day DESC
+            subq_30.user
+            , subq_30.metric_time__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_29.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_27.visit__referrer_id) OVER (
           PARTITION BY
-            subq_32.user
-            , subq_32.metric_time__day
-            , subq_32.mf_internal_uuid
-          ORDER BY subq_29.metric_time__day DESC
+            subq_30.user
+            , subq_30.metric_time__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_29.metric_time__day) OVER (
+        , FIRST_VALUE(subq_27.metric_time__day) OVER (
           PARTITION BY
-            subq_32.user
-            , subq_32.metric_time__day
-            , subq_32.mf_internal_uuid
-          ORDER BY subq_29.metric_time__day DESC
+            subq_30.user
+            , subq_30.metric_time__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_29.user) OVER (
+        , FIRST_VALUE(subq_27.user) OVER (
           PARTITION BY
-            subq_32.user
-            , subq_32.metric_time__day
-            , subq_32.mf_internal_uuid
-          ORDER BY subq_29.metric_time__day DESC
+            subq_30.user
+            , subq_30.metric_time__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_32.mf_internal_uuid AS mf_internal_uuid
-        , subq_32.buys AS buys
+        , subq_30.mf_internal_uuid AS mf_internal_uuid
+        , subq_30.buys AS buys
       FROM (
         -- Constrain Output with WHERE
         -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user']
         SELECT
           metric_time__day
-          , subq_27.user
+          , subq_25.user
           , visit__referrer_id
           , visits
         FROM (
-          -- Read Elements From Semantic Model 'visits_source'
-          -- Metric Time Dimension 'ds'
-          -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
+          -- Read From CTE For node_id=ctr_0
           SELECT
-            DATE_TRUNC('day', ds) AS metric_time__day
-            , user_id AS user
-            , referrer_id AS visit__referrer_id
-            , 1 AS visits
-          FROM ***************************.fct_visits visits_source_src_28000
-          WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
-        ) subq_27
+            metric_time__day
+            , ctr_0_cte.user
+            , visit__referrer_id
+            , visits
+          FROM ctr_0_cte ctr_0_cte
+        ) subq_25
         WHERE visit__referrer_id = 'ref_id_01'
-      ) subq_29
+      ) subq_27
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -117,29 +125,29 @@ FROM (
           , 1 AS buys
           , GEN_RANDOM_UUID() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_32
+      ) subq_30
       ON
         (
-          subq_29.user = subq_32.user
+          subq_27.user = subq_30.user
         ) AND (
           (
-            subq_29.metric_time__day <= subq_32.metric_time__day
+            subq_27.metric_time__day <= subq_30.metric_time__day
           ) AND (
-            subq_29.metric_time__day > subq_32.metric_time__day - INTERVAL 7 day
+            subq_27.metric_time__day > subq_30.metric_time__day - INTERVAL 7 day
           )
         )
-    ) subq_33
+    ) subq_31
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_36
+  ) subq_34
   ON
     (
-      subq_24.visit__referrer_id = subq_36.visit__referrer_id
+      subq_24.visit__referrer_id = subq_34.visit__referrer_id
     ) AND (
-      subq_24.metric_time__day = subq_36.metric_time__day
+      subq_24.metric_time__day = subq_34.metric_time__day
     )
   GROUP BY
-    COALESCE(subq_24.metric_time__day, subq_36.metric_time__day)
-    , COALESCE(subq_24.visit__referrer_id, subq_36.visit__referrer_id)
-) subq_37
+    COALESCE(subq_24.metric_time__day, subq_34.metric_time__day)
+    , COALESCE(subq_24.visit__referrer_id, subq_34.visit__referrer_id)
+) subq_35

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Postgres/test_conversion_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Postgres/test_conversion_metric__plan0_optimized.sql
@@ -5,15 +5,25 @@ docstring:
 sql_engine: Postgres
 ---
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
-  metric_time__day
+  metric_time__day AS metric_time__day
   , CAST(buys AS DOUBLE PRECISION) / CAST(NULLIF(visits, 0) AS DOUBLE PRECISION) AS visit_buy_conversion_rate
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_21.metric_time__day, subq_32.metric_time__day) AS metric_time__day
+    COALESCE(subq_21.metric_time__day, subq_31.metric_time__day) AS metric_time__day
     , MAX(subq_21.visits) AS visits
-    , MAX(subq_32.buys) AS buys
+    , MAX(subq_31.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['visits', 'metric_time__day']
@@ -22,12 +32,12 @@ FROM (
       metric_time__day
       , SUM(visits) AS visits
     FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
+      -- Read From CTE For node_id=sma_28019
       SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
+        metric_time__day
+        , sma_28019_cte.user
+        , visits
+      FROM sma_28019_cte sma_28019_cte
     ) subq_18
     WHERE metric_time__day = '2020-01-01'
     GROUP BY
@@ -43,50 +53,49 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_25.visits) OVER (
+        FIRST_VALUE(subq_24.visits) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_25.metric_time__day) OVER (
+        , FIRST_VALUE(subq_24.metric_time__day) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_25.user) OVER (
+        , FIRST_VALUE(subq_24.user) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_28.mf_internal_uuid AS mf_internal_uuid
-        , subq_28.buys AS buys
+        , subq_27.mf_internal_uuid AS mf_internal_uuid
+        , subq_27.buys AS buys
       FROM (
         -- Constrain Output with WHERE
         -- Pass Only Elements: ['visits', 'metric_time__day', 'user']
         SELECT
           metric_time__day
-          , subq_23.user
+          , subq_22.user
           , visits
         FROM (
-          -- Read Elements From Semantic Model 'visits_source'
-          -- Metric Time Dimension 'ds'
+          -- Read From CTE For node_id=sma_28019
           SELECT
-            DATE_TRUNC('day', ds) AS metric_time__day
-            , user_id AS user
-            , 1 AS visits
-          FROM ***************************.fct_visits visits_source_src_28000
-        ) subq_23
+            metric_time__day
+            , sma_28019_cte.user
+            , visits
+          FROM sma_28019_cte sma_28019_cte
+        ) subq_22
         WHERE metric_time__day = '2020-01-01'
-      ) subq_25
+      ) subq_24
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -97,19 +106,19 @@ FROM (
           , 1 AS buys
           , GEN_RANDOM_UUID() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_28
+      ) subq_27
       ON
         (
-          subq_25.user = subq_28.user
+          subq_24.user = subq_27.user
         ) AND (
-          (subq_25.metric_time__day <= subq_28.metric_time__day)
+          (subq_24.metric_time__day <= subq_27.metric_time__day)
         )
-    ) subq_29
+    ) subq_28
     GROUP BY
       metric_time__day
-  ) subq_32
+  ) subq_31
   ON
-    subq_21.metric_time__day = subq_32.metric_time__day
+    subq_21.metric_time__day = subq_31.metric_time__day
   GROUP BY
-    COALESCE(subq_21.metric_time__day, subq_32.metric_time__day)
-) subq_33
+    COALESCE(subq_21.metric_time__day, subq_31.metric_time__day)
+) subq_32

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Postgres/test_conversion_metric_with_categorical_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Postgres/test_conversion_metric_with_categorical_filter__plan0_optimized.sql
@@ -5,17 +5,28 @@ docstring:
 sql_engine: Postgres
 ---
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , referrer_id AS visit__referrer_id
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
-  metric_time__day
-  , visit__referrer_id
+  metric_time__day AS metric_time__day
+  , visit__referrer_id AS visit__referrer_id
   , CAST(buys AS DOUBLE PRECISION) / CAST(NULLIF(visits, 0) AS DOUBLE PRECISION) AS visit_buy_conversion_rate
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_21.metric_time__day, subq_32.metric_time__day) AS metric_time__day
-    , COALESCE(subq_21.visit__referrer_id, subq_32.visit__referrer_id) AS visit__referrer_id
+    COALESCE(subq_21.metric_time__day, subq_31.metric_time__day) AS metric_time__day
+    , COALESCE(subq_21.visit__referrer_id, subq_31.visit__referrer_id) AS visit__referrer_id
     , MAX(subq_21.visits) AS visits
-    , MAX(subq_32.buys) AS buys
+    , MAX(subq_31.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
@@ -25,13 +36,13 @@ FROM (
       , visit__referrer_id
       , SUM(visits) AS visits
     FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
+      -- Read From CTE For node_id=sma_28019
       SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , referrer_id AS visit__referrer_id
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
+        metric_time__day
+        , sma_28019_cte.user
+        , visit__referrer_id
+        , visits
+      FROM sma_28019_cte sma_28019_cte
     ) subq_18
     WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
@@ -49,60 +60,59 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_25.visits) OVER (
+        FIRST_VALUE(subq_24.visits) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_25.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_24.visit__referrer_id) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_25.metric_time__day) OVER (
+        , FIRST_VALUE(subq_24.metric_time__day) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_25.user) OVER (
+        , FIRST_VALUE(subq_24.user) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_28.mf_internal_uuid AS mf_internal_uuid
-        , subq_28.buys AS buys
+        , subq_27.mf_internal_uuid AS mf_internal_uuid
+        , subq_27.buys AS buys
       FROM (
         -- Constrain Output with WHERE
         -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user']
         SELECT
           metric_time__day
-          , subq_23.user
+          , subq_22.user
           , visit__referrer_id
           , visits
         FROM (
-          -- Read Elements From Semantic Model 'visits_source'
-          -- Metric Time Dimension 'ds'
+          -- Read From CTE For node_id=sma_28019
           SELECT
-            DATE_TRUNC('day', ds) AS metric_time__day
-            , user_id AS user
-            , referrer_id AS visit__referrer_id
-            , 1 AS visits
-          FROM ***************************.fct_visits visits_source_src_28000
-        ) subq_23
+            metric_time__day
+            , sma_28019_cte.user
+            , visit__referrer_id
+            , visits
+          FROM sma_28019_cte sma_28019_cte
+        ) subq_22
         WHERE visit__referrer_id = 'ref_id_01'
-      ) subq_25
+      ) subq_24
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -113,25 +123,25 @@ FROM (
           , 1 AS buys
           , GEN_RANDOM_UUID() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_28
+      ) subq_27
       ON
         (
-          subq_25.user = subq_28.user
+          subq_24.user = subq_27.user
         ) AND (
-          (subq_25.metric_time__day <= subq_28.metric_time__day)
+          (subq_24.metric_time__day <= subq_27.metric_time__day)
         )
-    ) subq_29
+    ) subq_28
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_32
+  ) subq_31
   ON
     (
-      subq_21.visit__referrer_id = subq_32.visit__referrer_id
+      subq_21.visit__referrer_id = subq_31.visit__referrer_id
     ) AND (
-      subq_21.metric_time__day = subq_32.metric_time__day
+      subq_21.metric_time__day = subq_31.metric_time__day
     )
   GROUP BY
-    COALESCE(subq_21.metric_time__day, subq_32.metric_time__day)
-    , COALESCE(subq_21.visit__referrer_id, subq_32.visit__referrer_id)
-) subq_33
+    COALESCE(subq_21.metric_time__day, subq_31.metric_time__day)
+    , COALESCE(subq_21.visit__referrer_id, subq_31.visit__referrer_id)
+) subq_32

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Postgres/test_conversion_metric_with_different_time_dimension_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Postgres/test_conversion_metric_with_different_time_dimension_grains__plan0_optimized.sql
@@ -6,16 +6,25 @@ sql_engine: Postgres
 ---
 -- Combine Aggregated Outputs
 -- Compute Metrics via Expressions
-SELECT
-  CAST(MAX(subq_28.buys_month) AS DOUBLE PRECISION) / CAST(NULLIF(MAX(subq_18.visits), 0) AS DOUBLE PRECISION) AS visit_buy_conversion_rate_with_monthly_conversion
-FROM (
+WITH sma_28019_cte AS (
   -- Read Elements From Semantic Model 'visits_source'
   -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('month', ds) AS metric_time__month
+    , user_id AS user
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
+SELECT
+  CAST(MAX(subq_27.buys_month) AS DOUBLE PRECISION) / CAST(NULLIF(MAX(subq_18.visits), 0) AS DOUBLE PRECISION) AS visit_buy_conversion_rate_with_monthly_conversion
+FROM (
+  -- Read From CTE For node_id=sma_28019
   -- Pass Only Elements: ['visits',]
   -- Aggregate Measures
   SELECT
-    SUM(1) AS visits
-  FROM ***************************.fct_visits visits_source_src_28000
+    SUM(visits) AS visits
+  FROM sma_28019_cte sma_28019_cte
 ) subq_18
 CROSS JOIN (
   -- Find conversions for user within the range of 1 month
@@ -26,42 +35,33 @@ CROSS JOIN (
   FROM (
     -- Dedupe the fanout with mf_internal_uuid in the conversion data set
     SELECT DISTINCT
-      FIRST_VALUE(subq_21.visits) OVER (
+      FIRST_VALUE(sma_28019_cte.visits) OVER (
         PARTITION BY
-          subq_24.user
-          , subq_24.metric_time__month
-          , subq_24.mf_internal_uuid
-        ORDER BY subq_21.metric_time__month DESC
+          subq_23.user
+          , subq_23.metric_time__month
+          , subq_23.mf_internal_uuid
+        ORDER BY sma_28019_cte.metric_time__month DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS visits
-      , FIRST_VALUE(subq_21.metric_time__month) OVER (
+      , FIRST_VALUE(sma_28019_cte.metric_time__month) OVER (
         PARTITION BY
-          subq_24.user
-          , subq_24.metric_time__month
-          , subq_24.mf_internal_uuid
-        ORDER BY subq_21.metric_time__month DESC
+          subq_23.user
+          , subq_23.metric_time__month
+          , subq_23.mf_internal_uuid
+        ORDER BY sma_28019_cte.metric_time__month DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS metric_time__month
-      , FIRST_VALUE(subq_21.user) OVER (
+      , FIRST_VALUE(sma_28019_cte.user) OVER (
         PARTITION BY
-          subq_24.user
-          , subq_24.metric_time__month
-          , subq_24.mf_internal_uuid
-        ORDER BY subq_21.metric_time__month DESC
+          subq_23.user
+          , subq_23.metric_time__month
+          , subq_23.mf_internal_uuid
+        ORDER BY sma_28019_cte.metric_time__month DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS user
-      , subq_24.mf_internal_uuid AS mf_internal_uuid
-      , subq_24.buys_month AS buys_month
-    FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['visits', 'metric_time__month', 'user']
-      SELECT
-        DATE_TRUNC('month', ds) AS metric_time__month
-        , user_id AS user
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
-    ) subq_21
+      , subq_23.mf_internal_uuid AS mf_internal_uuid
+      , subq_23.buys_month AS buys_month
+    FROM sma_28019_cte sma_28019_cte
     INNER JOIN (
       -- Read Elements From Semantic Model 'buys_source'
       -- Metric Time Dimension 'ds_month'
@@ -72,16 +72,16 @@ CROSS JOIN (
         , 1 AS buys_month
         , GEN_RANDOM_UUID() AS mf_internal_uuid
       FROM ***************************.fct_buys buys_source_src_28000
-    ) subq_24
+    ) subq_23
     ON
       (
-        subq_21.user = subq_24.user
+        sma_28019_cte.user = subq_23.user
       ) AND (
         (
-          subq_21.metric_time__month <= subq_24.metric_time__month
+          sma_28019_cte.metric_time__month <= subq_23.metric_time__month
         ) AND (
-          subq_21.metric_time__month > subq_24.metric_time__month - MAKE_INTERVAL(months => 1)
+          sma_28019_cte.metric_time__month > subq_23.metric_time__month - MAKE_INTERVAL(months => 1)
         )
       )
-  ) subq_25
-) subq_28
+  ) subq_24
+) subq_27

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Postgres/test_conversion_metric_with_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Postgres/test_conversion_metric_with_filter__plan0_optimized.sql
@@ -6,8 +6,18 @@ sql_engine: Postgres
 ---
 -- Combine Aggregated Outputs
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
-  CAST(MAX(subq_32.buys) AS DOUBLE PRECISION) / CAST(NULLIF(MAX(subq_21.visits), 0) AS DOUBLE PRECISION) AS visit_buy_conversion_rate
+  CAST(MAX(subq_31.buys) AS DOUBLE PRECISION) / CAST(NULLIF(MAX(subq_21.visits), 0) AS DOUBLE PRECISION) AS visit_buy_conversion_rate
 FROM (
   -- Constrain Output with WHERE
   -- Pass Only Elements: ['visits',]
@@ -15,12 +25,12 @@ FROM (
   SELECT
     SUM(visits) AS visits
   FROM (
-    -- Read Elements From Semantic Model 'visits_source'
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28019
     SELECT
-      DATE_TRUNC('day', ds) AS metric_time__day
-      , 1 AS visits
-    FROM ***************************.fct_visits visits_source_src_28000
+      metric_time__day
+      , sma_28019_cte.user
+      , visits
+    FROM sma_28019_cte sma_28019_cte
   ) subq_18
   WHERE metric_time__day = '2020-01-01'
 ) subq_21
@@ -33,50 +43,49 @@ CROSS JOIN (
   FROM (
     -- Dedupe the fanout with mf_internal_uuid in the conversion data set
     SELECT DISTINCT
-      FIRST_VALUE(subq_25.visits) OVER (
+      FIRST_VALUE(subq_24.visits) OVER (
         PARTITION BY
-          subq_28.user
-          , subq_28.metric_time__day
-          , subq_28.mf_internal_uuid
-        ORDER BY subq_25.metric_time__day DESC
+          subq_27.user
+          , subq_27.metric_time__day
+          , subq_27.mf_internal_uuid
+        ORDER BY subq_24.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS visits
-      , FIRST_VALUE(subq_25.metric_time__day) OVER (
+      , FIRST_VALUE(subq_24.metric_time__day) OVER (
         PARTITION BY
-          subq_28.user
-          , subq_28.metric_time__day
-          , subq_28.mf_internal_uuid
-        ORDER BY subq_25.metric_time__day DESC
+          subq_27.user
+          , subq_27.metric_time__day
+          , subq_27.mf_internal_uuid
+        ORDER BY subq_24.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS metric_time__day
-      , FIRST_VALUE(subq_25.user) OVER (
+      , FIRST_VALUE(subq_24.user) OVER (
         PARTITION BY
-          subq_28.user
-          , subq_28.metric_time__day
-          , subq_28.mf_internal_uuid
-        ORDER BY subq_25.metric_time__day DESC
+          subq_27.user
+          , subq_27.metric_time__day
+          , subq_27.mf_internal_uuid
+        ORDER BY subq_24.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS user
-      , subq_28.mf_internal_uuid AS mf_internal_uuid
-      , subq_28.buys AS buys
+      , subq_27.mf_internal_uuid AS mf_internal_uuid
+      , subq_27.buys AS buys
     FROM (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['visits', 'metric_time__day', 'user']
       SELECT
         metric_time__day
-        , subq_23.user
+        , subq_22.user
         , visits
       FROM (
-        -- Read Elements From Semantic Model 'visits_source'
-        -- Metric Time Dimension 'ds'
+        -- Read From CTE For node_id=sma_28019
         SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , user_id AS user
-          , 1 AS visits
-        FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_23
+          metric_time__day
+          , sma_28019_cte.user
+          , visits
+        FROM sma_28019_cte sma_28019_cte
+      ) subq_22
       WHERE metric_time__day = '2020-01-01'
-    ) subq_25
+    ) subq_24
     INNER JOIN (
       -- Read Elements From Semantic Model 'buys_source'
       -- Metric Time Dimension 'ds'
@@ -87,12 +96,12 @@ CROSS JOIN (
         , 1 AS buys
         , GEN_RANDOM_UUID() AS mf_internal_uuid
       FROM ***************************.fct_buys buys_source_src_28000
-    ) subq_28
+    ) subq_27
     ON
       (
-        subq_25.user = subq_28.user
+        subq_24.user = subq_27.user
       ) AND (
-        (subq_25.metric_time__day <= subq_28.metric_time__day)
+        (subq_24.metric_time__day <= subq_27.metric_time__day)
       )
-  ) subq_29
-) subq_32
+  ) subq_28
+) subq_31

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Postgres/test_conversion_metric_with_filter_not_in_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Postgres/test_conversion_metric_with_filter_not_in_group_by__plan0_optimized.sql
@@ -6,8 +6,19 @@ sql_engine: Postgres
 ---
 -- Combine Aggregated Outputs
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , referrer_id AS visit__referrer_id
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
-  COALESCE(MAX(subq_32.buys), 0) AS visit_buy_conversions
+  COALESCE(MAX(subq_31.buys), 0) AS visit_buy_conversions
 FROM (
   -- Constrain Output with WHERE
   -- Pass Only Elements: ['visits',]
@@ -15,12 +26,13 @@ FROM (
   SELECT
     SUM(visits) AS visits
   FROM (
-    -- Read Elements From Semantic Model 'visits_source'
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28019
     SELECT
-      referrer_id AS visit__referrer_id
-      , 1 AS visits
-    FROM ***************************.fct_visits visits_source_src_28000
+      metric_time__day
+      , sma_28019_cte.user
+      , visit__referrer_id
+      , visits
+    FROM sma_28019_cte sma_28019_cte
   ) subq_18
   WHERE visit__referrer_id = 'ref_id_01'
 ) subq_21
@@ -33,60 +45,59 @@ CROSS JOIN (
   FROM (
     -- Dedupe the fanout with mf_internal_uuid in the conversion data set
     SELECT DISTINCT
-      FIRST_VALUE(subq_25.visits) OVER (
+      FIRST_VALUE(subq_24.visits) OVER (
         PARTITION BY
-          subq_28.user
-          , subq_28.metric_time__day
-          , subq_28.mf_internal_uuid
-        ORDER BY subq_25.metric_time__day DESC
+          subq_27.user
+          , subq_27.metric_time__day
+          , subq_27.mf_internal_uuid
+        ORDER BY subq_24.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS visits
-      , FIRST_VALUE(subq_25.visit__referrer_id) OVER (
+      , FIRST_VALUE(subq_24.visit__referrer_id) OVER (
         PARTITION BY
-          subq_28.user
-          , subq_28.metric_time__day
-          , subq_28.mf_internal_uuid
-        ORDER BY subq_25.metric_time__day DESC
+          subq_27.user
+          , subq_27.metric_time__day
+          , subq_27.mf_internal_uuid
+        ORDER BY subq_24.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS visit__referrer_id
-      , FIRST_VALUE(subq_25.metric_time__day) OVER (
+      , FIRST_VALUE(subq_24.metric_time__day) OVER (
         PARTITION BY
-          subq_28.user
-          , subq_28.metric_time__day
-          , subq_28.mf_internal_uuid
-        ORDER BY subq_25.metric_time__day DESC
+          subq_27.user
+          , subq_27.metric_time__day
+          , subq_27.mf_internal_uuid
+        ORDER BY subq_24.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS metric_time__day
-      , FIRST_VALUE(subq_25.user) OVER (
+      , FIRST_VALUE(subq_24.user) OVER (
         PARTITION BY
-          subq_28.user
-          , subq_28.metric_time__day
-          , subq_28.mf_internal_uuid
-        ORDER BY subq_25.metric_time__day DESC
+          subq_27.user
+          , subq_27.metric_time__day
+          , subq_27.mf_internal_uuid
+        ORDER BY subq_24.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS user
-      , subq_28.mf_internal_uuid AS mf_internal_uuid
-      , subq_28.buys AS buys
+      , subq_27.mf_internal_uuid AS mf_internal_uuid
+      , subq_27.buys AS buys
     FROM (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user']
       SELECT
         metric_time__day
-        , subq_23.user
+        , subq_22.user
         , visit__referrer_id
         , visits
       FROM (
-        -- Read Elements From Semantic Model 'visits_source'
-        -- Metric Time Dimension 'ds'
+        -- Read From CTE For node_id=sma_28019
         SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , user_id AS user
-          , referrer_id AS visit__referrer_id
-          , 1 AS visits
-        FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_23
+          metric_time__day
+          , sma_28019_cte.user
+          , visit__referrer_id
+          , visits
+        FROM sma_28019_cte sma_28019_cte
+      ) subq_22
       WHERE visit__referrer_id = 'ref_id_01'
-    ) subq_25
+    ) subq_24
     INNER JOIN (
       -- Read Elements From Semantic Model 'buys_source'
       -- Metric Time Dimension 'ds'
@@ -97,16 +108,16 @@ CROSS JOIN (
         , 1 AS buys
         , GEN_RANDOM_UUID() AS mf_internal_uuid
       FROM ***************************.fct_buys buys_source_src_28000
-    ) subq_28
+    ) subq_27
     ON
       (
-        subq_25.user = subq_28.user
+        subq_24.user = subq_27.user
       ) AND (
         (
-          subq_25.metric_time__day <= subq_28.metric_time__day
+          subq_24.metric_time__day <= subq_27.metric_time__day
         ) AND (
-          subq_25.metric_time__day > subq_28.metric_time__day - MAKE_INTERVAL(days => 7)
+          subq_24.metric_time__day > subq_27.metric_time__day - MAKE_INTERVAL(days => 7)
         )
       )
-  ) subq_29
-) subq_32
+  ) subq_28
+) subq_31

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Postgres/test_conversion_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Postgres/test_conversion_metric_with_time_constraint__plan0_optimized.sql
@@ -5,15 +5,28 @@ docstring:
 sql_engine: Postgres
 ---
 -- Compute Metrics via Expressions
+WITH ctr_0_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , referrer_id AS visit__referrer_id
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+  WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
+)
+
 SELECT
-  visit__referrer_id
+  visit__referrer_id AS visit__referrer_id
   , CAST(buys AS DOUBLE PRECISION) / CAST(NULLIF(visits, 0) AS DOUBLE PRECISION) AS visit_buy_conversion_rate
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_24.visit__referrer_id, subq_36.visit__referrer_id) AS visit__referrer_id
+    COALESCE(subq_24.visit__referrer_id, subq_34.visit__referrer_id) AS visit__referrer_id
     , MAX(subq_24.visits) AS visits
-    , MAX(subq_36.buys) AS buys
+    , MAX(subq_34.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['visits', 'visit__referrer_id']
@@ -22,14 +35,13 @@ FROM (
       visit__referrer_id
       , SUM(visits) AS visits
     FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
-      -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
+      -- Read From CTE For node_id=ctr_0
       SELECT
-        referrer_id AS visit__referrer_id
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
-      WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
+        metric_time__day
+        , ctr_0_cte.user
+        , visit__referrer_id
+        , visits
+      FROM ctr_0_cte ctr_0_cte
     ) subq_21
     WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
@@ -45,62 +57,59 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_29.visits) OVER (
+        FIRST_VALUE(subq_27.visits) OVER (
           PARTITION BY
-            subq_32.user
-            , subq_32.metric_time__day
-            , subq_32.mf_internal_uuid
-          ORDER BY subq_29.metric_time__day DESC
+            subq_30.user
+            , subq_30.metric_time__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_29.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_27.visit__referrer_id) OVER (
           PARTITION BY
-            subq_32.user
-            , subq_32.metric_time__day
-            , subq_32.mf_internal_uuid
-          ORDER BY subq_29.metric_time__day DESC
+            subq_30.user
+            , subq_30.metric_time__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_29.metric_time__day) OVER (
+        , FIRST_VALUE(subq_27.metric_time__day) OVER (
           PARTITION BY
-            subq_32.user
-            , subq_32.metric_time__day
-            , subq_32.mf_internal_uuid
-          ORDER BY subq_29.metric_time__day DESC
+            subq_30.user
+            , subq_30.metric_time__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_29.user) OVER (
+        , FIRST_VALUE(subq_27.user) OVER (
           PARTITION BY
-            subq_32.user
-            , subq_32.metric_time__day
-            , subq_32.mf_internal_uuid
-          ORDER BY subq_29.metric_time__day DESC
+            subq_30.user
+            , subq_30.metric_time__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_32.mf_internal_uuid AS mf_internal_uuid
-        , subq_32.buys AS buys
+        , subq_30.mf_internal_uuid AS mf_internal_uuid
+        , subq_30.buys AS buys
       FROM (
         -- Constrain Output with WHERE
         -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user']
         SELECT
           metric_time__day
-          , subq_27.user
+          , subq_25.user
           , visit__referrer_id
           , visits
         FROM (
-          -- Read Elements From Semantic Model 'visits_source'
-          -- Metric Time Dimension 'ds'
-          -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
+          -- Read From CTE For node_id=ctr_0
           SELECT
-            DATE_TRUNC('day', ds) AS metric_time__day
-            , user_id AS user
-            , referrer_id AS visit__referrer_id
-            , 1 AS visits
-          FROM ***************************.fct_visits visits_source_src_28000
-          WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
-        ) subq_27
+            metric_time__day
+            , ctr_0_cte.user
+            , visit__referrer_id
+            , visits
+          FROM ctr_0_cte ctr_0_cte
+        ) subq_25
         WHERE visit__referrer_id = 'ref_id_01'
-      ) subq_29
+      ) subq_27
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -111,19 +120,19 @@ FROM (
           , 1 AS buys
           , GEN_RANDOM_UUID() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_32
+      ) subq_30
       ON
         (
-          subq_29.user = subq_32.user
+          subq_27.user = subq_30.user
         ) AND (
-          (subq_29.metric_time__day <= subq_32.metric_time__day)
+          (subq_27.metric_time__day <= subq_30.metric_time__day)
         )
-    ) subq_33
+    ) subq_31
     GROUP BY
       visit__referrer_id
-  ) subq_36
+  ) subq_34
   ON
-    subq_24.visit__referrer_id = subq_36.visit__referrer_id
+    subq_24.visit__referrer_id = subq_34.visit__referrer_id
   GROUP BY
-    COALESCE(subq_24.visit__referrer_id, subq_36.visit__referrer_id)
-) subq_37
+    COALESCE(subq_24.visit__referrer_id, subq_34.visit__referrer_id)
+) subq_35

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Postgres/test_conversion_metric_with_window__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Postgres/test_conversion_metric_with_window__plan0_optimized.sql
@@ -5,15 +5,25 @@ docstring:
 sql_engine: Postgres
 ---
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
-  metric_time__day
+  metric_time__day AS metric_time__day
   , CAST(buys AS DOUBLE PRECISION) / CAST(NULLIF(visits, 0) AS DOUBLE PRECISION) AS visit_buy_conversion_rate_7days
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_21.metric_time__day, subq_32.metric_time__day) AS metric_time__day
+    COALESCE(subq_21.metric_time__day, subq_31.metric_time__day) AS metric_time__day
     , MAX(subq_21.visits) AS visits
-    , MAX(subq_32.buys) AS buys
+    , MAX(subq_31.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['visits', 'metric_time__day']
@@ -22,12 +32,12 @@ FROM (
       metric_time__day
       , SUM(visits) AS visits
     FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
+      -- Read From CTE For node_id=sma_28019
       SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
+        metric_time__day
+        , sma_28019_cte.user
+        , visits
+      FROM sma_28019_cte sma_28019_cte
     ) subq_18
     WHERE metric_time__day = '2020-01-01'
     GROUP BY
@@ -43,50 +53,49 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_25.visits) OVER (
+        FIRST_VALUE(subq_24.visits) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_25.metric_time__day) OVER (
+        , FIRST_VALUE(subq_24.metric_time__day) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_25.user) OVER (
+        , FIRST_VALUE(subq_24.user) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_28.mf_internal_uuid AS mf_internal_uuid
-        , subq_28.buys AS buys
+        , subq_27.mf_internal_uuid AS mf_internal_uuid
+        , subq_27.buys AS buys
       FROM (
         -- Constrain Output with WHERE
         -- Pass Only Elements: ['visits', 'metric_time__day', 'user']
         SELECT
           metric_time__day
-          , subq_23.user
+          , subq_22.user
           , visits
         FROM (
-          -- Read Elements From Semantic Model 'visits_source'
-          -- Metric Time Dimension 'ds'
+          -- Read From CTE For node_id=sma_28019
           SELECT
-            DATE_TRUNC('day', ds) AS metric_time__day
-            , user_id AS user
-            , 1 AS visits
-          FROM ***************************.fct_visits visits_source_src_28000
-        ) subq_23
+            metric_time__day
+            , sma_28019_cte.user
+            , visits
+          FROM sma_28019_cte sma_28019_cte
+        ) subq_22
         WHERE metric_time__day = '2020-01-01'
-      ) subq_25
+      ) subq_24
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -97,23 +106,23 @@ FROM (
           , 1 AS buys
           , GEN_RANDOM_UUID() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_28
+      ) subq_27
       ON
         (
-          subq_25.user = subq_28.user
+          subq_24.user = subq_27.user
         ) AND (
           (
-            subq_25.metric_time__day <= subq_28.metric_time__day
+            subq_24.metric_time__day <= subq_27.metric_time__day
           ) AND (
-            subq_25.metric_time__day > subq_28.metric_time__day - MAKE_INTERVAL(days => 7)
+            subq_24.metric_time__day > subq_27.metric_time__day - MAKE_INTERVAL(days => 7)
           )
         )
-    ) subq_29
+    ) subq_28
     GROUP BY
       metric_time__day
-  ) subq_32
+  ) subq_31
   ON
-    subq_21.metric_time__day = subq_32.metric_time__day
+    subq_21.metric_time__day = subq_31.metric_time__day
   GROUP BY
-    COALESCE(subq_21.metric_time__day, subq_32.metric_time__day)
-) subq_33
+    COALESCE(subq_21.metric_time__day, subq_31.metric_time__day)
+) subq_32

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Postgres/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Postgres/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
@@ -5,17 +5,30 @@ docstring:
 sql_engine: Postgres
 ---
 -- Compute Metrics via Expressions
+WITH ctr_0_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , referrer_id AS visit__referrer_id
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+  WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
+)
+
 SELECT
-  metric_time__day
-  , visit__referrer_id
+  metric_time__day AS metric_time__day
+  , visit__referrer_id AS visit__referrer_id
   , CAST(buys AS DOUBLE PRECISION) / CAST(NULLIF(visits, 0) AS DOUBLE PRECISION) AS visit_buy_conversion_rate_7days
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_24.metric_time__day, subq_36.metric_time__day) AS metric_time__day
-    , COALESCE(subq_24.visit__referrer_id, subq_36.visit__referrer_id) AS visit__referrer_id
+    COALESCE(subq_24.metric_time__day, subq_34.metric_time__day) AS metric_time__day
+    , COALESCE(subq_24.visit__referrer_id, subq_34.visit__referrer_id) AS visit__referrer_id
     , MAX(subq_24.visits) AS visits
-    , MAX(subq_36.buys) AS buys
+    , MAX(subq_34.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
@@ -25,15 +38,13 @@ FROM (
       , visit__referrer_id
       , SUM(visits) AS visits
     FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
-      -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
+      -- Read From CTE For node_id=ctr_0
       SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , referrer_id AS visit__referrer_id
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
-      WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
+        metric_time__day
+        , ctr_0_cte.user
+        , visit__referrer_id
+        , visits
+      FROM ctr_0_cte ctr_0_cte
     ) subq_21
     WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
@@ -51,62 +62,59 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_29.visits) OVER (
+        FIRST_VALUE(subq_27.visits) OVER (
           PARTITION BY
-            subq_32.user
-            , subq_32.metric_time__day
-            , subq_32.mf_internal_uuid
-          ORDER BY subq_29.metric_time__day DESC
+            subq_30.user
+            , subq_30.metric_time__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_29.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_27.visit__referrer_id) OVER (
           PARTITION BY
-            subq_32.user
-            , subq_32.metric_time__day
-            , subq_32.mf_internal_uuid
-          ORDER BY subq_29.metric_time__day DESC
+            subq_30.user
+            , subq_30.metric_time__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_29.metric_time__day) OVER (
+        , FIRST_VALUE(subq_27.metric_time__day) OVER (
           PARTITION BY
-            subq_32.user
-            , subq_32.metric_time__day
-            , subq_32.mf_internal_uuid
-          ORDER BY subq_29.metric_time__day DESC
+            subq_30.user
+            , subq_30.metric_time__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_29.user) OVER (
+        , FIRST_VALUE(subq_27.user) OVER (
           PARTITION BY
-            subq_32.user
-            , subq_32.metric_time__day
-            , subq_32.mf_internal_uuid
-          ORDER BY subq_29.metric_time__day DESC
+            subq_30.user
+            , subq_30.metric_time__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_32.mf_internal_uuid AS mf_internal_uuid
-        , subq_32.buys AS buys
+        , subq_30.mf_internal_uuid AS mf_internal_uuid
+        , subq_30.buys AS buys
       FROM (
         -- Constrain Output with WHERE
         -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user']
         SELECT
           metric_time__day
-          , subq_27.user
+          , subq_25.user
           , visit__referrer_id
           , visits
         FROM (
-          -- Read Elements From Semantic Model 'visits_source'
-          -- Metric Time Dimension 'ds'
-          -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
+          -- Read From CTE For node_id=ctr_0
           SELECT
-            DATE_TRUNC('day', ds) AS metric_time__day
-            , user_id AS user
-            , referrer_id AS visit__referrer_id
-            , 1 AS visits
-          FROM ***************************.fct_visits visits_source_src_28000
-          WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
-        ) subq_27
+            metric_time__day
+            , ctr_0_cte.user
+            , visit__referrer_id
+            , visits
+          FROM ctr_0_cte ctr_0_cte
+        ) subq_25
         WHERE visit__referrer_id = 'ref_id_01'
-      ) subq_29
+      ) subq_27
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -117,29 +125,29 @@ FROM (
           , 1 AS buys
           , GEN_RANDOM_UUID() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_32
+      ) subq_30
       ON
         (
-          subq_29.user = subq_32.user
+          subq_27.user = subq_30.user
         ) AND (
           (
-            subq_29.metric_time__day <= subq_32.metric_time__day
+            subq_27.metric_time__day <= subq_30.metric_time__day
           ) AND (
-            subq_29.metric_time__day > subq_32.metric_time__day - MAKE_INTERVAL(days => 7)
+            subq_27.metric_time__day > subq_30.metric_time__day - MAKE_INTERVAL(days => 7)
           )
         )
-    ) subq_33
+    ) subq_31
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_36
+  ) subq_34
   ON
     (
-      subq_24.visit__referrer_id = subq_36.visit__referrer_id
+      subq_24.visit__referrer_id = subq_34.visit__referrer_id
     ) AND (
-      subq_24.metric_time__day = subq_36.metric_time__day
+      subq_24.metric_time__day = subq_34.metric_time__day
     )
   GROUP BY
-    COALESCE(subq_24.metric_time__day, subq_36.metric_time__day)
-    , COALESCE(subq_24.visit__referrer_id, subq_36.visit__referrer_id)
-) subq_37
+    COALESCE(subq_24.metric_time__day, subq_34.metric_time__day)
+    , COALESCE(subq_24.visit__referrer_id, subq_34.visit__referrer_id)
+) subq_35

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Redshift/test_conversion_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Redshift/test_conversion_metric__plan0_optimized.sql
@@ -5,15 +5,25 @@ docstring:
 sql_engine: Redshift
 ---
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
-  metric_time__day
+  metric_time__day AS metric_time__day
   , CAST(buys AS DOUBLE PRECISION) / CAST(NULLIF(visits, 0) AS DOUBLE PRECISION) AS visit_buy_conversion_rate
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_21.metric_time__day, subq_32.metric_time__day) AS metric_time__day
+    COALESCE(subq_21.metric_time__day, subq_31.metric_time__day) AS metric_time__day
     , MAX(subq_21.visits) AS visits
-    , MAX(subq_32.buys) AS buys
+    , MAX(subq_31.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['visits', 'metric_time__day']
@@ -22,12 +32,12 @@ FROM (
       metric_time__day
       , SUM(visits) AS visits
     FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
+      -- Read From CTE For node_id=sma_28019
       SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
+        metric_time__day
+        , sma_28019_cte.user
+        , visits
+      FROM sma_28019_cte sma_28019_cte
     ) subq_18
     WHERE metric_time__day = '2020-01-01'
     GROUP BY
@@ -43,50 +53,49 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_25.visits) OVER (
+        FIRST_VALUE(subq_24.visits) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_25.metric_time__day) OVER (
+        , FIRST_VALUE(subq_24.metric_time__day) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_25.user) OVER (
+        , FIRST_VALUE(subq_24.user) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_28.mf_internal_uuid AS mf_internal_uuid
-        , subq_28.buys AS buys
+        , subq_27.mf_internal_uuid AS mf_internal_uuid
+        , subq_27.buys AS buys
       FROM (
         -- Constrain Output with WHERE
         -- Pass Only Elements: ['visits', 'metric_time__day', 'user']
         SELECT
           metric_time__day
-          , subq_23.user
+          , subq_22.user
           , visits
         FROM (
-          -- Read Elements From Semantic Model 'visits_source'
-          -- Metric Time Dimension 'ds'
+          -- Read From CTE For node_id=sma_28019
           SELECT
-            DATE_TRUNC('day', ds) AS metric_time__day
-            , user_id AS user
-            , 1 AS visits
-          FROM ***************************.fct_visits visits_source_src_28000
-        ) subq_23
+            metric_time__day
+            , sma_28019_cte.user
+            , visits
+          FROM sma_28019_cte sma_28019_cte
+        ) subq_22
         WHERE metric_time__day = '2020-01-01'
-      ) subq_25
+      ) subq_24
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -97,19 +106,19 @@ FROM (
           , 1 AS buys
           , CONCAT(CAST(RANDOM()*100000000 AS INT)::VARCHAR,CAST(RANDOM()*100000000 AS INT)::VARCHAR) AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_28
+      ) subq_27
       ON
         (
-          subq_25.user = subq_28.user
+          subq_24.user = subq_27.user
         ) AND (
-          (subq_25.metric_time__day <= subq_28.metric_time__day)
+          (subq_24.metric_time__day <= subq_27.metric_time__day)
         )
-    ) subq_29
+    ) subq_28
     GROUP BY
       metric_time__day
-  ) subq_32
+  ) subq_31
   ON
-    subq_21.metric_time__day = subq_32.metric_time__day
+    subq_21.metric_time__day = subq_31.metric_time__day
   GROUP BY
-    COALESCE(subq_21.metric_time__day, subq_32.metric_time__day)
-) subq_33
+    COALESCE(subq_21.metric_time__day, subq_31.metric_time__day)
+) subq_32

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Redshift/test_conversion_metric_with_categorical_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Redshift/test_conversion_metric_with_categorical_filter__plan0_optimized.sql
@@ -5,17 +5,28 @@ docstring:
 sql_engine: Redshift
 ---
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , referrer_id AS visit__referrer_id
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
-  metric_time__day
-  , visit__referrer_id
+  metric_time__day AS metric_time__day
+  , visit__referrer_id AS visit__referrer_id
   , CAST(buys AS DOUBLE PRECISION) / CAST(NULLIF(visits, 0) AS DOUBLE PRECISION) AS visit_buy_conversion_rate
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_21.metric_time__day, subq_32.metric_time__day) AS metric_time__day
-    , COALESCE(subq_21.visit__referrer_id, subq_32.visit__referrer_id) AS visit__referrer_id
+    COALESCE(subq_21.metric_time__day, subq_31.metric_time__day) AS metric_time__day
+    , COALESCE(subq_21.visit__referrer_id, subq_31.visit__referrer_id) AS visit__referrer_id
     , MAX(subq_21.visits) AS visits
-    , MAX(subq_32.buys) AS buys
+    , MAX(subq_31.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
@@ -25,13 +36,13 @@ FROM (
       , visit__referrer_id
       , SUM(visits) AS visits
     FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
+      -- Read From CTE For node_id=sma_28019
       SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , referrer_id AS visit__referrer_id
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
+        metric_time__day
+        , sma_28019_cte.user
+        , visit__referrer_id
+        , visits
+      FROM sma_28019_cte sma_28019_cte
     ) subq_18
     WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
@@ -49,60 +60,59 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_25.visits) OVER (
+        FIRST_VALUE(subq_24.visits) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_25.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_24.visit__referrer_id) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_25.metric_time__day) OVER (
+        , FIRST_VALUE(subq_24.metric_time__day) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_25.user) OVER (
+        , FIRST_VALUE(subq_24.user) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_28.mf_internal_uuid AS mf_internal_uuid
-        , subq_28.buys AS buys
+        , subq_27.mf_internal_uuid AS mf_internal_uuid
+        , subq_27.buys AS buys
       FROM (
         -- Constrain Output with WHERE
         -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user']
         SELECT
           metric_time__day
-          , subq_23.user
+          , subq_22.user
           , visit__referrer_id
           , visits
         FROM (
-          -- Read Elements From Semantic Model 'visits_source'
-          -- Metric Time Dimension 'ds'
+          -- Read From CTE For node_id=sma_28019
           SELECT
-            DATE_TRUNC('day', ds) AS metric_time__day
-            , user_id AS user
-            , referrer_id AS visit__referrer_id
-            , 1 AS visits
-          FROM ***************************.fct_visits visits_source_src_28000
-        ) subq_23
+            metric_time__day
+            , sma_28019_cte.user
+            , visit__referrer_id
+            , visits
+          FROM sma_28019_cte sma_28019_cte
+        ) subq_22
         WHERE visit__referrer_id = 'ref_id_01'
-      ) subq_25
+      ) subq_24
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -113,25 +123,25 @@ FROM (
           , 1 AS buys
           , CONCAT(CAST(RANDOM()*100000000 AS INT)::VARCHAR,CAST(RANDOM()*100000000 AS INT)::VARCHAR) AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_28
+      ) subq_27
       ON
         (
-          subq_25.user = subq_28.user
+          subq_24.user = subq_27.user
         ) AND (
-          (subq_25.metric_time__day <= subq_28.metric_time__day)
+          (subq_24.metric_time__day <= subq_27.metric_time__day)
         )
-    ) subq_29
+    ) subq_28
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_32
+  ) subq_31
   ON
     (
-      subq_21.visit__referrer_id = subq_32.visit__referrer_id
+      subq_21.visit__referrer_id = subq_31.visit__referrer_id
     ) AND (
-      subq_21.metric_time__day = subq_32.metric_time__day
+      subq_21.metric_time__day = subq_31.metric_time__day
     )
   GROUP BY
-    COALESCE(subq_21.metric_time__day, subq_32.metric_time__day)
-    , COALESCE(subq_21.visit__referrer_id, subq_32.visit__referrer_id)
-) subq_33
+    COALESCE(subq_21.metric_time__day, subq_31.metric_time__day)
+    , COALESCE(subq_21.visit__referrer_id, subq_31.visit__referrer_id)
+) subq_32

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Redshift/test_conversion_metric_with_different_time_dimension_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Redshift/test_conversion_metric_with_different_time_dimension_grains__plan0_optimized.sql
@@ -6,16 +6,25 @@ sql_engine: Redshift
 ---
 -- Combine Aggregated Outputs
 -- Compute Metrics via Expressions
-SELECT
-  CAST(MAX(subq_28.buys_month) AS DOUBLE PRECISION) / CAST(NULLIF(MAX(subq_18.visits), 0) AS DOUBLE PRECISION) AS visit_buy_conversion_rate_with_monthly_conversion
-FROM (
+WITH sma_28019_cte AS (
   -- Read Elements From Semantic Model 'visits_source'
   -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('month', ds) AS metric_time__month
+    , user_id AS user
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
+SELECT
+  CAST(MAX(subq_27.buys_month) AS DOUBLE PRECISION) / CAST(NULLIF(MAX(subq_18.visits), 0) AS DOUBLE PRECISION) AS visit_buy_conversion_rate_with_monthly_conversion
+FROM (
+  -- Read From CTE For node_id=sma_28019
   -- Pass Only Elements: ['visits',]
   -- Aggregate Measures
   SELECT
-    SUM(1) AS visits
-  FROM ***************************.fct_visits visits_source_src_28000
+    SUM(visits) AS visits
+  FROM sma_28019_cte sma_28019_cte
 ) subq_18
 CROSS JOIN (
   -- Find conversions for user within the range of 1 month
@@ -26,42 +35,33 @@ CROSS JOIN (
   FROM (
     -- Dedupe the fanout with mf_internal_uuid in the conversion data set
     SELECT DISTINCT
-      FIRST_VALUE(subq_21.visits) OVER (
+      FIRST_VALUE(sma_28019_cte.visits) OVER (
         PARTITION BY
-          subq_24.user
-          , subq_24.metric_time__month
-          , subq_24.mf_internal_uuid
-        ORDER BY subq_21.metric_time__month DESC
+          subq_23.user
+          , subq_23.metric_time__month
+          , subq_23.mf_internal_uuid
+        ORDER BY sma_28019_cte.metric_time__month DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS visits
-      , FIRST_VALUE(subq_21.metric_time__month) OVER (
+      , FIRST_VALUE(sma_28019_cte.metric_time__month) OVER (
         PARTITION BY
-          subq_24.user
-          , subq_24.metric_time__month
-          , subq_24.mf_internal_uuid
-        ORDER BY subq_21.metric_time__month DESC
+          subq_23.user
+          , subq_23.metric_time__month
+          , subq_23.mf_internal_uuid
+        ORDER BY sma_28019_cte.metric_time__month DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS metric_time__month
-      , FIRST_VALUE(subq_21.user) OVER (
+      , FIRST_VALUE(sma_28019_cte.user) OVER (
         PARTITION BY
-          subq_24.user
-          , subq_24.metric_time__month
-          , subq_24.mf_internal_uuid
-        ORDER BY subq_21.metric_time__month DESC
+          subq_23.user
+          , subq_23.metric_time__month
+          , subq_23.mf_internal_uuid
+        ORDER BY sma_28019_cte.metric_time__month DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS user
-      , subq_24.mf_internal_uuid AS mf_internal_uuid
-      , subq_24.buys_month AS buys_month
-    FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['visits', 'metric_time__month', 'user']
-      SELECT
-        DATE_TRUNC('month', ds) AS metric_time__month
-        , user_id AS user
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
-    ) subq_21
+      , subq_23.mf_internal_uuid AS mf_internal_uuid
+      , subq_23.buys_month AS buys_month
+    FROM sma_28019_cte sma_28019_cte
     INNER JOIN (
       -- Read Elements From Semantic Model 'buys_source'
       -- Metric Time Dimension 'ds_month'
@@ -72,16 +72,16 @@ CROSS JOIN (
         , 1 AS buys_month
         , CONCAT(CAST(RANDOM()*100000000 AS INT)::VARCHAR,CAST(RANDOM()*100000000 AS INT)::VARCHAR) AS mf_internal_uuid
       FROM ***************************.fct_buys buys_source_src_28000
-    ) subq_24
+    ) subq_23
     ON
       (
-        subq_21.user = subq_24.user
+        sma_28019_cte.user = subq_23.user
       ) AND (
         (
-          subq_21.metric_time__month <= subq_24.metric_time__month
+          sma_28019_cte.metric_time__month <= subq_23.metric_time__month
         ) AND (
-          subq_21.metric_time__month > DATEADD(month, -1, subq_24.metric_time__month)
+          sma_28019_cte.metric_time__month > DATEADD(month, -1, subq_23.metric_time__month)
         )
       )
-  ) subq_25
-) subq_28
+  ) subq_24
+) subq_27

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Redshift/test_conversion_metric_with_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Redshift/test_conversion_metric_with_filter__plan0_optimized.sql
@@ -6,8 +6,18 @@ sql_engine: Redshift
 ---
 -- Combine Aggregated Outputs
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
-  CAST(MAX(subq_32.buys) AS DOUBLE PRECISION) / CAST(NULLIF(MAX(subq_21.visits), 0) AS DOUBLE PRECISION) AS visit_buy_conversion_rate
+  CAST(MAX(subq_31.buys) AS DOUBLE PRECISION) / CAST(NULLIF(MAX(subq_21.visits), 0) AS DOUBLE PRECISION) AS visit_buy_conversion_rate
 FROM (
   -- Constrain Output with WHERE
   -- Pass Only Elements: ['visits',]
@@ -15,12 +25,12 @@ FROM (
   SELECT
     SUM(visits) AS visits
   FROM (
-    -- Read Elements From Semantic Model 'visits_source'
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28019
     SELECT
-      DATE_TRUNC('day', ds) AS metric_time__day
-      , 1 AS visits
-    FROM ***************************.fct_visits visits_source_src_28000
+      metric_time__day
+      , sma_28019_cte.user
+      , visits
+    FROM sma_28019_cte sma_28019_cte
   ) subq_18
   WHERE metric_time__day = '2020-01-01'
 ) subq_21
@@ -33,50 +43,49 @@ CROSS JOIN (
   FROM (
     -- Dedupe the fanout with mf_internal_uuid in the conversion data set
     SELECT DISTINCT
-      FIRST_VALUE(subq_25.visits) OVER (
+      FIRST_VALUE(subq_24.visits) OVER (
         PARTITION BY
-          subq_28.user
-          , subq_28.metric_time__day
-          , subq_28.mf_internal_uuid
-        ORDER BY subq_25.metric_time__day DESC
+          subq_27.user
+          , subq_27.metric_time__day
+          , subq_27.mf_internal_uuid
+        ORDER BY subq_24.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS visits
-      , FIRST_VALUE(subq_25.metric_time__day) OVER (
+      , FIRST_VALUE(subq_24.metric_time__day) OVER (
         PARTITION BY
-          subq_28.user
-          , subq_28.metric_time__day
-          , subq_28.mf_internal_uuid
-        ORDER BY subq_25.metric_time__day DESC
+          subq_27.user
+          , subq_27.metric_time__day
+          , subq_27.mf_internal_uuid
+        ORDER BY subq_24.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS metric_time__day
-      , FIRST_VALUE(subq_25.user) OVER (
+      , FIRST_VALUE(subq_24.user) OVER (
         PARTITION BY
-          subq_28.user
-          , subq_28.metric_time__day
-          , subq_28.mf_internal_uuid
-        ORDER BY subq_25.metric_time__day DESC
+          subq_27.user
+          , subq_27.metric_time__day
+          , subq_27.mf_internal_uuid
+        ORDER BY subq_24.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS user
-      , subq_28.mf_internal_uuid AS mf_internal_uuid
-      , subq_28.buys AS buys
+      , subq_27.mf_internal_uuid AS mf_internal_uuid
+      , subq_27.buys AS buys
     FROM (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['visits', 'metric_time__day', 'user']
       SELECT
         metric_time__day
-        , subq_23.user
+        , subq_22.user
         , visits
       FROM (
-        -- Read Elements From Semantic Model 'visits_source'
-        -- Metric Time Dimension 'ds'
+        -- Read From CTE For node_id=sma_28019
         SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , user_id AS user
-          , 1 AS visits
-        FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_23
+          metric_time__day
+          , sma_28019_cte.user
+          , visits
+        FROM sma_28019_cte sma_28019_cte
+      ) subq_22
       WHERE metric_time__day = '2020-01-01'
-    ) subq_25
+    ) subq_24
     INNER JOIN (
       -- Read Elements From Semantic Model 'buys_source'
       -- Metric Time Dimension 'ds'
@@ -87,12 +96,12 @@ CROSS JOIN (
         , 1 AS buys
         , CONCAT(CAST(RANDOM()*100000000 AS INT)::VARCHAR,CAST(RANDOM()*100000000 AS INT)::VARCHAR) AS mf_internal_uuid
       FROM ***************************.fct_buys buys_source_src_28000
-    ) subq_28
+    ) subq_27
     ON
       (
-        subq_25.user = subq_28.user
+        subq_24.user = subq_27.user
       ) AND (
-        (subq_25.metric_time__day <= subq_28.metric_time__day)
+        (subq_24.metric_time__day <= subq_27.metric_time__day)
       )
-  ) subq_29
-) subq_32
+  ) subq_28
+) subq_31

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Redshift/test_conversion_metric_with_filter_not_in_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Redshift/test_conversion_metric_with_filter_not_in_group_by__plan0_optimized.sql
@@ -6,8 +6,19 @@ sql_engine: Redshift
 ---
 -- Combine Aggregated Outputs
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , referrer_id AS visit__referrer_id
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
-  COALESCE(MAX(subq_32.buys), 0) AS visit_buy_conversions
+  COALESCE(MAX(subq_31.buys), 0) AS visit_buy_conversions
 FROM (
   -- Constrain Output with WHERE
   -- Pass Only Elements: ['visits',]
@@ -15,12 +26,13 @@ FROM (
   SELECT
     SUM(visits) AS visits
   FROM (
-    -- Read Elements From Semantic Model 'visits_source'
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28019
     SELECT
-      referrer_id AS visit__referrer_id
-      , 1 AS visits
-    FROM ***************************.fct_visits visits_source_src_28000
+      metric_time__day
+      , sma_28019_cte.user
+      , visit__referrer_id
+      , visits
+    FROM sma_28019_cte sma_28019_cte
   ) subq_18
   WHERE visit__referrer_id = 'ref_id_01'
 ) subq_21
@@ -33,60 +45,59 @@ CROSS JOIN (
   FROM (
     -- Dedupe the fanout with mf_internal_uuid in the conversion data set
     SELECT DISTINCT
-      FIRST_VALUE(subq_25.visits) OVER (
+      FIRST_VALUE(subq_24.visits) OVER (
         PARTITION BY
-          subq_28.user
-          , subq_28.metric_time__day
-          , subq_28.mf_internal_uuid
-        ORDER BY subq_25.metric_time__day DESC
+          subq_27.user
+          , subq_27.metric_time__day
+          , subq_27.mf_internal_uuid
+        ORDER BY subq_24.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS visits
-      , FIRST_VALUE(subq_25.visit__referrer_id) OVER (
+      , FIRST_VALUE(subq_24.visit__referrer_id) OVER (
         PARTITION BY
-          subq_28.user
-          , subq_28.metric_time__day
-          , subq_28.mf_internal_uuid
-        ORDER BY subq_25.metric_time__day DESC
+          subq_27.user
+          , subq_27.metric_time__day
+          , subq_27.mf_internal_uuid
+        ORDER BY subq_24.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS visit__referrer_id
-      , FIRST_VALUE(subq_25.metric_time__day) OVER (
+      , FIRST_VALUE(subq_24.metric_time__day) OVER (
         PARTITION BY
-          subq_28.user
-          , subq_28.metric_time__day
-          , subq_28.mf_internal_uuid
-        ORDER BY subq_25.metric_time__day DESC
+          subq_27.user
+          , subq_27.metric_time__day
+          , subq_27.mf_internal_uuid
+        ORDER BY subq_24.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS metric_time__day
-      , FIRST_VALUE(subq_25.user) OVER (
+      , FIRST_VALUE(subq_24.user) OVER (
         PARTITION BY
-          subq_28.user
-          , subq_28.metric_time__day
-          , subq_28.mf_internal_uuid
-        ORDER BY subq_25.metric_time__day DESC
+          subq_27.user
+          , subq_27.metric_time__day
+          , subq_27.mf_internal_uuid
+        ORDER BY subq_24.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS user
-      , subq_28.mf_internal_uuid AS mf_internal_uuid
-      , subq_28.buys AS buys
+      , subq_27.mf_internal_uuid AS mf_internal_uuid
+      , subq_27.buys AS buys
     FROM (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user']
       SELECT
         metric_time__day
-        , subq_23.user
+        , subq_22.user
         , visit__referrer_id
         , visits
       FROM (
-        -- Read Elements From Semantic Model 'visits_source'
-        -- Metric Time Dimension 'ds'
+        -- Read From CTE For node_id=sma_28019
         SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , user_id AS user
-          , referrer_id AS visit__referrer_id
-          , 1 AS visits
-        FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_23
+          metric_time__day
+          , sma_28019_cte.user
+          , visit__referrer_id
+          , visits
+        FROM sma_28019_cte sma_28019_cte
+      ) subq_22
       WHERE visit__referrer_id = 'ref_id_01'
-    ) subq_25
+    ) subq_24
     INNER JOIN (
       -- Read Elements From Semantic Model 'buys_source'
       -- Metric Time Dimension 'ds'
@@ -97,16 +108,16 @@ CROSS JOIN (
         , 1 AS buys
         , CONCAT(CAST(RANDOM()*100000000 AS INT)::VARCHAR,CAST(RANDOM()*100000000 AS INT)::VARCHAR) AS mf_internal_uuid
       FROM ***************************.fct_buys buys_source_src_28000
-    ) subq_28
+    ) subq_27
     ON
       (
-        subq_25.user = subq_28.user
+        subq_24.user = subq_27.user
       ) AND (
         (
-          subq_25.metric_time__day <= subq_28.metric_time__day
+          subq_24.metric_time__day <= subq_27.metric_time__day
         ) AND (
-          subq_25.metric_time__day > DATEADD(day, -7, subq_28.metric_time__day)
+          subq_24.metric_time__day > DATEADD(day, -7, subq_27.metric_time__day)
         )
       )
-  ) subq_29
-) subq_32
+  ) subq_28
+) subq_31

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Redshift/test_conversion_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Redshift/test_conversion_metric_with_time_constraint__plan0_optimized.sql
@@ -5,15 +5,28 @@ docstring:
 sql_engine: Redshift
 ---
 -- Compute Metrics via Expressions
+WITH ctr_0_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , referrer_id AS visit__referrer_id
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+  WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
+)
+
 SELECT
-  visit__referrer_id
+  visit__referrer_id AS visit__referrer_id
   , CAST(buys AS DOUBLE PRECISION) / CAST(NULLIF(visits, 0) AS DOUBLE PRECISION) AS visit_buy_conversion_rate
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_24.visit__referrer_id, subq_36.visit__referrer_id) AS visit__referrer_id
+    COALESCE(subq_24.visit__referrer_id, subq_34.visit__referrer_id) AS visit__referrer_id
     , MAX(subq_24.visits) AS visits
-    , MAX(subq_36.buys) AS buys
+    , MAX(subq_34.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['visits', 'visit__referrer_id']
@@ -22,14 +35,13 @@ FROM (
       visit__referrer_id
       , SUM(visits) AS visits
     FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
-      -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
+      -- Read From CTE For node_id=ctr_0
       SELECT
-        referrer_id AS visit__referrer_id
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
-      WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
+        metric_time__day
+        , ctr_0_cte.user
+        , visit__referrer_id
+        , visits
+      FROM ctr_0_cte ctr_0_cte
     ) subq_21
     WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
@@ -45,62 +57,59 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_29.visits) OVER (
+        FIRST_VALUE(subq_27.visits) OVER (
           PARTITION BY
-            subq_32.user
-            , subq_32.metric_time__day
-            , subq_32.mf_internal_uuid
-          ORDER BY subq_29.metric_time__day DESC
+            subq_30.user
+            , subq_30.metric_time__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_29.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_27.visit__referrer_id) OVER (
           PARTITION BY
-            subq_32.user
-            , subq_32.metric_time__day
-            , subq_32.mf_internal_uuid
-          ORDER BY subq_29.metric_time__day DESC
+            subq_30.user
+            , subq_30.metric_time__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_29.metric_time__day) OVER (
+        , FIRST_VALUE(subq_27.metric_time__day) OVER (
           PARTITION BY
-            subq_32.user
-            , subq_32.metric_time__day
-            , subq_32.mf_internal_uuid
-          ORDER BY subq_29.metric_time__day DESC
+            subq_30.user
+            , subq_30.metric_time__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_29.user) OVER (
+        , FIRST_VALUE(subq_27.user) OVER (
           PARTITION BY
-            subq_32.user
-            , subq_32.metric_time__day
-            , subq_32.mf_internal_uuid
-          ORDER BY subq_29.metric_time__day DESC
+            subq_30.user
+            , subq_30.metric_time__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_32.mf_internal_uuid AS mf_internal_uuid
-        , subq_32.buys AS buys
+        , subq_30.mf_internal_uuid AS mf_internal_uuid
+        , subq_30.buys AS buys
       FROM (
         -- Constrain Output with WHERE
         -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user']
         SELECT
           metric_time__day
-          , subq_27.user
+          , subq_25.user
           , visit__referrer_id
           , visits
         FROM (
-          -- Read Elements From Semantic Model 'visits_source'
-          -- Metric Time Dimension 'ds'
-          -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
+          -- Read From CTE For node_id=ctr_0
           SELECT
-            DATE_TRUNC('day', ds) AS metric_time__day
-            , user_id AS user
-            , referrer_id AS visit__referrer_id
-            , 1 AS visits
-          FROM ***************************.fct_visits visits_source_src_28000
-          WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
-        ) subq_27
+            metric_time__day
+            , ctr_0_cte.user
+            , visit__referrer_id
+            , visits
+          FROM ctr_0_cte ctr_0_cte
+        ) subq_25
         WHERE visit__referrer_id = 'ref_id_01'
-      ) subq_29
+      ) subq_27
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -111,19 +120,19 @@ FROM (
           , 1 AS buys
           , CONCAT(CAST(RANDOM()*100000000 AS INT)::VARCHAR,CAST(RANDOM()*100000000 AS INT)::VARCHAR) AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_32
+      ) subq_30
       ON
         (
-          subq_29.user = subq_32.user
+          subq_27.user = subq_30.user
         ) AND (
-          (subq_29.metric_time__day <= subq_32.metric_time__day)
+          (subq_27.metric_time__day <= subq_30.metric_time__day)
         )
-    ) subq_33
+    ) subq_31
     GROUP BY
       visit__referrer_id
-  ) subq_36
+  ) subq_34
   ON
-    subq_24.visit__referrer_id = subq_36.visit__referrer_id
+    subq_24.visit__referrer_id = subq_34.visit__referrer_id
   GROUP BY
-    COALESCE(subq_24.visit__referrer_id, subq_36.visit__referrer_id)
-) subq_37
+    COALESCE(subq_24.visit__referrer_id, subq_34.visit__referrer_id)
+) subq_35

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Redshift/test_conversion_metric_with_window__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Redshift/test_conversion_metric_with_window__plan0_optimized.sql
@@ -5,15 +5,25 @@ docstring:
 sql_engine: Redshift
 ---
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
-  metric_time__day
+  metric_time__day AS metric_time__day
   , CAST(buys AS DOUBLE PRECISION) / CAST(NULLIF(visits, 0) AS DOUBLE PRECISION) AS visit_buy_conversion_rate_7days
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_21.metric_time__day, subq_32.metric_time__day) AS metric_time__day
+    COALESCE(subq_21.metric_time__day, subq_31.metric_time__day) AS metric_time__day
     , MAX(subq_21.visits) AS visits
-    , MAX(subq_32.buys) AS buys
+    , MAX(subq_31.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['visits', 'metric_time__day']
@@ -22,12 +32,12 @@ FROM (
       metric_time__day
       , SUM(visits) AS visits
     FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
+      -- Read From CTE For node_id=sma_28019
       SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
+        metric_time__day
+        , sma_28019_cte.user
+        , visits
+      FROM sma_28019_cte sma_28019_cte
     ) subq_18
     WHERE metric_time__day = '2020-01-01'
     GROUP BY
@@ -43,50 +53,49 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_25.visits) OVER (
+        FIRST_VALUE(subq_24.visits) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_25.metric_time__day) OVER (
+        , FIRST_VALUE(subq_24.metric_time__day) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_25.user) OVER (
+        , FIRST_VALUE(subq_24.user) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_28.mf_internal_uuid AS mf_internal_uuid
-        , subq_28.buys AS buys
+        , subq_27.mf_internal_uuid AS mf_internal_uuid
+        , subq_27.buys AS buys
       FROM (
         -- Constrain Output with WHERE
         -- Pass Only Elements: ['visits', 'metric_time__day', 'user']
         SELECT
           metric_time__day
-          , subq_23.user
+          , subq_22.user
           , visits
         FROM (
-          -- Read Elements From Semantic Model 'visits_source'
-          -- Metric Time Dimension 'ds'
+          -- Read From CTE For node_id=sma_28019
           SELECT
-            DATE_TRUNC('day', ds) AS metric_time__day
-            , user_id AS user
-            , 1 AS visits
-          FROM ***************************.fct_visits visits_source_src_28000
-        ) subq_23
+            metric_time__day
+            , sma_28019_cte.user
+            , visits
+          FROM sma_28019_cte sma_28019_cte
+        ) subq_22
         WHERE metric_time__day = '2020-01-01'
-      ) subq_25
+      ) subq_24
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -97,23 +106,23 @@ FROM (
           , 1 AS buys
           , CONCAT(CAST(RANDOM()*100000000 AS INT)::VARCHAR,CAST(RANDOM()*100000000 AS INT)::VARCHAR) AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_28
+      ) subq_27
       ON
         (
-          subq_25.user = subq_28.user
+          subq_24.user = subq_27.user
         ) AND (
           (
-            subq_25.metric_time__day <= subq_28.metric_time__day
+            subq_24.metric_time__day <= subq_27.metric_time__day
           ) AND (
-            subq_25.metric_time__day > DATEADD(day, -7, subq_28.metric_time__day)
+            subq_24.metric_time__day > DATEADD(day, -7, subq_27.metric_time__day)
           )
         )
-    ) subq_29
+    ) subq_28
     GROUP BY
       metric_time__day
-  ) subq_32
+  ) subq_31
   ON
-    subq_21.metric_time__day = subq_32.metric_time__day
+    subq_21.metric_time__day = subq_31.metric_time__day
   GROUP BY
-    COALESCE(subq_21.metric_time__day, subq_32.metric_time__day)
-) subq_33
+    COALESCE(subq_21.metric_time__day, subq_31.metric_time__day)
+) subq_32

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Redshift/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Redshift/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
@@ -5,17 +5,30 @@ docstring:
 sql_engine: Redshift
 ---
 -- Compute Metrics via Expressions
+WITH ctr_0_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , referrer_id AS visit__referrer_id
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+  WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
+)
+
 SELECT
-  metric_time__day
-  , visit__referrer_id
+  metric_time__day AS metric_time__day
+  , visit__referrer_id AS visit__referrer_id
   , CAST(buys AS DOUBLE PRECISION) / CAST(NULLIF(visits, 0) AS DOUBLE PRECISION) AS visit_buy_conversion_rate_7days
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_24.metric_time__day, subq_36.metric_time__day) AS metric_time__day
-    , COALESCE(subq_24.visit__referrer_id, subq_36.visit__referrer_id) AS visit__referrer_id
+    COALESCE(subq_24.metric_time__day, subq_34.metric_time__day) AS metric_time__day
+    , COALESCE(subq_24.visit__referrer_id, subq_34.visit__referrer_id) AS visit__referrer_id
     , MAX(subq_24.visits) AS visits
-    , MAX(subq_36.buys) AS buys
+    , MAX(subq_34.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
@@ -25,15 +38,13 @@ FROM (
       , visit__referrer_id
       , SUM(visits) AS visits
     FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
-      -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
+      -- Read From CTE For node_id=ctr_0
       SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , referrer_id AS visit__referrer_id
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
-      WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
+        metric_time__day
+        , ctr_0_cte.user
+        , visit__referrer_id
+        , visits
+      FROM ctr_0_cte ctr_0_cte
     ) subq_21
     WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
@@ -51,62 +62,59 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_29.visits) OVER (
+        FIRST_VALUE(subq_27.visits) OVER (
           PARTITION BY
-            subq_32.user
-            , subq_32.metric_time__day
-            , subq_32.mf_internal_uuid
-          ORDER BY subq_29.metric_time__day DESC
+            subq_30.user
+            , subq_30.metric_time__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_29.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_27.visit__referrer_id) OVER (
           PARTITION BY
-            subq_32.user
-            , subq_32.metric_time__day
-            , subq_32.mf_internal_uuid
-          ORDER BY subq_29.metric_time__day DESC
+            subq_30.user
+            , subq_30.metric_time__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_29.metric_time__day) OVER (
+        , FIRST_VALUE(subq_27.metric_time__day) OVER (
           PARTITION BY
-            subq_32.user
-            , subq_32.metric_time__day
-            , subq_32.mf_internal_uuid
-          ORDER BY subq_29.metric_time__day DESC
+            subq_30.user
+            , subq_30.metric_time__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_29.user) OVER (
+        , FIRST_VALUE(subq_27.user) OVER (
           PARTITION BY
-            subq_32.user
-            , subq_32.metric_time__day
-            , subq_32.mf_internal_uuid
-          ORDER BY subq_29.metric_time__day DESC
+            subq_30.user
+            , subq_30.metric_time__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_32.mf_internal_uuid AS mf_internal_uuid
-        , subq_32.buys AS buys
+        , subq_30.mf_internal_uuid AS mf_internal_uuid
+        , subq_30.buys AS buys
       FROM (
         -- Constrain Output with WHERE
         -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user']
         SELECT
           metric_time__day
-          , subq_27.user
+          , subq_25.user
           , visit__referrer_id
           , visits
         FROM (
-          -- Read Elements From Semantic Model 'visits_source'
-          -- Metric Time Dimension 'ds'
-          -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
+          -- Read From CTE For node_id=ctr_0
           SELECT
-            DATE_TRUNC('day', ds) AS metric_time__day
-            , user_id AS user
-            , referrer_id AS visit__referrer_id
-            , 1 AS visits
-          FROM ***************************.fct_visits visits_source_src_28000
-          WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
-        ) subq_27
+            metric_time__day
+            , ctr_0_cte.user
+            , visit__referrer_id
+            , visits
+          FROM ctr_0_cte ctr_0_cte
+        ) subq_25
         WHERE visit__referrer_id = 'ref_id_01'
-      ) subq_29
+      ) subq_27
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -117,29 +125,29 @@ FROM (
           , 1 AS buys
           , CONCAT(CAST(RANDOM()*100000000 AS INT)::VARCHAR,CAST(RANDOM()*100000000 AS INT)::VARCHAR) AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_32
+      ) subq_30
       ON
         (
-          subq_29.user = subq_32.user
+          subq_27.user = subq_30.user
         ) AND (
           (
-            subq_29.metric_time__day <= subq_32.metric_time__day
+            subq_27.metric_time__day <= subq_30.metric_time__day
           ) AND (
-            subq_29.metric_time__day > DATEADD(day, -7, subq_32.metric_time__day)
+            subq_27.metric_time__day > DATEADD(day, -7, subq_30.metric_time__day)
           )
         )
-    ) subq_33
+    ) subq_31
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_36
+  ) subq_34
   ON
     (
-      subq_24.visit__referrer_id = subq_36.visit__referrer_id
+      subq_24.visit__referrer_id = subq_34.visit__referrer_id
     ) AND (
-      subq_24.metric_time__day = subq_36.metric_time__day
+      subq_24.metric_time__day = subq_34.metric_time__day
     )
   GROUP BY
-    COALESCE(subq_24.metric_time__day, subq_36.metric_time__day)
-    , COALESCE(subq_24.visit__referrer_id, subq_36.visit__referrer_id)
-) subq_37
+    COALESCE(subq_24.metric_time__day, subq_34.metric_time__day)
+    , COALESCE(subq_24.visit__referrer_id, subq_34.visit__referrer_id)
+) subq_35

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Snowflake/test_conversion_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Snowflake/test_conversion_metric__plan0_optimized.sql
@@ -5,15 +5,25 @@ docstring:
 sql_engine: Snowflake
 ---
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
-  metric_time__day
+  metric_time__day AS metric_time__day
   , CAST(buys AS DOUBLE) / CAST(NULLIF(visits, 0) AS DOUBLE) AS visit_buy_conversion_rate
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_21.metric_time__day, subq_32.metric_time__day) AS metric_time__day
+    COALESCE(subq_21.metric_time__day, subq_31.metric_time__day) AS metric_time__day
     , MAX(subq_21.visits) AS visits
-    , MAX(subq_32.buys) AS buys
+    , MAX(subq_31.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['visits', 'metric_time__day']
@@ -22,12 +32,12 @@ FROM (
       metric_time__day
       , SUM(visits) AS visits
     FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
+      -- Read From CTE For node_id=sma_28019
       SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
+        metric_time__day
+        , sma_28019_cte.user
+        , visits
+      FROM sma_28019_cte sma_28019_cte
     ) subq_18
     WHERE metric_time__day = '2020-01-01'
     GROUP BY
@@ -43,50 +53,49 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_25.visits) OVER (
+        FIRST_VALUE(subq_24.visits) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_25.metric_time__day) OVER (
+        , FIRST_VALUE(subq_24.metric_time__day) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_25.user) OVER (
+        , FIRST_VALUE(subq_24.user) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_28.mf_internal_uuid AS mf_internal_uuid
-        , subq_28.buys AS buys
+        , subq_27.mf_internal_uuid AS mf_internal_uuid
+        , subq_27.buys AS buys
       FROM (
         -- Constrain Output with WHERE
         -- Pass Only Elements: ['visits', 'metric_time__day', 'user']
         SELECT
           metric_time__day
-          , subq_23.user
+          , subq_22.user
           , visits
         FROM (
-          -- Read Elements From Semantic Model 'visits_source'
-          -- Metric Time Dimension 'ds'
+          -- Read From CTE For node_id=sma_28019
           SELECT
-            DATE_TRUNC('day', ds) AS metric_time__day
-            , user_id AS user
-            , 1 AS visits
-          FROM ***************************.fct_visits visits_source_src_28000
-        ) subq_23
+            metric_time__day
+            , sma_28019_cte.user
+            , visits
+          FROM sma_28019_cte sma_28019_cte
+        ) subq_22
         WHERE metric_time__day = '2020-01-01'
-      ) subq_25
+      ) subq_24
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -97,19 +106,19 @@ FROM (
           , 1 AS buys
           , UUID_STRING() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_28
+      ) subq_27
       ON
         (
-          subq_25.user = subq_28.user
+          subq_24.user = subq_27.user
         ) AND (
-          (subq_25.metric_time__day <= subq_28.metric_time__day)
+          (subq_24.metric_time__day <= subq_27.metric_time__day)
         )
-    ) subq_29
+    ) subq_28
     GROUP BY
       metric_time__day
-  ) subq_32
+  ) subq_31
   ON
-    subq_21.metric_time__day = subq_32.metric_time__day
+    subq_21.metric_time__day = subq_31.metric_time__day
   GROUP BY
-    COALESCE(subq_21.metric_time__day, subq_32.metric_time__day)
-) subq_33
+    COALESCE(subq_21.metric_time__day, subq_31.metric_time__day)
+) subq_32

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Snowflake/test_conversion_metric_with_categorical_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Snowflake/test_conversion_metric_with_categorical_filter__plan0_optimized.sql
@@ -5,17 +5,28 @@ docstring:
 sql_engine: Snowflake
 ---
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , referrer_id AS visit__referrer_id
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
-  metric_time__day
-  , visit__referrer_id
+  metric_time__day AS metric_time__day
+  , visit__referrer_id AS visit__referrer_id
   , CAST(buys AS DOUBLE) / CAST(NULLIF(visits, 0) AS DOUBLE) AS visit_buy_conversion_rate
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_21.metric_time__day, subq_32.metric_time__day) AS metric_time__day
-    , COALESCE(subq_21.visit__referrer_id, subq_32.visit__referrer_id) AS visit__referrer_id
+    COALESCE(subq_21.metric_time__day, subq_31.metric_time__day) AS metric_time__day
+    , COALESCE(subq_21.visit__referrer_id, subq_31.visit__referrer_id) AS visit__referrer_id
     , MAX(subq_21.visits) AS visits
-    , MAX(subq_32.buys) AS buys
+    , MAX(subq_31.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
@@ -25,13 +36,13 @@ FROM (
       , visit__referrer_id
       , SUM(visits) AS visits
     FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
+      -- Read From CTE For node_id=sma_28019
       SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , referrer_id AS visit__referrer_id
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
+        metric_time__day
+        , sma_28019_cte.user
+        , visit__referrer_id
+        , visits
+      FROM sma_28019_cte sma_28019_cte
     ) subq_18
     WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
@@ -49,60 +60,59 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_25.visits) OVER (
+        FIRST_VALUE(subq_24.visits) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_25.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_24.visit__referrer_id) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_25.metric_time__day) OVER (
+        , FIRST_VALUE(subq_24.metric_time__day) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_25.user) OVER (
+        , FIRST_VALUE(subq_24.user) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_28.mf_internal_uuid AS mf_internal_uuid
-        , subq_28.buys AS buys
+        , subq_27.mf_internal_uuid AS mf_internal_uuid
+        , subq_27.buys AS buys
       FROM (
         -- Constrain Output with WHERE
         -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user']
         SELECT
           metric_time__day
-          , subq_23.user
+          , subq_22.user
           , visit__referrer_id
           , visits
         FROM (
-          -- Read Elements From Semantic Model 'visits_source'
-          -- Metric Time Dimension 'ds'
+          -- Read From CTE For node_id=sma_28019
           SELECT
-            DATE_TRUNC('day', ds) AS metric_time__day
-            , user_id AS user
-            , referrer_id AS visit__referrer_id
-            , 1 AS visits
-          FROM ***************************.fct_visits visits_source_src_28000
-        ) subq_23
+            metric_time__day
+            , sma_28019_cte.user
+            , visit__referrer_id
+            , visits
+          FROM sma_28019_cte sma_28019_cte
+        ) subq_22
         WHERE visit__referrer_id = 'ref_id_01'
-      ) subq_25
+      ) subq_24
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -113,25 +123,25 @@ FROM (
           , 1 AS buys
           , UUID_STRING() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_28
+      ) subq_27
       ON
         (
-          subq_25.user = subq_28.user
+          subq_24.user = subq_27.user
         ) AND (
-          (subq_25.metric_time__day <= subq_28.metric_time__day)
+          (subq_24.metric_time__day <= subq_27.metric_time__day)
         )
-    ) subq_29
+    ) subq_28
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_32
+  ) subq_31
   ON
     (
-      subq_21.visit__referrer_id = subq_32.visit__referrer_id
+      subq_21.visit__referrer_id = subq_31.visit__referrer_id
     ) AND (
-      subq_21.metric_time__day = subq_32.metric_time__day
+      subq_21.metric_time__day = subq_31.metric_time__day
     )
   GROUP BY
-    COALESCE(subq_21.metric_time__day, subq_32.metric_time__day)
-    , COALESCE(subq_21.visit__referrer_id, subq_32.visit__referrer_id)
-) subq_33
+    COALESCE(subq_21.metric_time__day, subq_31.metric_time__day)
+    , COALESCE(subq_21.visit__referrer_id, subq_31.visit__referrer_id)
+) subq_32

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Snowflake/test_conversion_metric_with_different_time_dimension_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Snowflake/test_conversion_metric_with_different_time_dimension_grains__plan0_optimized.sql
@@ -6,16 +6,25 @@ sql_engine: Snowflake
 ---
 -- Combine Aggregated Outputs
 -- Compute Metrics via Expressions
-SELECT
-  CAST(MAX(subq_28.buys_month) AS DOUBLE) / CAST(NULLIF(MAX(subq_18.visits), 0) AS DOUBLE) AS visit_buy_conversion_rate_with_monthly_conversion
-FROM (
+WITH sma_28019_cte AS (
   -- Read Elements From Semantic Model 'visits_source'
   -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('month', ds) AS metric_time__month
+    , user_id AS user
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
+SELECT
+  CAST(MAX(subq_27.buys_month) AS DOUBLE) / CAST(NULLIF(MAX(subq_18.visits), 0) AS DOUBLE) AS visit_buy_conversion_rate_with_monthly_conversion
+FROM (
+  -- Read From CTE For node_id=sma_28019
   -- Pass Only Elements: ['visits',]
   -- Aggregate Measures
   SELECT
-    SUM(1) AS visits
-  FROM ***************************.fct_visits visits_source_src_28000
+    SUM(visits) AS visits
+  FROM sma_28019_cte sma_28019_cte
 ) subq_18
 CROSS JOIN (
   -- Find conversions for user within the range of 1 month
@@ -26,42 +35,33 @@ CROSS JOIN (
   FROM (
     -- Dedupe the fanout with mf_internal_uuid in the conversion data set
     SELECT DISTINCT
-      FIRST_VALUE(subq_21.visits) OVER (
+      FIRST_VALUE(sma_28019_cte.visits) OVER (
         PARTITION BY
-          subq_24.user
-          , subq_24.metric_time__month
-          , subq_24.mf_internal_uuid
-        ORDER BY subq_21.metric_time__month DESC
+          subq_23.user
+          , subq_23.metric_time__month
+          , subq_23.mf_internal_uuid
+        ORDER BY sma_28019_cte.metric_time__month DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS visits
-      , FIRST_VALUE(subq_21.metric_time__month) OVER (
+      , FIRST_VALUE(sma_28019_cte.metric_time__month) OVER (
         PARTITION BY
-          subq_24.user
-          , subq_24.metric_time__month
-          , subq_24.mf_internal_uuid
-        ORDER BY subq_21.metric_time__month DESC
+          subq_23.user
+          , subq_23.metric_time__month
+          , subq_23.mf_internal_uuid
+        ORDER BY sma_28019_cte.metric_time__month DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS metric_time__month
-      , FIRST_VALUE(subq_21.user) OVER (
+      , FIRST_VALUE(sma_28019_cte.user) OVER (
         PARTITION BY
-          subq_24.user
-          , subq_24.metric_time__month
-          , subq_24.mf_internal_uuid
-        ORDER BY subq_21.metric_time__month DESC
+          subq_23.user
+          , subq_23.metric_time__month
+          , subq_23.mf_internal_uuid
+        ORDER BY sma_28019_cte.metric_time__month DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS user
-      , subq_24.mf_internal_uuid AS mf_internal_uuid
-      , subq_24.buys_month AS buys_month
-    FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['visits', 'metric_time__month', 'user']
-      SELECT
-        DATE_TRUNC('month', ds) AS metric_time__month
-        , user_id AS user
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
-    ) subq_21
+      , subq_23.mf_internal_uuid AS mf_internal_uuid
+      , subq_23.buys_month AS buys_month
+    FROM sma_28019_cte sma_28019_cte
     INNER JOIN (
       -- Read Elements From Semantic Model 'buys_source'
       -- Metric Time Dimension 'ds_month'
@@ -72,16 +72,16 @@ CROSS JOIN (
         , 1 AS buys_month
         , UUID_STRING() AS mf_internal_uuid
       FROM ***************************.fct_buys buys_source_src_28000
-    ) subq_24
+    ) subq_23
     ON
       (
-        subq_21.user = subq_24.user
+        sma_28019_cte.user = subq_23.user
       ) AND (
         (
-          subq_21.metric_time__month <= subq_24.metric_time__month
+          sma_28019_cte.metric_time__month <= subq_23.metric_time__month
         ) AND (
-          subq_21.metric_time__month > DATEADD(month, -1, subq_24.metric_time__month)
+          sma_28019_cte.metric_time__month > DATEADD(month, -1, subq_23.metric_time__month)
         )
       )
-  ) subq_25
-) subq_28
+  ) subq_24
+) subq_27

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Snowflake/test_conversion_metric_with_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Snowflake/test_conversion_metric_with_filter__plan0_optimized.sql
@@ -6,8 +6,18 @@ sql_engine: Snowflake
 ---
 -- Combine Aggregated Outputs
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
-  CAST(MAX(subq_32.buys) AS DOUBLE) / CAST(NULLIF(MAX(subq_21.visits), 0) AS DOUBLE) AS visit_buy_conversion_rate
+  CAST(MAX(subq_31.buys) AS DOUBLE) / CAST(NULLIF(MAX(subq_21.visits), 0) AS DOUBLE) AS visit_buy_conversion_rate
 FROM (
   -- Constrain Output with WHERE
   -- Pass Only Elements: ['visits',]
@@ -15,12 +25,12 @@ FROM (
   SELECT
     SUM(visits) AS visits
   FROM (
-    -- Read Elements From Semantic Model 'visits_source'
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28019
     SELECT
-      DATE_TRUNC('day', ds) AS metric_time__day
-      , 1 AS visits
-    FROM ***************************.fct_visits visits_source_src_28000
+      metric_time__day
+      , sma_28019_cte.user
+      , visits
+    FROM sma_28019_cte sma_28019_cte
   ) subq_18
   WHERE metric_time__day = '2020-01-01'
 ) subq_21
@@ -33,50 +43,49 @@ CROSS JOIN (
   FROM (
     -- Dedupe the fanout with mf_internal_uuid in the conversion data set
     SELECT DISTINCT
-      FIRST_VALUE(subq_25.visits) OVER (
+      FIRST_VALUE(subq_24.visits) OVER (
         PARTITION BY
-          subq_28.user
-          , subq_28.metric_time__day
-          , subq_28.mf_internal_uuid
-        ORDER BY subq_25.metric_time__day DESC
+          subq_27.user
+          , subq_27.metric_time__day
+          , subq_27.mf_internal_uuid
+        ORDER BY subq_24.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS visits
-      , FIRST_VALUE(subq_25.metric_time__day) OVER (
+      , FIRST_VALUE(subq_24.metric_time__day) OVER (
         PARTITION BY
-          subq_28.user
-          , subq_28.metric_time__day
-          , subq_28.mf_internal_uuid
-        ORDER BY subq_25.metric_time__day DESC
+          subq_27.user
+          , subq_27.metric_time__day
+          , subq_27.mf_internal_uuid
+        ORDER BY subq_24.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS metric_time__day
-      , FIRST_VALUE(subq_25.user) OVER (
+      , FIRST_VALUE(subq_24.user) OVER (
         PARTITION BY
-          subq_28.user
-          , subq_28.metric_time__day
-          , subq_28.mf_internal_uuid
-        ORDER BY subq_25.metric_time__day DESC
+          subq_27.user
+          , subq_27.metric_time__day
+          , subq_27.mf_internal_uuid
+        ORDER BY subq_24.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS user
-      , subq_28.mf_internal_uuid AS mf_internal_uuid
-      , subq_28.buys AS buys
+      , subq_27.mf_internal_uuid AS mf_internal_uuid
+      , subq_27.buys AS buys
     FROM (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['visits', 'metric_time__day', 'user']
       SELECT
         metric_time__day
-        , subq_23.user
+        , subq_22.user
         , visits
       FROM (
-        -- Read Elements From Semantic Model 'visits_source'
-        -- Metric Time Dimension 'ds'
+        -- Read From CTE For node_id=sma_28019
         SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , user_id AS user
-          , 1 AS visits
-        FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_23
+          metric_time__day
+          , sma_28019_cte.user
+          , visits
+        FROM sma_28019_cte sma_28019_cte
+      ) subq_22
       WHERE metric_time__day = '2020-01-01'
-    ) subq_25
+    ) subq_24
     INNER JOIN (
       -- Read Elements From Semantic Model 'buys_source'
       -- Metric Time Dimension 'ds'
@@ -87,12 +96,12 @@ CROSS JOIN (
         , 1 AS buys
         , UUID_STRING() AS mf_internal_uuid
       FROM ***************************.fct_buys buys_source_src_28000
-    ) subq_28
+    ) subq_27
     ON
       (
-        subq_25.user = subq_28.user
+        subq_24.user = subq_27.user
       ) AND (
-        (subq_25.metric_time__day <= subq_28.metric_time__day)
+        (subq_24.metric_time__day <= subq_27.metric_time__day)
       )
-  ) subq_29
-) subq_32
+  ) subq_28
+) subq_31

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Snowflake/test_conversion_metric_with_filter_not_in_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Snowflake/test_conversion_metric_with_filter_not_in_group_by__plan0_optimized.sql
@@ -6,8 +6,19 @@ sql_engine: Snowflake
 ---
 -- Combine Aggregated Outputs
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , referrer_id AS visit__referrer_id
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
-  COALESCE(MAX(subq_32.buys), 0) AS visit_buy_conversions
+  COALESCE(MAX(subq_31.buys), 0) AS visit_buy_conversions
 FROM (
   -- Constrain Output with WHERE
   -- Pass Only Elements: ['visits',]
@@ -15,12 +26,13 @@ FROM (
   SELECT
     SUM(visits) AS visits
   FROM (
-    -- Read Elements From Semantic Model 'visits_source'
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28019
     SELECT
-      referrer_id AS visit__referrer_id
-      , 1 AS visits
-    FROM ***************************.fct_visits visits_source_src_28000
+      metric_time__day
+      , sma_28019_cte.user
+      , visit__referrer_id
+      , visits
+    FROM sma_28019_cte sma_28019_cte
   ) subq_18
   WHERE visit__referrer_id = 'ref_id_01'
 ) subq_21
@@ -33,60 +45,59 @@ CROSS JOIN (
   FROM (
     -- Dedupe the fanout with mf_internal_uuid in the conversion data set
     SELECT DISTINCT
-      FIRST_VALUE(subq_25.visits) OVER (
+      FIRST_VALUE(subq_24.visits) OVER (
         PARTITION BY
-          subq_28.user
-          , subq_28.metric_time__day
-          , subq_28.mf_internal_uuid
-        ORDER BY subq_25.metric_time__day DESC
+          subq_27.user
+          , subq_27.metric_time__day
+          , subq_27.mf_internal_uuid
+        ORDER BY subq_24.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS visits
-      , FIRST_VALUE(subq_25.visit__referrer_id) OVER (
+      , FIRST_VALUE(subq_24.visit__referrer_id) OVER (
         PARTITION BY
-          subq_28.user
-          , subq_28.metric_time__day
-          , subq_28.mf_internal_uuid
-        ORDER BY subq_25.metric_time__day DESC
+          subq_27.user
+          , subq_27.metric_time__day
+          , subq_27.mf_internal_uuid
+        ORDER BY subq_24.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS visit__referrer_id
-      , FIRST_VALUE(subq_25.metric_time__day) OVER (
+      , FIRST_VALUE(subq_24.metric_time__day) OVER (
         PARTITION BY
-          subq_28.user
-          , subq_28.metric_time__day
-          , subq_28.mf_internal_uuid
-        ORDER BY subq_25.metric_time__day DESC
+          subq_27.user
+          , subq_27.metric_time__day
+          , subq_27.mf_internal_uuid
+        ORDER BY subq_24.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS metric_time__day
-      , FIRST_VALUE(subq_25.user) OVER (
+      , FIRST_VALUE(subq_24.user) OVER (
         PARTITION BY
-          subq_28.user
-          , subq_28.metric_time__day
-          , subq_28.mf_internal_uuid
-        ORDER BY subq_25.metric_time__day DESC
+          subq_27.user
+          , subq_27.metric_time__day
+          , subq_27.mf_internal_uuid
+        ORDER BY subq_24.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS user
-      , subq_28.mf_internal_uuid AS mf_internal_uuid
-      , subq_28.buys AS buys
+      , subq_27.mf_internal_uuid AS mf_internal_uuid
+      , subq_27.buys AS buys
     FROM (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user']
       SELECT
         metric_time__day
-        , subq_23.user
+        , subq_22.user
         , visit__referrer_id
         , visits
       FROM (
-        -- Read Elements From Semantic Model 'visits_source'
-        -- Metric Time Dimension 'ds'
+        -- Read From CTE For node_id=sma_28019
         SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , user_id AS user
-          , referrer_id AS visit__referrer_id
-          , 1 AS visits
-        FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_23
+          metric_time__day
+          , sma_28019_cte.user
+          , visit__referrer_id
+          , visits
+        FROM sma_28019_cte sma_28019_cte
+      ) subq_22
       WHERE visit__referrer_id = 'ref_id_01'
-    ) subq_25
+    ) subq_24
     INNER JOIN (
       -- Read Elements From Semantic Model 'buys_source'
       -- Metric Time Dimension 'ds'
@@ -97,16 +108,16 @@ CROSS JOIN (
         , 1 AS buys
         , UUID_STRING() AS mf_internal_uuid
       FROM ***************************.fct_buys buys_source_src_28000
-    ) subq_28
+    ) subq_27
     ON
       (
-        subq_25.user = subq_28.user
+        subq_24.user = subq_27.user
       ) AND (
         (
-          subq_25.metric_time__day <= subq_28.metric_time__day
+          subq_24.metric_time__day <= subq_27.metric_time__day
         ) AND (
-          subq_25.metric_time__day > DATEADD(day, -7, subq_28.metric_time__day)
+          subq_24.metric_time__day > DATEADD(day, -7, subq_27.metric_time__day)
         )
       )
-  ) subq_29
-) subq_32
+  ) subq_28
+) subq_31

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Snowflake/test_conversion_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Snowflake/test_conversion_metric_with_time_constraint__plan0_optimized.sql
@@ -5,15 +5,28 @@ docstring:
 sql_engine: Snowflake
 ---
 -- Compute Metrics via Expressions
+WITH ctr_0_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , referrer_id AS visit__referrer_id
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+  WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
+)
+
 SELECT
-  visit__referrer_id
+  visit__referrer_id AS visit__referrer_id
   , CAST(buys AS DOUBLE) / CAST(NULLIF(visits, 0) AS DOUBLE) AS visit_buy_conversion_rate
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_24.visit__referrer_id, subq_36.visit__referrer_id) AS visit__referrer_id
+    COALESCE(subq_24.visit__referrer_id, subq_34.visit__referrer_id) AS visit__referrer_id
     , MAX(subq_24.visits) AS visits
-    , MAX(subq_36.buys) AS buys
+    , MAX(subq_34.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['visits', 'visit__referrer_id']
@@ -22,14 +35,13 @@ FROM (
       visit__referrer_id
       , SUM(visits) AS visits
     FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
-      -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
+      -- Read From CTE For node_id=ctr_0
       SELECT
-        referrer_id AS visit__referrer_id
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
-      WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
+        metric_time__day
+        , ctr_0_cte.user
+        , visit__referrer_id
+        , visits
+      FROM ctr_0_cte ctr_0_cte
     ) subq_21
     WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
@@ -45,62 +57,59 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_29.visits) OVER (
+        FIRST_VALUE(subq_27.visits) OVER (
           PARTITION BY
-            subq_32.user
-            , subq_32.metric_time__day
-            , subq_32.mf_internal_uuid
-          ORDER BY subq_29.metric_time__day DESC
+            subq_30.user
+            , subq_30.metric_time__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_29.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_27.visit__referrer_id) OVER (
           PARTITION BY
-            subq_32.user
-            , subq_32.metric_time__day
-            , subq_32.mf_internal_uuid
-          ORDER BY subq_29.metric_time__day DESC
+            subq_30.user
+            , subq_30.metric_time__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_29.metric_time__day) OVER (
+        , FIRST_VALUE(subq_27.metric_time__day) OVER (
           PARTITION BY
-            subq_32.user
-            , subq_32.metric_time__day
-            , subq_32.mf_internal_uuid
-          ORDER BY subq_29.metric_time__day DESC
+            subq_30.user
+            , subq_30.metric_time__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_29.user) OVER (
+        , FIRST_VALUE(subq_27.user) OVER (
           PARTITION BY
-            subq_32.user
-            , subq_32.metric_time__day
-            , subq_32.mf_internal_uuid
-          ORDER BY subq_29.metric_time__day DESC
+            subq_30.user
+            , subq_30.metric_time__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_32.mf_internal_uuid AS mf_internal_uuid
-        , subq_32.buys AS buys
+        , subq_30.mf_internal_uuid AS mf_internal_uuid
+        , subq_30.buys AS buys
       FROM (
         -- Constrain Output with WHERE
         -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user']
         SELECT
           metric_time__day
-          , subq_27.user
+          , subq_25.user
           , visit__referrer_id
           , visits
         FROM (
-          -- Read Elements From Semantic Model 'visits_source'
-          -- Metric Time Dimension 'ds'
-          -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
+          -- Read From CTE For node_id=ctr_0
           SELECT
-            DATE_TRUNC('day', ds) AS metric_time__day
-            , user_id AS user
-            , referrer_id AS visit__referrer_id
-            , 1 AS visits
-          FROM ***************************.fct_visits visits_source_src_28000
-          WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
-        ) subq_27
+            metric_time__day
+            , ctr_0_cte.user
+            , visit__referrer_id
+            , visits
+          FROM ctr_0_cte ctr_0_cte
+        ) subq_25
         WHERE visit__referrer_id = 'ref_id_01'
-      ) subq_29
+      ) subq_27
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -111,19 +120,19 @@ FROM (
           , 1 AS buys
           , UUID_STRING() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_32
+      ) subq_30
       ON
         (
-          subq_29.user = subq_32.user
+          subq_27.user = subq_30.user
         ) AND (
-          (subq_29.metric_time__day <= subq_32.metric_time__day)
+          (subq_27.metric_time__day <= subq_30.metric_time__day)
         )
-    ) subq_33
+    ) subq_31
     GROUP BY
       visit__referrer_id
-  ) subq_36
+  ) subq_34
   ON
-    subq_24.visit__referrer_id = subq_36.visit__referrer_id
+    subq_24.visit__referrer_id = subq_34.visit__referrer_id
   GROUP BY
-    COALESCE(subq_24.visit__referrer_id, subq_36.visit__referrer_id)
-) subq_37
+    COALESCE(subq_24.visit__referrer_id, subq_34.visit__referrer_id)
+) subq_35

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Snowflake/test_conversion_metric_with_window__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Snowflake/test_conversion_metric_with_window__plan0_optimized.sql
@@ -5,15 +5,25 @@ docstring:
 sql_engine: Snowflake
 ---
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
-  metric_time__day
+  metric_time__day AS metric_time__day
   , CAST(buys AS DOUBLE) / CAST(NULLIF(visits, 0) AS DOUBLE) AS visit_buy_conversion_rate_7days
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_21.metric_time__day, subq_32.metric_time__day) AS metric_time__day
+    COALESCE(subq_21.metric_time__day, subq_31.metric_time__day) AS metric_time__day
     , MAX(subq_21.visits) AS visits
-    , MAX(subq_32.buys) AS buys
+    , MAX(subq_31.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['visits', 'metric_time__day']
@@ -22,12 +32,12 @@ FROM (
       metric_time__day
       , SUM(visits) AS visits
     FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
+      -- Read From CTE For node_id=sma_28019
       SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
+        metric_time__day
+        , sma_28019_cte.user
+        , visits
+      FROM sma_28019_cte sma_28019_cte
     ) subq_18
     WHERE metric_time__day = '2020-01-01'
     GROUP BY
@@ -43,50 +53,49 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_25.visits) OVER (
+        FIRST_VALUE(subq_24.visits) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_25.metric_time__day) OVER (
+        , FIRST_VALUE(subq_24.metric_time__day) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_25.user) OVER (
+        , FIRST_VALUE(subq_24.user) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_28.mf_internal_uuid AS mf_internal_uuid
-        , subq_28.buys AS buys
+        , subq_27.mf_internal_uuid AS mf_internal_uuid
+        , subq_27.buys AS buys
       FROM (
         -- Constrain Output with WHERE
         -- Pass Only Elements: ['visits', 'metric_time__day', 'user']
         SELECT
           metric_time__day
-          , subq_23.user
+          , subq_22.user
           , visits
         FROM (
-          -- Read Elements From Semantic Model 'visits_source'
-          -- Metric Time Dimension 'ds'
+          -- Read From CTE For node_id=sma_28019
           SELECT
-            DATE_TRUNC('day', ds) AS metric_time__day
-            , user_id AS user
-            , 1 AS visits
-          FROM ***************************.fct_visits visits_source_src_28000
-        ) subq_23
+            metric_time__day
+            , sma_28019_cte.user
+            , visits
+          FROM sma_28019_cte sma_28019_cte
+        ) subq_22
         WHERE metric_time__day = '2020-01-01'
-      ) subq_25
+      ) subq_24
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -97,23 +106,23 @@ FROM (
           , 1 AS buys
           , UUID_STRING() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_28
+      ) subq_27
       ON
         (
-          subq_25.user = subq_28.user
+          subq_24.user = subq_27.user
         ) AND (
           (
-            subq_25.metric_time__day <= subq_28.metric_time__day
+            subq_24.metric_time__day <= subq_27.metric_time__day
           ) AND (
-            subq_25.metric_time__day > DATEADD(day, -7, subq_28.metric_time__day)
+            subq_24.metric_time__day > DATEADD(day, -7, subq_27.metric_time__day)
           )
         )
-    ) subq_29
+    ) subq_28
     GROUP BY
       metric_time__day
-  ) subq_32
+  ) subq_31
   ON
-    subq_21.metric_time__day = subq_32.metric_time__day
+    subq_21.metric_time__day = subq_31.metric_time__day
   GROUP BY
-    COALESCE(subq_21.metric_time__day, subq_32.metric_time__day)
-) subq_33
+    COALESCE(subq_21.metric_time__day, subq_31.metric_time__day)
+) subq_32

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Snowflake/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Snowflake/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
@@ -5,17 +5,30 @@ docstring:
 sql_engine: Snowflake
 ---
 -- Compute Metrics via Expressions
+WITH ctr_0_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , referrer_id AS visit__referrer_id
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+  WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
+)
+
 SELECT
-  metric_time__day
-  , visit__referrer_id
+  metric_time__day AS metric_time__day
+  , visit__referrer_id AS visit__referrer_id
   , CAST(buys AS DOUBLE) / CAST(NULLIF(visits, 0) AS DOUBLE) AS visit_buy_conversion_rate_7days
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_24.metric_time__day, subq_36.metric_time__day) AS metric_time__day
-    , COALESCE(subq_24.visit__referrer_id, subq_36.visit__referrer_id) AS visit__referrer_id
+    COALESCE(subq_24.metric_time__day, subq_34.metric_time__day) AS metric_time__day
+    , COALESCE(subq_24.visit__referrer_id, subq_34.visit__referrer_id) AS visit__referrer_id
     , MAX(subq_24.visits) AS visits
-    , MAX(subq_36.buys) AS buys
+    , MAX(subq_34.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
@@ -25,15 +38,13 @@ FROM (
       , visit__referrer_id
       , SUM(visits) AS visits
     FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
-      -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
+      -- Read From CTE For node_id=ctr_0
       SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , referrer_id AS visit__referrer_id
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
-      WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
+        metric_time__day
+        , ctr_0_cte.user
+        , visit__referrer_id
+        , visits
+      FROM ctr_0_cte ctr_0_cte
     ) subq_21
     WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
@@ -51,62 +62,59 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_29.visits) OVER (
+        FIRST_VALUE(subq_27.visits) OVER (
           PARTITION BY
-            subq_32.user
-            , subq_32.metric_time__day
-            , subq_32.mf_internal_uuid
-          ORDER BY subq_29.metric_time__day DESC
+            subq_30.user
+            , subq_30.metric_time__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_29.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_27.visit__referrer_id) OVER (
           PARTITION BY
-            subq_32.user
-            , subq_32.metric_time__day
-            , subq_32.mf_internal_uuid
-          ORDER BY subq_29.metric_time__day DESC
+            subq_30.user
+            , subq_30.metric_time__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_29.metric_time__day) OVER (
+        , FIRST_VALUE(subq_27.metric_time__day) OVER (
           PARTITION BY
-            subq_32.user
-            , subq_32.metric_time__day
-            , subq_32.mf_internal_uuid
-          ORDER BY subq_29.metric_time__day DESC
+            subq_30.user
+            , subq_30.metric_time__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_29.user) OVER (
+        , FIRST_VALUE(subq_27.user) OVER (
           PARTITION BY
-            subq_32.user
-            , subq_32.metric_time__day
-            , subq_32.mf_internal_uuid
-          ORDER BY subq_29.metric_time__day DESC
+            subq_30.user
+            , subq_30.metric_time__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_32.mf_internal_uuid AS mf_internal_uuid
-        , subq_32.buys AS buys
+        , subq_30.mf_internal_uuid AS mf_internal_uuid
+        , subq_30.buys AS buys
       FROM (
         -- Constrain Output with WHERE
         -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user']
         SELECT
           metric_time__day
-          , subq_27.user
+          , subq_25.user
           , visit__referrer_id
           , visits
         FROM (
-          -- Read Elements From Semantic Model 'visits_source'
-          -- Metric Time Dimension 'ds'
-          -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
+          -- Read From CTE For node_id=ctr_0
           SELECT
-            DATE_TRUNC('day', ds) AS metric_time__day
-            , user_id AS user
-            , referrer_id AS visit__referrer_id
-            , 1 AS visits
-          FROM ***************************.fct_visits visits_source_src_28000
-          WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
-        ) subq_27
+            metric_time__day
+            , ctr_0_cte.user
+            , visit__referrer_id
+            , visits
+          FROM ctr_0_cte ctr_0_cte
+        ) subq_25
         WHERE visit__referrer_id = 'ref_id_01'
-      ) subq_29
+      ) subq_27
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -117,29 +125,29 @@ FROM (
           , 1 AS buys
           , UUID_STRING() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_32
+      ) subq_30
       ON
         (
-          subq_29.user = subq_32.user
+          subq_27.user = subq_30.user
         ) AND (
           (
-            subq_29.metric_time__day <= subq_32.metric_time__day
+            subq_27.metric_time__day <= subq_30.metric_time__day
           ) AND (
-            subq_29.metric_time__day > DATEADD(day, -7, subq_32.metric_time__day)
+            subq_27.metric_time__day > DATEADD(day, -7, subq_30.metric_time__day)
           )
         )
-    ) subq_33
+    ) subq_31
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_36
+  ) subq_34
   ON
     (
-      subq_24.visit__referrer_id = subq_36.visit__referrer_id
+      subq_24.visit__referrer_id = subq_34.visit__referrer_id
     ) AND (
-      subq_24.metric_time__day = subq_36.metric_time__day
+      subq_24.metric_time__day = subq_34.metric_time__day
     )
   GROUP BY
-    COALESCE(subq_24.metric_time__day, subq_36.metric_time__day)
-    , COALESCE(subq_24.visit__referrer_id, subq_36.visit__referrer_id)
-) subq_37
+    COALESCE(subq_24.metric_time__day, subq_34.metric_time__day)
+    , COALESCE(subq_24.visit__referrer_id, subq_34.visit__referrer_id)
+) subq_35

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Trino/test_conversion_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Trino/test_conversion_metric__plan0_optimized.sql
@@ -5,15 +5,25 @@ docstring:
 sql_engine: Trino
 ---
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
-  metric_time__day
+  metric_time__day AS metric_time__day
   , CAST(buys AS DOUBLE) / CAST(NULLIF(visits, 0) AS DOUBLE) AS visit_buy_conversion_rate
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_21.metric_time__day, subq_32.metric_time__day) AS metric_time__day
+    COALESCE(subq_21.metric_time__day, subq_31.metric_time__day) AS metric_time__day
     , MAX(subq_21.visits) AS visits
-    , MAX(subq_32.buys) AS buys
+    , MAX(subq_31.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['visits', 'metric_time__day']
@@ -22,12 +32,12 @@ FROM (
       metric_time__day
       , SUM(visits) AS visits
     FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
+      -- Read From CTE For node_id=sma_28019
       SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
+        metric_time__day
+        , sma_28019_cte.user
+        , visits
+      FROM sma_28019_cte sma_28019_cte
     ) subq_18
     WHERE metric_time__day = '2020-01-01'
     GROUP BY
@@ -43,50 +53,49 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_25.visits) OVER (
+        FIRST_VALUE(subq_24.visits) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_25.metric_time__day) OVER (
+        , FIRST_VALUE(subq_24.metric_time__day) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_25.user) OVER (
+        , FIRST_VALUE(subq_24.user) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_28.mf_internal_uuid AS mf_internal_uuid
-        , subq_28.buys AS buys
+        , subq_27.mf_internal_uuid AS mf_internal_uuid
+        , subq_27.buys AS buys
       FROM (
         -- Constrain Output with WHERE
         -- Pass Only Elements: ['visits', 'metric_time__day', 'user']
         SELECT
           metric_time__day
-          , subq_23.user
+          , subq_22.user
           , visits
         FROM (
-          -- Read Elements From Semantic Model 'visits_source'
-          -- Metric Time Dimension 'ds'
+          -- Read From CTE For node_id=sma_28019
           SELECT
-            DATE_TRUNC('day', ds) AS metric_time__day
-            , user_id AS user
-            , 1 AS visits
-          FROM ***************************.fct_visits visits_source_src_28000
-        ) subq_23
+            metric_time__day
+            , sma_28019_cte.user
+            , visits
+          FROM sma_28019_cte sma_28019_cte
+        ) subq_22
         WHERE metric_time__day = '2020-01-01'
-      ) subq_25
+      ) subq_24
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -97,19 +106,19 @@ FROM (
           , 1 AS buys
           , uuid() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_28
+      ) subq_27
       ON
         (
-          subq_25.user = subq_28.user
+          subq_24.user = subq_27.user
         ) AND (
-          (subq_25.metric_time__day <= subq_28.metric_time__day)
+          (subq_24.metric_time__day <= subq_27.metric_time__day)
         )
-    ) subq_29
+    ) subq_28
     GROUP BY
       metric_time__day
-  ) subq_32
+  ) subq_31
   ON
-    subq_21.metric_time__day = subq_32.metric_time__day
+    subq_21.metric_time__day = subq_31.metric_time__day
   GROUP BY
-    COALESCE(subq_21.metric_time__day, subq_32.metric_time__day)
-) subq_33
+    COALESCE(subq_21.metric_time__day, subq_31.metric_time__day)
+) subq_32

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Trino/test_conversion_metric_with_categorical_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Trino/test_conversion_metric_with_categorical_filter__plan0_optimized.sql
@@ -5,17 +5,28 @@ docstring:
 sql_engine: Trino
 ---
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , referrer_id AS visit__referrer_id
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
-  metric_time__day
-  , visit__referrer_id
+  metric_time__day AS metric_time__day
+  , visit__referrer_id AS visit__referrer_id
   , CAST(buys AS DOUBLE) / CAST(NULLIF(visits, 0) AS DOUBLE) AS visit_buy_conversion_rate
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_21.metric_time__day, subq_32.metric_time__day) AS metric_time__day
-    , COALESCE(subq_21.visit__referrer_id, subq_32.visit__referrer_id) AS visit__referrer_id
+    COALESCE(subq_21.metric_time__day, subq_31.metric_time__day) AS metric_time__day
+    , COALESCE(subq_21.visit__referrer_id, subq_31.visit__referrer_id) AS visit__referrer_id
     , MAX(subq_21.visits) AS visits
-    , MAX(subq_32.buys) AS buys
+    , MAX(subq_31.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
@@ -25,13 +36,13 @@ FROM (
       , visit__referrer_id
       , SUM(visits) AS visits
     FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
+      -- Read From CTE For node_id=sma_28019
       SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , referrer_id AS visit__referrer_id
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
+        metric_time__day
+        , sma_28019_cte.user
+        , visit__referrer_id
+        , visits
+      FROM sma_28019_cte sma_28019_cte
     ) subq_18
     WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
@@ -49,60 +60,59 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_25.visits) OVER (
+        FIRST_VALUE(subq_24.visits) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_25.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_24.visit__referrer_id) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_25.metric_time__day) OVER (
+        , FIRST_VALUE(subq_24.metric_time__day) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_25.user) OVER (
+        , FIRST_VALUE(subq_24.user) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_28.mf_internal_uuid AS mf_internal_uuid
-        , subq_28.buys AS buys
+        , subq_27.mf_internal_uuid AS mf_internal_uuid
+        , subq_27.buys AS buys
       FROM (
         -- Constrain Output with WHERE
         -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user']
         SELECT
           metric_time__day
-          , subq_23.user
+          , subq_22.user
           , visit__referrer_id
           , visits
         FROM (
-          -- Read Elements From Semantic Model 'visits_source'
-          -- Metric Time Dimension 'ds'
+          -- Read From CTE For node_id=sma_28019
           SELECT
-            DATE_TRUNC('day', ds) AS metric_time__day
-            , user_id AS user
-            , referrer_id AS visit__referrer_id
-            , 1 AS visits
-          FROM ***************************.fct_visits visits_source_src_28000
-        ) subq_23
+            metric_time__day
+            , sma_28019_cte.user
+            , visit__referrer_id
+            , visits
+          FROM sma_28019_cte sma_28019_cte
+        ) subq_22
         WHERE visit__referrer_id = 'ref_id_01'
-      ) subq_25
+      ) subq_24
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -113,25 +123,25 @@ FROM (
           , 1 AS buys
           , uuid() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_28
+      ) subq_27
       ON
         (
-          subq_25.user = subq_28.user
+          subq_24.user = subq_27.user
         ) AND (
-          (subq_25.metric_time__day <= subq_28.metric_time__day)
+          (subq_24.metric_time__day <= subq_27.metric_time__day)
         )
-    ) subq_29
+    ) subq_28
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_32
+  ) subq_31
   ON
     (
-      subq_21.visit__referrer_id = subq_32.visit__referrer_id
+      subq_21.visit__referrer_id = subq_31.visit__referrer_id
     ) AND (
-      subq_21.metric_time__day = subq_32.metric_time__day
+      subq_21.metric_time__day = subq_31.metric_time__day
     )
   GROUP BY
-    COALESCE(subq_21.metric_time__day, subq_32.metric_time__day)
-    , COALESCE(subq_21.visit__referrer_id, subq_32.visit__referrer_id)
-) subq_33
+    COALESCE(subq_21.metric_time__day, subq_31.metric_time__day)
+    , COALESCE(subq_21.visit__referrer_id, subq_31.visit__referrer_id)
+) subq_32

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Trino/test_conversion_metric_with_different_time_dimension_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Trino/test_conversion_metric_with_different_time_dimension_grains__plan0_optimized.sql
@@ -6,16 +6,25 @@ sql_engine: Trino
 ---
 -- Combine Aggregated Outputs
 -- Compute Metrics via Expressions
-SELECT
-  CAST(MAX(subq_28.buys_month) AS DOUBLE) / CAST(NULLIF(MAX(subq_18.visits), 0) AS DOUBLE) AS visit_buy_conversion_rate_with_monthly_conversion
-FROM (
+WITH sma_28019_cte AS (
   -- Read Elements From Semantic Model 'visits_source'
   -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('month', ds) AS metric_time__month
+    , user_id AS user
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
+SELECT
+  CAST(MAX(subq_27.buys_month) AS DOUBLE) / CAST(NULLIF(MAX(subq_18.visits), 0) AS DOUBLE) AS visit_buy_conversion_rate_with_monthly_conversion
+FROM (
+  -- Read From CTE For node_id=sma_28019
   -- Pass Only Elements: ['visits',]
   -- Aggregate Measures
   SELECT
-    SUM(1) AS visits
-  FROM ***************************.fct_visits visits_source_src_28000
+    SUM(visits) AS visits
+  FROM sma_28019_cte sma_28019_cte
 ) subq_18
 CROSS JOIN (
   -- Find conversions for user within the range of 1 month
@@ -26,42 +35,33 @@ CROSS JOIN (
   FROM (
     -- Dedupe the fanout with mf_internal_uuid in the conversion data set
     SELECT DISTINCT
-      FIRST_VALUE(subq_21.visits) OVER (
+      FIRST_VALUE(sma_28019_cte.visits) OVER (
         PARTITION BY
-          subq_24.user
-          , subq_24.metric_time__month
-          , subq_24.mf_internal_uuid
-        ORDER BY subq_21.metric_time__month DESC
+          subq_23.user
+          , subq_23.metric_time__month
+          , subq_23.mf_internal_uuid
+        ORDER BY sma_28019_cte.metric_time__month DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS visits
-      , FIRST_VALUE(subq_21.metric_time__month) OVER (
+      , FIRST_VALUE(sma_28019_cte.metric_time__month) OVER (
         PARTITION BY
-          subq_24.user
-          , subq_24.metric_time__month
-          , subq_24.mf_internal_uuid
-        ORDER BY subq_21.metric_time__month DESC
+          subq_23.user
+          , subq_23.metric_time__month
+          , subq_23.mf_internal_uuid
+        ORDER BY sma_28019_cte.metric_time__month DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS metric_time__month
-      , FIRST_VALUE(subq_21.user) OVER (
+      , FIRST_VALUE(sma_28019_cte.user) OVER (
         PARTITION BY
-          subq_24.user
-          , subq_24.metric_time__month
-          , subq_24.mf_internal_uuid
-        ORDER BY subq_21.metric_time__month DESC
+          subq_23.user
+          , subq_23.metric_time__month
+          , subq_23.mf_internal_uuid
+        ORDER BY sma_28019_cte.metric_time__month DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS user
-      , subq_24.mf_internal_uuid AS mf_internal_uuid
-      , subq_24.buys_month AS buys_month
-    FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['visits', 'metric_time__month', 'user']
-      SELECT
-        DATE_TRUNC('month', ds) AS metric_time__month
-        , user_id AS user
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
-    ) subq_21
+      , subq_23.mf_internal_uuid AS mf_internal_uuid
+      , subq_23.buys_month AS buys_month
+    FROM sma_28019_cte sma_28019_cte
     INNER JOIN (
       -- Read Elements From Semantic Model 'buys_source'
       -- Metric Time Dimension 'ds_month'
@@ -72,16 +72,16 @@ CROSS JOIN (
         , 1 AS buys_month
         , uuid() AS mf_internal_uuid
       FROM ***************************.fct_buys buys_source_src_28000
-    ) subq_24
+    ) subq_23
     ON
       (
-        subq_21.user = subq_24.user
+        sma_28019_cte.user = subq_23.user
       ) AND (
         (
-          subq_21.metric_time__month <= subq_24.metric_time__month
+          sma_28019_cte.metric_time__month <= subq_23.metric_time__month
         ) AND (
-          subq_21.metric_time__month > DATE_ADD('month', -1, subq_24.metric_time__month)
+          sma_28019_cte.metric_time__month > DATE_ADD('month', -1, subq_23.metric_time__month)
         )
       )
-  ) subq_25
-) subq_28
+  ) subq_24
+) subq_27

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Trino/test_conversion_metric_with_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Trino/test_conversion_metric_with_filter__plan0_optimized.sql
@@ -6,8 +6,18 @@ sql_engine: Trino
 ---
 -- Combine Aggregated Outputs
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
-  CAST(MAX(subq_32.buys) AS DOUBLE) / CAST(NULLIF(MAX(subq_21.visits), 0) AS DOUBLE) AS visit_buy_conversion_rate
+  CAST(MAX(subq_31.buys) AS DOUBLE) / CAST(NULLIF(MAX(subq_21.visits), 0) AS DOUBLE) AS visit_buy_conversion_rate
 FROM (
   -- Constrain Output with WHERE
   -- Pass Only Elements: ['visits',]
@@ -15,12 +25,12 @@ FROM (
   SELECT
     SUM(visits) AS visits
   FROM (
-    -- Read Elements From Semantic Model 'visits_source'
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28019
     SELECT
-      DATE_TRUNC('day', ds) AS metric_time__day
-      , 1 AS visits
-    FROM ***************************.fct_visits visits_source_src_28000
+      metric_time__day
+      , sma_28019_cte.user
+      , visits
+    FROM sma_28019_cte sma_28019_cte
   ) subq_18
   WHERE metric_time__day = '2020-01-01'
 ) subq_21
@@ -33,50 +43,49 @@ CROSS JOIN (
   FROM (
     -- Dedupe the fanout with mf_internal_uuid in the conversion data set
     SELECT DISTINCT
-      FIRST_VALUE(subq_25.visits) OVER (
+      FIRST_VALUE(subq_24.visits) OVER (
         PARTITION BY
-          subq_28.user
-          , subq_28.metric_time__day
-          , subq_28.mf_internal_uuid
-        ORDER BY subq_25.metric_time__day DESC
+          subq_27.user
+          , subq_27.metric_time__day
+          , subq_27.mf_internal_uuid
+        ORDER BY subq_24.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS visits
-      , FIRST_VALUE(subq_25.metric_time__day) OVER (
+      , FIRST_VALUE(subq_24.metric_time__day) OVER (
         PARTITION BY
-          subq_28.user
-          , subq_28.metric_time__day
-          , subq_28.mf_internal_uuid
-        ORDER BY subq_25.metric_time__day DESC
+          subq_27.user
+          , subq_27.metric_time__day
+          , subq_27.mf_internal_uuid
+        ORDER BY subq_24.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS metric_time__day
-      , FIRST_VALUE(subq_25.user) OVER (
+      , FIRST_VALUE(subq_24.user) OVER (
         PARTITION BY
-          subq_28.user
-          , subq_28.metric_time__day
-          , subq_28.mf_internal_uuid
-        ORDER BY subq_25.metric_time__day DESC
+          subq_27.user
+          , subq_27.metric_time__day
+          , subq_27.mf_internal_uuid
+        ORDER BY subq_24.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS user
-      , subq_28.mf_internal_uuid AS mf_internal_uuid
-      , subq_28.buys AS buys
+      , subq_27.mf_internal_uuid AS mf_internal_uuid
+      , subq_27.buys AS buys
     FROM (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['visits', 'metric_time__day', 'user']
       SELECT
         metric_time__day
-        , subq_23.user
+        , subq_22.user
         , visits
       FROM (
-        -- Read Elements From Semantic Model 'visits_source'
-        -- Metric Time Dimension 'ds'
+        -- Read From CTE For node_id=sma_28019
         SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , user_id AS user
-          , 1 AS visits
-        FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_23
+          metric_time__day
+          , sma_28019_cte.user
+          , visits
+        FROM sma_28019_cte sma_28019_cte
+      ) subq_22
       WHERE metric_time__day = '2020-01-01'
-    ) subq_25
+    ) subq_24
     INNER JOIN (
       -- Read Elements From Semantic Model 'buys_source'
       -- Metric Time Dimension 'ds'
@@ -87,12 +96,12 @@ CROSS JOIN (
         , 1 AS buys
         , uuid() AS mf_internal_uuid
       FROM ***************************.fct_buys buys_source_src_28000
-    ) subq_28
+    ) subq_27
     ON
       (
-        subq_25.user = subq_28.user
+        subq_24.user = subq_27.user
       ) AND (
-        (subq_25.metric_time__day <= subq_28.metric_time__day)
+        (subq_24.metric_time__day <= subq_27.metric_time__day)
       )
-  ) subq_29
-) subq_32
+  ) subq_28
+) subq_31

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Trino/test_conversion_metric_with_filter_not_in_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Trino/test_conversion_metric_with_filter_not_in_group_by__plan0_optimized.sql
@@ -6,8 +6,19 @@ sql_engine: Trino
 ---
 -- Combine Aggregated Outputs
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , referrer_id AS visit__referrer_id
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
-  COALESCE(MAX(subq_32.buys), 0) AS visit_buy_conversions
+  COALESCE(MAX(subq_31.buys), 0) AS visit_buy_conversions
 FROM (
   -- Constrain Output with WHERE
   -- Pass Only Elements: ['visits',]
@@ -15,12 +26,13 @@ FROM (
   SELECT
     SUM(visits) AS visits
   FROM (
-    -- Read Elements From Semantic Model 'visits_source'
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28019
     SELECT
-      referrer_id AS visit__referrer_id
-      , 1 AS visits
-    FROM ***************************.fct_visits visits_source_src_28000
+      metric_time__day
+      , sma_28019_cte.user
+      , visit__referrer_id
+      , visits
+    FROM sma_28019_cte sma_28019_cte
   ) subq_18
   WHERE visit__referrer_id = 'ref_id_01'
 ) subq_21
@@ -33,60 +45,59 @@ CROSS JOIN (
   FROM (
     -- Dedupe the fanout with mf_internal_uuid in the conversion data set
     SELECT DISTINCT
-      FIRST_VALUE(subq_25.visits) OVER (
+      FIRST_VALUE(subq_24.visits) OVER (
         PARTITION BY
-          subq_28.user
-          , subq_28.metric_time__day
-          , subq_28.mf_internal_uuid
-        ORDER BY subq_25.metric_time__day DESC
+          subq_27.user
+          , subq_27.metric_time__day
+          , subq_27.mf_internal_uuid
+        ORDER BY subq_24.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS visits
-      , FIRST_VALUE(subq_25.visit__referrer_id) OVER (
+      , FIRST_VALUE(subq_24.visit__referrer_id) OVER (
         PARTITION BY
-          subq_28.user
-          , subq_28.metric_time__day
-          , subq_28.mf_internal_uuid
-        ORDER BY subq_25.metric_time__day DESC
+          subq_27.user
+          , subq_27.metric_time__day
+          , subq_27.mf_internal_uuid
+        ORDER BY subq_24.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS visit__referrer_id
-      , FIRST_VALUE(subq_25.metric_time__day) OVER (
+      , FIRST_VALUE(subq_24.metric_time__day) OVER (
         PARTITION BY
-          subq_28.user
-          , subq_28.metric_time__day
-          , subq_28.mf_internal_uuid
-        ORDER BY subq_25.metric_time__day DESC
+          subq_27.user
+          , subq_27.metric_time__day
+          , subq_27.mf_internal_uuid
+        ORDER BY subq_24.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS metric_time__day
-      , FIRST_VALUE(subq_25.user) OVER (
+      , FIRST_VALUE(subq_24.user) OVER (
         PARTITION BY
-          subq_28.user
-          , subq_28.metric_time__day
-          , subq_28.mf_internal_uuid
-        ORDER BY subq_25.metric_time__day DESC
+          subq_27.user
+          , subq_27.metric_time__day
+          , subq_27.mf_internal_uuid
+        ORDER BY subq_24.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS user
-      , subq_28.mf_internal_uuid AS mf_internal_uuid
-      , subq_28.buys AS buys
+      , subq_27.mf_internal_uuid AS mf_internal_uuid
+      , subq_27.buys AS buys
     FROM (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user']
       SELECT
         metric_time__day
-        , subq_23.user
+        , subq_22.user
         , visit__referrer_id
         , visits
       FROM (
-        -- Read Elements From Semantic Model 'visits_source'
-        -- Metric Time Dimension 'ds'
+        -- Read From CTE For node_id=sma_28019
         SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , user_id AS user
-          , referrer_id AS visit__referrer_id
-          , 1 AS visits
-        FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_23
+          metric_time__day
+          , sma_28019_cte.user
+          , visit__referrer_id
+          , visits
+        FROM sma_28019_cte sma_28019_cte
+      ) subq_22
       WHERE visit__referrer_id = 'ref_id_01'
-    ) subq_25
+    ) subq_24
     INNER JOIN (
       -- Read Elements From Semantic Model 'buys_source'
       -- Metric Time Dimension 'ds'
@@ -97,16 +108,16 @@ CROSS JOIN (
         , 1 AS buys
         , uuid() AS mf_internal_uuid
       FROM ***************************.fct_buys buys_source_src_28000
-    ) subq_28
+    ) subq_27
     ON
       (
-        subq_25.user = subq_28.user
+        subq_24.user = subq_27.user
       ) AND (
         (
-          subq_25.metric_time__day <= subq_28.metric_time__day
+          subq_24.metric_time__day <= subq_27.metric_time__day
         ) AND (
-          subq_25.metric_time__day > DATE_ADD('day', -7, subq_28.metric_time__day)
+          subq_24.metric_time__day > DATE_ADD('day', -7, subq_27.metric_time__day)
         )
       )
-  ) subq_29
-) subq_32
+  ) subq_28
+) subq_31

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Trino/test_conversion_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Trino/test_conversion_metric_with_time_constraint__plan0_optimized.sql
@@ -5,15 +5,28 @@ docstring:
 sql_engine: Trino
 ---
 -- Compute Metrics via Expressions
+WITH ctr_0_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , referrer_id AS visit__referrer_id
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+  WHERE DATE_TRUNC('day', ds) BETWEEN timestamp '2020-01-01' AND timestamp '2020-01-02'
+)
+
 SELECT
-  visit__referrer_id
+  visit__referrer_id AS visit__referrer_id
   , CAST(buys AS DOUBLE) / CAST(NULLIF(visits, 0) AS DOUBLE) AS visit_buy_conversion_rate
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_24.visit__referrer_id, subq_36.visit__referrer_id) AS visit__referrer_id
+    COALESCE(subq_24.visit__referrer_id, subq_34.visit__referrer_id) AS visit__referrer_id
     , MAX(subq_24.visits) AS visits
-    , MAX(subq_36.buys) AS buys
+    , MAX(subq_34.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['visits', 'visit__referrer_id']
@@ -22,14 +35,13 @@ FROM (
       visit__referrer_id
       , SUM(visits) AS visits
     FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
-      -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
+      -- Read From CTE For node_id=ctr_0
       SELECT
-        referrer_id AS visit__referrer_id
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
-      WHERE DATE_TRUNC('day', ds) BETWEEN timestamp '2020-01-01' AND timestamp '2020-01-02'
+        metric_time__day
+        , ctr_0_cte.user
+        , visit__referrer_id
+        , visits
+      FROM ctr_0_cte ctr_0_cte
     ) subq_21
     WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
@@ -45,62 +57,59 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_29.visits) OVER (
+        FIRST_VALUE(subq_27.visits) OVER (
           PARTITION BY
-            subq_32.user
-            , subq_32.metric_time__day
-            , subq_32.mf_internal_uuid
-          ORDER BY subq_29.metric_time__day DESC
+            subq_30.user
+            , subq_30.metric_time__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_29.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_27.visit__referrer_id) OVER (
           PARTITION BY
-            subq_32.user
-            , subq_32.metric_time__day
-            , subq_32.mf_internal_uuid
-          ORDER BY subq_29.metric_time__day DESC
+            subq_30.user
+            , subq_30.metric_time__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_29.metric_time__day) OVER (
+        , FIRST_VALUE(subq_27.metric_time__day) OVER (
           PARTITION BY
-            subq_32.user
-            , subq_32.metric_time__day
-            , subq_32.mf_internal_uuid
-          ORDER BY subq_29.metric_time__day DESC
+            subq_30.user
+            , subq_30.metric_time__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_29.user) OVER (
+        , FIRST_VALUE(subq_27.user) OVER (
           PARTITION BY
-            subq_32.user
-            , subq_32.metric_time__day
-            , subq_32.mf_internal_uuid
-          ORDER BY subq_29.metric_time__day DESC
+            subq_30.user
+            , subq_30.metric_time__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_32.mf_internal_uuid AS mf_internal_uuid
-        , subq_32.buys AS buys
+        , subq_30.mf_internal_uuid AS mf_internal_uuid
+        , subq_30.buys AS buys
       FROM (
         -- Constrain Output with WHERE
         -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user']
         SELECT
           metric_time__day
-          , subq_27.user
+          , subq_25.user
           , visit__referrer_id
           , visits
         FROM (
-          -- Read Elements From Semantic Model 'visits_source'
-          -- Metric Time Dimension 'ds'
-          -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
+          -- Read From CTE For node_id=ctr_0
           SELECT
-            DATE_TRUNC('day', ds) AS metric_time__day
-            , user_id AS user
-            , referrer_id AS visit__referrer_id
-            , 1 AS visits
-          FROM ***************************.fct_visits visits_source_src_28000
-          WHERE DATE_TRUNC('day', ds) BETWEEN timestamp '2020-01-01' AND timestamp '2020-01-02'
-        ) subq_27
+            metric_time__day
+            , ctr_0_cte.user
+            , visit__referrer_id
+            , visits
+          FROM ctr_0_cte ctr_0_cte
+        ) subq_25
         WHERE visit__referrer_id = 'ref_id_01'
-      ) subq_29
+      ) subq_27
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -111,19 +120,19 @@ FROM (
           , 1 AS buys
           , uuid() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_32
+      ) subq_30
       ON
         (
-          subq_29.user = subq_32.user
+          subq_27.user = subq_30.user
         ) AND (
-          (subq_29.metric_time__day <= subq_32.metric_time__day)
+          (subq_27.metric_time__day <= subq_30.metric_time__day)
         )
-    ) subq_33
+    ) subq_31
     GROUP BY
       visit__referrer_id
-  ) subq_36
+  ) subq_34
   ON
-    subq_24.visit__referrer_id = subq_36.visit__referrer_id
+    subq_24.visit__referrer_id = subq_34.visit__referrer_id
   GROUP BY
-    COALESCE(subq_24.visit__referrer_id, subq_36.visit__referrer_id)
-) subq_37
+    COALESCE(subq_24.visit__referrer_id, subq_34.visit__referrer_id)
+) subq_35

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Trino/test_conversion_metric_with_window__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Trino/test_conversion_metric_with_window__plan0_optimized.sql
@@ -5,15 +5,25 @@ docstring:
 sql_engine: Trino
 ---
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
-  metric_time__day
+  metric_time__day AS metric_time__day
   , CAST(buys AS DOUBLE) / CAST(NULLIF(visits, 0) AS DOUBLE) AS visit_buy_conversion_rate_7days
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_21.metric_time__day, subq_32.metric_time__day) AS metric_time__day
+    COALESCE(subq_21.metric_time__day, subq_31.metric_time__day) AS metric_time__day
     , MAX(subq_21.visits) AS visits
-    , MAX(subq_32.buys) AS buys
+    , MAX(subq_31.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['visits', 'metric_time__day']
@@ -22,12 +32,12 @@ FROM (
       metric_time__day
       , SUM(visits) AS visits
     FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
+      -- Read From CTE For node_id=sma_28019
       SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
+        metric_time__day
+        , sma_28019_cte.user
+        , visits
+      FROM sma_28019_cte sma_28019_cte
     ) subq_18
     WHERE metric_time__day = '2020-01-01'
     GROUP BY
@@ -43,50 +53,49 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_25.visits) OVER (
+        FIRST_VALUE(subq_24.visits) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_25.metric_time__day) OVER (
+        , FIRST_VALUE(subq_24.metric_time__day) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_25.user) OVER (
+        , FIRST_VALUE(subq_24.user) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_28.mf_internal_uuid AS mf_internal_uuid
-        , subq_28.buys AS buys
+        , subq_27.mf_internal_uuid AS mf_internal_uuid
+        , subq_27.buys AS buys
       FROM (
         -- Constrain Output with WHERE
         -- Pass Only Elements: ['visits', 'metric_time__day', 'user']
         SELECT
           metric_time__day
-          , subq_23.user
+          , subq_22.user
           , visits
         FROM (
-          -- Read Elements From Semantic Model 'visits_source'
-          -- Metric Time Dimension 'ds'
+          -- Read From CTE For node_id=sma_28019
           SELECT
-            DATE_TRUNC('day', ds) AS metric_time__day
-            , user_id AS user
-            , 1 AS visits
-          FROM ***************************.fct_visits visits_source_src_28000
-        ) subq_23
+            metric_time__day
+            , sma_28019_cte.user
+            , visits
+          FROM sma_28019_cte sma_28019_cte
+        ) subq_22
         WHERE metric_time__day = '2020-01-01'
-      ) subq_25
+      ) subq_24
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -97,23 +106,23 @@ FROM (
           , 1 AS buys
           , uuid() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_28
+      ) subq_27
       ON
         (
-          subq_25.user = subq_28.user
+          subq_24.user = subq_27.user
         ) AND (
           (
-            subq_25.metric_time__day <= subq_28.metric_time__day
+            subq_24.metric_time__day <= subq_27.metric_time__day
           ) AND (
-            subq_25.metric_time__day > DATE_ADD('day', -7, subq_28.metric_time__day)
+            subq_24.metric_time__day > DATE_ADD('day', -7, subq_27.metric_time__day)
           )
         )
-    ) subq_29
+    ) subq_28
     GROUP BY
       metric_time__day
-  ) subq_32
+  ) subq_31
   ON
-    subq_21.metric_time__day = subq_32.metric_time__day
+    subq_21.metric_time__day = subq_31.metric_time__day
   GROUP BY
-    COALESCE(subq_21.metric_time__day, subq_32.metric_time__day)
-) subq_33
+    COALESCE(subq_21.metric_time__day, subq_31.metric_time__day)
+) subq_32

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Trino/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Trino/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
@@ -5,17 +5,30 @@ docstring:
 sql_engine: Trino
 ---
 -- Compute Metrics via Expressions
+WITH ctr_0_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , referrer_id AS visit__referrer_id
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+  WHERE DATE_TRUNC('day', ds) BETWEEN timestamp '2020-01-01' AND timestamp '2020-01-02'
+)
+
 SELECT
-  metric_time__day
-  , visit__referrer_id
+  metric_time__day AS metric_time__day
+  , visit__referrer_id AS visit__referrer_id
   , CAST(buys AS DOUBLE) / CAST(NULLIF(visits, 0) AS DOUBLE) AS visit_buy_conversion_rate_7days
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_24.metric_time__day, subq_36.metric_time__day) AS metric_time__day
-    , COALESCE(subq_24.visit__referrer_id, subq_36.visit__referrer_id) AS visit__referrer_id
+    COALESCE(subq_24.metric_time__day, subq_34.metric_time__day) AS metric_time__day
+    , COALESCE(subq_24.visit__referrer_id, subq_34.visit__referrer_id) AS visit__referrer_id
     , MAX(subq_24.visits) AS visits
-    , MAX(subq_36.buys) AS buys
+    , MAX(subq_34.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
@@ -25,15 +38,13 @@ FROM (
       , visit__referrer_id
       , SUM(visits) AS visits
     FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
-      -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
+      -- Read From CTE For node_id=ctr_0
       SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , referrer_id AS visit__referrer_id
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
-      WHERE DATE_TRUNC('day', ds) BETWEEN timestamp '2020-01-01' AND timestamp '2020-01-02'
+        metric_time__day
+        , ctr_0_cte.user
+        , visit__referrer_id
+        , visits
+      FROM ctr_0_cte ctr_0_cte
     ) subq_21
     WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
@@ -51,62 +62,59 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_29.visits) OVER (
+        FIRST_VALUE(subq_27.visits) OVER (
           PARTITION BY
-            subq_32.user
-            , subq_32.metric_time__day
-            , subq_32.mf_internal_uuid
-          ORDER BY subq_29.metric_time__day DESC
+            subq_30.user
+            , subq_30.metric_time__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_29.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_27.visit__referrer_id) OVER (
           PARTITION BY
-            subq_32.user
-            , subq_32.metric_time__day
-            , subq_32.mf_internal_uuid
-          ORDER BY subq_29.metric_time__day DESC
+            subq_30.user
+            , subq_30.metric_time__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_29.metric_time__day) OVER (
+        , FIRST_VALUE(subq_27.metric_time__day) OVER (
           PARTITION BY
-            subq_32.user
-            , subq_32.metric_time__day
-            , subq_32.mf_internal_uuid
-          ORDER BY subq_29.metric_time__day DESC
+            subq_30.user
+            , subq_30.metric_time__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_29.user) OVER (
+        , FIRST_VALUE(subq_27.user) OVER (
           PARTITION BY
-            subq_32.user
-            , subq_32.metric_time__day
-            , subq_32.mf_internal_uuid
-          ORDER BY subq_29.metric_time__day DESC
+            subq_30.user
+            , subq_30.metric_time__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_32.mf_internal_uuid AS mf_internal_uuid
-        , subq_32.buys AS buys
+        , subq_30.mf_internal_uuid AS mf_internal_uuid
+        , subq_30.buys AS buys
       FROM (
         -- Constrain Output with WHERE
         -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user']
         SELECT
           metric_time__day
-          , subq_27.user
+          , subq_25.user
           , visit__referrer_id
           , visits
         FROM (
-          -- Read Elements From Semantic Model 'visits_source'
-          -- Metric Time Dimension 'ds'
-          -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
+          -- Read From CTE For node_id=ctr_0
           SELECT
-            DATE_TRUNC('day', ds) AS metric_time__day
-            , user_id AS user
-            , referrer_id AS visit__referrer_id
-            , 1 AS visits
-          FROM ***************************.fct_visits visits_source_src_28000
-          WHERE DATE_TRUNC('day', ds) BETWEEN timestamp '2020-01-01' AND timestamp '2020-01-02'
-        ) subq_27
+            metric_time__day
+            , ctr_0_cte.user
+            , visit__referrer_id
+            , visits
+          FROM ctr_0_cte ctr_0_cte
+        ) subq_25
         WHERE visit__referrer_id = 'ref_id_01'
-      ) subq_29
+      ) subq_27
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -117,29 +125,29 @@ FROM (
           , 1 AS buys
           , uuid() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_32
+      ) subq_30
       ON
         (
-          subq_29.user = subq_32.user
+          subq_27.user = subq_30.user
         ) AND (
           (
-            subq_29.metric_time__day <= subq_32.metric_time__day
+            subq_27.metric_time__day <= subq_30.metric_time__day
           ) AND (
-            subq_29.metric_time__day > DATE_ADD('day', -7, subq_32.metric_time__day)
+            subq_27.metric_time__day > DATE_ADD('day', -7, subq_30.metric_time__day)
           )
         )
-    ) subq_33
+    ) subq_31
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_36
+  ) subq_34
   ON
     (
-      subq_24.visit__referrer_id = subq_36.visit__referrer_id
+      subq_24.visit__referrer_id = subq_34.visit__referrer_id
     ) AND (
-      subq_24.metric_time__day = subq_36.metric_time__day
+      subq_24.metric_time__day = subq_34.metric_time__day
     )
   GROUP BY
-    COALESCE(subq_24.metric_time__day, subq_36.metric_time__day)
-    , COALESCE(subq_24.visit__referrer_id, subq_36.visit__referrer_id)
-) subq_37
+    COALESCE(subq_24.metric_time__day, subq_34.metric_time__day)
+    , COALESCE(subq_24.visit__referrer_id, subq_34.visit__referrer_id)
+) subq_35

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/BigQuery/test_conversion_metric_with_custom_granularity__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/BigQuery/test_conversion_metric_with_custom_granularity__plan0_optimized.sql
@@ -3,34 +3,38 @@ test_filename: test_custom_granularity.py
 sql_engine: BigQuery
 ---
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATETIME_TRUNC(ds, day) AS metric_time__day
+    , user_id AS user
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
-  metric_time__martian_day
+  metric_time__martian_day AS metric_time__martian_day
   , CAST(buys AS FLOAT64) / CAST(NULLIF(visits, 0) AS FLOAT64) AS visit_buy_conversion_rate_7days
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_21.metric_time__martian_day, subq_32.metric_time__martian_day) AS metric_time__martian_day
+    COALESCE(subq_21.metric_time__martian_day, subq_31.metric_time__martian_day) AS metric_time__martian_day
     , MAX(subq_21.visits) AS visits
-    , MAX(subq_32.buys) AS buys
+    , MAX(subq_31.buys) AS buys
   FROM (
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28019
     -- Join to Custom Granularity Dataset
     -- Pass Only Elements: ['visits', 'metric_time__martian_day']
     -- Aggregate Measures
     SELECT
       subq_18.martian_day AS metric_time__martian_day
-      , SUM(subq_17.visits) AS visits
-    FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      SELECT
-        1 AS visits
-        , DATETIME_TRUNC(ds, day) AS ds__day
-      FROM ***************************.fct_visits visits_source_src_28000
-    ) subq_17
+      , SUM(sma_28019_cte.visits) AS visits
+    FROM sma_28019_cte sma_28019_cte
     LEFT OUTER JOIN
       ***************************.mf_time_spine subq_18
     ON
-      subq_17.ds__day = subq_18.ds
+      sma_28019_cte.metric_time__day = subq_18.ds
     GROUP BY
       metric_time__martian_day
   ) subq_21
@@ -44,62 +48,55 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_25.visits) OVER (
+        FIRST_VALUE(subq_24.visits) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_25.metric_time__martian_day) OVER (
+        , FIRST_VALUE(subq_24.metric_time__martian_day) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__martian_day
-        , FIRST_VALUE(subq_25.metric_time__day) OVER (
+        , FIRST_VALUE(subq_24.metric_time__day) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_25.user) OVER (
+        , FIRST_VALUE(subq_24.user) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_28.mf_internal_uuid AS mf_internal_uuid
-        , subq_28.buys AS buys
+        , subq_27.mf_internal_uuid AS mf_internal_uuid
+        , subq_27.buys AS buys
       FROM (
-        -- Metric Time Dimension 'ds'
+        -- Read From CTE For node_id=sma_28019
         -- Join to Custom Granularity Dataset
         -- Pass Only Elements: ['visits', 'metric_time__day', 'metric_time__martian_day', 'user']
         SELECT
-          subq_23.martian_day AS metric_time__martian_day
-          , subq_22.ds__day AS metric_time__day
-          , subq_22.user AS user
-          , subq_22.visits AS visits
-        FROM (
-          -- Read Elements From Semantic Model 'visits_source'
-          SELECT
-            1 AS visits
-            , DATETIME_TRUNC(ds, day) AS ds__day
-            , user_id AS user
-          FROM ***************************.fct_visits visits_source_src_28000
-        ) subq_22
+          subq_22.martian_day AS metric_time__martian_day
+          , sma_28019_cte.metric_time__day AS metric_time__day
+          , sma_28019_cte.user AS user
+          , sma_28019_cte.visits AS visits
+        FROM sma_28019_cte sma_28019_cte
         LEFT OUTER JOIN
-          ***************************.mf_time_spine subq_23
+          ***************************.mf_time_spine subq_22
         ON
-          subq_22.ds__day = subq_23.ds
-      ) subq_25
+          sma_28019_cte.metric_time__day = subq_22.ds
+      ) subq_24
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -110,23 +107,23 @@ FROM (
           , 1 AS buys
           , GENERATE_UUID() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_28
+      ) subq_27
       ON
         (
-          subq_25.user = subq_28.user
+          subq_24.user = subq_27.user
         ) AND (
           (
-            subq_25.metric_time__day <= subq_28.metric_time__day
+            subq_24.metric_time__day <= subq_27.metric_time__day
           ) AND (
-            subq_25.metric_time__day > DATE_SUB(CAST(subq_28.metric_time__day AS DATETIME), INTERVAL 7 day)
+            subq_24.metric_time__day > DATE_SUB(CAST(subq_27.metric_time__day AS DATETIME), INTERVAL 7 day)
           )
         )
-    ) subq_29
+    ) subq_28
     GROUP BY
       metric_time__martian_day
-  ) subq_32
+  ) subq_31
   ON
-    subq_21.metric_time__martian_day = subq_32.metric_time__martian_day
+    subq_21.metric_time__martian_day = subq_31.metric_time__martian_day
   GROUP BY
     metric_time__martian_day
-) subq_33
+) subq_32

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/BigQuery/test_conversion_metric_with_custom_granularity_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/BigQuery/test_conversion_metric_with_custom_granularity_filter__plan0_optimized.sql
@@ -3,15 +3,25 @@ test_filename: test_custom_granularity.py
 sql_engine: BigQuery
 ---
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATETIME_TRUNC(ds, day) AS metric_time__day
+    , user_id AS user
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
-  metric_time__martian_day
+  metric_time__martian_day AS metric_time__martian_day
   , CAST(buys AS FLOAT64) / CAST(NULLIF(visits, 0) AS FLOAT64) AS visit_buy_conversion_rate_7days
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_24.metric_time__martian_day, subq_36.metric_time__martian_day) AS metric_time__martian_day
+    COALESCE(subq_24.metric_time__martian_day, subq_35.metric_time__martian_day) AS metric_time__martian_day
     , MAX(subq_24.visits) AS visits
-    , MAX(subq_36.buys) AS buys
+    , MAX(subq_35.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['visits', 'metric_time__martian_day']
@@ -20,22 +30,16 @@ FROM (
       metric_time__martian_day
       , SUM(visits) AS visits
     FROM (
-      -- Metric Time Dimension 'ds'
+      -- Read From CTE For node_id=sma_28019
       -- Join to Custom Granularity Dataset
       SELECT
-        subq_19.visits AS visits
+        sma_28019_cte.visits AS visits
         , subq_20.martian_day AS metric_time__martian_day
-      FROM (
-        -- Read Elements From Semantic Model 'visits_source'
-        SELECT
-          1 AS visits
-          , DATETIME_TRUNC(ds, day) AS ds__day
-        FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_19
+      FROM sma_28019_cte sma_28019_cte
       LEFT OUTER JOIN
         ***************************.mf_time_spine subq_20
       ON
-        subq_19.ds__day = subq_20.ds
+        sma_28019_cte.metric_time__day = subq_20.ds
     ) subq_21
     WHERE metric_time__martian_day = '2020-01-01'
     GROUP BY
@@ -51,71 +55,64 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_29.visits) OVER (
+        FIRST_VALUE(subq_28.visits) OVER (
           PARTITION BY
-            subq_32.user
-            , subq_32.metric_time__day
-            , subq_32.mf_internal_uuid
-          ORDER BY subq_29.metric_time__day DESC
+            subq_31.user
+            , subq_31.metric_time__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_29.metric_time__martian_day) OVER (
+        , FIRST_VALUE(subq_28.metric_time__martian_day) OVER (
           PARTITION BY
-            subq_32.user
-            , subq_32.metric_time__day
-            , subq_32.mf_internal_uuid
-          ORDER BY subq_29.metric_time__day DESC
+            subq_31.user
+            , subq_31.metric_time__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__martian_day
-        , FIRST_VALUE(subq_29.metric_time__day) OVER (
+        , FIRST_VALUE(subq_28.metric_time__day) OVER (
           PARTITION BY
-            subq_32.user
-            , subq_32.metric_time__day
-            , subq_32.mf_internal_uuid
-          ORDER BY subq_29.metric_time__day DESC
+            subq_31.user
+            , subq_31.metric_time__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_29.user) OVER (
+        , FIRST_VALUE(subq_28.user) OVER (
           PARTITION BY
-            subq_32.user
-            , subq_32.metric_time__day
-            , subq_32.mf_internal_uuid
-          ORDER BY subq_29.metric_time__day DESC
+            subq_31.user
+            , subq_31.metric_time__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_32.mf_internal_uuid AS mf_internal_uuid
-        , subq_32.buys AS buys
+        , subq_31.mf_internal_uuid AS mf_internal_uuid
+        , subq_31.buys AS buys
       FROM (
         -- Constrain Output with WHERE
         -- Pass Only Elements: ['visits', 'metric_time__day', 'metric_time__martian_day', 'user']
         SELECT
           metric_time__martian_day
           , metric_time__day
-          , subq_27.user
+          , subq_26.user
           , visits
         FROM (
-          -- Metric Time Dimension 'ds'
+          -- Read From CTE For node_id=sma_28019
           -- Join to Custom Granularity Dataset
           SELECT
-            subq_25.ds__day AS metric_time__day
-            , subq_25.user AS user
-            , subq_25.visits AS visits
-            , subq_26.martian_day AS metric_time__martian_day
-          FROM (
-            -- Read Elements From Semantic Model 'visits_source'
-            SELECT
-              1 AS visits
-              , DATETIME_TRUNC(ds, day) AS ds__day
-              , user_id AS user
-            FROM ***************************.fct_visits visits_source_src_28000
-          ) subq_25
+            sma_28019_cte.metric_time__day AS metric_time__day
+            , sma_28019_cte.user AS user
+            , sma_28019_cte.visits AS visits
+            , subq_25.martian_day AS metric_time__martian_day
+          FROM sma_28019_cte sma_28019_cte
           LEFT OUTER JOIN
-            ***************************.mf_time_spine subq_26
+            ***************************.mf_time_spine subq_25
           ON
-            subq_25.ds__day = subq_26.ds
-        ) subq_27
+            sma_28019_cte.metric_time__day = subq_25.ds
+        ) subq_26
         WHERE metric_time__martian_day = '2020-01-01'
-      ) subq_29
+      ) subq_28
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -126,23 +123,23 @@ FROM (
           , 1 AS buys
           , GENERATE_UUID() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_32
+      ) subq_31
       ON
         (
-          subq_29.user = subq_32.user
+          subq_28.user = subq_31.user
         ) AND (
           (
-            subq_29.metric_time__day <= subq_32.metric_time__day
+            subq_28.metric_time__day <= subq_31.metric_time__day
           ) AND (
-            subq_29.metric_time__day > DATE_SUB(CAST(subq_32.metric_time__day AS DATETIME), INTERVAL 7 day)
+            subq_28.metric_time__day > DATE_SUB(CAST(subq_31.metric_time__day AS DATETIME), INTERVAL 7 day)
           )
         )
-    ) subq_33
+    ) subq_32
     GROUP BY
       metric_time__martian_day
-  ) subq_36
+  ) subq_35
   ON
-    subq_24.metric_time__martian_day = subq_36.metric_time__martian_day
+    subq_24.metric_time__martian_day = subq_35.metric_time__martian_day
   GROUP BY
     metric_time__martian_day
-) subq_37
+) subq_36

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/BigQuery/test_conversion_metric_with_custom_granularity_filter_not_in_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/BigQuery/test_conversion_metric_with_custom_granularity_filter_not_in_group_by__plan0_optimized.sql
@@ -4,8 +4,18 @@ sql_engine: BigQuery
 ---
 -- Combine Aggregated Outputs
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATETIME_TRUNC(ds, day) AS metric_time__day
+    , user_id AS user
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
-  CAST(MAX(subq_36.buys) AS FLOAT64) / CAST(NULLIF(MAX(subq_24.visits), 0) AS FLOAT64) AS visit_buy_conversion_rate_7days
+  CAST(MAX(subq_35.buys) AS FLOAT64) / CAST(NULLIF(MAX(subq_24.visits), 0) AS FLOAT64) AS visit_buy_conversion_rate_7days
 FROM (
   -- Constrain Output with WHERE
   -- Pass Only Elements: ['visits',]
@@ -13,22 +23,16 @@ FROM (
   SELECT
     SUM(visits) AS visits
   FROM (
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28019
     -- Join to Custom Granularity Dataset
     SELECT
-      subq_19.visits AS visits
+      sma_28019_cte.visits AS visits
       , subq_20.martian_day AS metric_time__martian_day
-    FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      SELECT
-        1 AS visits
-        , DATETIME_TRUNC(ds, day) AS ds__day
-      FROM ***************************.fct_visits visits_source_src_28000
-    ) subq_19
+    FROM sma_28019_cte sma_28019_cte
     LEFT OUTER JOIN
       ***************************.mf_time_spine subq_20
     ON
-      subq_19.ds__day = subq_20.ds
+      sma_28019_cte.metric_time__day = subq_20.ds
   ) subq_21
   WHERE metric_time__martian_day = '2020-01-01'
 ) subq_24
@@ -41,71 +45,64 @@ CROSS JOIN (
   FROM (
     -- Dedupe the fanout with mf_internal_uuid in the conversion data set
     SELECT DISTINCT
-      FIRST_VALUE(subq_29.visits) OVER (
+      FIRST_VALUE(subq_28.visits) OVER (
         PARTITION BY
-          subq_32.user
-          , subq_32.metric_time__day
-          , subq_32.mf_internal_uuid
-        ORDER BY subq_29.metric_time__day DESC
+          subq_31.user
+          , subq_31.metric_time__day
+          , subq_31.mf_internal_uuid
+        ORDER BY subq_28.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS visits
-      , FIRST_VALUE(subq_29.metric_time__martian_day) OVER (
+      , FIRST_VALUE(subq_28.metric_time__martian_day) OVER (
         PARTITION BY
-          subq_32.user
-          , subq_32.metric_time__day
-          , subq_32.mf_internal_uuid
-        ORDER BY subq_29.metric_time__day DESC
+          subq_31.user
+          , subq_31.metric_time__day
+          , subq_31.mf_internal_uuid
+        ORDER BY subq_28.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS metric_time__martian_day
-      , FIRST_VALUE(subq_29.metric_time__day) OVER (
+      , FIRST_VALUE(subq_28.metric_time__day) OVER (
         PARTITION BY
-          subq_32.user
-          , subq_32.metric_time__day
-          , subq_32.mf_internal_uuid
-        ORDER BY subq_29.metric_time__day DESC
+          subq_31.user
+          , subq_31.metric_time__day
+          , subq_31.mf_internal_uuid
+        ORDER BY subq_28.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS metric_time__day
-      , FIRST_VALUE(subq_29.user) OVER (
+      , FIRST_VALUE(subq_28.user) OVER (
         PARTITION BY
-          subq_32.user
-          , subq_32.metric_time__day
-          , subq_32.mf_internal_uuid
-        ORDER BY subq_29.metric_time__day DESC
+          subq_31.user
+          , subq_31.metric_time__day
+          , subq_31.mf_internal_uuid
+        ORDER BY subq_28.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS user
-      , subq_32.mf_internal_uuid AS mf_internal_uuid
-      , subq_32.buys AS buys
+      , subq_31.mf_internal_uuid AS mf_internal_uuid
+      , subq_31.buys AS buys
     FROM (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['visits', 'metric_time__day', 'metric_time__martian_day', 'user']
       SELECT
         metric_time__martian_day
         , metric_time__day
-        , subq_27.user
+        , subq_26.user
         , visits
       FROM (
-        -- Metric Time Dimension 'ds'
+        -- Read From CTE For node_id=sma_28019
         -- Join to Custom Granularity Dataset
         SELECT
-          subq_25.ds__day AS metric_time__day
-          , subq_25.user AS user
-          , subq_25.visits AS visits
-          , subq_26.martian_day AS metric_time__martian_day
-        FROM (
-          -- Read Elements From Semantic Model 'visits_source'
-          SELECT
-            1 AS visits
-            , DATETIME_TRUNC(ds, day) AS ds__day
-            , user_id AS user
-          FROM ***************************.fct_visits visits_source_src_28000
-        ) subq_25
+          sma_28019_cte.metric_time__day AS metric_time__day
+          , sma_28019_cte.user AS user
+          , sma_28019_cte.visits AS visits
+          , subq_25.martian_day AS metric_time__martian_day
+        FROM sma_28019_cte sma_28019_cte
         LEFT OUTER JOIN
-          ***************************.mf_time_spine subq_26
+          ***************************.mf_time_spine subq_25
         ON
-          subq_25.ds__day = subq_26.ds
-      ) subq_27
+          sma_28019_cte.metric_time__day = subq_25.ds
+      ) subq_26
       WHERE metric_time__martian_day = '2020-01-01'
-    ) subq_29
+    ) subq_28
     INNER JOIN (
       -- Read Elements From Semantic Model 'buys_source'
       -- Metric Time Dimension 'ds'
@@ -116,16 +113,16 @@ CROSS JOIN (
         , 1 AS buys
         , GENERATE_UUID() AS mf_internal_uuid
       FROM ***************************.fct_buys buys_source_src_28000
-    ) subq_32
+    ) subq_31
     ON
       (
-        subq_29.user = subq_32.user
+        subq_28.user = subq_31.user
       ) AND (
         (
-          subq_29.metric_time__day <= subq_32.metric_time__day
+          subq_28.metric_time__day <= subq_31.metric_time__day
         ) AND (
-          subq_29.metric_time__day > DATE_SUB(CAST(subq_32.metric_time__day AS DATETIME), INTERVAL 7 day)
+          subq_28.metric_time__day > DATE_SUB(CAST(subq_31.metric_time__day AS DATETIME), INTERVAL 7 day)
         )
       )
-  ) subq_33
-) subq_36
+  ) subq_32
+) subq_35

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Databricks/test_conversion_metric_with_custom_granularity__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Databricks/test_conversion_metric_with_custom_granularity__plan0_optimized.sql
@@ -3,34 +3,38 @@ test_filename: test_custom_granularity.py
 sql_engine: Databricks
 ---
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
-  metric_time__martian_day
+  metric_time__martian_day AS metric_time__martian_day
   , CAST(buys AS DOUBLE) / CAST(NULLIF(visits, 0) AS DOUBLE) AS visit_buy_conversion_rate_7days
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_21.metric_time__martian_day, subq_32.metric_time__martian_day) AS metric_time__martian_day
+    COALESCE(subq_21.metric_time__martian_day, subq_31.metric_time__martian_day) AS metric_time__martian_day
     , MAX(subq_21.visits) AS visits
-    , MAX(subq_32.buys) AS buys
+    , MAX(subq_31.buys) AS buys
   FROM (
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28019
     -- Join to Custom Granularity Dataset
     -- Pass Only Elements: ['visits', 'metric_time__martian_day']
     -- Aggregate Measures
     SELECT
       subq_18.martian_day AS metric_time__martian_day
-      , SUM(subq_17.visits) AS visits
-    FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      SELECT
-        1 AS visits
-        , DATE_TRUNC('day', ds) AS ds__day
-      FROM ***************************.fct_visits visits_source_src_28000
-    ) subq_17
+      , SUM(sma_28019_cte.visits) AS visits
+    FROM sma_28019_cte sma_28019_cte
     LEFT OUTER JOIN
       ***************************.mf_time_spine subq_18
     ON
-      subq_17.ds__day = subq_18.ds
+      sma_28019_cte.metric_time__day = subq_18.ds
     GROUP BY
       subq_18.martian_day
   ) subq_21
@@ -44,62 +48,55 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_25.visits) OVER (
+        FIRST_VALUE(subq_24.visits) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_25.metric_time__martian_day) OVER (
+        , FIRST_VALUE(subq_24.metric_time__martian_day) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__martian_day
-        , FIRST_VALUE(subq_25.metric_time__day) OVER (
+        , FIRST_VALUE(subq_24.metric_time__day) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_25.user) OVER (
+        , FIRST_VALUE(subq_24.user) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_28.mf_internal_uuid AS mf_internal_uuid
-        , subq_28.buys AS buys
+        , subq_27.mf_internal_uuid AS mf_internal_uuid
+        , subq_27.buys AS buys
       FROM (
-        -- Metric Time Dimension 'ds'
+        -- Read From CTE For node_id=sma_28019
         -- Join to Custom Granularity Dataset
         -- Pass Only Elements: ['visits', 'metric_time__day', 'metric_time__martian_day', 'user']
         SELECT
-          subq_23.martian_day AS metric_time__martian_day
-          , subq_22.ds__day AS metric_time__day
-          , subq_22.user AS user
-          , subq_22.visits AS visits
-        FROM (
-          -- Read Elements From Semantic Model 'visits_source'
-          SELECT
-            1 AS visits
-            , DATE_TRUNC('day', ds) AS ds__day
-            , user_id AS user
-          FROM ***************************.fct_visits visits_source_src_28000
-        ) subq_22
+          subq_22.martian_day AS metric_time__martian_day
+          , sma_28019_cte.metric_time__day AS metric_time__day
+          , sma_28019_cte.user AS user
+          , sma_28019_cte.visits AS visits
+        FROM sma_28019_cte sma_28019_cte
         LEFT OUTER JOIN
-          ***************************.mf_time_spine subq_23
+          ***************************.mf_time_spine subq_22
         ON
-          subq_22.ds__day = subq_23.ds
-      ) subq_25
+          sma_28019_cte.metric_time__day = subq_22.ds
+      ) subq_24
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -110,23 +107,23 @@ FROM (
           , 1 AS buys
           , UUID() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_28
+      ) subq_27
       ON
         (
-          subq_25.user = subq_28.user
+          subq_24.user = subq_27.user
         ) AND (
           (
-            subq_25.metric_time__day <= subq_28.metric_time__day
+            subq_24.metric_time__day <= subq_27.metric_time__day
           ) AND (
-            subq_25.metric_time__day > DATEADD(day, -7, subq_28.metric_time__day)
+            subq_24.metric_time__day > DATEADD(day, -7, subq_27.metric_time__day)
           )
         )
-    ) subq_29
+    ) subq_28
     GROUP BY
       metric_time__martian_day
-  ) subq_32
+  ) subq_31
   ON
-    subq_21.metric_time__martian_day = subq_32.metric_time__martian_day
+    subq_21.metric_time__martian_day = subq_31.metric_time__martian_day
   GROUP BY
-    COALESCE(subq_21.metric_time__martian_day, subq_32.metric_time__martian_day)
-) subq_33
+    COALESCE(subq_21.metric_time__martian_day, subq_31.metric_time__martian_day)
+) subq_32

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Databricks/test_conversion_metric_with_custom_granularity_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Databricks/test_conversion_metric_with_custom_granularity_filter__plan0_optimized.sql
@@ -3,15 +3,25 @@ test_filename: test_custom_granularity.py
 sql_engine: Databricks
 ---
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
-  metric_time__martian_day
+  metric_time__martian_day AS metric_time__martian_day
   , CAST(buys AS DOUBLE) / CAST(NULLIF(visits, 0) AS DOUBLE) AS visit_buy_conversion_rate_7days
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_24.metric_time__martian_day, subq_36.metric_time__martian_day) AS metric_time__martian_day
+    COALESCE(subq_24.metric_time__martian_day, subq_35.metric_time__martian_day) AS metric_time__martian_day
     , MAX(subq_24.visits) AS visits
-    , MAX(subq_36.buys) AS buys
+    , MAX(subq_35.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['visits', 'metric_time__martian_day']
@@ -20,22 +30,16 @@ FROM (
       metric_time__martian_day
       , SUM(visits) AS visits
     FROM (
-      -- Metric Time Dimension 'ds'
+      -- Read From CTE For node_id=sma_28019
       -- Join to Custom Granularity Dataset
       SELECT
-        subq_19.visits AS visits
+        sma_28019_cte.visits AS visits
         , subq_20.martian_day AS metric_time__martian_day
-      FROM (
-        -- Read Elements From Semantic Model 'visits_source'
-        SELECT
-          1 AS visits
-          , DATE_TRUNC('day', ds) AS ds__day
-        FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_19
+      FROM sma_28019_cte sma_28019_cte
       LEFT OUTER JOIN
         ***************************.mf_time_spine subq_20
       ON
-        subq_19.ds__day = subq_20.ds
+        sma_28019_cte.metric_time__day = subq_20.ds
     ) subq_21
     WHERE metric_time__martian_day = '2020-01-01'
     GROUP BY
@@ -51,71 +55,64 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_29.visits) OVER (
+        FIRST_VALUE(subq_28.visits) OVER (
           PARTITION BY
-            subq_32.user
-            , subq_32.metric_time__day
-            , subq_32.mf_internal_uuid
-          ORDER BY subq_29.metric_time__day DESC
+            subq_31.user
+            , subq_31.metric_time__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_29.metric_time__martian_day) OVER (
+        , FIRST_VALUE(subq_28.metric_time__martian_day) OVER (
           PARTITION BY
-            subq_32.user
-            , subq_32.metric_time__day
-            , subq_32.mf_internal_uuid
-          ORDER BY subq_29.metric_time__day DESC
+            subq_31.user
+            , subq_31.metric_time__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__martian_day
-        , FIRST_VALUE(subq_29.metric_time__day) OVER (
+        , FIRST_VALUE(subq_28.metric_time__day) OVER (
           PARTITION BY
-            subq_32.user
-            , subq_32.metric_time__day
-            , subq_32.mf_internal_uuid
-          ORDER BY subq_29.metric_time__day DESC
+            subq_31.user
+            , subq_31.metric_time__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_29.user) OVER (
+        , FIRST_VALUE(subq_28.user) OVER (
           PARTITION BY
-            subq_32.user
-            , subq_32.metric_time__day
-            , subq_32.mf_internal_uuid
-          ORDER BY subq_29.metric_time__day DESC
+            subq_31.user
+            , subq_31.metric_time__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_32.mf_internal_uuid AS mf_internal_uuid
-        , subq_32.buys AS buys
+        , subq_31.mf_internal_uuid AS mf_internal_uuid
+        , subq_31.buys AS buys
       FROM (
         -- Constrain Output with WHERE
         -- Pass Only Elements: ['visits', 'metric_time__day', 'metric_time__martian_day', 'user']
         SELECT
           metric_time__martian_day
           , metric_time__day
-          , subq_27.user
+          , subq_26.user
           , visits
         FROM (
-          -- Metric Time Dimension 'ds'
+          -- Read From CTE For node_id=sma_28019
           -- Join to Custom Granularity Dataset
           SELECT
-            subq_25.ds__day AS metric_time__day
-            , subq_25.user AS user
-            , subq_25.visits AS visits
-            , subq_26.martian_day AS metric_time__martian_day
-          FROM (
-            -- Read Elements From Semantic Model 'visits_source'
-            SELECT
-              1 AS visits
-              , DATE_TRUNC('day', ds) AS ds__day
-              , user_id AS user
-            FROM ***************************.fct_visits visits_source_src_28000
-          ) subq_25
+            sma_28019_cte.metric_time__day AS metric_time__day
+            , sma_28019_cte.user AS user
+            , sma_28019_cte.visits AS visits
+            , subq_25.martian_day AS metric_time__martian_day
+          FROM sma_28019_cte sma_28019_cte
           LEFT OUTER JOIN
-            ***************************.mf_time_spine subq_26
+            ***************************.mf_time_spine subq_25
           ON
-            subq_25.ds__day = subq_26.ds
-        ) subq_27
+            sma_28019_cte.metric_time__day = subq_25.ds
+        ) subq_26
         WHERE metric_time__martian_day = '2020-01-01'
-      ) subq_29
+      ) subq_28
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -126,23 +123,23 @@ FROM (
           , 1 AS buys
           , UUID() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_32
+      ) subq_31
       ON
         (
-          subq_29.user = subq_32.user
+          subq_28.user = subq_31.user
         ) AND (
           (
-            subq_29.metric_time__day <= subq_32.metric_time__day
+            subq_28.metric_time__day <= subq_31.metric_time__day
           ) AND (
-            subq_29.metric_time__day > DATEADD(day, -7, subq_32.metric_time__day)
+            subq_28.metric_time__day > DATEADD(day, -7, subq_31.metric_time__day)
           )
         )
-    ) subq_33
+    ) subq_32
     GROUP BY
       metric_time__martian_day
-  ) subq_36
+  ) subq_35
   ON
-    subq_24.metric_time__martian_day = subq_36.metric_time__martian_day
+    subq_24.metric_time__martian_day = subq_35.metric_time__martian_day
   GROUP BY
-    COALESCE(subq_24.metric_time__martian_day, subq_36.metric_time__martian_day)
-) subq_37
+    COALESCE(subq_24.metric_time__martian_day, subq_35.metric_time__martian_day)
+) subq_36

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Databricks/test_conversion_metric_with_custom_granularity_filter_not_in_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Databricks/test_conversion_metric_with_custom_granularity_filter_not_in_group_by__plan0_optimized.sql
@@ -4,8 +4,18 @@ sql_engine: Databricks
 ---
 -- Combine Aggregated Outputs
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
-  CAST(MAX(subq_36.buys) AS DOUBLE) / CAST(NULLIF(MAX(subq_24.visits), 0) AS DOUBLE) AS visit_buy_conversion_rate_7days
+  CAST(MAX(subq_35.buys) AS DOUBLE) / CAST(NULLIF(MAX(subq_24.visits), 0) AS DOUBLE) AS visit_buy_conversion_rate_7days
 FROM (
   -- Constrain Output with WHERE
   -- Pass Only Elements: ['visits',]
@@ -13,22 +23,16 @@ FROM (
   SELECT
     SUM(visits) AS visits
   FROM (
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28019
     -- Join to Custom Granularity Dataset
     SELECT
-      subq_19.visits AS visits
+      sma_28019_cte.visits AS visits
       , subq_20.martian_day AS metric_time__martian_day
-    FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      SELECT
-        1 AS visits
-        , DATE_TRUNC('day', ds) AS ds__day
-      FROM ***************************.fct_visits visits_source_src_28000
-    ) subq_19
+    FROM sma_28019_cte sma_28019_cte
     LEFT OUTER JOIN
       ***************************.mf_time_spine subq_20
     ON
-      subq_19.ds__day = subq_20.ds
+      sma_28019_cte.metric_time__day = subq_20.ds
   ) subq_21
   WHERE metric_time__martian_day = '2020-01-01'
 ) subq_24
@@ -41,71 +45,64 @@ CROSS JOIN (
   FROM (
     -- Dedupe the fanout with mf_internal_uuid in the conversion data set
     SELECT DISTINCT
-      FIRST_VALUE(subq_29.visits) OVER (
+      FIRST_VALUE(subq_28.visits) OVER (
         PARTITION BY
-          subq_32.user
-          , subq_32.metric_time__day
-          , subq_32.mf_internal_uuid
-        ORDER BY subq_29.metric_time__day DESC
+          subq_31.user
+          , subq_31.metric_time__day
+          , subq_31.mf_internal_uuid
+        ORDER BY subq_28.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS visits
-      , FIRST_VALUE(subq_29.metric_time__martian_day) OVER (
+      , FIRST_VALUE(subq_28.metric_time__martian_day) OVER (
         PARTITION BY
-          subq_32.user
-          , subq_32.metric_time__day
-          , subq_32.mf_internal_uuid
-        ORDER BY subq_29.metric_time__day DESC
+          subq_31.user
+          , subq_31.metric_time__day
+          , subq_31.mf_internal_uuid
+        ORDER BY subq_28.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS metric_time__martian_day
-      , FIRST_VALUE(subq_29.metric_time__day) OVER (
+      , FIRST_VALUE(subq_28.metric_time__day) OVER (
         PARTITION BY
-          subq_32.user
-          , subq_32.metric_time__day
-          , subq_32.mf_internal_uuid
-        ORDER BY subq_29.metric_time__day DESC
+          subq_31.user
+          , subq_31.metric_time__day
+          , subq_31.mf_internal_uuid
+        ORDER BY subq_28.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS metric_time__day
-      , FIRST_VALUE(subq_29.user) OVER (
+      , FIRST_VALUE(subq_28.user) OVER (
         PARTITION BY
-          subq_32.user
-          , subq_32.metric_time__day
-          , subq_32.mf_internal_uuid
-        ORDER BY subq_29.metric_time__day DESC
+          subq_31.user
+          , subq_31.metric_time__day
+          , subq_31.mf_internal_uuid
+        ORDER BY subq_28.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS user
-      , subq_32.mf_internal_uuid AS mf_internal_uuid
-      , subq_32.buys AS buys
+      , subq_31.mf_internal_uuid AS mf_internal_uuid
+      , subq_31.buys AS buys
     FROM (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['visits', 'metric_time__day', 'metric_time__martian_day', 'user']
       SELECT
         metric_time__martian_day
         , metric_time__day
-        , subq_27.user
+        , subq_26.user
         , visits
       FROM (
-        -- Metric Time Dimension 'ds'
+        -- Read From CTE For node_id=sma_28019
         -- Join to Custom Granularity Dataset
         SELECT
-          subq_25.ds__day AS metric_time__day
-          , subq_25.user AS user
-          , subq_25.visits AS visits
-          , subq_26.martian_day AS metric_time__martian_day
-        FROM (
-          -- Read Elements From Semantic Model 'visits_source'
-          SELECT
-            1 AS visits
-            , DATE_TRUNC('day', ds) AS ds__day
-            , user_id AS user
-          FROM ***************************.fct_visits visits_source_src_28000
-        ) subq_25
+          sma_28019_cte.metric_time__day AS metric_time__day
+          , sma_28019_cte.user AS user
+          , sma_28019_cte.visits AS visits
+          , subq_25.martian_day AS metric_time__martian_day
+        FROM sma_28019_cte sma_28019_cte
         LEFT OUTER JOIN
-          ***************************.mf_time_spine subq_26
+          ***************************.mf_time_spine subq_25
         ON
-          subq_25.ds__day = subq_26.ds
-      ) subq_27
+          sma_28019_cte.metric_time__day = subq_25.ds
+      ) subq_26
       WHERE metric_time__martian_day = '2020-01-01'
-    ) subq_29
+    ) subq_28
     INNER JOIN (
       -- Read Elements From Semantic Model 'buys_source'
       -- Metric Time Dimension 'ds'
@@ -116,16 +113,16 @@ CROSS JOIN (
         , 1 AS buys
         , UUID() AS mf_internal_uuid
       FROM ***************************.fct_buys buys_source_src_28000
-    ) subq_32
+    ) subq_31
     ON
       (
-        subq_29.user = subq_32.user
+        subq_28.user = subq_31.user
       ) AND (
         (
-          subq_29.metric_time__day <= subq_32.metric_time__day
+          subq_28.metric_time__day <= subq_31.metric_time__day
         ) AND (
-          subq_29.metric_time__day > DATEADD(day, -7, subq_32.metric_time__day)
+          subq_28.metric_time__day > DATEADD(day, -7, subq_31.metric_time__day)
         )
       )
-  ) subq_33
-) subq_36
+  ) subq_32
+) subq_35

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/DuckDB/test_conversion_metric_with_custom_granularity__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/DuckDB/test_conversion_metric_with_custom_granularity__plan0_optimized.sql
@@ -3,34 +3,38 @@ test_filename: test_custom_granularity.py
 sql_engine: DuckDB
 ---
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
-  metric_time__martian_day
+  metric_time__martian_day AS metric_time__martian_day
   , CAST(buys AS DOUBLE) / CAST(NULLIF(visits, 0) AS DOUBLE) AS visit_buy_conversion_rate_7days
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_21.metric_time__martian_day, subq_32.metric_time__martian_day) AS metric_time__martian_day
+    COALESCE(subq_21.metric_time__martian_day, subq_31.metric_time__martian_day) AS metric_time__martian_day
     , MAX(subq_21.visits) AS visits
-    , MAX(subq_32.buys) AS buys
+    , MAX(subq_31.buys) AS buys
   FROM (
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28019
     -- Join to Custom Granularity Dataset
     -- Pass Only Elements: ['visits', 'metric_time__martian_day']
     -- Aggregate Measures
     SELECT
       subq_18.martian_day AS metric_time__martian_day
-      , SUM(subq_17.visits) AS visits
-    FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      SELECT
-        1 AS visits
-        , DATE_TRUNC('day', ds) AS ds__day
-      FROM ***************************.fct_visits visits_source_src_28000
-    ) subq_17
+      , SUM(sma_28019_cte.visits) AS visits
+    FROM sma_28019_cte sma_28019_cte
     LEFT OUTER JOIN
       ***************************.mf_time_spine subq_18
     ON
-      subq_17.ds__day = subq_18.ds
+      sma_28019_cte.metric_time__day = subq_18.ds
     GROUP BY
       subq_18.martian_day
   ) subq_21
@@ -44,62 +48,55 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_25.visits) OVER (
+        FIRST_VALUE(subq_24.visits) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_25.metric_time__martian_day) OVER (
+        , FIRST_VALUE(subq_24.metric_time__martian_day) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__martian_day
-        , FIRST_VALUE(subq_25.metric_time__day) OVER (
+        , FIRST_VALUE(subq_24.metric_time__day) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_25.user) OVER (
+        , FIRST_VALUE(subq_24.user) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_28.mf_internal_uuid AS mf_internal_uuid
-        , subq_28.buys AS buys
+        , subq_27.mf_internal_uuid AS mf_internal_uuid
+        , subq_27.buys AS buys
       FROM (
-        -- Metric Time Dimension 'ds'
+        -- Read From CTE For node_id=sma_28019
         -- Join to Custom Granularity Dataset
         -- Pass Only Elements: ['visits', 'metric_time__day', 'metric_time__martian_day', 'user']
         SELECT
-          subq_23.martian_day AS metric_time__martian_day
-          , subq_22.ds__day AS metric_time__day
-          , subq_22.user AS user
-          , subq_22.visits AS visits
-        FROM (
-          -- Read Elements From Semantic Model 'visits_source'
-          SELECT
-            1 AS visits
-            , DATE_TRUNC('day', ds) AS ds__day
-            , user_id AS user
-          FROM ***************************.fct_visits visits_source_src_28000
-        ) subq_22
+          subq_22.martian_day AS metric_time__martian_day
+          , sma_28019_cte.metric_time__day AS metric_time__day
+          , sma_28019_cte.user AS user
+          , sma_28019_cte.visits AS visits
+        FROM sma_28019_cte sma_28019_cte
         LEFT OUTER JOIN
-          ***************************.mf_time_spine subq_23
+          ***************************.mf_time_spine subq_22
         ON
-          subq_22.ds__day = subq_23.ds
-      ) subq_25
+          sma_28019_cte.metric_time__day = subq_22.ds
+      ) subq_24
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -110,23 +107,23 @@ FROM (
           , 1 AS buys
           , GEN_RANDOM_UUID() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_28
+      ) subq_27
       ON
         (
-          subq_25.user = subq_28.user
+          subq_24.user = subq_27.user
         ) AND (
           (
-            subq_25.metric_time__day <= subq_28.metric_time__day
+            subq_24.metric_time__day <= subq_27.metric_time__day
           ) AND (
-            subq_25.metric_time__day > subq_28.metric_time__day - INTERVAL 7 day
+            subq_24.metric_time__day > subq_27.metric_time__day - INTERVAL 7 day
           )
         )
-    ) subq_29
+    ) subq_28
     GROUP BY
       metric_time__martian_day
-  ) subq_32
+  ) subq_31
   ON
-    subq_21.metric_time__martian_day = subq_32.metric_time__martian_day
+    subq_21.metric_time__martian_day = subq_31.metric_time__martian_day
   GROUP BY
-    COALESCE(subq_21.metric_time__martian_day, subq_32.metric_time__martian_day)
-) subq_33
+    COALESCE(subq_21.metric_time__martian_day, subq_31.metric_time__martian_day)
+) subq_32

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/DuckDB/test_conversion_metric_with_custom_granularity_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/DuckDB/test_conversion_metric_with_custom_granularity_filter__plan0_optimized.sql
@@ -3,15 +3,25 @@ test_filename: test_custom_granularity.py
 sql_engine: DuckDB
 ---
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
-  metric_time__martian_day
+  metric_time__martian_day AS metric_time__martian_day
   , CAST(buys AS DOUBLE) / CAST(NULLIF(visits, 0) AS DOUBLE) AS visit_buy_conversion_rate_7days
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_24.metric_time__martian_day, subq_36.metric_time__martian_day) AS metric_time__martian_day
+    COALESCE(subq_24.metric_time__martian_day, subq_35.metric_time__martian_day) AS metric_time__martian_day
     , MAX(subq_24.visits) AS visits
-    , MAX(subq_36.buys) AS buys
+    , MAX(subq_35.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['visits', 'metric_time__martian_day']
@@ -20,22 +30,16 @@ FROM (
       metric_time__martian_day
       , SUM(visits) AS visits
     FROM (
-      -- Metric Time Dimension 'ds'
+      -- Read From CTE For node_id=sma_28019
       -- Join to Custom Granularity Dataset
       SELECT
-        subq_19.visits AS visits
+        sma_28019_cte.visits AS visits
         , subq_20.martian_day AS metric_time__martian_day
-      FROM (
-        -- Read Elements From Semantic Model 'visits_source'
-        SELECT
-          1 AS visits
-          , DATE_TRUNC('day', ds) AS ds__day
-        FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_19
+      FROM sma_28019_cte sma_28019_cte
       LEFT OUTER JOIN
         ***************************.mf_time_spine subq_20
       ON
-        subq_19.ds__day = subq_20.ds
+        sma_28019_cte.metric_time__day = subq_20.ds
     ) subq_21
     WHERE metric_time__martian_day = '2020-01-01'
     GROUP BY
@@ -51,71 +55,64 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_29.visits) OVER (
+        FIRST_VALUE(subq_28.visits) OVER (
           PARTITION BY
-            subq_32.user
-            , subq_32.metric_time__day
-            , subq_32.mf_internal_uuid
-          ORDER BY subq_29.metric_time__day DESC
+            subq_31.user
+            , subq_31.metric_time__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_29.metric_time__martian_day) OVER (
+        , FIRST_VALUE(subq_28.metric_time__martian_day) OVER (
           PARTITION BY
-            subq_32.user
-            , subq_32.metric_time__day
-            , subq_32.mf_internal_uuid
-          ORDER BY subq_29.metric_time__day DESC
+            subq_31.user
+            , subq_31.metric_time__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__martian_day
-        , FIRST_VALUE(subq_29.metric_time__day) OVER (
+        , FIRST_VALUE(subq_28.metric_time__day) OVER (
           PARTITION BY
-            subq_32.user
-            , subq_32.metric_time__day
-            , subq_32.mf_internal_uuid
-          ORDER BY subq_29.metric_time__day DESC
+            subq_31.user
+            , subq_31.metric_time__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_29.user) OVER (
+        , FIRST_VALUE(subq_28.user) OVER (
           PARTITION BY
-            subq_32.user
-            , subq_32.metric_time__day
-            , subq_32.mf_internal_uuid
-          ORDER BY subq_29.metric_time__day DESC
+            subq_31.user
+            , subq_31.metric_time__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_32.mf_internal_uuid AS mf_internal_uuid
-        , subq_32.buys AS buys
+        , subq_31.mf_internal_uuid AS mf_internal_uuid
+        , subq_31.buys AS buys
       FROM (
         -- Constrain Output with WHERE
         -- Pass Only Elements: ['visits', 'metric_time__day', 'metric_time__martian_day', 'user']
         SELECT
           metric_time__martian_day
           , metric_time__day
-          , subq_27.user
+          , subq_26.user
           , visits
         FROM (
-          -- Metric Time Dimension 'ds'
+          -- Read From CTE For node_id=sma_28019
           -- Join to Custom Granularity Dataset
           SELECT
-            subq_25.ds__day AS metric_time__day
-            , subq_25.user AS user
-            , subq_25.visits AS visits
-            , subq_26.martian_day AS metric_time__martian_day
-          FROM (
-            -- Read Elements From Semantic Model 'visits_source'
-            SELECT
-              1 AS visits
-              , DATE_TRUNC('day', ds) AS ds__day
-              , user_id AS user
-            FROM ***************************.fct_visits visits_source_src_28000
-          ) subq_25
+            sma_28019_cte.metric_time__day AS metric_time__day
+            , sma_28019_cte.user AS user
+            , sma_28019_cte.visits AS visits
+            , subq_25.martian_day AS metric_time__martian_day
+          FROM sma_28019_cte sma_28019_cte
           LEFT OUTER JOIN
-            ***************************.mf_time_spine subq_26
+            ***************************.mf_time_spine subq_25
           ON
-            subq_25.ds__day = subq_26.ds
-        ) subq_27
+            sma_28019_cte.metric_time__day = subq_25.ds
+        ) subq_26
         WHERE metric_time__martian_day = '2020-01-01'
-      ) subq_29
+      ) subq_28
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -126,23 +123,23 @@ FROM (
           , 1 AS buys
           , GEN_RANDOM_UUID() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_32
+      ) subq_31
       ON
         (
-          subq_29.user = subq_32.user
+          subq_28.user = subq_31.user
         ) AND (
           (
-            subq_29.metric_time__day <= subq_32.metric_time__day
+            subq_28.metric_time__day <= subq_31.metric_time__day
           ) AND (
-            subq_29.metric_time__day > subq_32.metric_time__day - INTERVAL 7 day
+            subq_28.metric_time__day > subq_31.metric_time__day - INTERVAL 7 day
           )
         )
-    ) subq_33
+    ) subq_32
     GROUP BY
       metric_time__martian_day
-  ) subq_36
+  ) subq_35
   ON
-    subq_24.metric_time__martian_day = subq_36.metric_time__martian_day
+    subq_24.metric_time__martian_day = subq_35.metric_time__martian_day
   GROUP BY
-    COALESCE(subq_24.metric_time__martian_day, subq_36.metric_time__martian_day)
-) subq_37
+    COALESCE(subq_24.metric_time__martian_day, subq_35.metric_time__martian_day)
+) subq_36

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/DuckDB/test_conversion_metric_with_custom_granularity_filter_not_in_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/DuckDB/test_conversion_metric_with_custom_granularity_filter_not_in_group_by__plan0_optimized.sql
@@ -4,8 +4,18 @@ sql_engine: DuckDB
 ---
 -- Combine Aggregated Outputs
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
-  CAST(MAX(subq_36.buys) AS DOUBLE) / CAST(NULLIF(MAX(subq_24.visits), 0) AS DOUBLE) AS visit_buy_conversion_rate_7days
+  CAST(MAX(subq_35.buys) AS DOUBLE) / CAST(NULLIF(MAX(subq_24.visits), 0) AS DOUBLE) AS visit_buy_conversion_rate_7days
 FROM (
   -- Constrain Output with WHERE
   -- Pass Only Elements: ['visits',]
@@ -13,22 +23,16 @@ FROM (
   SELECT
     SUM(visits) AS visits
   FROM (
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28019
     -- Join to Custom Granularity Dataset
     SELECT
-      subq_19.visits AS visits
+      sma_28019_cte.visits AS visits
       , subq_20.martian_day AS metric_time__martian_day
-    FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      SELECT
-        1 AS visits
-        , DATE_TRUNC('day', ds) AS ds__day
-      FROM ***************************.fct_visits visits_source_src_28000
-    ) subq_19
+    FROM sma_28019_cte sma_28019_cte
     LEFT OUTER JOIN
       ***************************.mf_time_spine subq_20
     ON
-      subq_19.ds__day = subq_20.ds
+      sma_28019_cte.metric_time__day = subq_20.ds
   ) subq_21
   WHERE metric_time__martian_day = '2020-01-01'
 ) subq_24
@@ -41,71 +45,64 @@ CROSS JOIN (
   FROM (
     -- Dedupe the fanout with mf_internal_uuid in the conversion data set
     SELECT DISTINCT
-      FIRST_VALUE(subq_29.visits) OVER (
+      FIRST_VALUE(subq_28.visits) OVER (
         PARTITION BY
-          subq_32.user
-          , subq_32.metric_time__day
-          , subq_32.mf_internal_uuid
-        ORDER BY subq_29.metric_time__day DESC
+          subq_31.user
+          , subq_31.metric_time__day
+          , subq_31.mf_internal_uuid
+        ORDER BY subq_28.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS visits
-      , FIRST_VALUE(subq_29.metric_time__martian_day) OVER (
+      , FIRST_VALUE(subq_28.metric_time__martian_day) OVER (
         PARTITION BY
-          subq_32.user
-          , subq_32.metric_time__day
-          , subq_32.mf_internal_uuid
-        ORDER BY subq_29.metric_time__day DESC
+          subq_31.user
+          , subq_31.metric_time__day
+          , subq_31.mf_internal_uuid
+        ORDER BY subq_28.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS metric_time__martian_day
-      , FIRST_VALUE(subq_29.metric_time__day) OVER (
+      , FIRST_VALUE(subq_28.metric_time__day) OVER (
         PARTITION BY
-          subq_32.user
-          , subq_32.metric_time__day
-          , subq_32.mf_internal_uuid
-        ORDER BY subq_29.metric_time__day DESC
+          subq_31.user
+          , subq_31.metric_time__day
+          , subq_31.mf_internal_uuid
+        ORDER BY subq_28.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS metric_time__day
-      , FIRST_VALUE(subq_29.user) OVER (
+      , FIRST_VALUE(subq_28.user) OVER (
         PARTITION BY
-          subq_32.user
-          , subq_32.metric_time__day
-          , subq_32.mf_internal_uuid
-        ORDER BY subq_29.metric_time__day DESC
+          subq_31.user
+          , subq_31.metric_time__day
+          , subq_31.mf_internal_uuid
+        ORDER BY subq_28.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS user
-      , subq_32.mf_internal_uuid AS mf_internal_uuid
-      , subq_32.buys AS buys
+      , subq_31.mf_internal_uuid AS mf_internal_uuid
+      , subq_31.buys AS buys
     FROM (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['visits', 'metric_time__day', 'metric_time__martian_day', 'user']
       SELECT
         metric_time__martian_day
         , metric_time__day
-        , subq_27.user
+        , subq_26.user
         , visits
       FROM (
-        -- Metric Time Dimension 'ds'
+        -- Read From CTE For node_id=sma_28019
         -- Join to Custom Granularity Dataset
         SELECT
-          subq_25.ds__day AS metric_time__day
-          , subq_25.user AS user
-          , subq_25.visits AS visits
-          , subq_26.martian_day AS metric_time__martian_day
-        FROM (
-          -- Read Elements From Semantic Model 'visits_source'
-          SELECT
-            1 AS visits
-            , DATE_TRUNC('day', ds) AS ds__day
-            , user_id AS user
-          FROM ***************************.fct_visits visits_source_src_28000
-        ) subq_25
+          sma_28019_cte.metric_time__day AS metric_time__day
+          , sma_28019_cte.user AS user
+          , sma_28019_cte.visits AS visits
+          , subq_25.martian_day AS metric_time__martian_day
+        FROM sma_28019_cte sma_28019_cte
         LEFT OUTER JOIN
-          ***************************.mf_time_spine subq_26
+          ***************************.mf_time_spine subq_25
         ON
-          subq_25.ds__day = subq_26.ds
-      ) subq_27
+          sma_28019_cte.metric_time__day = subq_25.ds
+      ) subq_26
       WHERE metric_time__martian_day = '2020-01-01'
-    ) subq_29
+    ) subq_28
     INNER JOIN (
       -- Read Elements From Semantic Model 'buys_source'
       -- Metric Time Dimension 'ds'
@@ -116,16 +113,16 @@ CROSS JOIN (
         , 1 AS buys
         , GEN_RANDOM_UUID() AS mf_internal_uuid
       FROM ***************************.fct_buys buys_source_src_28000
-    ) subq_32
+    ) subq_31
     ON
       (
-        subq_29.user = subq_32.user
+        subq_28.user = subq_31.user
       ) AND (
         (
-          subq_29.metric_time__day <= subq_32.metric_time__day
+          subq_28.metric_time__day <= subq_31.metric_time__day
         ) AND (
-          subq_29.metric_time__day > subq_32.metric_time__day - INTERVAL 7 day
+          subq_28.metric_time__day > subq_31.metric_time__day - INTERVAL 7 day
         )
       )
-  ) subq_33
-) subq_36
+  ) subq_32
+) subq_35

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Postgres/test_conversion_metric_with_custom_granularity__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Postgres/test_conversion_metric_with_custom_granularity__plan0_optimized.sql
@@ -3,34 +3,38 @@ test_filename: test_custom_granularity.py
 sql_engine: Postgres
 ---
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
-  metric_time__martian_day
+  metric_time__martian_day AS metric_time__martian_day
   , CAST(buys AS DOUBLE PRECISION) / CAST(NULLIF(visits, 0) AS DOUBLE PRECISION) AS visit_buy_conversion_rate_7days
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_21.metric_time__martian_day, subq_32.metric_time__martian_day) AS metric_time__martian_day
+    COALESCE(subq_21.metric_time__martian_day, subq_31.metric_time__martian_day) AS metric_time__martian_day
     , MAX(subq_21.visits) AS visits
-    , MAX(subq_32.buys) AS buys
+    , MAX(subq_31.buys) AS buys
   FROM (
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28019
     -- Join to Custom Granularity Dataset
     -- Pass Only Elements: ['visits', 'metric_time__martian_day']
     -- Aggregate Measures
     SELECT
       subq_18.martian_day AS metric_time__martian_day
-      , SUM(subq_17.visits) AS visits
-    FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      SELECT
-        1 AS visits
-        , DATE_TRUNC('day', ds) AS ds__day
-      FROM ***************************.fct_visits visits_source_src_28000
-    ) subq_17
+      , SUM(sma_28019_cte.visits) AS visits
+    FROM sma_28019_cte sma_28019_cte
     LEFT OUTER JOIN
       ***************************.mf_time_spine subq_18
     ON
-      subq_17.ds__day = subq_18.ds
+      sma_28019_cte.metric_time__day = subq_18.ds
     GROUP BY
       subq_18.martian_day
   ) subq_21
@@ -44,62 +48,55 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_25.visits) OVER (
+        FIRST_VALUE(subq_24.visits) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_25.metric_time__martian_day) OVER (
+        , FIRST_VALUE(subq_24.metric_time__martian_day) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__martian_day
-        , FIRST_VALUE(subq_25.metric_time__day) OVER (
+        , FIRST_VALUE(subq_24.metric_time__day) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_25.user) OVER (
+        , FIRST_VALUE(subq_24.user) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_28.mf_internal_uuid AS mf_internal_uuid
-        , subq_28.buys AS buys
+        , subq_27.mf_internal_uuid AS mf_internal_uuid
+        , subq_27.buys AS buys
       FROM (
-        -- Metric Time Dimension 'ds'
+        -- Read From CTE For node_id=sma_28019
         -- Join to Custom Granularity Dataset
         -- Pass Only Elements: ['visits', 'metric_time__day', 'metric_time__martian_day', 'user']
         SELECT
-          subq_23.martian_day AS metric_time__martian_day
-          , subq_22.ds__day AS metric_time__day
-          , subq_22.user AS user
-          , subq_22.visits AS visits
-        FROM (
-          -- Read Elements From Semantic Model 'visits_source'
-          SELECT
-            1 AS visits
-            , DATE_TRUNC('day', ds) AS ds__day
-            , user_id AS user
-          FROM ***************************.fct_visits visits_source_src_28000
-        ) subq_22
+          subq_22.martian_day AS metric_time__martian_day
+          , sma_28019_cte.metric_time__day AS metric_time__day
+          , sma_28019_cte.user AS user
+          , sma_28019_cte.visits AS visits
+        FROM sma_28019_cte sma_28019_cte
         LEFT OUTER JOIN
-          ***************************.mf_time_spine subq_23
+          ***************************.mf_time_spine subq_22
         ON
-          subq_22.ds__day = subq_23.ds
-      ) subq_25
+          sma_28019_cte.metric_time__day = subq_22.ds
+      ) subq_24
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -110,23 +107,23 @@ FROM (
           , 1 AS buys
           , GEN_RANDOM_UUID() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_28
+      ) subq_27
       ON
         (
-          subq_25.user = subq_28.user
+          subq_24.user = subq_27.user
         ) AND (
           (
-            subq_25.metric_time__day <= subq_28.metric_time__day
+            subq_24.metric_time__day <= subq_27.metric_time__day
           ) AND (
-            subq_25.metric_time__day > subq_28.metric_time__day - MAKE_INTERVAL(days => 7)
+            subq_24.metric_time__day > subq_27.metric_time__day - MAKE_INTERVAL(days => 7)
           )
         )
-    ) subq_29
+    ) subq_28
     GROUP BY
       metric_time__martian_day
-  ) subq_32
+  ) subq_31
   ON
-    subq_21.metric_time__martian_day = subq_32.metric_time__martian_day
+    subq_21.metric_time__martian_day = subq_31.metric_time__martian_day
   GROUP BY
-    COALESCE(subq_21.metric_time__martian_day, subq_32.metric_time__martian_day)
-) subq_33
+    COALESCE(subq_21.metric_time__martian_day, subq_31.metric_time__martian_day)
+) subq_32

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Postgres/test_conversion_metric_with_custom_granularity_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Postgres/test_conversion_metric_with_custom_granularity_filter__plan0_optimized.sql
@@ -3,15 +3,25 @@ test_filename: test_custom_granularity.py
 sql_engine: Postgres
 ---
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
-  metric_time__martian_day
+  metric_time__martian_day AS metric_time__martian_day
   , CAST(buys AS DOUBLE PRECISION) / CAST(NULLIF(visits, 0) AS DOUBLE PRECISION) AS visit_buy_conversion_rate_7days
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_24.metric_time__martian_day, subq_36.metric_time__martian_day) AS metric_time__martian_day
+    COALESCE(subq_24.metric_time__martian_day, subq_35.metric_time__martian_day) AS metric_time__martian_day
     , MAX(subq_24.visits) AS visits
-    , MAX(subq_36.buys) AS buys
+    , MAX(subq_35.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['visits', 'metric_time__martian_day']
@@ -20,22 +30,16 @@ FROM (
       metric_time__martian_day
       , SUM(visits) AS visits
     FROM (
-      -- Metric Time Dimension 'ds'
+      -- Read From CTE For node_id=sma_28019
       -- Join to Custom Granularity Dataset
       SELECT
-        subq_19.visits AS visits
+        sma_28019_cte.visits AS visits
         , subq_20.martian_day AS metric_time__martian_day
-      FROM (
-        -- Read Elements From Semantic Model 'visits_source'
-        SELECT
-          1 AS visits
-          , DATE_TRUNC('day', ds) AS ds__day
-        FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_19
+      FROM sma_28019_cte sma_28019_cte
       LEFT OUTER JOIN
         ***************************.mf_time_spine subq_20
       ON
-        subq_19.ds__day = subq_20.ds
+        sma_28019_cte.metric_time__day = subq_20.ds
     ) subq_21
     WHERE metric_time__martian_day = '2020-01-01'
     GROUP BY
@@ -51,71 +55,64 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_29.visits) OVER (
+        FIRST_VALUE(subq_28.visits) OVER (
           PARTITION BY
-            subq_32.user
-            , subq_32.metric_time__day
-            , subq_32.mf_internal_uuid
-          ORDER BY subq_29.metric_time__day DESC
+            subq_31.user
+            , subq_31.metric_time__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_29.metric_time__martian_day) OVER (
+        , FIRST_VALUE(subq_28.metric_time__martian_day) OVER (
           PARTITION BY
-            subq_32.user
-            , subq_32.metric_time__day
-            , subq_32.mf_internal_uuid
-          ORDER BY subq_29.metric_time__day DESC
+            subq_31.user
+            , subq_31.metric_time__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__martian_day
-        , FIRST_VALUE(subq_29.metric_time__day) OVER (
+        , FIRST_VALUE(subq_28.metric_time__day) OVER (
           PARTITION BY
-            subq_32.user
-            , subq_32.metric_time__day
-            , subq_32.mf_internal_uuid
-          ORDER BY subq_29.metric_time__day DESC
+            subq_31.user
+            , subq_31.metric_time__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_29.user) OVER (
+        , FIRST_VALUE(subq_28.user) OVER (
           PARTITION BY
-            subq_32.user
-            , subq_32.metric_time__day
-            , subq_32.mf_internal_uuid
-          ORDER BY subq_29.metric_time__day DESC
+            subq_31.user
+            , subq_31.metric_time__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_32.mf_internal_uuid AS mf_internal_uuid
-        , subq_32.buys AS buys
+        , subq_31.mf_internal_uuid AS mf_internal_uuid
+        , subq_31.buys AS buys
       FROM (
         -- Constrain Output with WHERE
         -- Pass Only Elements: ['visits', 'metric_time__day', 'metric_time__martian_day', 'user']
         SELECT
           metric_time__martian_day
           , metric_time__day
-          , subq_27.user
+          , subq_26.user
           , visits
         FROM (
-          -- Metric Time Dimension 'ds'
+          -- Read From CTE For node_id=sma_28019
           -- Join to Custom Granularity Dataset
           SELECT
-            subq_25.ds__day AS metric_time__day
-            , subq_25.user AS user
-            , subq_25.visits AS visits
-            , subq_26.martian_day AS metric_time__martian_day
-          FROM (
-            -- Read Elements From Semantic Model 'visits_source'
-            SELECT
-              1 AS visits
-              , DATE_TRUNC('day', ds) AS ds__day
-              , user_id AS user
-            FROM ***************************.fct_visits visits_source_src_28000
-          ) subq_25
+            sma_28019_cte.metric_time__day AS metric_time__day
+            , sma_28019_cte.user AS user
+            , sma_28019_cte.visits AS visits
+            , subq_25.martian_day AS metric_time__martian_day
+          FROM sma_28019_cte sma_28019_cte
           LEFT OUTER JOIN
-            ***************************.mf_time_spine subq_26
+            ***************************.mf_time_spine subq_25
           ON
-            subq_25.ds__day = subq_26.ds
-        ) subq_27
+            sma_28019_cte.metric_time__day = subq_25.ds
+        ) subq_26
         WHERE metric_time__martian_day = '2020-01-01'
-      ) subq_29
+      ) subq_28
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -126,23 +123,23 @@ FROM (
           , 1 AS buys
           , GEN_RANDOM_UUID() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_32
+      ) subq_31
       ON
         (
-          subq_29.user = subq_32.user
+          subq_28.user = subq_31.user
         ) AND (
           (
-            subq_29.metric_time__day <= subq_32.metric_time__day
+            subq_28.metric_time__day <= subq_31.metric_time__day
           ) AND (
-            subq_29.metric_time__day > subq_32.metric_time__day - MAKE_INTERVAL(days => 7)
+            subq_28.metric_time__day > subq_31.metric_time__day - MAKE_INTERVAL(days => 7)
           )
         )
-    ) subq_33
+    ) subq_32
     GROUP BY
       metric_time__martian_day
-  ) subq_36
+  ) subq_35
   ON
-    subq_24.metric_time__martian_day = subq_36.metric_time__martian_day
+    subq_24.metric_time__martian_day = subq_35.metric_time__martian_day
   GROUP BY
-    COALESCE(subq_24.metric_time__martian_day, subq_36.metric_time__martian_day)
-) subq_37
+    COALESCE(subq_24.metric_time__martian_day, subq_35.metric_time__martian_day)
+) subq_36

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Postgres/test_conversion_metric_with_custom_granularity_filter_not_in_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Postgres/test_conversion_metric_with_custom_granularity_filter_not_in_group_by__plan0_optimized.sql
@@ -4,8 +4,18 @@ sql_engine: Postgres
 ---
 -- Combine Aggregated Outputs
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
-  CAST(MAX(subq_36.buys) AS DOUBLE PRECISION) / CAST(NULLIF(MAX(subq_24.visits), 0) AS DOUBLE PRECISION) AS visit_buy_conversion_rate_7days
+  CAST(MAX(subq_35.buys) AS DOUBLE PRECISION) / CAST(NULLIF(MAX(subq_24.visits), 0) AS DOUBLE PRECISION) AS visit_buy_conversion_rate_7days
 FROM (
   -- Constrain Output with WHERE
   -- Pass Only Elements: ['visits',]
@@ -13,22 +23,16 @@ FROM (
   SELECT
     SUM(visits) AS visits
   FROM (
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28019
     -- Join to Custom Granularity Dataset
     SELECT
-      subq_19.visits AS visits
+      sma_28019_cte.visits AS visits
       , subq_20.martian_day AS metric_time__martian_day
-    FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      SELECT
-        1 AS visits
-        , DATE_TRUNC('day', ds) AS ds__day
-      FROM ***************************.fct_visits visits_source_src_28000
-    ) subq_19
+    FROM sma_28019_cte sma_28019_cte
     LEFT OUTER JOIN
       ***************************.mf_time_spine subq_20
     ON
-      subq_19.ds__day = subq_20.ds
+      sma_28019_cte.metric_time__day = subq_20.ds
   ) subq_21
   WHERE metric_time__martian_day = '2020-01-01'
 ) subq_24
@@ -41,71 +45,64 @@ CROSS JOIN (
   FROM (
     -- Dedupe the fanout with mf_internal_uuid in the conversion data set
     SELECT DISTINCT
-      FIRST_VALUE(subq_29.visits) OVER (
+      FIRST_VALUE(subq_28.visits) OVER (
         PARTITION BY
-          subq_32.user
-          , subq_32.metric_time__day
-          , subq_32.mf_internal_uuid
-        ORDER BY subq_29.metric_time__day DESC
+          subq_31.user
+          , subq_31.metric_time__day
+          , subq_31.mf_internal_uuid
+        ORDER BY subq_28.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS visits
-      , FIRST_VALUE(subq_29.metric_time__martian_day) OVER (
+      , FIRST_VALUE(subq_28.metric_time__martian_day) OVER (
         PARTITION BY
-          subq_32.user
-          , subq_32.metric_time__day
-          , subq_32.mf_internal_uuid
-        ORDER BY subq_29.metric_time__day DESC
+          subq_31.user
+          , subq_31.metric_time__day
+          , subq_31.mf_internal_uuid
+        ORDER BY subq_28.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS metric_time__martian_day
-      , FIRST_VALUE(subq_29.metric_time__day) OVER (
+      , FIRST_VALUE(subq_28.metric_time__day) OVER (
         PARTITION BY
-          subq_32.user
-          , subq_32.metric_time__day
-          , subq_32.mf_internal_uuid
-        ORDER BY subq_29.metric_time__day DESC
+          subq_31.user
+          , subq_31.metric_time__day
+          , subq_31.mf_internal_uuid
+        ORDER BY subq_28.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS metric_time__day
-      , FIRST_VALUE(subq_29.user) OVER (
+      , FIRST_VALUE(subq_28.user) OVER (
         PARTITION BY
-          subq_32.user
-          , subq_32.metric_time__day
-          , subq_32.mf_internal_uuid
-        ORDER BY subq_29.metric_time__day DESC
+          subq_31.user
+          , subq_31.metric_time__day
+          , subq_31.mf_internal_uuid
+        ORDER BY subq_28.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS user
-      , subq_32.mf_internal_uuid AS mf_internal_uuid
-      , subq_32.buys AS buys
+      , subq_31.mf_internal_uuid AS mf_internal_uuid
+      , subq_31.buys AS buys
     FROM (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['visits', 'metric_time__day', 'metric_time__martian_day', 'user']
       SELECT
         metric_time__martian_day
         , metric_time__day
-        , subq_27.user
+        , subq_26.user
         , visits
       FROM (
-        -- Metric Time Dimension 'ds'
+        -- Read From CTE For node_id=sma_28019
         -- Join to Custom Granularity Dataset
         SELECT
-          subq_25.ds__day AS metric_time__day
-          , subq_25.user AS user
-          , subq_25.visits AS visits
-          , subq_26.martian_day AS metric_time__martian_day
-        FROM (
-          -- Read Elements From Semantic Model 'visits_source'
-          SELECT
-            1 AS visits
-            , DATE_TRUNC('day', ds) AS ds__day
-            , user_id AS user
-          FROM ***************************.fct_visits visits_source_src_28000
-        ) subq_25
+          sma_28019_cte.metric_time__day AS metric_time__day
+          , sma_28019_cte.user AS user
+          , sma_28019_cte.visits AS visits
+          , subq_25.martian_day AS metric_time__martian_day
+        FROM sma_28019_cte sma_28019_cte
         LEFT OUTER JOIN
-          ***************************.mf_time_spine subq_26
+          ***************************.mf_time_spine subq_25
         ON
-          subq_25.ds__day = subq_26.ds
-      ) subq_27
+          sma_28019_cte.metric_time__day = subq_25.ds
+      ) subq_26
       WHERE metric_time__martian_day = '2020-01-01'
-    ) subq_29
+    ) subq_28
     INNER JOIN (
       -- Read Elements From Semantic Model 'buys_source'
       -- Metric Time Dimension 'ds'
@@ -116,16 +113,16 @@ CROSS JOIN (
         , 1 AS buys
         , GEN_RANDOM_UUID() AS mf_internal_uuid
       FROM ***************************.fct_buys buys_source_src_28000
-    ) subq_32
+    ) subq_31
     ON
       (
-        subq_29.user = subq_32.user
+        subq_28.user = subq_31.user
       ) AND (
         (
-          subq_29.metric_time__day <= subq_32.metric_time__day
+          subq_28.metric_time__day <= subq_31.metric_time__day
         ) AND (
-          subq_29.metric_time__day > subq_32.metric_time__day - MAKE_INTERVAL(days => 7)
+          subq_28.metric_time__day > subq_31.metric_time__day - MAKE_INTERVAL(days => 7)
         )
       )
-  ) subq_33
-) subq_36
+  ) subq_32
+) subq_35

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Redshift/test_conversion_metric_with_custom_granularity_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Redshift/test_conversion_metric_with_custom_granularity_filter__plan0_optimized.sql
@@ -3,15 +3,25 @@ test_filename: test_custom_granularity.py
 sql_engine: Redshift
 ---
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
-  metric_time__martian_day
+  metric_time__martian_day AS metric_time__martian_day
   , CAST(buys AS DOUBLE PRECISION) / CAST(NULLIF(visits, 0) AS DOUBLE PRECISION) AS visit_buy_conversion_rate_7days
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_24.metric_time__martian_day, subq_36.metric_time__martian_day) AS metric_time__martian_day
+    COALESCE(subq_24.metric_time__martian_day, subq_35.metric_time__martian_day) AS metric_time__martian_day
     , MAX(subq_24.visits) AS visits
-    , MAX(subq_36.buys) AS buys
+    , MAX(subq_35.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['visits', 'metric_time__martian_day']
@@ -20,22 +30,16 @@ FROM (
       metric_time__martian_day
       , SUM(visits) AS visits
     FROM (
-      -- Metric Time Dimension 'ds'
+      -- Read From CTE For node_id=sma_28019
       -- Join to Custom Granularity Dataset
       SELECT
-        subq_19.visits AS visits
+        sma_28019_cte.visits AS visits
         , subq_20.martian_day AS metric_time__martian_day
-      FROM (
-        -- Read Elements From Semantic Model 'visits_source'
-        SELECT
-          1 AS visits
-          , DATE_TRUNC('day', ds) AS ds__day
-        FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_19
+      FROM sma_28019_cte sma_28019_cte
       LEFT OUTER JOIN
         ***************************.mf_time_spine subq_20
       ON
-        subq_19.ds__day = subq_20.ds
+        sma_28019_cte.metric_time__day = subq_20.ds
     ) subq_21
     WHERE metric_time__martian_day = '2020-01-01'
     GROUP BY
@@ -51,71 +55,64 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_29.visits) OVER (
+        FIRST_VALUE(subq_28.visits) OVER (
           PARTITION BY
-            subq_32.user
-            , subq_32.metric_time__day
-            , subq_32.mf_internal_uuid
-          ORDER BY subq_29.metric_time__day DESC
+            subq_31.user
+            , subq_31.metric_time__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_29.metric_time__martian_day) OVER (
+        , FIRST_VALUE(subq_28.metric_time__martian_day) OVER (
           PARTITION BY
-            subq_32.user
-            , subq_32.metric_time__day
-            , subq_32.mf_internal_uuid
-          ORDER BY subq_29.metric_time__day DESC
+            subq_31.user
+            , subq_31.metric_time__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__martian_day
-        , FIRST_VALUE(subq_29.metric_time__day) OVER (
+        , FIRST_VALUE(subq_28.metric_time__day) OVER (
           PARTITION BY
-            subq_32.user
-            , subq_32.metric_time__day
-            , subq_32.mf_internal_uuid
-          ORDER BY subq_29.metric_time__day DESC
+            subq_31.user
+            , subq_31.metric_time__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_29.user) OVER (
+        , FIRST_VALUE(subq_28.user) OVER (
           PARTITION BY
-            subq_32.user
-            , subq_32.metric_time__day
-            , subq_32.mf_internal_uuid
-          ORDER BY subq_29.metric_time__day DESC
+            subq_31.user
+            , subq_31.metric_time__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_32.mf_internal_uuid AS mf_internal_uuid
-        , subq_32.buys AS buys
+        , subq_31.mf_internal_uuid AS mf_internal_uuid
+        , subq_31.buys AS buys
       FROM (
         -- Constrain Output with WHERE
         -- Pass Only Elements: ['visits', 'metric_time__day', 'metric_time__martian_day', 'user']
         SELECT
           metric_time__martian_day
           , metric_time__day
-          , subq_27.user
+          , subq_26.user
           , visits
         FROM (
-          -- Metric Time Dimension 'ds'
+          -- Read From CTE For node_id=sma_28019
           -- Join to Custom Granularity Dataset
           SELECT
-            subq_25.ds__day AS metric_time__day
-            , subq_25.user AS user
-            , subq_25.visits AS visits
-            , subq_26.martian_day AS metric_time__martian_day
-          FROM (
-            -- Read Elements From Semantic Model 'visits_source'
-            SELECT
-              1 AS visits
-              , DATE_TRUNC('day', ds) AS ds__day
-              , user_id AS user
-            FROM ***************************.fct_visits visits_source_src_28000
-          ) subq_25
+            sma_28019_cte.metric_time__day AS metric_time__day
+            , sma_28019_cte.user AS user
+            , sma_28019_cte.visits AS visits
+            , subq_25.martian_day AS metric_time__martian_day
+          FROM sma_28019_cte sma_28019_cte
           LEFT OUTER JOIN
-            ***************************.mf_time_spine subq_26
+            ***************************.mf_time_spine subq_25
           ON
-            subq_25.ds__day = subq_26.ds
-        ) subq_27
+            sma_28019_cte.metric_time__day = subq_25.ds
+        ) subq_26
         WHERE metric_time__martian_day = '2020-01-01'
-      ) subq_29
+      ) subq_28
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -126,23 +123,23 @@ FROM (
           , 1 AS buys
           , CONCAT(CAST(RANDOM()*100000000 AS INT)::VARCHAR,CAST(RANDOM()*100000000 AS INT)::VARCHAR) AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_32
+      ) subq_31
       ON
         (
-          subq_29.user = subq_32.user
+          subq_28.user = subq_31.user
         ) AND (
           (
-            subq_29.metric_time__day <= subq_32.metric_time__day
+            subq_28.metric_time__day <= subq_31.metric_time__day
           ) AND (
-            subq_29.metric_time__day > DATEADD(day, -7, subq_32.metric_time__day)
+            subq_28.metric_time__day > DATEADD(day, -7, subq_31.metric_time__day)
           )
         )
-    ) subq_33
+    ) subq_32
     GROUP BY
       metric_time__martian_day
-  ) subq_36
+  ) subq_35
   ON
-    subq_24.metric_time__martian_day = subq_36.metric_time__martian_day
+    subq_24.metric_time__martian_day = subq_35.metric_time__martian_day
   GROUP BY
-    COALESCE(subq_24.metric_time__martian_day, subq_36.metric_time__martian_day)
-) subq_37
+    COALESCE(subq_24.metric_time__martian_day, subq_35.metric_time__martian_day)
+) subq_36

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Redshift/test_conversion_metric_with_custom_granularity_filter_not_in_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Redshift/test_conversion_metric_with_custom_granularity_filter_not_in_group_by__plan0_optimized.sql
@@ -4,8 +4,18 @@ sql_engine: Redshift
 ---
 -- Combine Aggregated Outputs
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
-  CAST(MAX(subq_36.buys) AS DOUBLE PRECISION) / CAST(NULLIF(MAX(subq_24.visits), 0) AS DOUBLE PRECISION) AS visit_buy_conversion_rate_7days
+  CAST(MAX(subq_35.buys) AS DOUBLE PRECISION) / CAST(NULLIF(MAX(subq_24.visits), 0) AS DOUBLE PRECISION) AS visit_buy_conversion_rate_7days
 FROM (
   -- Constrain Output with WHERE
   -- Pass Only Elements: ['visits',]
@@ -13,22 +23,16 @@ FROM (
   SELECT
     SUM(visits) AS visits
   FROM (
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28019
     -- Join to Custom Granularity Dataset
     SELECT
-      subq_19.visits AS visits
+      sma_28019_cte.visits AS visits
       , subq_20.martian_day AS metric_time__martian_day
-    FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      SELECT
-        1 AS visits
-        , DATE_TRUNC('day', ds) AS ds__day
-      FROM ***************************.fct_visits visits_source_src_28000
-    ) subq_19
+    FROM sma_28019_cte sma_28019_cte
     LEFT OUTER JOIN
       ***************************.mf_time_spine subq_20
     ON
-      subq_19.ds__day = subq_20.ds
+      sma_28019_cte.metric_time__day = subq_20.ds
   ) subq_21
   WHERE metric_time__martian_day = '2020-01-01'
 ) subq_24
@@ -41,71 +45,64 @@ CROSS JOIN (
   FROM (
     -- Dedupe the fanout with mf_internal_uuid in the conversion data set
     SELECT DISTINCT
-      FIRST_VALUE(subq_29.visits) OVER (
+      FIRST_VALUE(subq_28.visits) OVER (
         PARTITION BY
-          subq_32.user
-          , subq_32.metric_time__day
-          , subq_32.mf_internal_uuid
-        ORDER BY subq_29.metric_time__day DESC
+          subq_31.user
+          , subq_31.metric_time__day
+          , subq_31.mf_internal_uuid
+        ORDER BY subq_28.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS visits
-      , FIRST_VALUE(subq_29.metric_time__martian_day) OVER (
+      , FIRST_VALUE(subq_28.metric_time__martian_day) OVER (
         PARTITION BY
-          subq_32.user
-          , subq_32.metric_time__day
-          , subq_32.mf_internal_uuid
-        ORDER BY subq_29.metric_time__day DESC
+          subq_31.user
+          , subq_31.metric_time__day
+          , subq_31.mf_internal_uuid
+        ORDER BY subq_28.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS metric_time__martian_day
-      , FIRST_VALUE(subq_29.metric_time__day) OVER (
+      , FIRST_VALUE(subq_28.metric_time__day) OVER (
         PARTITION BY
-          subq_32.user
-          , subq_32.metric_time__day
-          , subq_32.mf_internal_uuid
-        ORDER BY subq_29.metric_time__day DESC
+          subq_31.user
+          , subq_31.metric_time__day
+          , subq_31.mf_internal_uuid
+        ORDER BY subq_28.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS metric_time__day
-      , FIRST_VALUE(subq_29.user) OVER (
+      , FIRST_VALUE(subq_28.user) OVER (
         PARTITION BY
-          subq_32.user
-          , subq_32.metric_time__day
-          , subq_32.mf_internal_uuid
-        ORDER BY subq_29.metric_time__day DESC
+          subq_31.user
+          , subq_31.metric_time__day
+          , subq_31.mf_internal_uuid
+        ORDER BY subq_28.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS user
-      , subq_32.mf_internal_uuid AS mf_internal_uuid
-      , subq_32.buys AS buys
+      , subq_31.mf_internal_uuid AS mf_internal_uuid
+      , subq_31.buys AS buys
     FROM (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['visits', 'metric_time__day', 'metric_time__martian_day', 'user']
       SELECT
         metric_time__martian_day
         , metric_time__day
-        , subq_27.user
+        , subq_26.user
         , visits
       FROM (
-        -- Metric Time Dimension 'ds'
+        -- Read From CTE For node_id=sma_28019
         -- Join to Custom Granularity Dataset
         SELECT
-          subq_25.ds__day AS metric_time__day
-          , subq_25.user AS user
-          , subq_25.visits AS visits
-          , subq_26.martian_day AS metric_time__martian_day
-        FROM (
-          -- Read Elements From Semantic Model 'visits_source'
-          SELECT
-            1 AS visits
-            , DATE_TRUNC('day', ds) AS ds__day
-            , user_id AS user
-          FROM ***************************.fct_visits visits_source_src_28000
-        ) subq_25
+          sma_28019_cte.metric_time__day AS metric_time__day
+          , sma_28019_cte.user AS user
+          , sma_28019_cte.visits AS visits
+          , subq_25.martian_day AS metric_time__martian_day
+        FROM sma_28019_cte sma_28019_cte
         LEFT OUTER JOIN
-          ***************************.mf_time_spine subq_26
+          ***************************.mf_time_spine subq_25
         ON
-          subq_25.ds__day = subq_26.ds
-      ) subq_27
+          sma_28019_cte.metric_time__day = subq_25.ds
+      ) subq_26
       WHERE metric_time__martian_day = '2020-01-01'
-    ) subq_29
+    ) subq_28
     INNER JOIN (
       -- Read Elements From Semantic Model 'buys_source'
       -- Metric Time Dimension 'ds'
@@ -116,16 +113,16 @@ CROSS JOIN (
         , 1 AS buys
         , CONCAT(CAST(RANDOM()*100000000 AS INT)::VARCHAR,CAST(RANDOM()*100000000 AS INT)::VARCHAR) AS mf_internal_uuid
       FROM ***************************.fct_buys buys_source_src_28000
-    ) subq_32
+    ) subq_31
     ON
       (
-        subq_29.user = subq_32.user
+        subq_28.user = subq_31.user
       ) AND (
         (
-          subq_29.metric_time__day <= subq_32.metric_time__day
+          subq_28.metric_time__day <= subq_31.metric_time__day
         ) AND (
-          subq_29.metric_time__day > DATEADD(day, -7, subq_32.metric_time__day)
+          subq_28.metric_time__day > DATEADD(day, -7, subq_31.metric_time__day)
         )
       )
-  ) subq_33
-) subq_36
+  ) subq_32
+) subq_35

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Snowflake/test_conversion_metric_with_custom_granularity__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Snowflake/test_conversion_metric_with_custom_granularity__plan0_optimized.sql
@@ -3,34 +3,38 @@ test_filename: test_custom_granularity.py
 sql_engine: Snowflake
 ---
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
-  metric_time__martian_day
+  metric_time__martian_day AS metric_time__martian_day
   , CAST(buys AS DOUBLE) / CAST(NULLIF(visits, 0) AS DOUBLE) AS visit_buy_conversion_rate_7days
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_21.metric_time__martian_day, subq_32.metric_time__martian_day) AS metric_time__martian_day
+    COALESCE(subq_21.metric_time__martian_day, subq_31.metric_time__martian_day) AS metric_time__martian_day
     , MAX(subq_21.visits) AS visits
-    , MAX(subq_32.buys) AS buys
+    , MAX(subq_31.buys) AS buys
   FROM (
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28019
     -- Join to Custom Granularity Dataset
     -- Pass Only Elements: ['visits', 'metric_time__martian_day']
     -- Aggregate Measures
     SELECT
       subq_18.martian_day AS metric_time__martian_day
-      , SUM(subq_17.visits) AS visits
-    FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      SELECT
-        1 AS visits
-        , DATE_TRUNC('day', ds) AS ds__day
-      FROM ***************************.fct_visits visits_source_src_28000
-    ) subq_17
+      , SUM(sma_28019_cte.visits) AS visits
+    FROM sma_28019_cte sma_28019_cte
     LEFT OUTER JOIN
       ***************************.mf_time_spine subq_18
     ON
-      subq_17.ds__day = subq_18.ds
+      sma_28019_cte.metric_time__day = subq_18.ds
     GROUP BY
       subq_18.martian_day
   ) subq_21
@@ -44,62 +48,55 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_25.visits) OVER (
+        FIRST_VALUE(subq_24.visits) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_25.metric_time__martian_day) OVER (
+        , FIRST_VALUE(subq_24.metric_time__martian_day) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__martian_day
-        , FIRST_VALUE(subq_25.metric_time__day) OVER (
+        , FIRST_VALUE(subq_24.metric_time__day) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_25.user) OVER (
+        , FIRST_VALUE(subq_24.user) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_28.mf_internal_uuid AS mf_internal_uuid
-        , subq_28.buys AS buys
+        , subq_27.mf_internal_uuid AS mf_internal_uuid
+        , subq_27.buys AS buys
       FROM (
-        -- Metric Time Dimension 'ds'
+        -- Read From CTE For node_id=sma_28019
         -- Join to Custom Granularity Dataset
         -- Pass Only Elements: ['visits', 'metric_time__day', 'metric_time__martian_day', 'user']
         SELECT
-          subq_23.martian_day AS metric_time__martian_day
-          , subq_22.ds__day AS metric_time__day
-          , subq_22.user AS user
-          , subq_22.visits AS visits
-        FROM (
-          -- Read Elements From Semantic Model 'visits_source'
-          SELECT
-            1 AS visits
-            , DATE_TRUNC('day', ds) AS ds__day
-            , user_id AS user
-          FROM ***************************.fct_visits visits_source_src_28000
-        ) subq_22
+          subq_22.martian_day AS metric_time__martian_day
+          , sma_28019_cte.metric_time__day AS metric_time__day
+          , sma_28019_cte.user AS user
+          , sma_28019_cte.visits AS visits
+        FROM sma_28019_cte sma_28019_cte
         LEFT OUTER JOIN
-          ***************************.mf_time_spine subq_23
+          ***************************.mf_time_spine subq_22
         ON
-          subq_22.ds__day = subq_23.ds
-      ) subq_25
+          sma_28019_cte.metric_time__day = subq_22.ds
+      ) subq_24
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -110,23 +107,23 @@ FROM (
           , 1 AS buys
           , UUID_STRING() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_28
+      ) subq_27
       ON
         (
-          subq_25.user = subq_28.user
+          subq_24.user = subq_27.user
         ) AND (
           (
-            subq_25.metric_time__day <= subq_28.metric_time__day
+            subq_24.metric_time__day <= subq_27.metric_time__day
           ) AND (
-            subq_25.metric_time__day > DATEADD(day, -7, subq_28.metric_time__day)
+            subq_24.metric_time__day > DATEADD(day, -7, subq_27.metric_time__day)
           )
         )
-    ) subq_29
+    ) subq_28
     GROUP BY
       metric_time__martian_day
-  ) subq_32
+  ) subq_31
   ON
-    subq_21.metric_time__martian_day = subq_32.metric_time__martian_day
+    subq_21.metric_time__martian_day = subq_31.metric_time__martian_day
   GROUP BY
-    COALESCE(subq_21.metric_time__martian_day, subq_32.metric_time__martian_day)
-) subq_33
+    COALESCE(subq_21.metric_time__martian_day, subq_31.metric_time__martian_day)
+) subq_32

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Snowflake/test_conversion_metric_with_custom_granularity_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Snowflake/test_conversion_metric_with_custom_granularity_filter__plan0_optimized.sql
@@ -3,15 +3,25 @@ test_filename: test_custom_granularity.py
 sql_engine: Snowflake
 ---
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
-  metric_time__martian_day
+  metric_time__martian_day AS metric_time__martian_day
   , CAST(buys AS DOUBLE) / CAST(NULLIF(visits, 0) AS DOUBLE) AS visit_buy_conversion_rate_7days
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_24.metric_time__martian_day, subq_36.metric_time__martian_day) AS metric_time__martian_day
+    COALESCE(subq_24.metric_time__martian_day, subq_35.metric_time__martian_day) AS metric_time__martian_day
     , MAX(subq_24.visits) AS visits
-    , MAX(subq_36.buys) AS buys
+    , MAX(subq_35.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['visits', 'metric_time__martian_day']
@@ -20,22 +30,16 @@ FROM (
       metric_time__martian_day
       , SUM(visits) AS visits
     FROM (
-      -- Metric Time Dimension 'ds'
+      -- Read From CTE For node_id=sma_28019
       -- Join to Custom Granularity Dataset
       SELECT
-        subq_19.visits AS visits
+        sma_28019_cte.visits AS visits
         , subq_20.martian_day AS metric_time__martian_day
-      FROM (
-        -- Read Elements From Semantic Model 'visits_source'
-        SELECT
-          1 AS visits
-          , DATE_TRUNC('day', ds) AS ds__day
-        FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_19
+      FROM sma_28019_cte sma_28019_cte
       LEFT OUTER JOIN
         ***************************.mf_time_spine subq_20
       ON
-        subq_19.ds__day = subq_20.ds
+        sma_28019_cte.metric_time__day = subq_20.ds
     ) subq_21
     WHERE metric_time__martian_day = '2020-01-01'
     GROUP BY
@@ -51,71 +55,64 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_29.visits) OVER (
+        FIRST_VALUE(subq_28.visits) OVER (
           PARTITION BY
-            subq_32.user
-            , subq_32.metric_time__day
-            , subq_32.mf_internal_uuid
-          ORDER BY subq_29.metric_time__day DESC
+            subq_31.user
+            , subq_31.metric_time__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_29.metric_time__martian_day) OVER (
+        , FIRST_VALUE(subq_28.metric_time__martian_day) OVER (
           PARTITION BY
-            subq_32.user
-            , subq_32.metric_time__day
-            , subq_32.mf_internal_uuid
-          ORDER BY subq_29.metric_time__day DESC
+            subq_31.user
+            , subq_31.metric_time__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__martian_day
-        , FIRST_VALUE(subq_29.metric_time__day) OVER (
+        , FIRST_VALUE(subq_28.metric_time__day) OVER (
           PARTITION BY
-            subq_32.user
-            , subq_32.metric_time__day
-            , subq_32.mf_internal_uuid
-          ORDER BY subq_29.metric_time__day DESC
+            subq_31.user
+            , subq_31.metric_time__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_29.user) OVER (
+        , FIRST_VALUE(subq_28.user) OVER (
           PARTITION BY
-            subq_32.user
-            , subq_32.metric_time__day
-            , subq_32.mf_internal_uuid
-          ORDER BY subq_29.metric_time__day DESC
+            subq_31.user
+            , subq_31.metric_time__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_32.mf_internal_uuid AS mf_internal_uuid
-        , subq_32.buys AS buys
+        , subq_31.mf_internal_uuid AS mf_internal_uuid
+        , subq_31.buys AS buys
       FROM (
         -- Constrain Output with WHERE
         -- Pass Only Elements: ['visits', 'metric_time__day', 'metric_time__martian_day', 'user']
         SELECT
           metric_time__martian_day
           , metric_time__day
-          , subq_27.user
+          , subq_26.user
           , visits
         FROM (
-          -- Metric Time Dimension 'ds'
+          -- Read From CTE For node_id=sma_28019
           -- Join to Custom Granularity Dataset
           SELECT
-            subq_25.ds__day AS metric_time__day
-            , subq_25.user AS user
-            , subq_25.visits AS visits
-            , subq_26.martian_day AS metric_time__martian_day
-          FROM (
-            -- Read Elements From Semantic Model 'visits_source'
-            SELECT
-              1 AS visits
-              , DATE_TRUNC('day', ds) AS ds__day
-              , user_id AS user
-            FROM ***************************.fct_visits visits_source_src_28000
-          ) subq_25
+            sma_28019_cte.metric_time__day AS metric_time__day
+            , sma_28019_cte.user AS user
+            , sma_28019_cte.visits AS visits
+            , subq_25.martian_day AS metric_time__martian_day
+          FROM sma_28019_cte sma_28019_cte
           LEFT OUTER JOIN
-            ***************************.mf_time_spine subq_26
+            ***************************.mf_time_spine subq_25
           ON
-            subq_25.ds__day = subq_26.ds
-        ) subq_27
+            sma_28019_cte.metric_time__day = subq_25.ds
+        ) subq_26
         WHERE metric_time__martian_day = '2020-01-01'
-      ) subq_29
+      ) subq_28
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -126,23 +123,23 @@ FROM (
           , 1 AS buys
           , UUID_STRING() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_32
+      ) subq_31
       ON
         (
-          subq_29.user = subq_32.user
+          subq_28.user = subq_31.user
         ) AND (
           (
-            subq_29.metric_time__day <= subq_32.metric_time__day
+            subq_28.metric_time__day <= subq_31.metric_time__day
           ) AND (
-            subq_29.metric_time__day > DATEADD(day, -7, subq_32.metric_time__day)
+            subq_28.metric_time__day > DATEADD(day, -7, subq_31.metric_time__day)
           )
         )
-    ) subq_33
+    ) subq_32
     GROUP BY
       metric_time__martian_day
-  ) subq_36
+  ) subq_35
   ON
-    subq_24.metric_time__martian_day = subq_36.metric_time__martian_day
+    subq_24.metric_time__martian_day = subq_35.metric_time__martian_day
   GROUP BY
-    COALESCE(subq_24.metric_time__martian_day, subq_36.metric_time__martian_day)
-) subq_37
+    COALESCE(subq_24.metric_time__martian_day, subq_35.metric_time__martian_day)
+) subq_36

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Trino/test_conversion_metric_with_custom_granularity__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Trino/test_conversion_metric_with_custom_granularity__plan0_optimized.sql
@@ -3,34 +3,38 @@ test_filename: test_custom_granularity.py
 sql_engine: Trino
 ---
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
-  metric_time__martian_day
+  metric_time__martian_day AS metric_time__martian_day
   , CAST(buys AS DOUBLE) / CAST(NULLIF(visits, 0) AS DOUBLE) AS visit_buy_conversion_rate_7days
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_21.metric_time__martian_day, subq_32.metric_time__martian_day) AS metric_time__martian_day
+    COALESCE(subq_21.metric_time__martian_day, subq_31.metric_time__martian_day) AS metric_time__martian_day
     , MAX(subq_21.visits) AS visits
-    , MAX(subq_32.buys) AS buys
+    , MAX(subq_31.buys) AS buys
   FROM (
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28019
     -- Join to Custom Granularity Dataset
     -- Pass Only Elements: ['visits', 'metric_time__martian_day']
     -- Aggregate Measures
     SELECT
       subq_18.martian_day AS metric_time__martian_day
-      , SUM(subq_17.visits) AS visits
-    FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      SELECT
-        1 AS visits
-        , DATE_TRUNC('day', ds) AS ds__day
-      FROM ***************************.fct_visits visits_source_src_28000
-    ) subq_17
+      , SUM(sma_28019_cte.visits) AS visits
+    FROM sma_28019_cte sma_28019_cte
     LEFT OUTER JOIN
       ***************************.mf_time_spine subq_18
     ON
-      subq_17.ds__day = subq_18.ds
+      sma_28019_cte.metric_time__day = subq_18.ds
     GROUP BY
       subq_18.martian_day
   ) subq_21
@@ -44,62 +48,55 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_25.visits) OVER (
+        FIRST_VALUE(subq_24.visits) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_25.metric_time__martian_day) OVER (
+        , FIRST_VALUE(subq_24.metric_time__martian_day) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__martian_day
-        , FIRST_VALUE(subq_25.metric_time__day) OVER (
+        , FIRST_VALUE(subq_24.metric_time__day) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_25.user) OVER (
+        , FIRST_VALUE(subq_24.user) OVER (
           PARTITION BY
-            subq_28.user
-            , subq_28.metric_time__day
-            , subq_28.mf_internal_uuid
-          ORDER BY subq_25.metric_time__day DESC
+            subq_27.user
+            , subq_27.metric_time__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_28.mf_internal_uuid AS mf_internal_uuid
-        , subq_28.buys AS buys
+        , subq_27.mf_internal_uuid AS mf_internal_uuid
+        , subq_27.buys AS buys
       FROM (
-        -- Metric Time Dimension 'ds'
+        -- Read From CTE For node_id=sma_28019
         -- Join to Custom Granularity Dataset
         -- Pass Only Elements: ['visits', 'metric_time__day', 'metric_time__martian_day', 'user']
         SELECT
-          subq_23.martian_day AS metric_time__martian_day
-          , subq_22.ds__day AS metric_time__day
-          , subq_22.user AS user
-          , subq_22.visits AS visits
-        FROM (
-          -- Read Elements From Semantic Model 'visits_source'
-          SELECT
-            1 AS visits
-            , DATE_TRUNC('day', ds) AS ds__day
-            , user_id AS user
-          FROM ***************************.fct_visits visits_source_src_28000
-        ) subq_22
+          subq_22.martian_day AS metric_time__martian_day
+          , sma_28019_cte.metric_time__day AS metric_time__day
+          , sma_28019_cte.user AS user
+          , sma_28019_cte.visits AS visits
+        FROM sma_28019_cte sma_28019_cte
         LEFT OUTER JOIN
-          ***************************.mf_time_spine subq_23
+          ***************************.mf_time_spine subq_22
         ON
-          subq_22.ds__day = subq_23.ds
-      ) subq_25
+          sma_28019_cte.metric_time__day = subq_22.ds
+      ) subq_24
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -110,23 +107,23 @@ FROM (
           , 1 AS buys
           , uuid() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_28
+      ) subq_27
       ON
         (
-          subq_25.user = subq_28.user
+          subq_24.user = subq_27.user
         ) AND (
           (
-            subq_25.metric_time__day <= subq_28.metric_time__day
+            subq_24.metric_time__day <= subq_27.metric_time__day
           ) AND (
-            subq_25.metric_time__day > DATE_ADD('day', -7, subq_28.metric_time__day)
+            subq_24.metric_time__day > DATE_ADD('day', -7, subq_27.metric_time__day)
           )
         )
-    ) subq_29
+    ) subq_28
     GROUP BY
       metric_time__martian_day
-  ) subq_32
+  ) subq_31
   ON
-    subq_21.metric_time__martian_day = subq_32.metric_time__martian_day
+    subq_21.metric_time__martian_day = subq_31.metric_time__martian_day
   GROUP BY
-    COALESCE(subq_21.metric_time__martian_day, subq_32.metric_time__martian_day)
-) subq_33
+    COALESCE(subq_21.metric_time__martian_day, subq_31.metric_time__martian_day)
+) subq_32

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Trino/test_conversion_metric_with_custom_granularity_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Trino/test_conversion_metric_with_custom_granularity_filter__plan0_optimized.sql
@@ -3,15 +3,25 @@ test_filename: test_custom_granularity.py
 sql_engine: Trino
 ---
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
-  metric_time__martian_day
+  metric_time__martian_day AS metric_time__martian_day
   , CAST(buys AS DOUBLE) / CAST(NULLIF(visits, 0) AS DOUBLE) AS visit_buy_conversion_rate_7days
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_24.metric_time__martian_day, subq_36.metric_time__martian_day) AS metric_time__martian_day
+    COALESCE(subq_24.metric_time__martian_day, subq_35.metric_time__martian_day) AS metric_time__martian_day
     , MAX(subq_24.visits) AS visits
-    , MAX(subq_36.buys) AS buys
+    , MAX(subq_35.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['visits', 'metric_time__martian_day']
@@ -20,22 +30,16 @@ FROM (
       metric_time__martian_day
       , SUM(visits) AS visits
     FROM (
-      -- Metric Time Dimension 'ds'
+      -- Read From CTE For node_id=sma_28019
       -- Join to Custom Granularity Dataset
       SELECT
-        subq_19.visits AS visits
+        sma_28019_cte.visits AS visits
         , subq_20.martian_day AS metric_time__martian_day
-      FROM (
-        -- Read Elements From Semantic Model 'visits_source'
-        SELECT
-          1 AS visits
-          , DATE_TRUNC('day', ds) AS ds__day
-        FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_19
+      FROM sma_28019_cte sma_28019_cte
       LEFT OUTER JOIN
         ***************************.mf_time_spine subq_20
       ON
-        subq_19.ds__day = subq_20.ds
+        sma_28019_cte.metric_time__day = subq_20.ds
     ) subq_21
     WHERE metric_time__martian_day = '2020-01-01'
     GROUP BY
@@ -51,71 +55,64 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_29.visits) OVER (
+        FIRST_VALUE(subq_28.visits) OVER (
           PARTITION BY
-            subq_32.user
-            , subq_32.metric_time__day
-            , subq_32.mf_internal_uuid
-          ORDER BY subq_29.metric_time__day DESC
+            subq_31.user
+            , subq_31.metric_time__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_29.metric_time__martian_day) OVER (
+        , FIRST_VALUE(subq_28.metric_time__martian_day) OVER (
           PARTITION BY
-            subq_32.user
-            , subq_32.metric_time__day
-            , subq_32.mf_internal_uuid
-          ORDER BY subq_29.metric_time__day DESC
+            subq_31.user
+            , subq_31.metric_time__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__martian_day
-        , FIRST_VALUE(subq_29.metric_time__day) OVER (
+        , FIRST_VALUE(subq_28.metric_time__day) OVER (
           PARTITION BY
-            subq_32.user
-            , subq_32.metric_time__day
-            , subq_32.mf_internal_uuid
-          ORDER BY subq_29.metric_time__day DESC
+            subq_31.user
+            , subq_31.metric_time__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_29.user) OVER (
+        , FIRST_VALUE(subq_28.user) OVER (
           PARTITION BY
-            subq_32.user
-            , subq_32.metric_time__day
-            , subq_32.mf_internal_uuid
-          ORDER BY subq_29.metric_time__day DESC
+            subq_31.user
+            , subq_31.metric_time__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_32.mf_internal_uuid AS mf_internal_uuid
-        , subq_32.buys AS buys
+        , subq_31.mf_internal_uuid AS mf_internal_uuid
+        , subq_31.buys AS buys
       FROM (
         -- Constrain Output with WHERE
         -- Pass Only Elements: ['visits', 'metric_time__day', 'metric_time__martian_day', 'user']
         SELECT
           metric_time__martian_day
           , metric_time__day
-          , subq_27.user
+          , subq_26.user
           , visits
         FROM (
-          -- Metric Time Dimension 'ds'
+          -- Read From CTE For node_id=sma_28019
           -- Join to Custom Granularity Dataset
           SELECT
-            subq_25.ds__day AS metric_time__day
-            , subq_25.user AS user
-            , subq_25.visits AS visits
-            , subq_26.martian_day AS metric_time__martian_day
-          FROM (
-            -- Read Elements From Semantic Model 'visits_source'
-            SELECT
-              1 AS visits
-              , DATE_TRUNC('day', ds) AS ds__day
-              , user_id AS user
-            FROM ***************************.fct_visits visits_source_src_28000
-          ) subq_25
+            sma_28019_cte.metric_time__day AS metric_time__day
+            , sma_28019_cte.user AS user
+            , sma_28019_cte.visits AS visits
+            , subq_25.martian_day AS metric_time__martian_day
+          FROM sma_28019_cte sma_28019_cte
           LEFT OUTER JOIN
-            ***************************.mf_time_spine subq_26
+            ***************************.mf_time_spine subq_25
           ON
-            subq_25.ds__day = subq_26.ds
-        ) subq_27
+            sma_28019_cte.metric_time__day = subq_25.ds
+        ) subq_26
         WHERE metric_time__martian_day = '2020-01-01'
-      ) subq_29
+      ) subq_28
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -126,23 +123,23 @@ FROM (
           , 1 AS buys
           , uuid() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_32
+      ) subq_31
       ON
         (
-          subq_29.user = subq_32.user
+          subq_28.user = subq_31.user
         ) AND (
           (
-            subq_29.metric_time__day <= subq_32.metric_time__day
+            subq_28.metric_time__day <= subq_31.metric_time__day
           ) AND (
-            subq_29.metric_time__day > DATE_ADD('day', -7, subq_32.metric_time__day)
+            subq_28.metric_time__day > DATE_ADD('day', -7, subq_31.metric_time__day)
           )
         )
-    ) subq_33
+    ) subq_32
     GROUP BY
       metric_time__martian_day
-  ) subq_36
+  ) subq_35
   ON
-    subq_24.metric_time__martian_day = subq_36.metric_time__martian_day
+    subq_24.metric_time__martian_day = subq_35.metric_time__martian_day
   GROUP BY
-    COALESCE(subq_24.metric_time__martian_day, subq_36.metric_time__martian_day)
-) subq_37
+    COALESCE(subq_24.metric_time__martian_day, subq_35.metric_time__martian_day)
+) subq_36

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Trino/test_conversion_metric_with_custom_granularity_filter_not_in_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Trino/test_conversion_metric_with_custom_granularity_filter_not_in_group_by__plan0_optimized.sql
@@ -4,8 +4,18 @@ sql_engine: Trino
 ---
 -- Combine Aggregated Outputs
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
-  CAST(MAX(subq_36.buys) AS DOUBLE) / CAST(NULLIF(MAX(subq_24.visits), 0) AS DOUBLE) AS visit_buy_conversion_rate_7days
+  CAST(MAX(subq_35.buys) AS DOUBLE) / CAST(NULLIF(MAX(subq_24.visits), 0) AS DOUBLE) AS visit_buy_conversion_rate_7days
 FROM (
   -- Constrain Output with WHERE
   -- Pass Only Elements: ['visits',]
@@ -13,22 +23,16 @@ FROM (
   SELECT
     SUM(visits) AS visits
   FROM (
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28019
     -- Join to Custom Granularity Dataset
     SELECT
-      subq_19.visits AS visits
+      sma_28019_cte.visits AS visits
       , subq_20.martian_day AS metric_time__martian_day
-    FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      SELECT
-        1 AS visits
-        , DATE_TRUNC('day', ds) AS ds__day
-      FROM ***************************.fct_visits visits_source_src_28000
-    ) subq_19
+    FROM sma_28019_cte sma_28019_cte
     LEFT OUTER JOIN
       ***************************.mf_time_spine subq_20
     ON
-      subq_19.ds__day = subq_20.ds
+      sma_28019_cte.metric_time__day = subq_20.ds
   ) subq_21
   WHERE metric_time__martian_day = '2020-01-01'
 ) subq_24
@@ -41,71 +45,64 @@ CROSS JOIN (
   FROM (
     -- Dedupe the fanout with mf_internal_uuid in the conversion data set
     SELECT DISTINCT
-      FIRST_VALUE(subq_29.visits) OVER (
+      FIRST_VALUE(subq_28.visits) OVER (
         PARTITION BY
-          subq_32.user
-          , subq_32.metric_time__day
-          , subq_32.mf_internal_uuid
-        ORDER BY subq_29.metric_time__day DESC
+          subq_31.user
+          , subq_31.metric_time__day
+          , subq_31.mf_internal_uuid
+        ORDER BY subq_28.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS visits
-      , FIRST_VALUE(subq_29.metric_time__martian_day) OVER (
+      , FIRST_VALUE(subq_28.metric_time__martian_day) OVER (
         PARTITION BY
-          subq_32.user
-          , subq_32.metric_time__day
-          , subq_32.mf_internal_uuid
-        ORDER BY subq_29.metric_time__day DESC
+          subq_31.user
+          , subq_31.metric_time__day
+          , subq_31.mf_internal_uuid
+        ORDER BY subq_28.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS metric_time__martian_day
-      , FIRST_VALUE(subq_29.metric_time__day) OVER (
+      , FIRST_VALUE(subq_28.metric_time__day) OVER (
         PARTITION BY
-          subq_32.user
-          , subq_32.metric_time__day
-          , subq_32.mf_internal_uuid
-        ORDER BY subq_29.metric_time__day DESC
+          subq_31.user
+          , subq_31.metric_time__day
+          , subq_31.mf_internal_uuid
+        ORDER BY subq_28.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS metric_time__day
-      , FIRST_VALUE(subq_29.user) OVER (
+      , FIRST_VALUE(subq_28.user) OVER (
         PARTITION BY
-          subq_32.user
-          , subq_32.metric_time__day
-          , subq_32.mf_internal_uuid
-        ORDER BY subq_29.metric_time__day DESC
+          subq_31.user
+          , subq_31.metric_time__day
+          , subq_31.mf_internal_uuid
+        ORDER BY subq_28.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS user
-      , subq_32.mf_internal_uuid AS mf_internal_uuid
-      , subq_32.buys AS buys
+      , subq_31.mf_internal_uuid AS mf_internal_uuid
+      , subq_31.buys AS buys
     FROM (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['visits', 'metric_time__day', 'metric_time__martian_day', 'user']
       SELECT
         metric_time__martian_day
         , metric_time__day
-        , subq_27.user
+        , subq_26.user
         , visits
       FROM (
-        -- Metric Time Dimension 'ds'
+        -- Read From CTE For node_id=sma_28019
         -- Join to Custom Granularity Dataset
         SELECT
-          subq_25.ds__day AS metric_time__day
-          , subq_25.user AS user
-          , subq_25.visits AS visits
-          , subq_26.martian_day AS metric_time__martian_day
-        FROM (
-          -- Read Elements From Semantic Model 'visits_source'
-          SELECT
-            1 AS visits
-            , DATE_TRUNC('day', ds) AS ds__day
-            , user_id AS user
-          FROM ***************************.fct_visits visits_source_src_28000
-        ) subq_25
+          sma_28019_cte.metric_time__day AS metric_time__day
+          , sma_28019_cte.user AS user
+          , sma_28019_cte.visits AS visits
+          , subq_25.martian_day AS metric_time__martian_day
+        FROM sma_28019_cte sma_28019_cte
         LEFT OUTER JOIN
-          ***************************.mf_time_spine subq_26
+          ***************************.mf_time_spine subq_25
         ON
-          subq_25.ds__day = subq_26.ds
-      ) subq_27
+          sma_28019_cte.metric_time__day = subq_25.ds
+      ) subq_26
       WHERE metric_time__martian_day = '2020-01-01'
-    ) subq_29
+    ) subq_28
     INNER JOIN (
       -- Read Elements From Semantic Model 'buys_source'
       -- Metric Time Dimension 'ds'
@@ -116,16 +113,16 @@ CROSS JOIN (
         , 1 AS buys
         , uuid() AS mf_internal_uuid
       FROM ***************************.fct_buys buys_source_src_28000
-    ) subq_32
+    ) subq_31
     ON
       (
-        subq_29.user = subq_32.user
+        subq_28.user = subq_31.user
       ) AND (
         (
-          subq_29.metric_time__day <= subq_32.metric_time__day
+          subq_28.metric_time__day <= subq_31.metric_time__day
         ) AND (
-          subq_29.metric_time__day > DATE_ADD('day', -7, subq_32.metric_time__day)
+          subq_28.metric_time__day > DATE_ADD('day', -7, subq_31.metric_time__day)
         )
       )
-  ) subq_33
-) subq_36
+  ) subq_32
+) subq_35

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_metric_that_defines_the_same_alias_in_different_components__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_metric_that_defines_the_same_alias_in_different_components__plan0_optimized.sql
@@ -6,30 +6,34 @@ sql_engine: BigQuery
 ---
 -- Combine Aggregated Outputs
 -- Order By [] Limit 1
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    is_instant AS booking__is_instant
+    , 1 AS bookings
+    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  COALESCE(subq_18.booking__is_instant, subq_24.booking__is_instant) AS booking__is_instant
+  COALESCE(subq_18.booking__is_instant, subq_23.booking__is_instant) AS booking__is_instant
   , MAX(subq_18.derived_shared_alias_1a) AS derived_shared_alias_1a
-  , MAX(subq_24.derived_shared_alias_2) AS derived_shared_alias_2
+  , MAX(subq_23.derived_shared_alias_2) AS derived_shared_alias_2
 FROM (
   -- Compute Metrics via Expressions
   SELECT
     booking__is_instant
     , shared_alias - 10 AS derived_shared_alias_1a
   FROM (
+    -- Read From CTE For node_id=sma_28009
+    -- Pass Only Elements: ['bookings', 'booking__is_instant']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
       booking__is_instant
       , SUM(bookings) AS shared_alias
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['bookings', 'booking__is_instant']
-      SELECT
-        is_instant AS booking__is_instant
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_15
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
       booking__is_instant
   ) subq_17
@@ -40,26 +44,20 @@ FULL OUTER JOIN (
     booking__is_instant
     , shared_alias + 10 AS derived_shared_alias_2
   FROM (
+    -- Read From CTE For node_id=sma_28009
+    -- Pass Only Elements: ['instant_bookings', 'booking__is_instant']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
       booking__is_instant
       , SUM(instant_bookings) AS shared_alias
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['instant_bookings', 'booking__is_instant']
-      SELECT
-        is_instant AS booking__is_instant
-        , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_21
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
       booking__is_instant
-  ) subq_23
-) subq_24
+  ) subq_22
+) subq_23
 ON
-  subq_18.booking__is_instant = subq_24.booking__is_instant
+  subq_18.booking__is_instant = subq_23.booking__is_instant
 GROUP BY
   booking__is_instant
 LIMIT 1

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_to_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_to_grain__plan0_optimized.sql
@@ -3,30 +3,33 @@ test_filename: test_derived_metric_rendering.py
 sql_engine: BigQuery
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATETIME_TRUNC(ds, day) AS metric_time__day
+    , 1 AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__day
+  metric_time__day AS metric_time__day
   , bookings - bookings_at_start_of_month AS bookings_growth_since_start_of_month
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_18.metric_time__day, subq_26.metric_time__day) AS metric_time__day
+    COALESCE(subq_18.metric_time__day, subq_25.metric_time__day) AS metric_time__day
     , MAX(subq_18.bookings) AS bookings
-    , MAX(subq_26.bookings_at_start_of_month) AS bookings_at_start_of_month
+    , MAX(subq_25.bookings_at_start_of_month) AS bookings_at_start_of_month
   FROM (
+    -- Read From CTE For node_id=sma_28009
+    -- Pass Only Elements: ['bookings', 'metric_time__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
       metric_time__day
       , SUM(bookings) AS bookings
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['bookings', 'metric_time__day']
-      SELECT
-        DATETIME_TRUNC(ds, day) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_16
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
       metric_time__day
   ) subq_18
@@ -36,24 +39,18 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      subq_22.ds AS metric_time__day
-      , SUM(subq_20.bookings) AS bookings_at_start_of_month
-    FROM ***************************.mf_time_spine subq_22
-    INNER JOIN (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATETIME_TRUNC(ds, day) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_20
+      subq_21.ds AS metric_time__day
+      , SUM(sma_28009_cte.bookings) AS bookings_at_start_of_month
+    FROM ***************************.mf_time_spine subq_21
+    INNER JOIN
+      sma_28009_cte sma_28009_cte
     ON
-      DATETIME_TRUNC(subq_22.ds, month) = subq_20.metric_time__day
+      DATETIME_TRUNC(subq_21.ds, month) = sma_28009_cte.metric_time__day
     GROUP BY
       metric_time__day
-  ) subq_26
+  ) subq_25
   ON
-    subq_18.metric_time__day = subq_26.metric_time__day
+    subq_18.metric_time__day = subq_25.metric_time__day
   GROUP BY
     metric_time__day
-) subq_27
+) subq_26

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_to_grain_and_granularity__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_to_grain_and_granularity__plan0_optimized.sql
@@ -3,30 +3,34 @@ test_filename: test_derived_metric_rendering.py
 sql_engine: BigQuery
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATETIME_TRUNC(ds, day) AS metric_time__day
+    , DATETIME_TRUNC(ds, isoweek) AS metric_time__week
+    , 1 AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__week
+  metric_time__week AS metric_time__week
   , bookings - bookings_at_start_of_month AS bookings_growth_since_start_of_month
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_18.metric_time__week, subq_26.metric_time__week) AS metric_time__week
+    COALESCE(subq_18.metric_time__week, subq_25.metric_time__week) AS metric_time__week
     , MAX(subq_18.bookings) AS bookings
-    , MAX(subq_26.bookings_at_start_of_month) AS bookings_at_start_of_month
+    , MAX(subq_25.bookings_at_start_of_month) AS bookings_at_start_of_month
   FROM (
+    -- Read From CTE For node_id=sma_28009
+    -- Pass Only Elements: ['bookings', 'metric_time__week']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
       metric_time__week
       , SUM(bookings) AS bookings
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['bookings', 'metric_time__week']
-      SELECT
-        DATETIME_TRUNC(ds, isoweek) AS metric_time__week
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_16
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
       metric_time__week
   ) subq_18
@@ -36,25 +40,19 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      DATETIME_TRUNC(subq_22.ds, isoweek) AS metric_time__week
-      , SUM(subq_20.bookings) AS bookings_at_start_of_month
-    FROM ***************************.mf_time_spine subq_22
-    INNER JOIN (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATETIME_TRUNC(ds, day) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_20
+      DATETIME_TRUNC(subq_21.ds, isoweek) AS metric_time__week
+      , SUM(sma_28009_cte.bookings) AS bookings_at_start_of_month
+    FROM ***************************.mf_time_spine subq_21
+    INNER JOIN
+      sma_28009_cte sma_28009_cte
     ON
-      DATETIME_TRUNC(subq_22.ds, month) = subq_20.metric_time__day
-    WHERE DATETIME_TRUNC(subq_22.ds, isoweek) = subq_22.ds
+      DATETIME_TRUNC(subq_21.ds, month) = sma_28009_cte.metric_time__day
+    WHERE DATETIME_TRUNC(subq_21.ds, isoweek) = subq_21.ds
     GROUP BY
       metric_time__week
-  ) subq_26
+  ) subq_25
   ON
-    subq_18.metric_time__week = subq_26.metric_time__week
+    subq_18.metric_time__week = subq_25.metric_time__week
   GROUP BY
     metric_time__week
-) subq_27
+) subq_26

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_window__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_window__plan0_optimized.sql
@@ -3,30 +3,33 @@ test_filename: test_derived_metric_rendering.py
 sql_engine: BigQuery
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATETIME_TRUNC(ds, day) AS metric_time__day
+    , 1 AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__day
+  metric_time__day AS metric_time__day
   , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_18.metric_time__day, subq_26.metric_time__day) AS metric_time__day
+    COALESCE(subq_18.metric_time__day, subq_25.metric_time__day) AS metric_time__day
     , MAX(subq_18.bookings) AS bookings
-    , MAX(subq_26.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+    , MAX(subq_25.bookings_2_weeks_ago) AS bookings_2_weeks_ago
   FROM (
+    -- Read From CTE For node_id=sma_28009
+    -- Pass Only Elements: ['bookings', 'metric_time__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
       metric_time__day
       , SUM(bookings) AS bookings
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['bookings', 'metric_time__day']
-      SELECT
-        DATETIME_TRUNC(ds, day) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_16
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
       metric_time__day
   ) subq_18
@@ -36,24 +39,18 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      subq_22.ds AS metric_time__day
-      , SUM(subq_20.bookings) AS bookings_2_weeks_ago
-    FROM ***************************.mf_time_spine subq_22
-    INNER JOIN (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATETIME_TRUNC(ds, day) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_20
+      subq_21.ds AS metric_time__day
+      , SUM(sma_28009_cte.bookings) AS bookings_2_weeks_ago
+    FROM ***************************.mf_time_spine subq_21
+    INNER JOIN
+      sma_28009_cte sma_28009_cte
     ON
-      DATE_SUB(CAST(subq_22.ds AS DATETIME), INTERVAL 14 day) = subq_20.metric_time__day
+      DATE_SUB(CAST(subq_21.ds AS DATETIME), INTERVAL 14 day) = sma_28009_cte.metric_time__day
     GROUP BY
       metric_time__day
-  ) subq_26
+  ) subq_25
   ON
-    subq_18.metric_time__day = subq_26.metric_time__day
+    subq_18.metric_time__day = subq_25.metric_time__day
   GROUP BY
     metric_time__day
-) subq_27
+) subq_26

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_window_and_granularity__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_window_and_granularity__plan0_optimized.sql
@@ -3,30 +3,34 @@ test_filename: test_derived_metric_rendering.py
 sql_engine: BigQuery
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATETIME_TRUNC(ds, day) AS metric_time__day
+    , DATETIME_TRUNC(ds, quarter) AS metric_time__quarter
+    , 1 AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__quarter
+  metric_time__quarter AS metric_time__quarter
   , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_18.metric_time__quarter, subq_26.metric_time__quarter) AS metric_time__quarter
+    COALESCE(subq_18.metric_time__quarter, subq_25.metric_time__quarter) AS metric_time__quarter
     , MAX(subq_18.bookings) AS bookings
-    , MAX(subq_26.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+    , MAX(subq_25.bookings_2_weeks_ago) AS bookings_2_weeks_ago
   FROM (
+    -- Read From CTE For node_id=sma_28009
+    -- Pass Only Elements: ['bookings', 'metric_time__quarter']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
       metric_time__quarter
       , SUM(bookings) AS bookings
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['bookings', 'metric_time__quarter']
-      SELECT
-        DATETIME_TRUNC(ds, quarter) AS metric_time__quarter
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_16
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
       metric_time__quarter
   ) subq_18
@@ -36,24 +40,18 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      DATETIME_TRUNC(subq_22.ds, quarter) AS metric_time__quarter
-      , SUM(subq_20.bookings) AS bookings_2_weeks_ago
-    FROM ***************************.mf_time_spine subq_22
-    INNER JOIN (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATETIME_TRUNC(ds, day) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_20
+      DATETIME_TRUNC(subq_21.ds, quarter) AS metric_time__quarter
+      , SUM(sma_28009_cte.bookings) AS bookings_2_weeks_ago
+    FROM ***************************.mf_time_spine subq_21
+    INNER JOIN
+      sma_28009_cte sma_28009_cte
     ON
-      DATE_SUB(CAST(subq_22.ds AS DATETIME), INTERVAL 14 day) = subq_20.metric_time__day
+      DATE_SUB(CAST(subq_21.ds AS DATETIME), INTERVAL 14 day) = sma_28009_cte.metric_time__day
     GROUP BY
       metric_time__quarter
-  ) subq_26
+  ) subq_25
   ON
-    subq_18.metric_time__quarter = subq_26.metric_time__quarter
+    subq_18.metric_time__quarter = subq_25.metric_time__quarter
   GROUP BY
     metric_time__quarter
-) subq_27
+) subq_26

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_window_and_offset_to_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_window_and_offset_to_grain__plan0_optimized.sql
@@ -3,15 +3,24 @@ test_filename: test_derived_metric_rendering.py
 sql_engine: BigQuery
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATETIME_TRUNC(ds, day) AS metric_time__day
+    , 1 AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__day
+  metric_time__day AS metric_time__day
   , month_start_bookings - bookings_1_month_ago AS bookings_month_start_compared_to_1_month_prior
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_24.metric_time__day, subq_32.metric_time__day) AS metric_time__day
+    COALESCE(subq_24.metric_time__day, subq_31.metric_time__day) AS metric_time__day
     , MAX(subq_24.month_start_bookings) AS month_start_bookings
-    , MAX(subq_32.bookings_1_month_ago) AS bookings_1_month_ago
+    , MAX(subq_31.bookings_1_month_ago) AS bookings_1_month_ago
   FROM (
     -- Join to Time Spine Dataset
     -- Pass Only Elements: ['bookings', 'metric_time__day']
@@ -19,18 +28,12 @@ FROM (
     -- Compute Metrics via Expressions
     SELECT
       subq_20.ds AS metric_time__day
-      , SUM(subq_18.bookings) AS month_start_bookings
+      , SUM(sma_28009_cte.bookings) AS month_start_bookings
     FROM ***************************.mf_time_spine subq_20
-    INNER JOIN (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATETIME_TRUNC(ds, day) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_18
+    INNER JOIN
+      sma_28009_cte sma_28009_cte
     ON
-      DATETIME_TRUNC(subq_20.ds, month) = subq_18.metric_time__day
+      DATETIME_TRUNC(subq_20.ds, month) = sma_28009_cte.metric_time__day
     GROUP BY
       metric_time__day
   ) subq_24
@@ -40,24 +43,18 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      subq_28.ds AS metric_time__day
-      , SUM(subq_26.bookings) AS bookings_1_month_ago
-    FROM ***************************.mf_time_spine subq_28
-    INNER JOIN (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATETIME_TRUNC(ds, day) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_26
+      subq_27.ds AS metric_time__day
+      , SUM(sma_28009_cte.bookings) AS bookings_1_month_ago
+    FROM ***************************.mf_time_spine subq_27
+    INNER JOIN
+      sma_28009_cte sma_28009_cte
     ON
-      DATE_SUB(CAST(subq_28.ds AS DATETIME), INTERVAL 1 month) = subq_26.metric_time__day
+      DATE_SUB(CAST(subq_27.ds AS DATETIME), INTERVAL 1 month) = sma_28009_cte.metric_time__day
     GROUP BY
       metric_time__day
-  ) subq_32
+  ) subq_31
   ON
-    subq_24.metric_time__day = subq_32.metric_time__day
+    subq_24.metric_time__day = subq_31.metric_time__day
   GROUP BY
     metric_time__day
-) subq_33
+) subq_32

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_window_and_time_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_window_and_time_filter__plan0_optimized.sql
@@ -3,15 +3,24 @@ test_filename: test_derived_metric_rendering.py
 sql_engine: BigQuery
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATETIME_TRUNC(ds, day) AS metric_time__day
+    , 1 AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__day
+  metric_time__day AS metric_time__day
   , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_21.metric_time__day, subq_30.metric_time__day) AS metric_time__day
+    COALESCE(subq_21.metric_time__day, subq_29.metric_time__day) AS metric_time__day
     , MAX(subq_21.bookings) AS bookings
-    , MAX(subq_30.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+    , MAX(subq_29.bookings_2_weeks_ago) AS bookings_2_weeks_ago
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['bookings', 'metric_time__day']
@@ -21,12 +30,11 @@ FROM (
       metric_time__day
       , SUM(bookings) AS bookings
     FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
+      -- Read From CTE For node_id=sma_28009
       SELECT
-        DATETIME_TRUNC(ds, day) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
+        metric_time__day
+        , bookings
+      FROM sma_28009_cte sma_28009_cte
     ) subq_17
     WHERE metric_time__day = '2020-01-01' or metric_time__day = '2020-01-14'
     GROUP BY
@@ -43,26 +51,20 @@ FROM (
     FROM (
       -- Join to Time Spine Dataset
       SELECT
-        subq_25.ds AS metric_time__day
-        , subq_23.bookings AS bookings
-      FROM ***************************.mf_time_spine subq_25
-      INNER JOIN (
-        -- Read Elements From Semantic Model 'bookings_source'
-        -- Metric Time Dimension 'ds'
-        SELECT
-          DATETIME_TRUNC(ds, day) AS metric_time__day
-          , 1 AS bookings
-        FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_23
+        subq_24.ds AS metric_time__day
+        , sma_28009_cte.bookings AS bookings
+      FROM ***************************.mf_time_spine subq_24
+      INNER JOIN
+        sma_28009_cte sma_28009_cte
       ON
-        DATE_SUB(CAST(subq_25.ds AS DATETIME), INTERVAL 14 day) = subq_23.metric_time__day
-    ) subq_26
+        DATE_SUB(CAST(subq_24.ds AS DATETIME), INTERVAL 14 day) = sma_28009_cte.metric_time__day
+    ) subq_25
     WHERE metric_time__day = '2020-01-01' or metric_time__day = '2020-01-14'
     GROUP BY
       metric_time__day
-  ) subq_30
+  ) subq_29
   ON
-    subq_21.metric_time__day = subq_30.metric_time__day
+    subq_21.metric_time__day = subq_29.metric_time__day
   GROUP BY
     metric_time__day
-) subq_31
+) subq_30

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_offset_metric_with_agg_time_dim__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_offset_metric_with_agg_time_dim__plan0_optimized.sql
@@ -3,15 +3,25 @@ test_filename: test_derived_metric_rendering.py
 sql_engine: BigQuery
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATETIME_TRUNC(ds, day) AS booking__ds__day
+    , booking_value
+    , guest_id AS bookers
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  booking__ds__day
+  booking__ds__day AS booking__ds__day
   , booking_value * 0.05 / bookers AS booking_fees_last_week_per_booker_this_week
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_21.booking__ds__day, subq_26.booking__ds__day) AS booking__ds__day
+    COALESCE(subq_21.booking__ds__day, subq_25.booking__ds__day) AS booking__ds__day
     , MAX(subq_21.booking_value) AS booking_value
-    , MAX(subq_26.bookers) AS bookers
+    , MAX(subq_25.bookers) AS bookers
   FROM (
     -- Join to Time Spine Dataset
     -- Pass Only Elements: ['booking_value', 'booking__ds__day']
@@ -19,30 +29,29 @@ FROM (
     -- Compute Metrics via Expressions
     SELECT
       subq_17.ds AS booking__ds__day
-      , SUM(bookings_source_src_28000.booking_value) AS booking_value
+      , SUM(sma_28009_cte.booking_value) AS booking_value
     FROM ***************************.mf_time_spine subq_17
     INNER JOIN
-      ***************************.fct_bookings bookings_source_src_28000
+      sma_28009_cte sma_28009_cte
     ON
-      DATE_SUB(CAST(subq_17.ds AS DATETIME), INTERVAL 1 week) = DATETIME_TRUNC(bookings_source_src_28000.ds, day)
+      DATE_SUB(CAST(subq_17.ds AS DATETIME), INTERVAL 1 week) = sma_28009_cte.booking__ds__day
     GROUP BY
       booking__ds__day
   ) subq_21
   FULL OUTER JOIN (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28009
     -- Pass Only Elements: ['bookers', 'booking__ds__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      DATETIME_TRUNC(ds, day) AS booking__ds__day
-      , COUNT(DISTINCT guest_id) AS bookers
-    FROM ***************************.fct_bookings bookings_source_src_28000
+      booking__ds__day
+      , COUNT(DISTINCT bookers) AS bookers
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
       booking__ds__day
-  ) subq_26
+  ) subq_25
   ON
-    subq_21.booking__ds__day = subq_26.booking__ds__day
+    subq_21.booking__ds__day = subq_25.booking__ds__day
   GROUP BY
     booking__ds__day
-) subq_27
+) subq_26

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0_optimized.sql
@@ -3,15 +3,24 @@ test_filename: test_derived_metric_rendering.py
 sql_engine: BigQuery
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATETIME_TRUNC(ds, day) AS metric_time__day
+    , booking_value
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__day
+  metric_time__day AS metric_time__day
   , booking_fees - booking_fees_start_of_month AS booking_fees_since_start_of_month
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_24.metric_time__day, subq_30.metric_time__day) AS metric_time__day
+    COALESCE(subq_24.metric_time__day, subq_29.metric_time__day) AS metric_time__day
     , MAX(subq_24.booking_fees_start_of_month) AS booking_fees_start_of_month
-    , MAX(subq_30.booking_fees) AS booking_fees
+    , MAX(subq_29.booking_fees) AS booking_fees
   FROM (
     -- Join to Time Spine Dataset
     SELECT
@@ -24,15 +33,14 @@ FROM (
         metric_time__day
         , booking_value * 0.05 AS booking_fees_start_of_month
       FROM (
-        -- Read Elements From Semantic Model 'bookings_source'
-        -- Metric Time Dimension 'ds'
+        -- Read From CTE For node_id=sma_28009
         -- Pass Only Elements: ['booking_value', 'metric_time__day']
         -- Aggregate Measures
         -- Compute Metrics via Expressions
         SELECT
-          DATETIME_TRUNC(ds, day) AS metric_time__day
+          metric_time__day
           , SUM(booking_value) AS booking_value
-        FROM ***************************.fct_bookings bookings_source_src_28000
+        FROM sma_28009_cte sma_28009_cte
         GROUP BY
           metric_time__day
       ) subq_20
@@ -46,21 +54,20 @@ FROM (
       metric_time__day
       , booking_value * 0.05 AS booking_fees
     FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
+      -- Read From CTE For node_id=sma_28009
       -- Pass Only Elements: ['booking_value', 'metric_time__day']
       -- Aggregate Measures
       -- Compute Metrics via Expressions
       SELECT
-        DATETIME_TRUNC(ds, day) AS metric_time__day
+        metric_time__day
         , SUM(booking_value) AS booking_value
-      FROM ***************************.fct_bookings bookings_source_src_28000
+      FROM sma_28009_cte sma_28009_cte
       GROUP BY
         metric_time__day
-    ) subq_29
-  ) subq_30
+    ) subq_28
+  ) subq_29
   ON
-    subq_24.metric_time__day = subq_30.metric_time__day
+    subq_24.metric_time__day = subq_29.metric_time__day
   GROUP BY
     metric_time__day
-) subq_31
+) subq_30

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_offset_to_grain_with_agg_time_dim__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_offset_to_grain_with_agg_time_dim__plan0_optimized.sql
@@ -3,30 +3,33 @@ test_filename: test_derived_metric_rendering.py
 sql_engine: BigQuery
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATETIME_TRUNC(ds, day) AS booking__ds__day
+    , 1 AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  booking__ds__day
+  booking__ds__day AS booking__ds__day
   , bookings - bookings_at_start_of_month AS bookings_growth_since_start_of_month
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_18.booking__ds__day, subq_26.booking__ds__day) AS booking__ds__day
+    COALESCE(subq_18.booking__ds__day, subq_25.booking__ds__day) AS booking__ds__day
     , MAX(subq_18.bookings) AS bookings
-    , MAX(subq_26.bookings_at_start_of_month) AS bookings_at_start_of_month
+    , MAX(subq_25.bookings_at_start_of_month) AS bookings_at_start_of_month
   FROM (
+    -- Read From CTE For node_id=sma_28009
+    -- Pass Only Elements: ['bookings', 'booking__ds__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
       booking__ds__day
       , SUM(bookings) AS bookings
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['bookings', 'booking__ds__day']
-      SELECT
-        DATETIME_TRUNC(ds, day) AS booking__ds__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_16
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
       booking__ds__day
   ) subq_18
@@ -36,24 +39,18 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      subq_22.ds AS booking__ds__day
-      , SUM(subq_20.bookings) AS bookings_at_start_of_month
-    FROM ***************************.mf_time_spine subq_22
-    INNER JOIN (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATETIME_TRUNC(ds, day) AS booking__ds__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_20
+      subq_21.ds AS booking__ds__day
+      , SUM(sma_28009_cte.bookings) AS bookings_at_start_of_month
+    FROM ***************************.mf_time_spine subq_21
+    INNER JOIN
+      sma_28009_cte sma_28009_cte
     ON
-      DATETIME_TRUNC(subq_22.ds, month) = subq_20.booking__ds__day
+      DATETIME_TRUNC(subq_21.ds, month) = sma_28009_cte.booking__ds__day
     GROUP BY
       booking__ds__day
-  ) subq_26
+  ) subq_25
   ON
-    subq_18.booking__ds__day = subq_26.booking__ds__day
+    subq_18.booking__ds__day = subq_25.booking__ds__day
   GROUP BY
     booking__ds__day
-) subq_27
+) subq_26

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_offset_window_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_offset_window_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
@@ -5,15 +5,26 @@ docstring:
 sql_engine: BigQuery
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATETIME_TRUNC(ds, day) AS metric_time__day
+    , DATETIME_TRUNC(ds, month) AS metric_time__month
+    , booking_value
+    , guest_id AS bookers
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__month
+  metric_time__month AS metric_time__month
   , booking_value * 0.05 / bookers AS booking_fees_last_week_per_booker_this_week
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_24.metric_time__month, subq_30.metric_time__month) AS metric_time__month
+    COALESCE(subq_24.metric_time__month, subq_29.metric_time__month) AS metric_time__month
     , MAX(subq_24.booking_value) AS booking_value
-    , MAX(subq_30.bookers) AS bookers
+    , MAX(subq_29.bookers) AS bookers
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['booking_value', 'metric_time__month']
@@ -27,12 +38,12 @@ FROM (
       SELECT
         subq_19.ds AS metric_time__day
         , DATETIME_TRUNC(subq_19.ds, month) AS metric_time__month
-        , bookings_source_src_28000.booking_value AS booking_value
+        , sma_28009_cte.booking_value AS booking_value
       FROM ***************************.mf_time_spine subq_19
       INNER JOIN
-        ***************************.fct_bookings bookings_source_src_28000
+        sma_28009_cte sma_28009_cte
       ON
-        DATE_SUB(CAST(subq_19.ds AS DATETIME), INTERVAL 1 week) = DATETIME_TRUNC(bookings_source_src_28000.ds, day)
+        DATE_SUB(CAST(subq_19.ds AS DATETIME), INTERVAL 1 week) = sma_28009_cte.metric_time__day
     ) subq_20
     WHERE metric_time__day = '2020-01-01'
     GROUP BY
@@ -47,20 +58,20 @@ FROM (
       metric_time__month
       , COUNT(DISTINCT bookers) AS bookers
     FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
+      -- Read From CTE For node_id=sma_28009
       SELECT
-        DATETIME_TRUNC(ds, day) AS metric_time__day
-        , DATETIME_TRUNC(ds, month) AS metric_time__month
-        , guest_id AS bookers
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_26
+        metric_time__day
+        , metric_time__month
+        , booking_value
+        , bookers
+      FROM sma_28009_cte sma_28009_cte
+    ) subq_25
     WHERE metric_time__day = '2020-01-01'
     GROUP BY
       metric_time__month
-  ) subq_30
+  ) subq_29
   ON
-    subq_24.metric_time__month = subq_30.metric_time__month
+    subq_24.metric_time__month = subq_29.metric_time__month
   GROUP BY
     metric_time__month
-) subq_31
+) subq_30

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_offset_window_metric_multiple_granularities__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_offset_window_metric_multiple_granularities__plan0_optimized.sql
@@ -5,19 +5,31 @@ docstring:
 sql_engine: BigQuery
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATETIME_TRUNC(ds, day) AS metric_time__day
+    , DATETIME_TRUNC(ds, month) AS metric_time__month
+    , DATETIME_TRUNC(ds, year) AS metric_time__year
+    , booking_value
+    , guest_id AS bookers
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__day
-  , metric_time__month
-  , metric_time__year
+  metric_time__day AS metric_time__day
+  , metric_time__month AS metric_time__month
+  , metric_time__year AS metric_time__year
   , booking_value * 0.05 / bookers AS booking_fees_last_week_per_booker_this_week
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_21.metric_time__day, subq_26.metric_time__day) AS metric_time__day
-    , COALESCE(subq_21.metric_time__month, subq_26.metric_time__month) AS metric_time__month
-    , COALESCE(subq_21.metric_time__year, subq_26.metric_time__year) AS metric_time__year
+    COALESCE(subq_21.metric_time__day, subq_25.metric_time__day) AS metric_time__day
+    , COALESCE(subq_21.metric_time__month, subq_25.metric_time__month) AS metric_time__month
+    , COALESCE(subq_21.metric_time__year, subq_25.metric_time__year) AS metric_time__year
     , MAX(subq_21.booking_value) AS booking_value
-    , MAX(subq_26.bookers) AS bookers
+    , MAX(subq_25.bookers) AS bookers
   FROM (
     -- Join to Time Spine Dataset
     -- Pass Only Elements: ['booking_value', 'metric_time__day', 'metric_time__month', 'metric_time__year']
@@ -27,44 +39,43 @@ FROM (
       subq_17.ds AS metric_time__day
       , DATETIME_TRUNC(subq_17.ds, month) AS metric_time__month
       , DATETIME_TRUNC(subq_17.ds, year) AS metric_time__year
-      , SUM(bookings_source_src_28000.booking_value) AS booking_value
+      , SUM(sma_28009_cte.booking_value) AS booking_value
     FROM ***************************.mf_time_spine subq_17
     INNER JOIN
-      ***************************.fct_bookings bookings_source_src_28000
+      sma_28009_cte sma_28009_cte
     ON
-      DATE_SUB(CAST(subq_17.ds AS DATETIME), INTERVAL 1 week) = DATETIME_TRUNC(bookings_source_src_28000.ds, day)
+      DATE_SUB(CAST(subq_17.ds AS DATETIME), INTERVAL 1 week) = sma_28009_cte.metric_time__day
     GROUP BY
       metric_time__day
       , metric_time__month
       , metric_time__year
   ) subq_21
   FULL OUTER JOIN (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28009
     -- Pass Only Elements: ['bookers', 'metric_time__day', 'metric_time__month', 'metric_time__year']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      DATETIME_TRUNC(ds, day) AS metric_time__day
-      , DATETIME_TRUNC(ds, month) AS metric_time__month
-      , DATETIME_TRUNC(ds, year) AS metric_time__year
-      , COUNT(DISTINCT guest_id) AS bookers
-    FROM ***************************.fct_bookings bookings_source_src_28000
+      metric_time__day
+      , metric_time__month
+      , metric_time__year
+      , COUNT(DISTINCT bookers) AS bookers
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
       metric_time__day
       , metric_time__month
       , metric_time__year
-  ) subq_26
+  ) subq_25
   ON
     (
-      subq_21.metric_time__day = subq_26.metric_time__day
+      subq_21.metric_time__day = subq_25.metric_time__day
     ) AND (
-      subq_21.metric_time__month = subq_26.metric_time__month
+      subq_21.metric_time__month = subq_25.metric_time__month
     ) AND (
-      subq_21.metric_time__year = subq_26.metric_time__year
+      subq_21.metric_time__year = subq_25.metric_time__year
     )
   GROUP BY
     metric_time__day
     , metric_time__month
     , metric_time__year
-) subq_27
+) subq_26

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_offset_window_with_agg_time_dim__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_offset_window_with_agg_time_dim__plan0_optimized.sql
@@ -3,30 +3,33 @@ test_filename: test_derived_metric_rendering.py
 sql_engine: BigQuery
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATETIME_TRUNC(ds, day) AS booking__ds__day
+    , 1 AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  booking__ds__day
+  booking__ds__day AS booking__ds__day
   , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_18.booking__ds__day, subq_26.booking__ds__day) AS booking__ds__day
+    COALESCE(subq_18.booking__ds__day, subq_25.booking__ds__day) AS booking__ds__day
     , MAX(subq_18.bookings) AS bookings
-    , MAX(subq_26.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+    , MAX(subq_25.bookings_2_weeks_ago) AS bookings_2_weeks_ago
   FROM (
+    -- Read From CTE For node_id=sma_28009
+    -- Pass Only Elements: ['bookings', 'booking__ds__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
       booking__ds__day
       , SUM(bookings) AS bookings
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['bookings', 'booking__ds__day']
-      SELECT
-        DATETIME_TRUNC(ds, day) AS booking__ds__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_16
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
       booking__ds__day
   ) subq_18
@@ -36,24 +39,18 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      subq_22.ds AS booking__ds__day
-      , SUM(subq_20.bookings) AS bookings_2_weeks_ago
-    FROM ***************************.mf_time_spine subq_22
-    INNER JOIN (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATETIME_TRUNC(ds, day) AS booking__ds__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_20
+      subq_21.ds AS booking__ds__day
+      , SUM(sma_28009_cte.bookings) AS bookings_2_weeks_ago
+    FROM ***************************.mf_time_spine subq_21
+    INNER JOIN
+      sma_28009_cte sma_28009_cte
     ON
-      DATE_SUB(CAST(subq_22.ds AS DATETIME), INTERVAL 14 day) = subq_20.booking__ds__day
+      DATE_SUB(CAST(subq_21.ds AS DATETIME), INTERVAL 14 day) = sma_28009_cte.booking__ds__day
     GROUP BY
       booking__ds__day
-  ) subq_26
+  ) subq_25
   ON
-    subq_18.booking__ds__day = subq_26.booking__ds__day
+    subq_18.booking__ds__day = subq_25.booking__ds__day
   GROUP BY
     booking__ds__day
-) subq_27
+) subq_26

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_metric_that_defines_the_same_alias_in_different_components__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_metric_that_defines_the_same_alias_in_different_components__plan0_optimized.sql
@@ -6,30 +6,34 @@ sql_engine: Databricks
 ---
 -- Combine Aggregated Outputs
 -- Order By [] Limit 1
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    is_instant AS booking__is_instant
+    , 1 AS bookings
+    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  COALESCE(subq_18.booking__is_instant, subq_24.booking__is_instant) AS booking__is_instant
+  COALESCE(subq_18.booking__is_instant, subq_23.booking__is_instant) AS booking__is_instant
   , MAX(subq_18.derived_shared_alias_1a) AS derived_shared_alias_1a
-  , MAX(subq_24.derived_shared_alias_2) AS derived_shared_alias_2
+  , MAX(subq_23.derived_shared_alias_2) AS derived_shared_alias_2
 FROM (
   -- Compute Metrics via Expressions
   SELECT
     booking__is_instant
     , shared_alias - 10 AS derived_shared_alias_1a
   FROM (
+    -- Read From CTE For node_id=sma_28009
+    -- Pass Only Elements: ['bookings', 'booking__is_instant']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
       booking__is_instant
       , SUM(bookings) AS shared_alias
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['bookings', 'booking__is_instant']
-      SELECT
-        is_instant AS booking__is_instant
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_15
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
       booking__is_instant
   ) subq_17
@@ -40,26 +44,20 @@ FULL OUTER JOIN (
     booking__is_instant
     , shared_alias + 10 AS derived_shared_alias_2
   FROM (
+    -- Read From CTE For node_id=sma_28009
+    -- Pass Only Elements: ['instant_bookings', 'booking__is_instant']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
       booking__is_instant
       , SUM(instant_bookings) AS shared_alias
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['instant_bookings', 'booking__is_instant']
-      SELECT
-        is_instant AS booking__is_instant
-        , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_21
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
       booking__is_instant
-  ) subq_23
-) subq_24
+  ) subq_22
+) subq_23
 ON
-  subq_18.booking__is_instant = subq_24.booking__is_instant
+  subq_18.booking__is_instant = subq_23.booking__is_instant
 GROUP BY
-  COALESCE(subq_18.booking__is_instant, subq_24.booking__is_instant)
+  COALESCE(subq_18.booking__is_instant, subq_23.booking__is_instant)
 LIMIT 1

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_to_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_to_grain__plan0_optimized.sql
@@ -3,30 +3,33 @@ test_filename: test_derived_metric_rendering.py
 sql_engine: Databricks
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , 1 AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__day
+  metric_time__day AS metric_time__day
   , bookings - bookings_at_start_of_month AS bookings_growth_since_start_of_month
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_18.metric_time__day, subq_26.metric_time__day) AS metric_time__day
+    COALESCE(subq_18.metric_time__day, subq_25.metric_time__day) AS metric_time__day
     , MAX(subq_18.bookings) AS bookings
-    , MAX(subq_26.bookings_at_start_of_month) AS bookings_at_start_of_month
+    , MAX(subq_25.bookings_at_start_of_month) AS bookings_at_start_of_month
   FROM (
+    -- Read From CTE For node_id=sma_28009
+    -- Pass Only Elements: ['bookings', 'metric_time__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
       metric_time__day
       , SUM(bookings) AS bookings
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['bookings', 'metric_time__day']
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_16
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
       metric_time__day
   ) subq_18
@@ -36,24 +39,18 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      subq_22.ds AS metric_time__day
-      , SUM(subq_20.bookings) AS bookings_at_start_of_month
-    FROM ***************************.mf_time_spine subq_22
-    INNER JOIN (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_20
+      subq_21.ds AS metric_time__day
+      , SUM(sma_28009_cte.bookings) AS bookings_at_start_of_month
+    FROM ***************************.mf_time_spine subq_21
+    INNER JOIN
+      sma_28009_cte sma_28009_cte
     ON
-      DATE_TRUNC('month', subq_22.ds) = subq_20.metric_time__day
+      DATE_TRUNC('month', subq_21.ds) = sma_28009_cte.metric_time__day
     GROUP BY
-      subq_22.ds
-  ) subq_26
+      subq_21.ds
+  ) subq_25
   ON
-    subq_18.metric_time__day = subq_26.metric_time__day
+    subq_18.metric_time__day = subq_25.metric_time__day
   GROUP BY
-    COALESCE(subq_18.metric_time__day, subq_26.metric_time__day)
-) subq_27
+    COALESCE(subq_18.metric_time__day, subq_25.metric_time__day)
+) subq_26

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_to_grain_and_granularity__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_to_grain_and_granularity__plan0_optimized.sql
@@ -3,30 +3,34 @@ test_filename: test_derived_metric_rendering.py
 sql_engine: Databricks
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , DATE_TRUNC('week', ds) AS metric_time__week
+    , 1 AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__week
+  metric_time__week AS metric_time__week
   , bookings - bookings_at_start_of_month AS bookings_growth_since_start_of_month
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_18.metric_time__week, subq_26.metric_time__week) AS metric_time__week
+    COALESCE(subq_18.metric_time__week, subq_25.metric_time__week) AS metric_time__week
     , MAX(subq_18.bookings) AS bookings
-    , MAX(subq_26.bookings_at_start_of_month) AS bookings_at_start_of_month
+    , MAX(subq_25.bookings_at_start_of_month) AS bookings_at_start_of_month
   FROM (
+    -- Read From CTE For node_id=sma_28009
+    -- Pass Only Elements: ['bookings', 'metric_time__week']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
       metric_time__week
       , SUM(bookings) AS bookings
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['bookings', 'metric_time__week']
-      SELECT
-        DATE_TRUNC('week', ds) AS metric_time__week
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_16
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
       metric_time__week
   ) subq_18
@@ -36,25 +40,19 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      DATE_TRUNC('week', subq_22.ds) AS metric_time__week
-      , SUM(subq_20.bookings) AS bookings_at_start_of_month
-    FROM ***************************.mf_time_spine subq_22
-    INNER JOIN (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_20
+      DATE_TRUNC('week', subq_21.ds) AS metric_time__week
+      , SUM(sma_28009_cte.bookings) AS bookings_at_start_of_month
+    FROM ***************************.mf_time_spine subq_21
+    INNER JOIN
+      sma_28009_cte sma_28009_cte
     ON
-      DATE_TRUNC('month', subq_22.ds) = subq_20.metric_time__day
-    WHERE DATE_TRUNC('week', subq_22.ds) = subq_22.ds
+      DATE_TRUNC('month', subq_21.ds) = sma_28009_cte.metric_time__day
+    WHERE DATE_TRUNC('week', subq_21.ds) = subq_21.ds
     GROUP BY
-      DATE_TRUNC('week', subq_22.ds)
-  ) subq_26
+      DATE_TRUNC('week', subq_21.ds)
+  ) subq_25
   ON
-    subq_18.metric_time__week = subq_26.metric_time__week
+    subq_18.metric_time__week = subq_25.metric_time__week
   GROUP BY
-    COALESCE(subq_18.metric_time__week, subq_26.metric_time__week)
-) subq_27
+    COALESCE(subq_18.metric_time__week, subq_25.metric_time__week)
+) subq_26

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_window__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_window__plan0_optimized.sql
@@ -3,30 +3,33 @@ test_filename: test_derived_metric_rendering.py
 sql_engine: Databricks
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , 1 AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__day
+  metric_time__day AS metric_time__day
   , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_18.metric_time__day, subq_26.metric_time__day) AS metric_time__day
+    COALESCE(subq_18.metric_time__day, subq_25.metric_time__day) AS metric_time__day
     , MAX(subq_18.bookings) AS bookings
-    , MAX(subq_26.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+    , MAX(subq_25.bookings_2_weeks_ago) AS bookings_2_weeks_ago
   FROM (
+    -- Read From CTE For node_id=sma_28009
+    -- Pass Only Elements: ['bookings', 'metric_time__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
       metric_time__day
       , SUM(bookings) AS bookings
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['bookings', 'metric_time__day']
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_16
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
       metric_time__day
   ) subq_18
@@ -36,24 +39,18 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      subq_22.ds AS metric_time__day
-      , SUM(subq_20.bookings) AS bookings_2_weeks_ago
-    FROM ***************************.mf_time_spine subq_22
-    INNER JOIN (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_20
+      subq_21.ds AS metric_time__day
+      , SUM(sma_28009_cte.bookings) AS bookings_2_weeks_ago
+    FROM ***************************.mf_time_spine subq_21
+    INNER JOIN
+      sma_28009_cte sma_28009_cte
     ON
-      DATEADD(day, -14, subq_22.ds) = subq_20.metric_time__day
+      DATEADD(day, -14, subq_21.ds) = sma_28009_cte.metric_time__day
     GROUP BY
-      subq_22.ds
-  ) subq_26
+      subq_21.ds
+  ) subq_25
   ON
-    subq_18.metric_time__day = subq_26.metric_time__day
+    subq_18.metric_time__day = subq_25.metric_time__day
   GROUP BY
-    COALESCE(subq_18.metric_time__day, subq_26.metric_time__day)
-) subq_27
+    COALESCE(subq_18.metric_time__day, subq_25.metric_time__day)
+) subq_26

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_window_and_granularity__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_window_and_granularity__plan0_optimized.sql
@@ -3,30 +3,34 @@ test_filename: test_derived_metric_rendering.py
 sql_engine: Databricks
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , DATE_TRUNC('quarter', ds) AS metric_time__quarter
+    , 1 AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__quarter
+  metric_time__quarter AS metric_time__quarter
   , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_18.metric_time__quarter, subq_26.metric_time__quarter) AS metric_time__quarter
+    COALESCE(subq_18.metric_time__quarter, subq_25.metric_time__quarter) AS metric_time__quarter
     , MAX(subq_18.bookings) AS bookings
-    , MAX(subq_26.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+    , MAX(subq_25.bookings_2_weeks_ago) AS bookings_2_weeks_ago
   FROM (
+    -- Read From CTE For node_id=sma_28009
+    -- Pass Only Elements: ['bookings', 'metric_time__quarter']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
       metric_time__quarter
       , SUM(bookings) AS bookings
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['bookings', 'metric_time__quarter']
-      SELECT
-        DATE_TRUNC('quarter', ds) AS metric_time__quarter
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_16
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
       metric_time__quarter
   ) subq_18
@@ -36,24 +40,18 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      DATE_TRUNC('quarter', subq_22.ds) AS metric_time__quarter
-      , SUM(subq_20.bookings) AS bookings_2_weeks_ago
-    FROM ***************************.mf_time_spine subq_22
-    INNER JOIN (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_20
+      DATE_TRUNC('quarter', subq_21.ds) AS metric_time__quarter
+      , SUM(sma_28009_cte.bookings) AS bookings_2_weeks_ago
+    FROM ***************************.mf_time_spine subq_21
+    INNER JOIN
+      sma_28009_cte sma_28009_cte
     ON
-      DATEADD(day, -14, subq_22.ds) = subq_20.metric_time__day
+      DATEADD(day, -14, subq_21.ds) = sma_28009_cte.metric_time__day
     GROUP BY
-      DATE_TRUNC('quarter', subq_22.ds)
-  ) subq_26
+      DATE_TRUNC('quarter', subq_21.ds)
+  ) subq_25
   ON
-    subq_18.metric_time__quarter = subq_26.metric_time__quarter
+    subq_18.metric_time__quarter = subq_25.metric_time__quarter
   GROUP BY
-    COALESCE(subq_18.metric_time__quarter, subq_26.metric_time__quarter)
-) subq_27
+    COALESCE(subq_18.metric_time__quarter, subq_25.metric_time__quarter)
+) subq_26

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_window_and_offset_to_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_window_and_offset_to_grain__plan0_optimized.sql
@@ -3,15 +3,24 @@ test_filename: test_derived_metric_rendering.py
 sql_engine: Databricks
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , 1 AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__day
+  metric_time__day AS metric_time__day
   , month_start_bookings - bookings_1_month_ago AS bookings_month_start_compared_to_1_month_prior
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_24.metric_time__day, subq_32.metric_time__day) AS metric_time__day
+    COALESCE(subq_24.metric_time__day, subq_31.metric_time__day) AS metric_time__day
     , MAX(subq_24.month_start_bookings) AS month_start_bookings
-    , MAX(subq_32.bookings_1_month_ago) AS bookings_1_month_ago
+    , MAX(subq_31.bookings_1_month_ago) AS bookings_1_month_ago
   FROM (
     -- Join to Time Spine Dataset
     -- Pass Only Elements: ['bookings', 'metric_time__day']
@@ -19,18 +28,12 @@ FROM (
     -- Compute Metrics via Expressions
     SELECT
       subq_20.ds AS metric_time__day
-      , SUM(subq_18.bookings) AS month_start_bookings
+      , SUM(sma_28009_cte.bookings) AS month_start_bookings
     FROM ***************************.mf_time_spine subq_20
-    INNER JOIN (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_18
+    INNER JOIN
+      sma_28009_cte sma_28009_cte
     ON
-      DATE_TRUNC('month', subq_20.ds) = subq_18.metric_time__day
+      DATE_TRUNC('month', subq_20.ds) = sma_28009_cte.metric_time__day
     GROUP BY
       subq_20.ds
   ) subq_24
@@ -40,24 +43,18 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      subq_28.ds AS metric_time__day
-      , SUM(subq_26.bookings) AS bookings_1_month_ago
-    FROM ***************************.mf_time_spine subq_28
-    INNER JOIN (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_26
+      subq_27.ds AS metric_time__day
+      , SUM(sma_28009_cte.bookings) AS bookings_1_month_ago
+    FROM ***************************.mf_time_spine subq_27
+    INNER JOIN
+      sma_28009_cte sma_28009_cte
     ON
-      DATEADD(month, -1, subq_28.ds) = subq_26.metric_time__day
+      DATEADD(month, -1, subq_27.ds) = sma_28009_cte.metric_time__day
     GROUP BY
-      subq_28.ds
-  ) subq_32
+      subq_27.ds
+  ) subq_31
   ON
-    subq_24.metric_time__day = subq_32.metric_time__day
+    subq_24.metric_time__day = subq_31.metric_time__day
   GROUP BY
-    COALESCE(subq_24.metric_time__day, subq_32.metric_time__day)
-) subq_33
+    COALESCE(subq_24.metric_time__day, subq_31.metric_time__day)
+) subq_32

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0_optimized.sql
@@ -3,15 +3,24 @@ test_filename: test_derived_metric_rendering.py
 sql_engine: Databricks
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , 1 AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__year
+  metric_time__year AS metric_time__year
   , month_start_bookings - bookings_1_month_ago AS bookings_month_start_compared_to_1_month_prior
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_24.metric_time__year, subq_32.metric_time__year) AS metric_time__year
+    COALESCE(subq_24.metric_time__year, subq_31.metric_time__year) AS metric_time__year
     , MAX(subq_24.month_start_bookings) AS month_start_bookings
-    , MAX(subq_32.bookings_1_month_ago) AS bookings_1_month_ago
+    , MAX(subq_31.bookings_1_month_ago) AS bookings_1_month_ago
   FROM (
     -- Join to Time Spine Dataset
     -- Pass Only Elements: ['bookings', 'metric_time__year']
@@ -19,18 +28,12 @@ FROM (
     -- Compute Metrics via Expressions
     SELECT
       DATE_TRUNC('year', subq_20.ds) AS metric_time__year
-      , SUM(subq_18.bookings) AS month_start_bookings
+      , SUM(sma_28009_cte.bookings) AS month_start_bookings
     FROM ***************************.mf_time_spine subq_20
-    INNER JOIN (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_18
+    INNER JOIN
+      sma_28009_cte sma_28009_cte
     ON
-      DATE_TRUNC('month', subq_20.ds) = subq_18.metric_time__day
+      DATE_TRUNC('month', subq_20.ds) = sma_28009_cte.metric_time__day
     WHERE DATE_TRUNC('year', subq_20.ds) = subq_20.ds
     GROUP BY
       DATE_TRUNC('year', subq_20.ds)
@@ -41,24 +44,18 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      DATE_TRUNC('year', subq_28.ds) AS metric_time__year
-      , SUM(subq_26.bookings) AS bookings_1_month_ago
-    FROM ***************************.mf_time_spine subq_28
-    INNER JOIN (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_26
+      DATE_TRUNC('year', subq_27.ds) AS metric_time__year
+      , SUM(sma_28009_cte.bookings) AS bookings_1_month_ago
+    FROM ***************************.mf_time_spine subq_27
+    INNER JOIN
+      sma_28009_cte sma_28009_cte
     ON
-      DATEADD(month, -1, subq_28.ds) = subq_26.metric_time__day
+      DATEADD(month, -1, subq_27.ds) = sma_28009_cte.metric_time__day
     GROUP BY
-      DATE_TRUNC('year', subq_28.ds)
-  ) subq_32
+      DATE_TRUNC('year', subq_27.ds)
+  ) subq_31
   ON
-    subq_24.metric_time__year = subq_32.metric_time__year
+    subq_24.metric_time__year = subq_31.metric_time__year
   GROUP BY
-    COALESCE(subq_24.metric_time__year, subq_32.metric_time__year)
-) subq_33
+    COALESCE(subq_24.metric_time__year, subq_31.metric_time__year)
+) subq_32

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_window_and_time_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_window_and_time_filter__plan0_optimized.sql
@@ -3,15 +3,24 @@ test_filename: test_derived_metric_rendering.py
 sql_engine: Databricks
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , 1 AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__day
+  metric_time__day AS metric_time__day
   , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_21.metric_time__day, subq_30.metric_time__day) AS metric_time__day
+    COALESCE(subq_21.metric_time__day, subq_29.metric_time__day) AS metric_time__day
     , MAX(subq_21.bookings) AS bookings
-    , MAX(subq_30.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+    , MAX(subq_29.bookings_2_weeks_ago) AS bookings_2_weeks_ago
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['bookings', 'metric_time__day']
@@ -21,12 +30,11 @@ FROM (
       metric_time__day
       , SUM(bookings) AS bookings
     FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
+      -- Read From CTE For node_id=sma_28009
       SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
+        metric_time__day
+        , bookings
+      FROM sma_28009_cte sma_28009_cte
     ) subq_17
     WHERE metric_time__day = '2020-01-01' or metric_time__day = '2020-01-14'
     GROUP BY
@@ -43,26 +51,20 @@ FROM (
     FROM (
       -- Join to Time Spine Dataset
       SELECT
-        subq_25.ds AS metric_time__day
-        , subq_23.bookings AS bookings
-      FROM ***************************.mf_time_spine subq_25
-      INNER JOIN (
-        -- Read Elements From Semantic Model 'bookings_source'
-        -- Metric Time Dimension 'ds'
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , 1 AS bookings
-        FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_23
+        subq_24.ds AS metric_time__day
+        , sma_28009_cte.bookings AS bookings
+      FROM ***************************.mf_time_spine subq_24
+      INNER JOIN
+        sma_28009_cte sma_28009_cte
       ON
-        DATEADD(day, -14, subq_25.ds) = subq_23.metric_time__day
-    ) subq_26
+        DATEADD(day, -14, subq_24.ds) = sma_28009_cte.metric_time__day
+    ) subq_25
     WHERE metric_time__day = '2020-01-01' or metric_time__day = '2020-01-14'
     GROUP BY
       metric_time__day
-  ) subq_30
+  ) subq_29
   ON
-    subq_21.metric_time__day = subq_30.metric_time__day
+    subq_21.metric_time__day = subq_29.metric_time__day
   GROUP BY
-    COALESCE(subq_21.metric_time__day, subq_30.metric_time__day)
-) subq_31
+    COALESCE(subq_21.metric_time__day, subq_29.metric_time__day)
+) subq_30

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_offset_metric_with_agg_time_dim__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_offset_metric_with_agg_time_dim__plan0_optimized.sql
@@ -3,15 +3,25 @@ test_filename: test_derived_metric_rendering.py
 sql_engine: Databricks
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS booking__ds__day
+    , booking_value
+    , guest_id AS bookers
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  booking__ds__day
+  booking__ds__day AS booking__ds__day
   , booking_value * 0.05 / bookers AS booking_fees_last_week_per_booker_this_week
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_21.booking__ds__day, subq_26.booking__ds__day) AS booking__ds__day
+    COALESCE(subq_21.booking__ds__day, subq_25.booking__ds__day) AS booking__ds__day
     , MAX(subq_21.booking_value) AS booking_value
-    , MAX(subq_26.bookers) AS bookers
+    , MAX(subq_25.bookers) AS bookers
   FROM (
     -- Join to Time Spine Dataset
     -- Pass Only Elements: ['booking_value', 'booking__ds__day']
@@ -19,30 +29,29 @@ FROM (
     -- Compute Metrics via Expressions
     SELECT
       subq_17.ds AS booking__ds__day
-      , SUM(bookings_source_src_28000.booking_value) AS booking_value
+      , SUM(sma_28009_cte.booking_value) AS booking_value
     FROM ***************************.mf_time_spine subq_17
     INNER JOIN
-      ***************************.fct_bookings bookings_source_src_28000
+      sma_28009_cte sma_28009_cte
     ON
-      DATEADD(week, -1, subq_17.ds) = DATE_TRUNC('day', bookings_source_src_28000.ds)
+      DATEADD(week, -1, subq_17.ds) = sma_28009_cte.booking__ds__day
     GROUP BY
       subq_17.ds
   ) subq_21
   FULL OUTER JOIN (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28009
     -- Pass Only Elements: ['bookers', 'booking__ds__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      DATE_TRUNC('day', ds) AS booking__ds__day
-      , COUNT(DISTINCT guest_id) AS bookers
-    FROM ***************************.fct_bookings bookings_source_src_28000
+      booking__ds__day
+      , COUNT(DISTINCT bookers) AS bookers
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
-      DATE_TRUNC('day', ds)
-  ) subq_26
+      booking__ds__day
+  ) subq_25
   ON
-    subq_21.booking__ds__day = subq_26.booking__ds__day
+    subq_21.booking__ds__day = subq_25.booking__ds__day
   GROUP BY
-    COALESCE(subq_21.booking__ds__day, subq_26.booking__ds__day)
-) subq_27
+    COALESCE(subq_21.booking__ds__day, subq_25.booking__ds__day)
+) subq_26

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0_optimized.sql
@@ -3,15 +3,24 @@ test_filename: test_derived_metric_rendering.py
 sql_engine: Databricks
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , booking_value
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__day
+  metric_time__day AS metric_time__day
   , booking_fees - booking_fees_start_of_month AS booking_fees_since_start_of_month
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_24.metric_time__day, subq_30.metric_time__day) AS metric_time__day
+    COALESCE(subq_24.metric_time__day, subq_29.metric_time__day) AS metric_time__day
     , MAX(subq_24.booking_fees_start_of_month) AS booking_fees_start_of_month
-    , MAX(subq_30.booking_fees) AS booking_fees
+    , MAX(subq_29.booking_fees) AS booking_fees
   FROM (
     -- Join to Time Spine Dataset
     SELECT
@@ -24,17 +33,16 @@ FROM (
         metric_time__day
         , booking_value * 0.05 AS booking_fees_start_of_month
       FROM (
-        -- Read Elements From Semantic Model 'bookings_source'
-        -- Metric Time Dimension 'ds'
+        -- Read From CTE For node_id=sma_28009
         -- Pass Only Elements: ['booking_value', 'metric_time__day']
         -- Aggregate Measures
         -- Compute Metrics via Expressions
         SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
+          metric_time__day
           , SUM(booking_value) AS booking_value
-        FROM ***************************.fct_bookings bookings_source_src_28000
+        FROM sma_28009_cte sma_28009_cte
         GROUP BY
-          DATE_TRUNC('day', ds)
+          metric_time__day
       ) subq_20
     ) subq_21
     ON
@@ -46,21 +54,20 @@ FROM (
       metric_time__day
       , booking_value * 0.05 AS booking_fees
     FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
+      -- Read From CTE For node_id=sma_28009
       -- Pass Only Elements: ['booking_value', 'metric_time__day']
       -- Aggregate Measures
       -- Compute Metrics via Expressions
       SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
+        metric_time__day
         , SUM(booking_value) AS booking_value
-      FROM ***************************.fct_bookings bookings_source_src_28000
+      FROM sma_28009_cte sma_28009_cte
       GROUP BY
-        DATE_TRUNC('day', ds)
-    ) subq_29
-  ) subq_30
+        metric_time__day
+    ) subq_28
+  ) subq_29
   ON
-    subq_24.metric_time__day = subq_30.metric_time__day
+    subq_24.metric_time__day = subq_29.metric_time__day
   GROUP BY
-    COALESCE(subq_24.metric_time__day, subq_30.metric_time__day)
-) subq_31
+    COALESCE(subq_24.metric_time__day, subq_29.metric_time__day)
+) subq_30

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_offset_to_grain_with_agg_time_dim__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_offset_to_grain_with_agg_time_dim__plan0_optimized.sql
@@ -3,30 +3,33 @@ test_filename: test_derived_metric_rendering.py
 sql_engine: Databricks
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS booking__ds__day
+    , 1 AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  booking__ds__day
+  booking__ds__day AS booking__ds__day
   , bookings - bookings_at_start_of_month AS bookings_growth_since_start_of_month
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_18.booking__ds__day, subq_26.booking__ds__day) AS booking__ds__day
+    COALESCE(subq_18.booking__ds__day, subq_25.booking__ds__day) AS booking__ds__day
     , MAX(subq_18.bookings) AS bookings
-    , MAX(subq_26.bookings_at_start_of_month) AS bookings_at_start_of_month
+    , MAX(subq_25.bookings_at_start_of_month) AS bookings_at_start_of_month
   FROM (
+    -- Read From CTE For node_id=sma_28009
+    -- Pass Only Elements: ['bookings', 'booking__ds__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
       booking__ds__day
       , SUM(bookings) AS bookings
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['bookings', 'booking__ds__day']
-      SELECT
-        DATE_TRUNC('day', ds) AS booking__ds__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_16
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
       booking__ds__day
   ) subq_18
@@ -36,24 +39,18 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      subq_22.ds AS booking__ds__day
-      , SUM(subq_20.bookings) AS bookings_at_start_of_month
-    FROM ***************************.mf_time_spine subq_22
-    INNER JOIN (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATE_TRUNC('day', ds) AS booking__ds__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_20
+      subq_21.ds AS booking__ds__day
+      , SUM(sma_28009_cte.bookings) AS bookings_at_start_of_month
+    FROM ***************************.mf_time_spine subq_21
+    INNER JOIN
+      sma_28009_cte sma_28009_cte
     ON
-      DATE_TRUNC('month', subq_22.ds) = subq_20.booking__ds__day
+      DATE_TRUNC('month', subq_21.ds) = sma_28009_cte.booking__ds__day
     GROUP BY
-      subq_22.ds
-  ) subq_26
+      subq_21.ds
+  ) subq_25
   ON
-    subq_18.booking__ds__day = subq_26.booking__ds__day
+    subq_18.booking__ds__day = subq_25.booking__ds__day
   GROUP BY
-    COALESCE(subq_18.booking__ds__day, subq_26.booking__ds__day)
-) subq_27
+    COALESCE(subq_18.booking__ds__day, subq_25.booking__ds__day)
+) subq_26

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_offset_window_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_offset_window_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
@@ -5,15 +5,26 @@ docstring:
 sql_engine: Databricks
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , DATE_TRUNC('month', ds) AS metric_time__month
+    , booking_value
+    , guest_id AS bookers
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__month
+  metric_time__month AS metric_time__month
   , booking_value * 0.05 / bookers AS booking_fees_last_week_per_booker_this_week
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_24.metric_time__month, subq_30.metric_time__month) AS metric_time__month
+    COALESCE(subq_24.metric_time__month, subq_29.metric_time__month) AS metric_time__month
     , MAX(subq_24.booking_value) AS booking_value
-    , MAX(subq_30.bookers) AS bookers
+    , MAX(subq_29.bookers) AS bookers
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['booking_value', 'metric_time__month']
@@ -27,12 +38,12 @@ FROM (
       SELECT
         subq_19.ds AS metric_time__day
         , DATE_TRUNC('month', subq_19.ds) AS metric_time__month
-        , bookings_source_src_28000.booking_value AS booking_value
+        , sma_28009_cte.booking_value AS booking_value
       FROM ***************************.mf_time_spine subq_19
       INNER JOIN
-        ***************************.fct_bookings bookings_source_src_28000
+        sma_28009_cte sma_28009_cte
       ON
-        DATEADD(week, -1, subq_19.ds) = DATE_TRUNC('day', bookings_source_src_28000.ds)
+        DATEADD(week, -1, subq_19.ds) = sma_28009_cte.metric_time__day
     ) subq_20
     WHERE metric_time__day = '2020-01-01'
     GROUP BY
@@ -47,20 +58,20 @@ FROM (
       metric_time__month
       , COUNT(DISTINCT bookers) AS bookers
     FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
+      -- Read From CTE For node_id=sma_28009
       SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , DATE_TRUNC('month', ds) AS metric_time__month
-        , guest_id AS bookers
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_26
+        metric_time__day
+        , metric_time__month
+        , booking_value
+        , bookers
+      FROM sma_28009_cte sma_28009_cte
+    ) subq_25
     WHERE metric_time__day = '2020-01-01'
     GROUP BY
       metric_time__month
-  ) subq_30
+  ) subq_29
   ON
-    subq_24.metric_time__month = subq_30.metric_time__month
+    subq_24.metric_time__month = subq_29.metric_time__month
   GROUP BY
-    COALESCE(subq_24.metric_time__month, subq_30.metric_time__month)
-) subq_31
+    COALESCE(subq_24.metric_time__month, subq_29.metric_time__month)
+) subq_30

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_offset_window_metric_multiple_granularities__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_offset_window_metric_multiple_granularities__plan0_optimized.sql
@@ -5,19 +5,31 @@ docstring:
 sql_engine: Databricks
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , DATE_TRUNC('month', ds) AS metric_time__month
+    , DATE_TRUNC('year', ds) AS metric_time__year
+    , booking_value
+    , guest_id AS bookers
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__day
-  , metric_time__month
-  , metric_time__year
+  metric_time__day AS metric_time__day
+  , metric_time__month AS metric_time__month
+  , metric_time__year AS metric_time__year
   , booking_value * 0.05 / bookers AS booking_fees_last_week_per_booker_this_week
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_21.metric_time__day, subq_26.metric_time__day) AS metric_time__day
-    , COALESCE(subq_21.metric_time__month, subq_26.metric_time__month) AS metric_time__month
-    , COALESCE(subq_21.metric_time__year, subq_26.metric_time__year) AS metric_time__year
+    COALESCE(subq_21.metric_time__day, subq_25.metric_time__day) AS metric_time__day
+    , COALESCE(subq_21.metric_time__month, subq_25.metric_time__month) AS metric_time__month
+    , COALESCE(subq_21.metric_time__year, subq_25.metric_time__year) AS metric_time__year
     , MAX(subq_21.booking_value) AS booking_value
-    , MAX(subq_26.bookers) AS bookers
+    , MAX(subq_25.bookers) AS bookers
   FROM (
     -- Join to Time Spine Dataset
     -- Pass Only Elements: ['booking_value', 'metric_time__day', 'metric_time__month', 'metric_time__year']
@@ -27,44 +39,43 @@ FROM (
       subq_17.ds AS metric_time__day
       , DATE_TRUNC('month', subq_17.ds) AS metric_time__month
       , DATE_TRUNC('year', subq_17.ds) AS metric_time__year
-      , SUM(bookings_source_src_28000.booking_value) AS booking_value
+      , SUM(sma_28009_cte.booking_value) AS booking_value
     FROM ***************************.mf_time_spine subq_17
     INNER JOIN
-      ***************************.fct_bookings bookings_source_src_28000
+      sma_28009_cte sma_28009_cte
     ON
-      DATEADD(week, -1, subq_17.ds) = DATE_TRUNC('day', bookings_source_src_28000.ds)
+      DATEADD(week, -1, subq_17.ds) = sma_28009_cte.metric_time__day
     GROUP BY
       subq_17.ds
       , DATE_TRUNC('month', subq_17.ds)
       , DATE_TRUNC('year', subq_17.ds)
   ) subq_21
   FULL OUTER JOIN (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28009
     -- Pass Only Elements: ['bookers', 'metric_time__day', 'metric_time__month', 'metric_time__year']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      DATE_TRUNC('day', ds) AS metric_time__day
-      , DATE_TRUNC('month', ds) AS metric_time__month
-      , DATE_TRUNC('year', ds) AS metric_time__year
-      , COUNT(DISTINCT guest_id) AS bookers
-    FROM ***************************.fct_bookings bookings_source_src_28000
+      metric_time__day
+      , metric_time__month
+      , metric_time__year
+      , COUNT(DISTINCT bookers) AS bookers
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
-      DATE_TRUNC('day', ds)
-      , DATE_TRUNC('month', ds)
-      , DATE_TRUNC('year', ds)
-  ) subq_26
+      metric_time__day
+      , metric_time__month
+      , metric_time__year
+  ) subq_25
   ON
     (
-      subq_21.metric_time__day = subq_26.metric_time__day
+      subq_21.metric_time__day = subq_25.metric_time__day
     ) AND (
-      subq_21.metric_time__month = subq_26.metric_time__month
+      subq_21.metric_time__month = subq_25.metric_time__month
     ) AND (
-      subq_21.metric_time__year = subq_26.metric_time__year
+      subq_21.metric_time__year = subq_25.metric_time__year
     )
   GROUP BY
-    COALESCE(subq_21.metric_time__day, subq_26.metric_time__day)
-    , COALESCE(subq_21.metric_time__month, subq_26.metric_time__month)
-    , COALESCE(subq_21.metric_time__year, subq_26.metric_time__year)
-) subq_27
+    COALESCE(subq_21.metric_time__day, subq_25.metric_time__day)
+    , COALESCE(subq_21.metric_time__month, subq_25.metric_time__month)
+    , COALESCE(subq_21.metric_time__year, subq_25.metric_time__year)
+) subq_26

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_offset_window_with_agg_time_dim__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_offset_window_with_agg_time_dim__plan0_optimized.sql
@@ -3,30 +3,33 @@ test_filename: test_derived_metric_rendering.py
 sql_engine: Databricks
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS booking__ds__day
+    , 1 AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  booking__ds__day
+  booking__ds__day AS booking__ds__day
   , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_18.booking__ds__day, subq_26.booking__ds__day) AS booking__ds__day
+    COALESCE(subq_18.booking__ds__day, subq_25.booking__ds__day) AS booking__ds__day
     , MAX(subq_18.bookings) AS bookings
-    , MAX(subq_26.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+    , MAX(subq_25.bookings_2_weeks_ago) AS bookings_2_weeks_ago
   FROM (
+    -- Read From CTE For node_id=sma_28009
+    -- Pass Only Elements: ['bookings', 'booking__ds__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
       booking__ds__day
       , SUM(bookings) AS bookings
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['bookings', 'booking__ds__day']
-      SELECT
-        DATE_TRUNC('day', ds) AS booking__ds__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_16
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
       booking__ds__day
   ) subq_18
@@ -36,24 +39,18 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      subq_22.ds AS booking__ds__day
-      , SUM(subq_20.bookings) AS bookings_2_weeks_ago
-    FROM ***************************.mf_time_spine subq_22
-    INNER JOIN (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATE_TRUNC('day', ds) AS booking__ds__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_20
+      subq_21.ds AS booking__ds__day
+      , SUM(sma_28009_cte.bookings) AS bookings_2_weeks_ago
+    FROM ***************************.mf_time_spine subq_21
+    INNER JOIN
+      sma_28009_cte sma_28009_cte
     ON
-      DATEADD(day, -14, subq_22.ds) = subq_20.booking__ds__day
+      DATEADD(day, -14, subq_21.ds) = sma_28009_cte.booking__ds__day
     GROUP BY
-      subq_22.ds
-  ) subq_26
+      subq_21.ds
+  ) subq_25
   ON
-    subq_18.booking__ds__day = subq_26.booking__ds__day
+    subq_18.booking__ds__day = subq_25.booking__ds__day
   GROUP BY
-    COALESCE(subq_18.booking__ds__day, subq_26.booking__ds__day)
-) subq_27
+    COALESCE(subq_18.booking__ds__day, subq_25.booking__ds__day)
+) subq_26

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_metric_that_defines_the_same_alias_in_different_components__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_metric_that_defines_the_same_alias_in_different_components__plan0_optimized.sql
@@ -6,30 +6,34 @@ sql_engine: DuckDB
 ---
 -- Combine Aggregated Outputs
 -- Order By [] Limit 1
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    is_instant AS booking__is_instant
+    , 1 AS bookings
+    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  COALESCE(subq_18.booking__is_instant, subq_24.booking__is_instant) AS booking__is_instant
+  COALESCE(subq_18.booking__is_instant, subq_23.booking__is_instant) AS booking__is_instant
   , MAX(subq_18.derived_shared_alias_1a) AS derived_shared_alias_1a
-  , MAX(subq_24.derived_shared_alias_2) AS derived_shared_alias_2
+  , MAX(subq_23.derived_shared_alias_2) AS derived_shared_alias_2
 FROM (
   -- Compute Metrics via Expressions
   SELECT
     booking__is_instant
     , shared_alias - 10 AS derived_shared_alias_1a
   FROM (
+    -- Read From CTE For node_id=sma_28009
+    -- Pass Only Elements: ['bookings', 'booking__is_instant']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
       booking__is_instant
       , SUM(bookings) AS shared_alias
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['bookings', 'booking__is_instant']
-      SELECT
-        is_instant AS booking__is_instant
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_15
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
       booking__is_instant
   ) subq_17
@@ -40,26 +44,20 @@ FULL OUTER JOIN (
     booking__is_instant
     , shared_alias + 10 AS derived_shared_alias_2
   FROM (
+    -- Read From CTE For node_id=sma_28009
+    -- Pass Only Elements: ['instant_bookings', 'booking__is_instant']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
       booking__is_instant
       , SUM(instant_bookings) AS shared_alias
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['instant_bookings', 'booking__is_instant']
-      SELECT
-        is_instant AS booking__is_instant
-        , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_21
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
       booking__is_instant
-  ) subq_23
-) subq_24
+  ) subq_22
+) subq_23
 ON
-  subq_18.booking__is_instant = subq_24.booking__is_instant
+  subq_18.booking__is_instant = subq_23.booking__is_instant
 GROUP BY
-  COALESCE(subq_18.booking__is_instant, subq_24.booking__is_instant)
+  COALESCE(subq_18.booking__is_instant, subq_23.booking__is_instant)
 LIMIT 1

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_to_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_to_grain__plan0_optimized.sql
@@ -3,30 +3,33 @@ test_filename: test_derived_metric_rendering.py
 sql_engine: DuckDB
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , 1 AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__day
+  metric_time__day AS metric_time__day
   , bookings - bookings_at_start_of_month AS bookings_growth_since_start_of_month
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_18.metric_time__day, subq_26.metric_time__day) AS metric_time__day
+    COALESCE(subq_18.metric_time__day, subq_25.metric_time__day) AS metric_time__day
     , MAX(subq_18.bookings) AS bookings
-    , MAX(subq_26.bookings_at_start_of_month) AS bookings_at_start_of_month
+    , MAX(subq_25.bookings_at_start_of_month) AS bookings_at_start_of_month
   FROM (
+    -- Read From CTE For node_id=sma_28009
+    -- Pass Only Elements: ['bookings', 'metric_time__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
       metric_time__day
       , SUM(bookings) AS bookings
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['bookings', 'metric_time__day']
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_16
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
       metric_time__day
   ) subq_18
@@ -36,24 +39,18 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      subq_22.ds AS metric_time__day
-      , SUM(subq_20.bookings) AS bookings_at_start_of_month
-    FROM ***************************.mf_time_spine subq_22
-    INNER JOIN (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_20
+      subq_21.ds AS metric_time__day
+      , SUM(sma_28009_cte.bookings) AS bookings_at_start_of_month
+    FROM ***************************.mf_time_spine subq_21
+    INNER JOIN
+      sma_28009_cte sma_28009_cte
     ON
-      DATE_TRUNC('month', subq_22.ds) = subq_20.metric_time__day
+      DATE_TRUNC('month', subq_21.ds) = sma_28009_cte.metric_time__day
     GROUP BY
-      subq_22.ds
-  ) subq_26
+      subq_21.ds
+  ) subq_25
   ON
-    subq_18.metric_time__day = subq_26.metric_time__day
+    subq_18.metric_time__day = subq_25.metric_time__day
   GROUP BY
-    COALESCE(subq_18.metric_time__day, subq_26.metric_time__day)
-) subq_27
+    COALESCE(subq_18.metric_time__day, subq_25.metric_time__day)
+) subq_26

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_to_grain_and_granularity__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_to_grain_and_granularity__plan0_optimized.sql
@@ -3,30 +3,34 @@ test_filename: test_derived_metric_rendering.py
 sql_engine: DuckDB
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , DATE_TRUNC('week', ds) AS metric_time__week
+    , 1 AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__week
+  metric_time__week AS metric_time__week
   , bookings - bookings_at_start_of_month AS bookings_growth_since_start_of_month
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_18.metric_time__week, subq_26.metric_time__week) AS metric_time__week
+    COALESCE(subq_18.metric_time__week, subq_25.metric_time__week) AS metric_time__week
     , MAX(subq_18.bookings) AS bookings
-    , MAX(subq_26.bookings_at_start_of_month) AS bookings_at_start_of_month
+    , MAX(subq_25.bookings_at_start_of_month) AS bookings_at_start_of_month
   FROM (
+    -- Read From CTE For node_id=sma_28009
+    -- Pass Only Elements: ['bookings', 'metric_time__week']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
       metric_time__week
       , SUM(bookings) AS bookings
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['bookings', 'metric_time__week']
-      SELECT
-        DATE_TRUNC('week', ds) AS metric_time__week
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_16
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
       metric_time__week
   ) subq_18
@@ -36,25 +40,19 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      DATE_TRUNC('week', subq_22.ds) AS metric_time__week
-      , SUM(subq_20.bookings) AS bookings_at_start_of_month
-    FROM ***************************.mf_time_spine subq_22
-    INNER JOIN (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_20
+      DATE_TRUNC('week', subq_21.ds) AS metric_time__week
+      , SUM(sma_28009_cte.bookings) AS bookings_at_start_of_month
+    FROM ***************************.mf_time_spine subq_21
+    INNER JOIN
+      sma_28009_cte sma_28009_cte
     ON
-      DATE_TRUNC('month', subq_22.ds) = subq_20.metric_time__day
-    WHERE DATE_TRUNC('week', subq_22.ds) = subq_22.ds
+      DATE_TRUNC('month', subq_21.ds) = sma_28009_cte.metric_time__day
+    WHERE DATE_TRUNC('week', subq_21.ds) = subq_21.ds
     GROUP BY
-      DATE_TRUNC('week', subq_22.ds)
-  ) subq_26
+      DATE_TRUNC('week', subq_21.ds)
+  ) subq_25
   ON
-    subq_18.metric_time__week = subq_26.metric_time__week
+    subq_18.metric_time__week = subq_25.metric_time__week
   GROUP BY
-    COALESCE(subq_18.metric_time__week, subq_26.metric_time__week)
-) subq_27
+    COALESCE(subq_18.metric_time__week, subq_25.metric_time__week)
+) subq_26

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_window__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_window__plan0_optimized.sql
@@ -3,30 +3,33 @@ test_filename: test_derived_metric_rendering.py
 sql_engine: DuckDB
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , 1 AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__day
+  metric_time__day AS metric_time__day
   , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_18.metric_time__day, subq_26.metric_time__day) AS metric_time__day
+    COALESCE(subq_18.metric_time__day, subq_25.metric_time__day) AS metric_time__day
     , MAX(subq_18.bookings) AS bookings
-    , MAX(subq_26.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+    , MAX(subq_25.bookings_2_weeks_ago) AS bookings_2_weeks_ago
   FROM (
+    -- Read From CTE For node_id=sma_28009
+    -- Pass Only Elements: ['bookings', 'metric_time__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
       metric_time__day
       , SUM(bookings) AS bookings
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['bookings', 'metric_time__day']
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_16
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
       metric_time__day
   ) subq_18
@@ -36,24 +39,18 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      subq_22.ds AS metric_time__day
-      , SUM(subq_20.bookings) AS bookings_2_weeks_ago
-    FROM ***************************.mf_time_spine subq_22
-    INNER JOIN (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_20
+      subq_21.ds AS metric_time__day
+      , SUM(sma_28009_cte.bookings) AS bookings_2_weeks_ago
+    FROM ***************************.mf_time_spine subq_21
+    INNER JOIN
+      sma_28009_cte sma_28009_cte
     ON
-      subq_22.ds - INTERVAL 14 day = subq_20.metric_time__day
+      subq_21.ds - INTERVAL 14 day = sma_28009_cte.metric_time__day
     GROUP BY
-      subq_22.ds
-  ) subq_26
+      subq_21.ds
+  ) subq_25
   ON
-    subq_18.metric_time__day = subq_26.metric_time__day
+    subq_18.metric_time__day = subq_25.metric_time__day
   GROUP BY
-    COALESCE(subq_18.metric_time__day, subq_26.metric_time__day)
-) subq_27
+    COALESCE(subq_18.metric_time__day, subq_25.metric_time__day)
+) subq_26

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_window_and_granularity__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_window_and_granularity__plan0_optimized.sql
@@ -3,30 +3,34 @@ test_filename: test_derived_metric_rendering.py
 sql_engine: DuckDB
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , DATE_TRUNC('quarter', ds) AS metric_time__quarter
+    , 1 AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__quarter
+  metric_time__quarter AS metric_time__quarter
   , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_18.metric_time__quarter, subq_26.metric_time__quarter) AS metric_time__quarter
+    COALESCE(subq_18.metric_time__quarter, subq_25.metric_time__quarter) AS metric_time__quarter
     , MAX(subq_18.bookings) AS bookings
-    , MAX(subq_26.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+    , MAX(subq_25.bookings_2_weeks_ago) AS bookings_2_weeks_ago
   FROM (
+    -- Read From CTE For node_id=sma_28009
+    -- Pass Only Elements: ['bookings', 'metric_time__quarter']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
       metric_time__quarter
       , SUM(bookings) AS bookings
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['bookings', 'metric_time__quarter']
-      SELECT
-        DATE_TRUNC('quarter', ds) AS metric_time__quarter
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_16
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
       metric_time__quarter
   ) subq_18
@@ -36,24 +40,18 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      DATE_TRUNC('quarter', subq_22.ds) AS metric_time__quarter
-      , SUM(subq_20.bookings) AS bookings_2_weeks_ago
-    FROM ***************************.mf_time_spine subq_22
-    INNER JOIN (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_20
+      DATE_TRUNC('quarter', subq_21.ds) AS metric_time__quarter
+      , SUM(sma_28009_cte.bookings) AS bookings_2_weeks_ago
+    FROM ***************************.mf_time_spine subq_21
+    INNER JOIN
+      sma_28009_cte sma_28009_cte
     ON
-      subq_22.ds - INTERVAL 14 day = subq_20.metric_time__day
+      subq_21.ds - INTERVAL 14 day = sma_28009_cte.metric_time__day
     GROUP BY
-      DATE_TRUNC('quarter', subq_22.ds)
-  ) subq_26
+      DATE_TRUNC('quarter', subq_21.ds)
+  ) subq_25
   ON
-    subq_18.metric_time__quarter = subq_26.metric_time__quarter
+    subq_18.metric_time__quarter = subq_25.metric_time__quarter
   GROUP BY
-    COALESCE(subq_18.metric_time__quarter, subq_26.metric_time__quarter)
-) subq_27
+    COALESCE(subq_18.metric_time__quarter, subq_25.metric_time__quarter)
+) subq_26

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_window_and_offset_to_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_window_and_offset_to_grain__plan0_optimized.sql
@@ -3,15 +3,24 @@ test_filename: test_derived_metric_rendering.py
 sql_engine: DuckDB
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , 1 AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__day
+  metric_time__day AS metric_time__day
   , month_start_bookings - bookings_1_month_ago AS bookings_month_start_compared_to_1_month_prior
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_24.metric_time__day, subq_32.metric_time__day) AS metric_time__day
+    COALESCE(subq_24.metric_time__day, subq_31.metric_time__day) AS metric_time__day
     , MAX(subq_24.month_start_bookings) AS month_start_bookings
-    , MAX(subq_32.bookings_1_month_ago) AS bookings_1_month_ago
+    , MAX(subq_31.bookings_1_month_ago) AS bookings_1_month_ago
   FROM (
     -- Join to Time Spine Dataset
     -- Pass Only Elements: ['bookings', 'metric_time__day']
@@ -19,18 +28,12 @@ FROM (
     -- Compute Metrics via Expressions
     SELECT
       subq_20.ds AS metric_time__day
-      , SUM(subq_18.bookings) AS month_start_bookings
+      , SUM(sma_28009_cte.bookings) AS month_start_bookings
     FROM ***************************.mf_time_spine subq_20
-    INNER JOIN (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_18
+    INNER JOIN
+      sma_28009_cte sma_28009_cte
     ON
-      DATE_TRUNC('month', subq_20.ds) = subq_18.metric_time__day
+      DATE_TRUNC('month', subq_20.ds) = sma_28009_cte.metric_time__day
     GROUP BY
       subq_20.ds
   ) subq_24
@@ -40,24 +43,18 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      subq_28.ds AS metric_time__day
-      , SUM(subq_26.bookings) AS bookings_1_month_ago
-    FROM ***************************.mf_time_spine subq_28
-    INNER JOIN (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_26
+      subq_27.ds AS metric_time__day
+      , SUM(sma_28009_cte.bookings) AS bookings_1_month_ago
+    FROM ***************************.mf_time_spine subq_27
+    INNER JOIN
+      sma_28009_cte sma_28009_cte
     ON
-      subq_28.ds - INTERVAL 1 month = subq_26.metric_time__day
+      subq_27.ds - INTERVAL 1 month = sma_28009_cte.metric_time__day
     GROUP BY
-      subq_28.ds
-  ) subq_32
+      subq_27.ds
+  ) subq_31
   ON
-    subq_24.metric_time__day = subq_32.metric_time__day
+    subq_24.metric_time__day = subq_31.metric_time__day
   GROUP BY
-    COALESCE(subq_24.metric_time__day, subq_32.metric_time__day)
-) subq_33
+    COALESCE(subq_24.metric_time__day, subq_31.metric_time__day)
+) subq_32

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0_optimized.sql
@@ -3,15 +3,24 @@ test_filename: test_derived_metric_rendering.py
 sql_engine: DuckDB
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , 1 AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__year
+  metric_time__year AS metric_time__year
   , month_start_bookings - bookings_1_month_ago AS bookings_month_start_compared_to_1_month_prior
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_24.metric_time__year, subq_32.metric_time__year) AS metric_time__year
+    COALESCE(subq_24.metric_time__year, subq_31.metric_time__year) AS metric_time__year
     , MAX(subq_24.month_start_bookings) AS month_start_bookings
-    , MAX(subq_32.bookings_1_month_ago) AS bookings_1_month_ago
+    , MAX(subq_31.bookings_1_month_ago) AS bookings_1_month_ago
   FROM (
     -- Join to Time Spine Dataset
     -- Pass Only Elements: ['bookings', 'metric_time__year']
@@ -19,18 +28,12 @@ FROM (
     -- Compute Metrics via Expressions
     SELECT
       DATE_TRUNC('year', subq_20.ds) AS metric_time__year
-      , SUM(subq_18.bookings) AS month_start_bookings
+      , SUM(sma_28009_cte.bookings) AS month_start_bookings
     FROM ***************************.mf_time_spine subq_20
-    INNER JOIN (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_18
+    INNER JOIN
+      sma_28009_cte sma_28009_cte
     ON
-      DATE_TRUNC('month', subq_20.ds) = subq_18.metric_time__day
+      DATE_TRUNC('month', subq_20.ds) = sma_28009_cte.metric_time__day
     WHERE DATE_TRUNC('year', subq_20.ds) = subq_20.ds
     GROUP BY
       DATE_TRUNC('year', subq_20.ds)
@@ -41,24 +44,18 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      DATE_TRUNC('year', subq_28.ds) AS metric_time__year
-      , SUM(subq_26.bookings) AS bookings_1_month_ago
-    FROM ***************************.mf_time_spine subq_28
-    INNER JOIN (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_26
+      DATE_TRUNC('year', subq_27.ds) AS metric_time__year
+      , SUM(sma_28009_cte.bookings) AS bookings_1_month_ago
+    FROM ***************************.mf_time_spine subq_27
+    INNER JOIN
+      sma_28009_cte sma_28009_cte
     ON
-      subq_28.ds - INTERVAL 1 month = subq_26.metric_time__day
+      subq_27.ds - INTERVAL 1 month = sma_28009_cte.metric_time__day
     GROUP BY
-      DATE_TRUNC('year', subq_28.ds)
-  ) subq_32
+      DATE_TRUNC('year', subq_27.ds)
+  ) subq_31
   ON
-    subq_24.metric_time__year = subq_32.metric_time__year
+    subq_24.metric_time__year = subq_31.metric_time__year
   GROUP BY
-    COALESCE(subq_24.metric_time__year, subq_32.metric_time__year)
-) subq_33
+    COALESCE(subq_24.metric_time__year, subq_31.metric_time__year)
+) subq_32

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_window_and_time_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_window_and_time_filter__plan0_optimized.sql
@@ -3,15 +3,24 @@ test_filename: test_derived_metric_rendering.py
 sql_engine: DuckDB
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , 1 AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__day
+  metric_time__day AS metric_time__day
   , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_21.metric_time__day, subq_30.metric_time__day) AS metric_time__day
+    COALESCE(subq_21.metric_time__day, subq_29.metric_time__day) AS metric_time__day
     , MAX(subq_21.bookings) AS bookings
-    , MAX(subq_30.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+    , MAX(subq_29.bookings_2_weeks_ago) AS bookings_2_weeks_ago
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['bookings', 'metric_time__day']
@@ -21,12 +30,11 @@ FROM (
       metric_time__day
       , SUM(bookings) AS bookings
     FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
+      -- Read From CTE For node_id=sma_28009
       SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
+        metric_time__day
+        , bookings
+      FROM sma_28009_cte sma_28009_cte
     ) subq_17
     WHERE metric_time__day = '2020-01-01' or metric_time__day = '2020-01-14'
     GROUP BY
@@ -43,26 +51,20 @@ FROM (
     FROM (
       -- Join to Time Spine Dataset
       SELECT
-        subq_25.ds AS metric_time__day
-        , subq_23.bookings AS bookings
-      FROM ***************************.mf_time_spine subq_25
-      INNER JOIN (
-        -- Read Elements From Semantic Model 'bookings_source'
-        -- Metric Time Dimension 'ds'
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , 1 AS bookings
-        FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_23
+        subq_24.ds AS metric_time__day
+        , sma_28009_cte.bookings AS bookings
+      FROM ***************************.mf_time_spine subq_24
+      INNER JOIN
+        sma_28009_cte sma_28009_cte
       ON
-        subq_25.ds - INTERVAL 14 day = subq_23.metric_time__day
-    ) subq_26
+        subq_24.ds - INTERVAL 14 day = sma_28009_cte.metric_time__day
+    ) subq_25
     WHERE metric_time__day = '2020-01-01' or metric_time__day = '2020-01-14'
     GROUP BY
       metric_time__day
-  ) subq_30
+  ) subq_29
   ON
-    subq_21.metric_time__day = subq_30.metric_time__day
+    subq_21.metric_time__day = subq_29.metric_time__day
   GROUP BY
-    COALESCE(subq_21.metric_time__day, subq_30.metric_time__day)
-) subq_31
+    COALESCE(subq_21.metric_time__day, subq_29.metric_time__day)
+) subq_30

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_offset_metric_with_agg_time_dim__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_offset_metric_with_agg_time_dim__plan0_optimized.sql
@@ -3,15 +3,25 @@ test_filename: test_derived_metric_rendering.py
 sql_engine: DuckDB
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS booking__ds__day
+    , booking_value
+    , guest_id AS bookers
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  booking__ds__day
+  booking__ds__day AS booking__ds__day
   , booking_value * 0.05 / bookers AS booking_fees_last_week_per_booker_this_week
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_21.booking__ds__day, subq_26.booking__ds__day) AS booking__ds__day
+    COALESCE(subq_21.booking__ds__day, subq_25.booking__ds__day) AS booking__ds__day
     , MAX(subq_21.booking_value) AS booking_value
-    , MAX(subq_26.bookers) AS bookers
+    , MAX(subq_25.bookers) AS bookers
   FROM (
     -- Join to Time Spine Dataset
     -- Pass Only Elements: ['booking_value', 'booking__ds__day']
@@ -19,30 +29,29 @@ FROM (
     -- Compute Metrics via Expressions
     SELECT
       subq_17.ds AS booking__ds__day
-      , SUM(bookings_source_src_28000.booking_value) AS booking_value
+      , SUM(sma_28009_cte.booking_value) AS booking_value
     FROM ***************************.mf_time_spine subq_17
     INNER JOIN
-      ***************************.fct_bookings bookings_source_src_28000
+      sma_28009_cte sma_28009_cte
     ON
-      subq_17.ds - INTERVAL 1 week = DATE_TRUNC('day', bookings_source_src_28000.ds)
+      subq_17.ds - INTERVAL 1 week = sma_28009_cte.booking__ds__day
     GROUP BY
       subq_17.ds
   ) subq_21
   FULL OUTER JOIN (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28009
     -- Pass Only Elements: ['bookers', 'booking__ds__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      DATE_TRUNC('day', ds) AS booking__ds__day
-      , COUNT(DISTINCT guest_id) AS bookers
-    FROM ***************************.fct_bookings bookings_source_src_28000
+      booking__ds__day
+      , COUNT(DISTINCT bookers) AS bookers
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
-      DATE_TRUNC('day', ds)
-  ) subq_26
+      booking__ds__day
+  ) subq_25
   ON
-    subq_21.booking__ds__day = subq_26.booking__ds__day
+    subq_21.booking__ds__day = subq_25.booking__ds__day
   GROUP BY
-    COALESCE(subq_21.booking__ds__day, subq_26.booking__ds__day)
-) subq_27
+    COALESCE(subq_21.booking__ds__day, subq_25.booking__ds__day)
+) subq_26

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0_optimized.sql
@@ -3,15 +3,24 @@ test_filename: test_derived_metric_rendering.py
 sql_engine: DuckDB
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , booking_value
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__day
+  metric_time__day AS metric_time__day
   , booking_fees - booking_fees_start_of_month AS booking_fees_since_start_of_month
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_24.metric_time__day, subq_30.metric_time__day) AS metric_time__day
+    COALESCE(subq_24.metric_time__day, subq_29.metric_time__day) AS metric_time__day
     , MAX(subq_24.booking_fees_start_of_month) AS booking_fees_start_of_month
-    , MAX(subq_30.booking_fees) AS booking_fees
+    , MAX(subq_29.booking_fees) AS booking_fees
   FROM (
     -- Join to Time Spine Dataset
     SELECT
@@ -24,17 +33,16 @@ FROM (
         metric_time__day
         , booking_value * 0.05 AS booking_fees_start_of_month
       FROM (
-        -- Read Elements From Semantic Model 'bookings_source'
-        -- Metric Time Dimension 'ds'
+        -- Read From CTE For node_id=sma_28009
         -- Pass Only Elements: ['booking_value', 'metric_time__day']
         -- Aggregate Measures
         -- Compute Metrics via Expressions
         SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
+          metric_time__day
           , SUM(booking_value) AS booking_value
-        FROM ***************************.fct_bookings bookings_source_src_28000
+        FROM sma_28009_cte sma_28009_cte
         GROUP BY
-          DATE_TRUNC('day', ds)
+          metric_time__day
       ) subq_20
     ) subq_21
     ON
@@ -46,21 +54,20 @@ FROM (
       metric_time__day
       , booking_value * 0.05 AS booking_fees
     FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
+      -- Read From CTE For node_id=sma_28009
       -- Pass Only Elements: ['booking_value', 'metric_time__day']
       -- Aggregate Measures
       -- Compute Metrics via Expressions
       SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
+        metric_time__day
         , SUM(booking_value) AS booking_value
-      FROM ***************************.fct_bookings bookings_source_src_28000
+      FROM sma_28009_cte sma_28009_cte
       GROUP BY
-        DATE_TRUNC('day', ds)
-    ) subq_29
-  ) subq_30
+        metric_time__day
+    ) subq_28
+  ) subq_29
   ON
-    subq_24.metric_time__day = subq_30.metric_time__day
+    subq_24.metric_time__day = subq_29.metric_time__day
   GROUP BY
-    COALESCE(subq_24.metric_time__day, subq_30.metric_time__day)
-) subq_31
+    COALESCE(subq_24.metric_time__day, subq_29.metric_time__day)
+) subq_30

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_offset_to_grain_with_agg_time_dim__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_offset_to_grain_with_agg_time_dim__plan0_optimized.sql
@@ -3,30 +3,33 @@ test_filename: test_derived_metric_rendering.py
 sql_engine: DuckDB
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS booking__ds__day
+    , 1 AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  booking__ds__day
+  booking__ds__day AS booking__ds__day
   , bookings - bookings_at_start_of_month AS bookings_growth_since_start_of_month
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_18.booking__ds__day, subq_26.booking__ds__day) AS booking__ds__day
+    COALESCE(subq_18.booking__ds__day, subq_25.booking__ds__day) AS booking__ds__day
     , MAX(subq_18.bookings) AS bookings
-    , MAX(subq_26.bookings_at_start_of_month) AS bookings_at_start_of_month
+    , MAX(subq_25.bookings_at_start_of_month) AS bookings_at_start_of_month
   FROM (
+    -- Read From CTE For node_id=sma_28009
+    -- Pass Only Elements: ['bookings', 'booking__ds__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
       booking__ds__day
       , SUM(bookings) AS bookings
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['bookings', 'booking__ds__day']
-      SELECT
-        DATE_TRUNC('day', ds) AS booking__ds__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_16
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
       booking__ds__day
   ) subq_18
@@ -36,24 +39,18 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      subq_22.ds AS booking__ds__day
-      , SUM(subq_20.bookings) AS bookings_at_start_of_month
-    FROM ***************************.mf_time_spine subq_22
-    INNER JOIN (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATE_TRUNC('day', ds) AS booking__ds__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_20
+      subq_21.ds AS booking__ds__day
+      , SUM(sma_28009_cte.bookings) AS bookings_at_start_of_month
+    FROM ***************************.mf_time_spine subq_21
+    INNER JOIN
+      sma_28009_cte sma_28009_cte
     ON
-      DATE_TRUNC('month', subq_22.ds) = subq_20.booking__ds__day
+      DATE_TRUNC('month', subq_21.ds) = sma_28009_cte.booking__ds__day
     GROUP BY
-      subq_22.ds
-  ) subq_26
+      subq_21.ds
+  ) subq_25
   ON
-    subq_18.booking__ds__day = subq_26.booking__ds__day
+    subq_18.booking__ds__day = subq_25.booking__ds__day
   GROUP BY
-    COALESCE(subq_18.booking__ds__day, subq_26.booking__ds__day)
-) subq_27
+    COALESCE(subq_18.booking__ds__day, subq_25.booking__ds__day)
+) subq_26

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_offset_window_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_offset_window_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
@@ -5,15 +5,26 @@ docstring:
 sql_engine: DuckDB
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , DATE_TRUNC('month', ds) AS metric_time__month
+    , booking_value
+    , guest_id AS bookers
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__month
+  metric_time__month AS metric_time__month
   , booking_value * 0.05 / bookers AS booking_fees_last_week_per_booker_this_week
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_24.metric_time__month, subq_30.metric_time__month) AS metric_time__month
+    COALESCE(subq_24.metric_time__month, subq_29.metric_time__month) AS metric_time__month
     , MAX(subq_24.booking_value) AS booking_value
-    , MAX(subq_30.bookers) AS bookers
+    , MAX(subq_29.bookers) AS bookers
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['booking_value', 'metric_time__month']
@@ -27,12 +38,12 @@ FROM (
       SELECT
         subq_19.ds AS metric_time__day
         , DATE_TRUNC('month', subq_19.ds) AS metric_time__month
-        , bookings_source_src_28000.booking_value AS booking_value
+        , sma_28009_cte.booking_value AS booking_value
       FROM ***************************.mf_time_spine subq_19
       INNER JOIN
-        ***************************.fct_bookings bookings_source_src_28000
+        sma_28009_cte sma_28009_cte
       ON
-        subq_19.ds - INTERVAL 1 week = DATE_TRUNC('day', bookings_source_src_28000.ds)
+        subq_19.ds - INTERVAL 1 week = sma_28009_cte.metric_time__day
     ) subq_20
     WHERE metric_time__day = '2020-01-01'
     GROUP BY
@@ -47,20 +58,20 @@ FROM (
       metric_time__month
       , COUNT(DISTINCT bookers) AS bookers
     FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
+      -- Read From CTE For node_id=sma_28009
       SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , DATE_TRUNC('month', ds) AS metric_time__month
-        , guest_id AS bookers
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_26
+        metric_time__day
+        , metric_time__month
+        , booking_value
+        , bookers
+      FROM sma_28009_cte sma_28009_cte
+    ) subq_25
     WHERE metric_time__day = '2020-01-01'
     GROUP BY
       metric_time__month
-  ) subq_30
+  ) subq_29
   ON
-    subq_24.metric_time__month = subq_30.metric_time__month
+    subq_24.metric_time__month = subq_29.metric_time__month
   GROUP BY
-    COALESCE(subq_24.metric_time__month, subq_30.metric_time__month)
-) subq_31
+    COALESCE(subq_24.metric_time__month, subq_29.metric_time__month)
+) subq_30

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_offset_window_metric_multiple_granularities__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_offset_window_metric_multiple_granularities__plan0_optimized.sql
@@ -5,19 +5,31 @@ docstring:
 sql_engine: DuckDB
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , DATE_TRUNC('month', ds) AS metric_time__month
+    , DATE_TRUNC('year', ds) AS metric_time__year
+    , booking_value
+    , guest_id AS bookers
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__day
-  , metric_time__month
-  , metric_time__year
+  metric_time__day AS metric_time__day
+  , metric_time__month AS metric_time__month
+  , metric_time__year AS metric_time__year
   , booking_value * 0.05 / bookers AS booking_fees_last_week_per_booker_this_week
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_21.metric_time__day, subq_26.metric_time__day) AS metric_time__day
-    , COALESCE(subq_21.metric_time__month, subq_26.metric_time__month) AS metric_time__month
-    , COALESCE(subq_21.metric_time__year, subq_26.metric_time__year) AS metric_time__year
+    COALESCE(subq_21.metric_time__day, subq_25.metric_time__day) AS metric_time__day
+    , COALESCE(subq_21.metric_time__month, subq_25.metric_time__month) AS metric_time__month
+    , COALESCE(subq_21.metric_time__year, subq_25.metric_time__year) AS metric_time__year
     , MAX(subq_21.booking_value) AS booking_value
-    , MAX(subq_26.bookers) AS bookers
+    , MAX(subq_25.bookers) AS bookers
   FROM (
     -- Join to Time Spine Dataset
     -- Pass Only Elements: ['booking_value', 'metric_time__day', 'metric_time__month', 'metric_time__year']
@@ -27,44 +39,43 @@ FROM (
       subq_17.ds AS metric_time__day
       , DATE_TRUNC('month', subq_17.ds) AS metric_time__month
       , DATE_TRUNC('year', subq_17.ds) AS metric_time__year
-      , SUM(bookings_source_src_28000.booking_value) AS booking_value
+      , SUM(sma_28009_cte.booking_value) AS booking_value
     FROM ***************************.mf_time_spine subq_17
     INNER JOIN
-      ***************************.fct_bookings bookings_source_src_28000
+      sma_28009_cte sma_28009_cte
     ON
-      subq_17.ds - INTERVAL 1 week = DATE_TRUNC('day', bookings_source_src_28000.ds)
+      subq_17.ds - INTERVAL 1 week = sma_28009_cte.metric_time__day
     GROUP BY
       subq_17.ds
       , DATE_TRUNC('month', subq_17.ds)
       , DATE_TRUNC('year', subq_17.ds)
   ) subq_21
   FULL OUTER JOIN (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28009
     -- Pass Only Elements: ['bookers', 'metric_time__day', 'metric_time__month', 'metric_time__year']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      DATE_TRUNC('day', ds) AS metric_time__day
-      , DATE_TRUNC('month', ds) AS metric_time__month
-      , DATE_TRUNC('year', ds) AS metric_time__year
-      , COUNT(DISTINCT guest_id) AS bookers
-    FROM ***************************.fct_bookings bookings_source_src_28000
+      metric_time__day
+      , metric_time__month
+      , metric_time__year
+      , COUNT(DISTINCT bookers) AS bookers
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
-      DATE_TRUNC('day', ds)
-      , DATE_TRUNC('month', ds)
-      , DATE_TRUNC('year', ds)
-  ) subq_26
+      metric_time__day
+      , metric_time__month
+      , metric_time__year
+  ) subq_25
   ON
     (
-      subq_21.metric_time__day = subq_26.metric_time__day
+      subq_21.metric_time__day = subq_25.metric_time__day
     ) AND (
-      subq_21.metric_time__month = subq_26.metric_time__month
+      subq_21.metric_time__month = subq_25.metric_time__month
     ) AND (
-      subq_21.metric_time__year = subq_26.metric_time__year
+      subq_21.metric_time__year = subq_25.metric_time__year
     )
   GROUP BY
-    COALESCE(subq_21.metric_time__day, subq_26.metric_time__day)
-    , COALESCE(subq_21.metric_time__month, subq_26.metric_time__month)
-    , COALESCE(subq_21.metric_time__year, subq_26.metric_time__year)
-) subq_27
+    COALESCE(subq_21.metric_time__day, subq_25.metric_time__day)
+    , COALESCE(subq_21.metric_time__month, subq_25.metric_time__month)
+    , COALESCE(subq_21.metric_time__year, subq_25.metric_time__year)
+) subq_26

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_offset_window_with_agg_time_dim__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_offset_window_with_agg_time_dim__plan0_optimized.sql
@@ -3,30 +3,33 @@ test_filename: test_derived_metric_rendering.py
 sql_engine: DuckDB
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS booking__ds__day
+    , 1 AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  booking__ds__day
+  booking__ds__day AS booking__ds__day
   , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_18.booking__ds__day, subq_26.booking__ds__day) AS booking__ds__day
+    COALESCE(subq_18.booking__ds__day, subq_25.booking__ds__day) AS booking__ds__day
     , MAX(subq_18.bookings) AS bookings
-    , MAX(subq_26.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+    , MAX(subq_25.bookings_2_weeks_ago) AS bookings_2_weeks_ago
   FROM (
+    -- Read From CTE For node_id=sma_28009
+    -- Pass Only Elements: ['bookings', 'booking__ds__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
       booking__ds__day
       , SUM(bookings) AS bookings
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['bookings', 'booking__ds__day']
-      SELECT
-        DATE_TRUNC('day', ds) AS booking__ds__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_16
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
       booking__ds__day
   ) subq_18
@@ -36,24 +39,18 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      subq_22.ds AS booking__ds__day
-      , SUM(subq_20.bookings) AS bookings_2_weeks_ago
-    FROM ***************************.mf_time_spine subq_22
-    INNER JOIN (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATE_TRUNC('day', ds) AS booking__ds__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_20
+      subq_21.ds AS booking__ds__day
+      , SUM(sma_28009_cte.bookings) AS bookings_2_weeks_ago
+    FROM ***************************.mf_time_spine subq_21
+    INNER JOIN
+      sma_28009_cte sma_28009_cte
     ON
-      subq_22.ds - INTERVAL 14 day = subq_20.booking__ds__day
+      subq_21.ds - INTERVAL 14 day = sma_28009_cte.booking__ds__day
     GROUP BY
-      subq_22.ds
-  ) subq_26
+      subq_21.ds
+  ) subq_25
   ON
-    subq_18.booking__ds__day = subq_26.booking__ds__day
+    subq_18.booking__ds__day = subq_25.booking__ds__day
   GROUP BY
-    COALESCE(subq_18.booking__ds__day, subq_26.booking__ds__day)
-) subq_27
+    COALESCE(subq_18.booking__ds__day, subq_25.booking__ds__day)
+) subq_26

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_metric_that_defines_the_same_alias_in_different_components__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_metric_that_defines_the_same_alias_in_different_components__plan0_optimized.sql
@@ -6,30 +6,34 @@ sql_engine: Postgres
 ---
 -- Combine Aggregated Outputs
 -- Order By [] Limit 1
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    is_instant AS booking__is_instant
+    , 1 AS bookings
+    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  COALESCE(subq_18.booking__is_instant, subq_24.booking__is_instant) AS booking__is_instant
+  COALESCE(subq_18.booking__is_instant, subq_23.booking__is_instant) AS booking__is_instant
   , MAX(subq_18.derived_shared_alias_1a) AS derived_shared_alias_1a
-  , MAX(subq_24.derived_shared_alias_2) AS derived_shared_alias_2
+  , MAX(subq_23.derived_shared_alias_2) AS derived_shared_alias_2
 FROM (
   -- Compute Metrics via Expressions
   SELECT
     booking__is_instant
     , shared_alias - 10 AS derived_shared_alias_1a
   FROM (
+    -- Read From CTE For node_id=sma_28009
+    -- Pass Only Elements: ['bookings', 'booking__is_instant']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
       booking__is_instant
       , SUM(bookings) AS shared_alias
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['bookings', 'booking__is_instant']
-      SELECT
-        is_instant AS booking__is_instant
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_15
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
       booking__is_instant
   ) subq_17
@@ -40,26 +44,20 @@ FULL OUTER JOIN (
     booking__is_instant
     , shared_alias + 10 AS derived_shared_alias_2
   FROM (
+    -- Read From CTE For node_id=sma_28009
+    -- Pass Only Elements: ['instant_bookings', 'booking__is_instant']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
       booking__is_instant
       , SUM(instant_bookings) AS shared_alias
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['instant_bookings', 'booking__is_instant']
-      SELECT
-        is_instant AS booking__is_instant
-        , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_21
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
       booking__is_instant
-  ) subq_23
-) subq_24
+  ) subq_22
+) subq_23
 ON
-  subq_18.booking__is_instant = subq_24.booking__is_instant
+  subq_18.booking__is_instant = subq_23.booking__is_instant
 GROUP BY
-  COALESCE(subq_18.booking__is_instant, subq_24.booking__is_instant)
+  COALESCE(subq_18.booking__is_instant, subq_23.booking__is_instant)
 LIMIT 1

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_to_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_to_grain__plan0_optimized.sql
@@ -3,30 +3,33 @@ test_filename: test_derived_metric_rendering.py
 sql_engine: Postgres
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , 1 AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__day
+  metric_time__day AS metric_time__day
   , bookings - bookings_at_start_of_month AS bookings_growth_since_start_of_month
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_18.metric_time__day, subq_26.metric_time__day) AS metric_time__day
+    COALESCE(subq_18.metric_time__day, subq_25.metric_time__day) AS metric_time__day
     , MAX(subq_18.bookings) AS bookings
-    , MAX(subq_26.bookings_at_start_of_month) AS bookings_at_start_of_month
+    , MAX(subq_25.bookings_at_start_of_month) AS bookings_at_start_of_month
   FROM (
+    -- Read From CTE For node_id=sma_28009
+    -- Pass Only Elements: ['bookings', 'metric_time__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
       metric_time__day
       , SUM(bookings) AS bookings
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['bookings', 'metric_time__day']
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_16
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
       metric_time__day
   ) subq_18
@@ -36,24 +39,18 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      subq_22.ds AS metric_time__day
-      , SUM(subq_20.bookings) AS bookings_at_start_of_month
-    FROM ***************************.mf_time_spine subq_22
-    INNER JOIN (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_20
+      subq_21.ds AS metric_time__day
+      , SUM(sma_28009_cte.bookings) AS bookings_at_start_of_month
+    FROM ***************************.mf_time_spine subq_21
+    INNER JOIN
+      sma_28009_cte sma_28009_cte
     ON
-      DATE_TRUNC('month', subq_22.ds) = subq_20.metric_time__day
+      DATE_TRUNC('month', subq_21.ds) = sma_28009_cte.metric_time__day
     GROUP BY
-      subq_22.ds
-  ) subq_26
+      subq_21.ds
+  ) subq_25
   ON
-    subq_18.metric_time__day = subq_26.metric_time__day
+    subq_18.metric_time__day = subq_25.metric_time__day
   GROUP BY
-    COALESCE(subq_18.metric_time__day, subq_26.metric_time__day)
-) subq_27
+    COALESCE(subq_18.metric_time__day, subq_25.metric_time__day)
+) subq_26

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_to_grain_and_granularity__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_to_grain_and_granularity__plan0_optimized.sql
@@ -3,30 +3,34 @@ test_filename: test_derived_metric_rendering.py
 sql_engine: Postgres
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , DATE_TRUNC('week', ds) AS metric_time__week
+    , 1 AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__week
+  metric_time__week AS metric_time__week
   , bookings - bookings_at_start_of_month AS bookings_growth_since_start_of_month
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_18.metric_time__week, subq_26.metric_time__week) AS metric_time__week
+    COALESCE(subq_18.metric_time__week, subq_25.metric_time__week) AS metric_time__week
     , MAX(subq_18.bookings) AS bookings
-    , MAX(subq_26.bookings_at_start_of_month) AS bookings_at_start_of_month
+    , MAX(subq_25.bookings_at_start_of_month) AS bookings_at_start_of_month
   FROM (
+    -- Read From CTE For node_id=sma_28009
+    -- Pass Only Elements: ['bookings', 'metric_time__week']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
       metric_time__week
       , SUM(bookings) AS bookings
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['bookings', 'metric_time__week']
-      SELECT
-        DATE_TRUNC('week', ds) AS metric_time__week
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_16
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
       metric_time__week
   ) subq_18
@@ -36,25 +40,19 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      DATE_TRUNC('week', subq_22.ds) AS metric_time__week
-      , SUM(subq_20.bookings) AS bookings_at_start_of_month
-    FROM ***************************.mf_time_spine subq_22
-    INNER JOIN (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_20
+      DATE_TRUNC('week', subq_21.ds) AS metric_time__week
+      , SUM(sma_28009_cte.bookings) AS bookings_at_start_of_month
+    FROM ***************************.mf_time_spine subq_21
+    INNER JOIN
+      sma_28009_cte sma_28009_cte
     ON
-      DATE_TRUNC('month', subq_22.ds) = subq_20.metric_time__day
-    WHERE DATE_TRUNC('week', subq_22.ds) = subq_22.ds
+      DATE_TRUNC('month', subq_21.ds) = sma_28009_cte.metric_time__day
+    WHERE DATE_TRUNC('week', subq_21.ds) = subq_21.ds
     GROUP BY
-      DATE_TRUNC('week', subq_22.ds)
-  ) subq_26
+      DATE_TRUNC('week', subq_21.ds)
+  ) subq_25
   ON
-    subq_18.metric_time__week = subq_26.metric_time__week
+    subq_18.metric_time__week = subq_25.metric_time__week
   GROUP BY
-    COALESCE(subq_18.metric_time__week, subq_26.metric_time__week)
-) subq_27
+    COALESCE(subq_18.metric_time__week, subq_25.metric_time__week)
+) subq_26

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_window__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_window__plan0_optimized.sql
@@ -3,30 +3,33 @@ test_filename: test_derived_metric_rendering.py
 sql_engine: Postgres
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , 1 AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__day
+  metric_time__day AS metric_time__day
   , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_18.metric_time__day, subq_26.metric_time__day) AS metric_time__day
+    COALESCE(subq_18.metric_time__day, subq_25.metric_time__day) AS metric_time__day
     , MAX(subq_18.bookings) AS bookings
-    , MAX(subq_26.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+    , MAX(subq_25.bookings_2_weeks_ago) AS bookings_2_weeks_ago
   FROM (
+    -- Read From CTE For node_id=sma_28009
+    -- Pass Only Elements: ['bookings', 'metric_time__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
       metric_time__day
       , SUM(bookings) AS bookings
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['bookings', 'metric_time__day']
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_16
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
       metric_time__day
   ) subq_18
@@ -36,24 +39,18 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      subq_22.ds AS metric_time__day
-      , SUM(subq_20.bookings) AS bookings_2_weeks_ago
-    FROM ***************************.mf_time_spine subq_22
-    INNER JOIN (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_20
+      subq_21.ds AS metric_time__day
+      , SUM(sma_28009_cte.bookings) AS bookings_2_weeks_ago
+    FROM ***************************.mf_time_spine subq_21
+    INNER JOIN
+      sma_28009_cte sma_28009_cte
     ON
-      subq_22.ds - MAKE_INTERVAL(days => 14) = subq_20.metric_time__day
+      subq_21.ds - MAKE_INTERVAL(days => 14) = sma_28009_cte.metric_time__day
     GROUP BY
-      subq_22.ds
-  ) subq_26
+      subq_21.ds
+  ) subq_25
   ON
-    subq_18.metric_time__day = subq_26.metric_time__day
+    subq_18.metric_time__day = subq_25.metric_time__day
   GROUP BY
-    COALESCE(subq_18.metric_time__day, subq_26.metric_time__day)
-) subq_27
+    COALESCE(subq_18.metric_time__day, subq_25.metric_time__day)
+) subq_26

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_window_and_granularity__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_window_and_granularity__plan0_optimized.sql
@@ -3,30 +3,34 @@ test_filename: test_derived_metric_rendering.py
 sql_engine: Postgres
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , DATE_TRUNC('quarter', ds) AS metric_time__quarter
+    , 1 AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__quarter
+  metric_time__quarter AS metric_time__quarter
   , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_18.metric_time__quarter, subq_26.metric_time__quarter) AS metric_time__quarter
+    COALESCE(subq_18.metric_time__quarter, subq_25.metric_time__quarter) AS metric_time__quarter
     , MAX(subq_18.bookings) AS bookings
-    , MAX(subq_26.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+    , MAX(subq_25.bookings_2_weeks_ago) AS bookings_2_weeks_ago
   FROM (
+    -- Read From CTE For node_id=sma_28009
+    -- Pass Only Elements: ['bookings', 'metric_time__quarter']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
       metric_time__quarter
       , SUM(bookings) AS bookings
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['bookings', 'metric_time__quarter']
-      SELECT
-        DATE_TRUNC('quarter', ds) AS metric_time__quarter
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_16
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
       metric_time__quarter
   ) subq_18
@@ -36,24 +40,18 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      DATE_TRUNC('quarter', subq_22.ds) AS metric_time__quarter
-      , SUM(subq_20.bookings) AS bookings_2_weeks_ago
-    FROM ***************************.mf_time_spine subq_22
-    INNER JOIN (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_20
+      DATE_TRUNC('quarter', subq_21.ds) AS metric_time__quarter
+      , SUM(sma_28009_cte.bookings) AS bookings_2_weeks_ago
+    FROM ***************************.mf_time_spine subq_21
+    INNER JOIN
+      sma_28009_cte sma_28009_cte
     ON
-      subq_22.ds - MAKE_INTERVAL(days => 14) = subq_20.metric_time__day
+      subq_21.ds - MAKE_INTERVAL(days => 14) = sma_28009_cte.metric_time__day
     GROUP BY
-      DATE_TRUNC('quarter', subq_22.ds)
-  ) subq_26
+      DATE_TRUNC('quarter', subq_21.ds)
+  ) subq_25
   ON
-    subq_18.metric_time__quarter = subq_26.metric_time__quarter
+    subq_18.metric_time__quarter = subq_25.metric_time__quarter
   GROUP BY
-    COALESCE(subq_18.metric_time__quarter, subq_26.metric_time__quarter)
-) subq_27
+    COALESCE(subq_18.metric_time__quarter, subq_25.metric_time__quarter)
+) subq_26

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_window_and_offset_to_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_window_and_offset_to_grain__plan0_optimized.sql
@@ -3,15 +3,24 @@ test_filename: test_derived_metric_rendering.py
 sql_engine: Postgres
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , 1 AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__day
+  metric_time__day AS metric_time__day
   , month_start_bookings - bookings_1_month_ago AS bookings_month_start_compared_to_1_month_prior
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_24.metric_time__day, subq_32.metric_time__day) AS metric_time__day
+    COALESCE(subq_24.metric_time__day, subq_31.metric_time__day) AS metric_time__day
     , MAX(subq_24.month_start_bookings) AS month_start_bookings
-    , MAX(subq_32.bookings_1_month_ago) AS bookings_1_month_ago
+    , MAX(subq_31.bookings_1_month_ago) AS bookings_1_month_ago
   FROM (
     -- Join to Time Spine Dataset
     -- Pass Only Elements: ['bookings', 'metric_time__day']
@@ -19,18 +28,12 @@ FROM (
     -- Compute Metrics via Expressions
     SELECT
       subq_20.ds AS metric_time__day
-      , SUM(subq_18.bookings) AS month_start_bookings
+      , SUM(sma_28009_cte.bookings) AS month_start_bookings
     FROM ***************************.mf_time_spine subq_20
-    INNER JOIN (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_18
+    INNER JOIN
+      sma_28009_cte sma_28009_cte
     ON
-      DATE_TRUNC('month', subq_20.ds) = subq_18.metric_time__day
+      DATE_TRUNC('month', subq_20.ds) = sma_28009_cte.metric_time__day
     GROUP BY
       subq_20.ds
   ) subq_24
@@ -40,24 +43,18 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      subq_28.ds AS metric_time__day
-      , SUM(subq_26.bookings) AS bookings_1_month_ago
-    FROM ***************************.mf_time_spine subq_28
-    INNER JOIN (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_26
+      subq_27.ds AS metric_time__day
+      , SUM(sma_28009_cte.bookings) AS bookings_1_month_ago
+    FROM ***************************.mf_time_spine subq_27
+    INNER JOIN
+      sma_28009_cte sma_28009_cte
     ON
-      subq_28.ds - MAKE_INTERVAL(months => 1) = subq_26.metric_time__day
+      subq_27.ds - MAKE_INTERVAL(months => 1) = sma_28009_cte.metric_time__day
     GROUP BY
-      subq_28.ds
-  ) subq_32
+      subq_27.ds
+  ) subq_31
   ON
-    subq_24.metric_time__day = subq_32.metric_time__day
+    subq_24.metric_time__day = subq_31.metric_time__day
   GROUP BY
-    COALESCE(subq_24.metric_time__day, subq_32.metric_time__day)
-) subq_33
+    COALESCE(subq_24.metric_time__day, subq_31.metric_time__day)
+) subq_32

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0_optimized.sql
@@ -3,15 +3,24 @@ test_filename: test_derived_metric_rendering.py
 sql_engine: Postgres
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , 1 AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__year
+  metric_time__year AS metric_time__year
   , month_start_bookings - bookings_1_month_ago AS bookings_month_start_compared_to_1_month_prior
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_24.metric_time__year, subq_32.metric_time__year) AS metric_time__year
+    COALESCE(subq_24.metric_time__year, subq_31.metric_time__year) AS metric_time__year
     , MAX(subq_24.month_start_bookings) AS month_start_bookings
-    , MAX(subq_32.bookings_1_month_ago) AS bookings_1_month_ago
+    , MAX(subq_31.bookings_1_month_ago) AS bookings_1_month_ago
   FROM (
     -- Join to Time Spine Dataset
     -- Pass Only Elements: ['bookings', 'metric_time__year']
@@ -19,18 +28,12 @@ FROM (
     -- Compute Metrics via Expressions
     SELECT
       DATE_TRUNC('year', subq_20.ds) AS metric_time__year
-      , SUM(subq_18.bookings) AS month_start_bookings
+      , SUM(sma_28009_cte.bookings) AS month_start_bookings
     FROM ***************************.mf_time_spine subq_20
-    INNER JOIN (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_18
+    INNER JOIN
+      sma_28009_cte sma_28009_cte
     ON
-      DATE_TRUNC('month', subq_20.ds) = subq_18.metric_time__day
+      DATE_TRUNC('month', subq_20.ds) = sma_28009_cte.metric_time__day
     WHERE DATE_TRUNC('year', subq_20.ds) = subq_20.ds
     GROUP BY
       DATE_TRUNC('year', subq_20.ds)
@@ -41,24 +44,18 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      DATE_TRUNC('year', subq_28.ds) AS metric_time__year
-      , SUM(subq_26.bookings) AS bookings_1_month_ago
-    FROM ***************************.mf_time_spine subq_28
-    INNER JOIN (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_26
+      DATE_TRUNC('year', subq_27.ds) AS metric_time__year
+      , SUM(sma_28009_cte.bookings) AS bookings_1_month_ago
+    FROM ***************************.mf_time_spine subq_27
+    INNER JOIN
+      sma_28009_cte sma_28009_cte
     ON
-      subq_28.ds - MAKE_INTERVAL(months => 1) = subq_26.metric_time__day
+      subq_27.ds - MAKE_INTERVAL(months => 1) = sma_28009_cte.metric_time__day
     GROUP BY
-      DATE_TRUNC('year', subq_28.ds)
-  ) subq_32
+      DATE_TRUNC('year', subq_27.ds)
+  ) subq_31
   ON
-    subq_24.metric_time__year = subq_32.metric_time__year
+    subq_24.metric_time__year = subq_31.metric_time__year
   GROUP BY
-    COALESCE(subq_24.metric_time__year, subq_32.metric_time__year)
-) subq_33
+    COALESCE(subq_24.metric_time__year, subq_31.metric_time__year)
+) subq_32

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_window_and_time_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_window_and_time_filter__plan0_optimized.sql
@@ -3,15 +3,24 @@ test_filename: test_derived_metric_rendering.py
 sql_engine: Postgres
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , 1 AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__day
+  metric_time__day AS metric_time__day
   , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_21.metric_time__day, subq_30.metric_time__day) AS metric_time__day
+    COALESCE(subq_21.metric_time__day, subq_29.metric_time__day) AS metric_time__day
     , MAX(subq_21.bookings) AS bookings
-    , MAX(subq_30.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+    , MAX(subq_29.bookings_2_weeks_ago) AS bookings_2_weeks_ago
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['bookings', 'metric_time__day']
@@ -21,12 +30,11 @@ FROM (
       metric_time__day
       , SUM(bookings) AS bookings
     FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
+      -- Read From CTE For node_id=sma_28009
       SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
+        metric_time__day
+        , bookings
+      FROM sma_28009_cte sma_28009_cte
     ) subq_17
     WHERE metric_time__day = '2020-01-01' or metric_time__day = '2020-01-14'
     GROUP BY
@@ -43,26 +51,20 @@ FROM (
     FROM (
       -- Join to Time Spine Dataset
       SELECT
-        subq_25.ds AS metric_time__day
-        , subq_23.bookings AS bookings
-      FROM ***************************.mf_time_spine subq_25
-      INNER JOIN (
-        -- Read Elements From Semantic Model 'bookings_source'
-        -- Metric Time Dimension 'ds'
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , 1 AS bookings
-        FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_23
+        subq_24.ds AS metric_time__day
+        , sma_28009_cte.bookings AS bookings
+      FROM ***************************.mf_time_spine subq_24
+      INNER JOIN
+        sma_28009_cte sma_28009_cte
       ON
-        subq_25.ds - MAKE_INTERVAL(days => 14) = subq_23.metric_time__day
-    ) subq_26
+        subq_24.ds - MAKE_INTERVAL(days => 14) = sma_28009_cte.metric_time__day
+    ) subq_25
     WHERE metric_time__day = '2020-01-01' or metric_time__day = '2020-01-14'
     GROUP BY
       metric_time__day
-  ) subq_30
+  ) subq_29
   ON
-    subq_21.metric_time__day = subq_30.metric_time__day
+    subq_21.metric_time__day = subq_29.metric_time__day
   GROUP BY
-    COALESCE(subq_21.metric_time__day, subq_30.metric_time__day)
-) subq_31
+    COALESCE(subq_21.metric_time__day, subq_29.metric_time__day)
+) subq_30

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_offset_metric_with_agg_time_dim__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_offset_metric_with_agg_time_dim__plan0_optimized.sql
@@ -3,15 +3,25 @@ test_filename: test_derived_metric_rendering.py
 sql_engine: Postgres
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS booking__ds__day
+    , booking_value
+    , guest_id AS bookers
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  booking__ds__day
+  booking__ds__day AS booking__ds__day
   , booking_value * 0.05 / bookers AS booking_fees_last_week_per_booker_this_week
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_21.booking__ds__day, subq_26.booking__ds__day) AS booking__ds__day
+    COALESCE(subq_21.booking__ds__day, subq_25.booking__ds__day) AS booking__ds__day
     , MAX(subq_21.booking_value) AS booking_value
-    , MAX(subq_26.bookers) AS bookers
+    , MAX(subq_25.bookers) AS bookers
   FROM (
     -- Join to Time Spine Dataset
     -- Pass Only Elements: ['booking_value', 'booking__ds__day']
@@ -19,30 +29,29 @@ FROM (
     -- Compute Metrics via Expressions
     SELECT
       subq_17.ds AS booking__ds__day
-      , SUM(bookings_source_src_28000.booking_value) AS booking_value
+      , SUM(sma_28009_cte.booking_value) AS booking_value
     FROM ***************************.mf_time_spine subq_17
     INNER JOIN
-      ***************************.fct_bookings bookings_source_src_28000
+      sma_28009_cte sma_28009_cte
     ON
-      subq_17.ds - MAKE_INTERVAL(weeks => 1) = DATE_TRUNC('day', bookings_source_src_28000.ds)
+      subq_17.ds - MAKE_INTERVAL(weeks => 1) = sma_28009_cte.booking__ds__day
     GROUP BY
       subq_17.ds
   ) subq_21
   FULL OUTER JOIN (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28009
     -- Pass Only Elements: ['bookers', 'booking__ds__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      DATE_TRUNC('day', ds) AS booking__ds__day
-      , COUNT(DISTINCT guest_id) AS bookers
-    FROM ***************************.fct_bookings bookings_source_src_28000
+      booking__ds__day
+      , COUNT(DISTINCT bookers) AS bookers
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
-      DATE_TRUNC('day', ds)
-  ) subq_26
+      booking__ds__day
+  ) subq_25
   ON
-    subq_21.booking__ds__day = subq_26.booking__ds__day
+    subq_21.booking__ds__day = subq_25.booking__ds__day
   GROUP BY
-    COALESCE(subq_21.booking__ds__day, subq_26.booking__ds__day)
-) subq_27
+    COALESCE(subq_21.booking__ds__day, subq_25.booking__ds__day)
+) subq_26

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0_optimized.sql
@@ -3,15 +3,24 @@ test_filename: test_derived_metric_rendering.py
 sql_engine: Postgres
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , booking_value
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__day
+  metric_time__day AS metric_time__day
   , booking_fees - booking_fees_start_of_month AS booking_fees_since_start_of_month
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_24.metric_time__day, subq_30.metric_time__day) AS metric_time__day
+    COALESCE(subq_24.metric_time__day, subq_29.metric_time__day) AS metric_time__day
     , MAX(subq_24.booking_fees_start_of_month) AS booking_fees_start_of_month
-    , MAX(subq_30.booking_fees) AS booking_fees
+    , MAX(subq_29.booking_fees) AS booking_fees
   FROM (
     -- Join to Time Spine Dataset
     SELECT
@@ -24,17 +33,16 @@ FROM (
         metric_time__day
         , booking_value * 0.05 AS booking_fees_start_of_month
       FROM (
-        -- Read Elements From Semantic Model 'bookings_source'
-        -- Metric Time Dimension 'ds'
+        -- Read From CTE For node_id=sma_28009
         -- Pass Only Elements: ['booking_value', 'metric_time__day']
         -- Aggregate Measures
         -- Compute Metrics via Expressions
         SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
+          metric_time__day
           , SUM(booking_value) AS booking_value
-        FROM ***************************.fct_bookings bookings_source_src_28000
+        FROM sma_28009_cte sma_28009_cte
         GROUP BY
-          DATE_TRUNC('day', ds)
+          metric_time__day
       ) subq_20
     ) subq_21
     ON
@@ -46,21 +54,20 @@ FROM (
       metric_time__day
       , booking_value * 0.05 AS booking_fees
     FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
+      -- Read From CTE For node_id=sma_28009
       -- Pass Only Elements: ['booking_value', 'metric_time__day']
       -- Aggregate Measures
       -- Compute Metrics via Expressions
       SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
+        metric_time__day
         , SUM(booking_value) AS booking_value
-      FROM ***************************.fct_bookings bookings_source_src_28000
+      FROM sma_28009_cte sma_28009_cte
       GROUP BY
-        DATE_TRUNC('day', ds)
-    ) subq_29
-  ) subq_30
+        metric_time__day
+    ) subq_28
+  ) subq_29
   ON
-    subq_24.metric_time__day = subq_30.metric_time__day
+    subq_24.metric_time__day = subq_29.metric_time__day
   GROUP BY
-    COALESCE(subq_24.metric_time__day, subq_30.metric_time__day)
-) subq_31
+    COALESCE(subq_24.metric_time__day, subq_29.metric_time__day)
+) subq_30

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_offset_to_grain_with_agg_time_dim__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_offset_to_grain_with_agg_time_dim__plan0_optimized.sql
@@ -3,30 +3,33 @@ test_filename: test_derived_metric_rendering.py
 sql_engine: Postgres
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS booking__ds__day
+    , 1 AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  booking__ds__day
+  booking__ds__day AS booking__ds__day
   , bookings - bookings_at_start_of_month AS bookings_growth_since_start_of_month
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_18.booking__ds__day, subq_26.booking__ds__day) AS booking__ds__day
+    COALESCE(subq_18.booking__ds__day, subq_25.booking__ds__day) AS booking__ds__day
     , MAX(subq_18.bookings) AS bookings
-    , MAX(subq_26.bookings_at_start_of_month) AS bookings_at_start_of_month
+    , MAX(subq_25.bookings_at_start_of_month) AS bookings_at_start_of_month
   FROM (
+    -- Read From CTE For node_id=sma_28009
+    -- Pass Only Elements: ['bookings', 'booking__ds__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
       booking__ds__day
       , SUM(bookings) AS bookings
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['bookings', 'booking__ds__day']
-      SELECT
-        DATE_TRUNC('day', ds) AS booking__ds__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_16
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
       booking__ds__day
   ) subq_18
@@ -36,24 +39,18 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      subq_22.ds AS booking__ds__day
-      , SUM(subq_20.bookings) AS bookings_at_start_of_month
-    FROM ***************************.mf_time_spine subq_22
-    INNER JOIN (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATE_TRUNC('day', ds) AS booking__ds__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_20
+      subq_21.ds AS booking__ds__day
+      , SUM(sma_28009_cte.bookings) AS bookings_at_start_of_month
+    FROM ***************************.mf_time_spine subq_21
+    INNER JOIN
+      sma_28009_cte sma_28009_cte
     ON
-      DATE_TRUNC('month', subq_22.ds) = subq_20.booking__ds__day
+      DATE_TRUNC('month', subq_21.ds) = sma_28009_cte.booking__ds__day
     GROUP BY
-      subq_22.ds
-  ) subq_26
+      subq_21.ds
+  ) subq_25
   ON
-    subq_18.booking__ds__day = subq_26.booking__ds__day
+    subq_18.booking__ds__day = subq_25.booking__ds__day
   GROUP BY
-    COALESCE(subq_18.booking__ds__day, subq_26.booking__ds__day)
-) subq_27
+    COALESCE(subq_18.booking__ds__day, subq_25.booking__ds__day)
+) subq_26

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_offset_window_metric_multiple_granularities__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_offset_window_metric_multiple_granularities__plan0_optimized.sql
@@ -5,19 +5,31 @@ docstring:
 sql_engine: Postgres
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , DATE_TRUNC('month', ds) AS metric_time__month
+    , DATE_TRUNC('year', ds) AS metric_time__year
+    , booking_value
+    , guest_id AS bookers
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__day
-  , metric_time__month
-  , metric_time__year
+  metric_time__day AS metric_time__day
+  , metric_time__month AS metric_time__month
+  , metric_time__year AS metric_time__year
   , booking_value * 0.05 / bookers AS booking_fees_last_week_per_booker_this_week
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_21.metric_time__day, subq_26.metric_time__day) AS metric_time__day
-    , COALESCE(subq_21.metric_time__month, subq_26.metric_time__month) AS metric_time__month
-    , COALESCE(subq_21.metric_time__year, subq_26.metric_time__year) AS metric_time__year
+    COALESCE(subq_21.metric_time__day, subq_25.metric_time__day) AS metric_time__day
+    , COALESCE(subq_21.metric_time__month, subq_25.metric_time__month) AS metric_time__month
+    , COALESCE(subq_21.metric_time__year, subq_25.metric_time__year) AS metric_time__year
     , MAX(subq_21.booking_value) AS booking_value
-    , MAX(subq_26.bookers) AS bookers
+    , MAX(subq_25.bookers) AS bookers
   FROM (
     -- Join to Time Spine Dataset
     -- Pass Only Elements: ['booking_value', 'metric_time__day', 'metric_time__month', 'metric_time__year']
@@ -27,44 +39,43 @@ FROM (
       subq_17.ds AS metric_time__day
       , DATE_TRUNC('month', subq_17.ds) AS metric_time__month
       , DATE_TRUNC('year', subq_17.ds) AS metric_time__year
-      , SUM(bookings_source_src_28000.booking_value) AS booking_value
+      , SUM(sma_28009_cte.booking_value) AS booking_value
     FROM ***************************.mf_time_spine subq_17
     INNER JOIN
-      ***************************.fct_bookings bookings_source_src_28000
+      sma_28009_cte sma_28009_cte
     ON
-      subq_17.ds - MAKE_INTERVAL(weeks => 1) = DATE_TRUNC('day', bookings_source_src_28000.ds)
+      subq_17.ds - MAKE_INTERVAL(weeks => 1) = sma_28009_cte.metric_time__day
     GROUP BY
       subq_17.ds
       , DATE_TRUNC('month', subq_17.ds)
       , DATE_TRUNC('year', subq_17.ds)
   ) subq_21
   FULL OUTER JOIN (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28009
     -- Pass Only Elements: ['bookers', 'metric_time__day', 'metric_time__month', 'metric_time__year']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      DATE_TRUNC('day', ds) AS metric_time__day
-      , DATE_TRUNC('month', ds) AS metric_time__month
-      , DATE_TRUNC('year', ds) AS metric_time__year
-      , COUNT(DISTINCT guest_id) AS bookers
-    FROM ***************************.fct_bookings bookings_source_src_28000
+      metric_time__day
+      , metric_time__month
+      , metric_time__year
+      , COUNT(DISTINCT bookers) AS bookers
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
-      DATE_TRUNC('day', ds)
-      , DATE_TRUNC('month', ds)
-      , DATE_TRUNC('year', ds)
-  ) subq_26
+      metric_time__day
+      , metric_time__month
+      , metric_time__year
+  ) subq_25
   ON
     (
-      subq_21.metric_time__day = subq_26.metric_time__day
+      subq_21.metric_time__day = subq_25.metric_time__day
     ) AND (
-      subq_21.metric_time__month = subq_26.metric_time__month
+      subq_21.metric_time__month = subq_25.metric_time__month
     ) AND (
-      subq_21.metric_time__year = subq_26.metric_time__year
+      subq_21.metric_time__year = subq_25.metric_time__year
     )
   GROUP BY
-    COALESCE(subq_21.metric_time__day, subq_26.metric_time__day)
-    , COALESCE(subq_21.metric_time__month, subq_26.metric_time__month)
-    , COALESCE(subq_21.metric_time__year, subq_26.metric_time__year)
-) subq_27
+    COALESCE(subq_21.metric_time__day, subq_25.metric_time__day)
+    , COALESCE(subq_21.metric_time__month, subq_25.metric_time__month)
+    , COALESCE(subq_21.metric_time__year, subq_25.metric_time__year)
+) subq_26

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_metric_that_defines_the_same_alias_in_different_components__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_metric_that_defines_the_same_alias_in_different_components__plan0_optimized.sql
@@ -6,30 +6,34 @@ sql_engine: Redshift
 ---
 -- Combine Aggregated Outputs
 -- Order By [] Limit 1
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    is_instant AS booking__is_instant
+    , 1 AS bookings
+    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  COALESCE(subq_18.booking__is_instant, subq_24.booking__is_instant) AS booking__is_instant
+  COALESCE(subq_18.booking__is_instant, subq_23.booking__is_instant) AS booking__is_instant
   , MAX(subq_18.derived_shared_alias_1a) AS derived_shared_alias_1a
-  , MAX(subq_24.derived_shared_alias_2) AS derived_shared_alias_2
+  , MAX(subq_23.derived_shared_alias_2) AS derived_shared_alias_2
 FROM (
   -- Compute Metrics via Expressions
   SELECT
     booking__is_instant
     , shared_alias - 10 AS derived_shared_alias_1a
   FROM (
+    -- Read From CTE For node_id=sma_28009
+    -- Pass Only Elements: ['bookings', 'booking__is_instant']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
       booking__is_instant
       , SUM(bookings) AS shared_alias
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['bookings', 'booking__is_instant']
-      SELECT
-        is_instant AS booking__is_instant
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_15
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
       booking__is_instant
   ) subq_17
@@ -40,26 +44,20 @@ FULL OUTER JOIN (
     booking__is_instant
     , shared_alias + 10 AS derived_shared_alias_2
   FROM (
+    -- Read From CTE For node_id=sma_28009
+    -- Pass Only Elements: ['instant_bookings', 'booking__is_instant']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
       booking__is_instant
       , SUM(instant_bookings) AS shared_alias
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['instant_bookings', 'booking__is_instant']
-      SELECT
-        is_instant AS booking__is_instant
-        , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_21
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
       booking__is_instant
-  ) subq_23
-) subq_24
+  ) subq_22
+) subq_23
 ON
-  subq_18.booking__is_instant = subq_24.booking__is_instant
+  subq_18.booking__is_instant = subq_23.booking__is_instant
 GROUP BY
-  COALESCE(subq_18.booking__is_instant, subq_24.booking__is_instant)
+  COALESCE(subq_18.booking__is_instant, subq_23.booking__is_instant)
 LIMIT 1

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_to_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_to_grain__plan0_optimized.sql
@@ -3,30 +3,33 @@ test_filename: test_derived_metric_rendering.py
 sql_engine: Redshift
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , 1 AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__day
+  metric_time__day AS metric_time__day
   , bookings - bookings_at_start_of_month AS bookings_growth_since_start_of_month
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_18.metric_time__day, subq_26.metric_time__day) AS metric_time__day
+    COALESCE(subq_18.metric_time__day, subq_25.metric_time__day) AS metric_time__day
     , MAX(subq_18.bookings) AS bookings
-    , MAX(subq_26.bookings_at_start_of_month) AS bookings_at_start_of_month
+    , MAX(subq_25.bookings_at_start_of_month) AS bookings_at_start_of_month
   FROM (
+    -- Read From CTE For node_id=sma_28009
+    -- Pass Only Elements: ['bookings', 'metric_time__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
       metric_time__day
       , SUM(bookings) AS bookings
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['bookings', 'metric_time__day']
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_16
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
       metric_time__day
   ) subq_18
@@ -36,24 +39,18 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      subq_22.ds AS metric_time__day
-      , SUM(subq_20.bookings) AS bookings_at_start_of_month
-    FROM ***************************.mf_time_spine subq_22
-    INNER JOIN (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_20
+      subq_21.ds AS metric_time__day
+      , SUM(sma_28009_cte.bookings) AS bookings_at_start_of_month
+    FROM ***************************.mf_time_spine subq_21
+    INNER JOIN
+      sma_28009_cte sma_28009_cte
     ON
-      DATE_TRUNC('month', subq_22.ds) = subq_20.metric_time__day
+      DATE_TRUNC('month', subq_21.ds) = sma_28009_cte.metric_time__day
     GROUP BY
-      subq_22.ds
-  ) subq_26
+      subq_21.ds
+  ) subq_25
   ON
-    subq_18.metric_time__day = subq_26.metric_time__day
+    subq_18.metric_time__day = subq_25.metric_time__day
   GROUP BY
-    COALESCE(subq_18.metric_time__day, subq_26.metric_time__day)
-) subq_27
+    COALESCE(subq_18.metric_time__day, subq_25.metric_time__day)
+) subq_26

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_to_grain_and_granularity__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_to_grain_and_granularity__plan0_optimized.sql
@@ -3,30 +3,34 @@ test_filename: test_derived_metric_rendering.py
 sql_engine: Redshift
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , DATE_TRUNC('week', ds) AS metric_time__week
+    , 1 AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__week
+  metric_time__week AS metric_time__week
   , bookings - bookings_at_start_of_month AS bookings_growth_since_start_of_month
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_18.metric_time__week, subq_26.metric_time__week) AS metric_time__week
+    COALESCE(subq_18.metric_time__week, subq_25.metric_time__week) AS metric_time__week
     , MAX(subq_18.bookings) AS bookings
-    , MAX(subq_26.bookings_at_start_of_month) AS bookings_at_start_of_month
+    , MAX(subq_25.bookings_at_start_of_month) AS bookings_at_start_of_month
   FROM (
+    -- Read From CTE For node_id=sma_28009
+    -- Pass Only Elements: ['bookings', 'metric_time__week']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
       metric_time__week
       , SUM(bookings) AS bookings
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['bookings', 'metric_time__week']
-      SELECT
-        DATE_TRUNC('week', ds) AS metric_time__week
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_16
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
       metric_time__week
   ) subq_18
@@ -36,25 +40,19 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      DATE_TRUNC('week', subq_22.ds) AS metric_time__week
-      , SUM(subq_20.bookings) AS bookings_at_start_of_month
-    FROM ***************************.mf_time_spine subq_22
-    INNER JOIN (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_20
+      DATE_TRUNC('week', subq_21.ds) AS metric_time__week
+      , SUM(sma_28009_cte.bookings) AS bookings_at_start_of_month
+    FROM ***************************.mf_time_spine subq_21
+    INNER JOIN
+      sma_28009_cte sma_28009_cte
     ON
-      DATE_TRUNC('month', subq_22.ds) = subq_20.metric_time__day
-    WHERE DATE_TRUNC('week', subq_22.ds) = subq_22.ds
+      DATE_TRUNC('month', subq_21.ds) = sma_28009_cte.metric_time__day
+    WHERE DATE_TRUNC('week', subq_21.ds) = subq_21.ds
     GROUP BY
-      DATE_TRUNC('week', subq_22.ds)
-  ) subq_26
+      DATE_TRUNC('week', subq_21.ds)
+  ) subq_25
   ON
-    subq_18.metric_time__week = subq_26.metric_time__week
+    subq_18.metric_time__week = subq_25.metric_time__week
   GROUP BY
-    COALESCE(subq_18.metric_time__week, subq_26.metric_time__week)
-) subq_27
+    COALESCE(subq_18.metric_time__week, subq_25.metric_time__week)
+) subq_26

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_window__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_window__plan0_optimized.sql
@@ -3,30 +3,33 @@ test_filename: test_derived_metric_rendering.py
 sql_engine: Redshift
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , 1 AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__day
+  metric_time__day AS metric_time__day
   , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_18.metric_time__day, subq_26.metric_time__day) AS metric_time__day
+    COALESCE(subq_18.metric_time__day, subq_25.metric_time__day) AS metric_time__day
     , MAX(subq_18.bookings) AS bookings
-    , MAX(subq_26.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+    , MAX(subq_25.bookings_2_weeks_ago) AS bookings_2_weeks_ago
   FROM (
+    -- Read From CTE For node_id=sma_28009
+    -- Pass Only Elements: ['bookings', 'metric_time__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
       metric_time__day
       , SUM(bookings) AS bookings
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['bookings', 'metric_time__day']
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_16
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
       metric_time__day
   ) subq_18
@@ -36,24 +39,18 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      subq_22.ds AS metric_time__day
-      , SUM(subq_20.bookings) AS bookings_2_weeks_ago
-    FROM ***************************.mf_time_spine subq_22
-    INNER JOIN (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_20
+      subq_21.ds AS metric_time__day
+      , SUM(sma_28009_cte.bookings) AS bookings_2_weeks_ago
+    FROM ***************************.mf_time_spine subq_21
+    INNER JOIN
+      sma_28009_cte sma_28009_cte
     ON
-      DATEADD(day, -14, subq_22.ds) = subq_20.metric_time__day
+      DATEADD(day, -14, subq_21.ds) = sma_28009_cte.metric_time__day
     GROUP BY
-      subq_22.ds
-  ) subq_26
+      subq_21.ds
+  ) subq_25
   ON
-    subq_18.metric_time__day = subq_26.metric_time__day
+    subq_18.metric_time__day = subq_25.metric_time__day
   GROUP BY
-    COALESCE(subq_18.metric_time__day, subq_26.metric_time__day)
-) subq_27
+    COALESCE(subq_18.metric_time__day, subq_25.metric_time__day)
+) subq_26

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_window_and_granularity__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_window_and_granularity__plan0_optimized.sql
@@ -3,30 +3,34 @@ test_filename: test_derived_metric_rendering.py
 sql_engine: Redshift
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , DATE_TRUNC('quarter', ds) AS metric_time__quarter
+    , 1 AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__quarter
+  metric_time__quarter AS metric_time__quarter
   , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_18.metric_time__quarter, subq_26.metric_time__quarter) AS metric_time__quarter
+    COALESCE(subq_18.metric_time__quarter, subq_25.metric_time__quarter) AS metric_time__quarter
     , MAX(subq_18.bookings) AS bookings
-    , MAX(subq_26.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+    , MAX(subq_25.bookings_2_weeks_ago) AS bookings_2_weeks_ago
   FROM (
+    -- Read From CTE For node_id=sma_28009
+    -- Pass Only Elements: ['bookings', 'metric_time__quarter']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
       metric_time__quarter
       , SUM(bookings) AS bookings
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['bookings', 'metric_time__quarter']
-      SELECT
-        DATE_TRUNC('quarter', ds) AS metric_time__quarter
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_16
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
       metric_time__quarter
   ) subq_18
@@ -36,24 +40,18 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      DATE_TRUNC('quarter', subq_22.ds) AS metric_time__quarter
-      , SUM(subq_20.bookings) AS bookings_2_weeks_ago
-    FROM ***************************.mf_time_spine subq_22
-    INNER JOIN (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_20
+      DATE_TRUNC('quarter', subq_21.ds) AS metric_time__quarter
+      , SUM(sma_28009_cte.bookings) AS bookings_2_weeks_ago
+    FROM ***************************.mf_time_spine subq_21
+    INNER JOIN
+      sma_28009_cte sma_28009_cte
     ON
-      DATEADD(day, -14, subq_22.ds) = subq_20.metric_time__day
+      DATEADD(day, -14, subq_21.ds) = sma_28009_cte.metric_time__day
     GROUP BY
-      DATE_TRUNC('quarter', subq_22.ds)
-  ) subq_26
+      DATE_TRUNC('quarter', subq_21.ds)
+  ) subq_25
   ON
-    subq_18.metric_time__quarter = subq_26.metric_time__quarter
+    subq_18.metric_time__quarter = subq_25.metric_time__quarter
   GROUP BY
-    COALESCE(subq_18.metric_time__quarter, subq_26.metric_time__quarter)
-) subq_27
+    COALESCE(subq_18.metric_time__quarter, subq_25.metric_time__quarter)
+) subq_26

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_window_and_offset_to_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_window_and_offset_to_grain__plan0_optimized.sql
@@ -3,15 +3,24 @@ test_filename: test_derived_metric_rendering.py
 sql_engine: Redshift
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , 1 AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__day
+  metric_time__day AS metric_time__day
   , month_start_bookings - bookings_1_month_ago AS bookings_month_start_compared_to_1_month_prior
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_24.metric_time__day, subq_32.metric_time__day) AS metric_time__day
+    COALESCE(subq_24.metric_time__day, subq_31.metric_time__day) AS metric_time__day
     , MAX(subq_24.month_start_bookings) AS month_start_bookings
-    , MAX(subq_32.bookings_1_month_ago) AS bookings_1_month_ago
+    , MAX(subq_31.bookings_1_month_ago) AS bookings_1_month_ago
   FROM (
     -- Join to Time Spine Dataset
     -- Pass Only Elements: ['bookings', 'metric_time__day']
@@ -19,18 +28,12 @@ FROM (
     -- Compute Metrics via Expressions
     SELECT
       subq_20.ds AS metric_time__day
-      , SUM(subq_18.bookings) AS month_start_bookings
+      , SUM(sma_28009_cte.bookings) AS month_start_bookings
     FROM ***************************.mf_time_spine subq_20
-    INNER JOIN (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_18
+    INNER JOIN
+      sma_28009_cte sma_28009_cte
     ON
-      DATE_TRUNC('month', subq_20.ds) = subq_18.metric_time__day
+      DATE_TRUNC('month', subq_20.ds) = sma_28009_cte.metric_time__day
     GROUP BY
       subq_20.ds
   ) subq_24
@@ -40,24 +43,18 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      subq_28.ds AS metric_time__day
-      , SUM(subq_26.bookings) AS bookings_1_month_ago
-    FROM ***************************.mf_time_spine subq_28
-    INNER JOIN (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_26
+      subq_27.ds AS metric_time__day
+      , SUM(sma_28009_cte.bookings) AS bookings_1_month_ago
+    FROM ***************************.mf_time_spine subq_27
+    INNER JOIN
+      sma_28009_cte sma_28009_cte
     ON
-      DATEADD(month, -1, subq_28.ds) = subq_26.metric_time__day
+      DATEADD(month, -1, subq_27.ds) = sma_28009_cte.metric_time__day
     GROUP BY
-      subq_28.ds
-  ) subq_32
+      subq_27.ds
+  ) subq_31
   ON
-    subq_24.metric_time__day = subq_32.metric_time__day
+    subq_24.metric_time__day = subq_31.metric_time__day
   GROUP BY
-    COALESCE(subq_24.metric_time__day, subq_32.metric_time__day)
-) subq_33
+    COALESCE(subq_24.metric_time__day, subq_31.metric_time__day)
+) subq_32

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0_optimized.sql
@@ -3,15 +3,24 @@ test_filename: test_derived_metric_rendering.py
 sql_engine: Redshift
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , 1 AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__year
+  metric_time__year AS metric_time__year
   , month_start_bookings - bookings_1_month_ago AS bookings_month_start_compared_to_1_month_prior
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_24.metric_time__year, subq_32.metric_time__year) AS metric_time__year
+    COALESCE(subq_24.metric_time__year, subq_31.metric_time__year) AS metric_time__year
     , MAX(subq_24.month_start_bookings) AS month_start_bookings
-    , MAX(subq_32.bookings_1_month_ago) AS bookings_1_month_ago
+    , MAX(subq_31.bookings_1_month_ago) AS bookings_1_month_ago
   FROM (
     -- Join to Time Spine Dataset
     -- Pass Only Elements: ['bookings', 'metric_time__year']
@@ -19,18 +28,12 @@ FROM (
     -- Compute Metrics via Expressions
     SELECT
       DATE_TRUNC('year', subq_20.ds) AS metric_time__year
-      , SUM(subq_18.bookings) AS month_start_bookings
+      , SUM(sma_28009_cte.bookings) AS month_start_bookings
     FROM ***************************.mf_time_spine subq_20
-    INNER JOIN (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_18
+    INNER JOIN
+      sma_28009_cte sma_28009_cte
     ON
-      DATE_TRUNC('month', subq_20.ds) = subq_18.metric_time__day
+      DATE_TRUNC('month', subq_20.ds) = sma_28009_cte.metric_time__day
     WHERE DATE_TRUNC('year', subq_20.ds) = subq_20.ds
     GROUP BY
       DATE_TRUNC('year', subq_20.ds)
@@ -41,24 +44,18 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      DATE_TRUNC('year', subq_28.ds) AS metric_time__year
-      , SUM(subq_26.bookings) AS bookings_1_month_ago
-    FROM ***************************.mf_time_spine subq_28
-    INNER JOIN (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_26
+      DATE_TRUNC('year', subq_27.ds) AS metric_time__year
+      , SUM(sma_28009_cte.bookings) AS bookings_1_month_ago
+    FROM ***************************.mf_time_spine subq_27
+    INNER JOIN
+      sma_28009_cte sma_28009_cte
     ON
-      DATEADD(month, -1, subq_28.ds) = subq_26.metric_time__day
+      DATEADD(month, -1, subq_27.ds) = sma_28009_cte.metric_time__day
     GROUP BY
-      DATE_TRUNC('year', subq_28.ds)
-  ) subq_32
+      DATE_TRUNC('year', subq_27.ds)
+  ) subq_31
   ON
-    subq_24.metric_time__year = subq_32.metric_time__year
+    subq_24.metric_time__year = subq_31.metric_time__year
   GROUP BY
-    COALESCE(subq_24.metric_time__year, subq_32.metric_time__year)
-) subq_33
+    COALESCE(subq_24.metric_time__year, subq_31.metric_time__year)
+) subq_32

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_window_and_time_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_window_and_time_filter__plan0_optimized.sql
@@ -3,15 +3,24 @@ test_filename: test_derived_metric_rendering.py
 sql_engine: Redshift
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , 1 AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__day
+  metric_time__day AS metric_time__day
   , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_21.metric_time__day, subq_30.metric_time__day) AS metric_time__day
+    COALESCE(subq_21.metric_time__day, subq_29.metric_time__day) AS metric_time__day
     , MAX(subq_21.bookings) AS bookings
-    , MAX(subq_30.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+    , MAX(subq_29.bookings_2_weeks_ago) AS bookings_2_weeks_ago
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['bookings', 'metric_time__day']
@@ -21,12 +30,11 @@ FROM (
       metric_time__day
       , SUM(bookings) AS bookings
     FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
+      -- Read From CTE For node_id=sma_28009
       SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
+        metric_time__day
+        , bookings
+      FROM sma_28009_cte sma_28009_cte
     ) subq_17
     WHERE metric_time__day = '2020-01-01' or metric_time__day = '2020-01-14'
     GROUP BY
@@ -43,26 +51,20 @@ FROM (
     FROM (
       -- Join to Time Spine Dataset
       SELECT
-        subq_25.ds AS metric_time__day
-        , subq_23.bookings AS bookings
-      FROM ***************************.mf_time_spine subq_25
-      INNER JOIN (
-        -- Read Elements From Semantic Model 'bookings_source'
-        -- Metric Time Dimension 'ds'
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , 1 AS bookings
-        FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_23
+        subq_24.ds AS metric_time__day
+        , sma_28009_cte.bookings AS bookings
+      FROM ***************************.mf_time_spine subq_24
+      INNER JOIN
+        sma_28009_cte sma_28009_cte
       ON
-        DATEADD(day, -14, subq_25.ds) = subq_23.metric_time__day
-    ) subq_26
+        DATEADD(day, -14, subq_24.ds) = sma_28009_cte.metric_time__day
+    ) subq_25
     WHERE metric_time__day = '2020-01-01' or metric_time__day = '2020-01-14'
     GROUP BY
       metric_time__day
-  ) subq_30
+  ) subq_29
   ON
-    subq_21.metric_time__day = subq_30.metric_time__day
+    subq_21.metric_time__day = subq_29.metric_time__day
   GROUP BY
-    COALESCE(subq_21.metric_time__day, subq_30.metric_time__day)
-) subq_31
+    COALESCE(subq_21.metric_time__day, subq_29.metric_time__day)
+) subq_30

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_offset_metric_with_agg_time_dim__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_offset_metric_with_agg_time_dim__plan0_optimized.sql
@@ -3,15 +3,25 @@ test_filename: test_derived_metric_rendering.py
 sql_engine: Redshift
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS booking__ds__day
+    , booking_value
+    , guest_id AS bookers
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  booking__ds__day
+  booking__ds__day AS booking__ds__day
   , booking_value * 0.05 / bookers AS booking_fees_last_week_per_booker_this_week
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_21.booking__ds__day, subq_26.booking__ds__day) AS booking__ds__day
+    COALESCE(subq_21.booking__ds__day, subq_25.booking__ds__day) AS booking__ds__day
     , MAX(subq_21.booking_value) AS booking_value
-    , MAX(subq_26.bookers) AS bookers
+    , MAX(subq_25.bookers) AS bookers
   FROM (
     -- Join to Time Spine Dataset
     -- Pass Only Elements: ['booking_value', 'booking__ds__day']
@@ -19,30 +29,29 @@ FROM (
     -- Compute Metrics via Expressions
     SELECT
       subq_17.ds AS booking__ds__day
-      , SUM(bookings_source_src_28000.booking_value) AS booking_value
+      , SUM(sma_28009_cte.booking_value) AS booking_value
     FROM ***************************.mf_time_spine subq_17
     INNER JOIN
-      ***************************.fct_bookings bookings_source_src_28000
+      sma_28009_cte sma_28009_cte
     ON
-      DATEADD(week, -1, subq_17.ds) = DATE_TRUNC('day', bookings_source_src_28000.ds)
+      DATEADD(week, -1, subq_17.ds) = sma_28009_cte.booking__ds__day
     GROUP BY
       subq_17.ds
   ) subq_21
   FULL OUTER JOIN (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28009
     -- Pass Only Elements: ['bookers', 'booking__ds__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      DATE_TRUNC('day', ds) AS booking__ds__day
-      , COUNT(DISTINCT guest_id) AS bookers
-    FROM ***************************.fct_bookings bookings_source_src_28000
+      booking__ds__day
+      , COUNT(DISTINCT bookers) AS bookers
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
-      DATE_TRUNC('day', ds)
-  ) subq_26
+      booking__ds__day
+  ) subq_25
   ON
-    subq_21.booking__ds__day = subq_26.booking__ds__day
+    subq_21.booking__ds__day = subq_25.booking__ds__day
   GROUP BY
-    COALESCE(subq_21.booking__ds__day, subq_26.booking__ds__day)
-) subq_27
+    COALESCE(subq_21.booking__ds__day, subq_25.booking__ds__day)
+) subq_26

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_offset_to_grain_with_agg_time_dim__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_offset_to_grain_with_agg_time_dim__plan0_optimized.sql
@@ -3,30 +3,33 @@ test_filename: test_derived_metric_rendering.py
 sql_engine: Redshift
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS booking__ds__day
+    , 1 AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  booking__ds__day
+  booking__ds__day AS booking__ds__day
   , bookings - bookings_at_start_of_month AS bookings_growth_since_start_of_month
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_18.booking__ds__day, subq_26.booking__ds__day) AS booking__ds__day
+    COALESCE(subq_18.booking__ds__day, subq_25.booking__ds__day) AS booking__ds__day
     , MAX(subq_18.bookings) AS bookings
-    , MAX(subq_26.bookings_at_start_of_month) AS bookings_at_start_of_month
+    , MAX(subq_25.bookings_at_start_of_month) AS bookings_at_start_of_month
   FROM (
+    -- Read From CTE For node_id=sma_28009
+    -- Pass Only Elements: ['bookings', 'booking__ds__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
       booking__ds__day
       , SUM(bookings) AS bookings
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['bookings', 'booking__ds__day']
-      SELECT
-        DATE_TRUNC('day', ds) AS booking__ds__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_16
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
       booking__ds__day
   ) subq_18
@@ -36,24 +39,18 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      subq_22.ds AS booking__ds__day
-      , SUM(subq_20.bookings) AS bookings_at_start_of_month
-    FROM ***************************.mf_time_spine subq_22
-    INNER JOIN (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATE_TRUNC('day', ds) AS booking__ds__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_20
+      subq_21.ds AS booking__ds__day
+      , SUM(sma_28009_cte.bookings) AS bookings_at_start_of_month
+    FROM ***************************.mf_time_spine subq_21
+    INNER JOIN
+      sma_28009_cte sma_28009_cte
     ON
-      DATE_TRUNC('month', subq_22.ds) = subq_20.booking__ds__day
+      DATE_TRUNC('month', subq_21.ds) = sma_28009_cte.booking__ds__day
     GROUP BY
-      subq_22.ds
-  ) subq_26
+      subq_21.ds
+  ) subq_25
   ON
-    subq_18.booking__ds__day = subq_26.booking__ds__day
+    subq_18.booking__ds__day = subq_25.booking__ds__day
   GROUP BY
-    COALESCE(subq_18.booking__ds__day, subq_26.booking__ds__day)
-) subq_27
+    COALESCE(subq_18.booking__ds__day, subq_25.booking__ds__day)
+) subq_26

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_offset_window_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_offset_window_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
@@ -5,15 +5,26 @@ docstring:
 sql_engine: Redshift
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , DATE_TRUNC('month', ds) AS metric_time__month
+    , booking_value
+    , guest_id AS bookers
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__month
+  metric_time__month AS metric_time__month
   , booking_value * 0.05 / bookers AS booking_fees_last_week_per_booker_this_week
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_24.metric_time__month, subq_30.metric_time__month) AS metric_time__month
+    COALESCE(subq_24.metric_time__month, subq_29.metric_time__month) AS metric_time__month
     , MAX(subq_24.booking_value) AS booking_value
-    , MAX(subq_30.bookers) AS bookers
+    , MAX(subq_29.bookers) AS bookers
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['booking_value', 'metric_time__month']
@@ -27,12 +38,12 @@ FROM (
       SELECT
         subq_19.ds AS metric_time__day
         , DATE_TRUNC('month', subq_19.ds) AS metric_time__month
-        , bookings_source_src_28000.booking_value AS booking_value
+        , sma_28009_cte.booking_value AS booking_value
       FROM ***************************.mf_time_spine subq_19
       INNER JOIN
-        ***************************.fct_bookings bookings_source_src_28000
+        sma_28009_cte sma_28009_cte
       ON
-        DATEADD(week, -1, subq_19.ds) = DATE_TRUNC('day', bookings_source_src_28000.ds)
+        DATEADD(week, -1, subq_19.ds) = sma_28009_cte.metric_time__day
     ) subq_20
     WHERE metric_time__day = '2020-01-01'
     GROUP BY
@@ -47,20 +58,20 @@ FROM (
       metric_time__month
       , COUNT(DISTINCT bookers) AS bookers
     FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
+      -- Read From CTE For node_id=sma_28009
       SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , DATE_TRUNC('month', ds) AS metric_time__month
-        , guest_id AS bookers
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_26
+        metric_time__day
+        , metric_time__month
+        , booking_value
+        , bookers
+      FROM sma_28009_cte sma_28009_cte
+    ) subq_25
     WHERE metric_time__day = '2020-01-01'
     GROUP BY
       metric_time__month
-  ) subq_30
+  ) subq_29
   ON
-    subq_24.metric_time__month = subq_30.metric_time__month
+    subq_24.metric_time__month = subq_29.metric_time__month
   GROUP BY
-    COALESCE(subq_24.metric_time__month, subq_30.metric_time__month)
-) subq_31
+    COALESCE(subq_24.metric_time__month, subq_29.metric_time__month)
+) subq_30

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_offset_window_metric_multiple_granularities__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_offset_window_metric_multiple_granularities__plan0_optimized.sql
@@ -5,19 +5,31 @@ docstring:
 sql_engine: Redshift
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , DATE_TRUNC('month', ds) AS metric_time__month
+    , DATE_TRUNC('year', ds) AS metric_time__year
+    , booking_value
+    , guest_id AS bookers
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__day
-  , metric_time__month
-  , metric_time__year
+  metric_time__day AS metric_time__day
+  , metric_time__month AS metric_time__month
+  , metric_time__year AS metric_time__year
   , booking_value * 0.05 / bookers AS booking_fees_last_week_per_booker_this_week
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_21.metric_time__day, subq_26.metric_time__day) AS metric_time__day
-    , COALESCE(subq_21.metric_time__month, subq_26.metric_time__month) AS metric_time__month
-    , COALESCE(subq_21.metric_time__year, subq_26.metric_time__year) AS metric_time__year
+    COALESCE(subq_21.metric_time__day, subq_25.metric_time__day) AS metric_time__day
+    , COALESCE(subq_21.metric_time__month, subq_25.metric_time__month) AS metric_time__month
+    , COALESCE(subq_21.metric_time__year, subq_25.metric_time__year) AS metric_time__year
     , MAX(subq_21.booking_value) AS booking_value
-    , MAX(subq_26.bookers) AS bookers
+    , MAX(subq_25.bookers) AS bookers
   FROM (
     -- Join to Time Spine Dataset
     -- Pass Only Elements: ['booking_value', 'metric_time__day', 'metric_time__month', 'metric_time__year']
@@ -27,44 +39,43 @@ FROM (
       subq_17.ds AS metric_time__day
       , DATE_TRUNC('month', subq_17.ds) AS metric_time__month
       , DATE_TRUNC('year', subq_17.ds) AS metric_time__year
-      , SUM(bookings_source_src_28000.booking_value) AS booking_value
+      , SUM(sma_28009_cte.booking_value) AS booking_value
     FROM ***************************.mf_time_spine subq_17
     INNER JOIN
-      ***************************.fct_bookings bookings_source_src_28000
+      sma_28009_cte sma_28009_cte
     ON
-      DATEADD(week, -1, subq_17.ds) = DATE_TRUNC('day', bookings_source_src_28000.ds)
+      DATEADD(week, -1, subq_17.ds) = sma_28009_cte.metric_time__day
     GROUP BY
       subq_17.ds
       , DATE_TRUNC('month', subq_17.ds)
       , DATE_TRUNC('year', subq_17.ds)
   ) subq_21
   FULL OUTER JOIN (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28009
     -- Pass Only Elements: ['bookers', 'metric_time__day', 'metric_time__month', 'metric_time__year']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      DATE_TRUNC('day', ds) AS metric_time__day
-      , DATE_TRUNC('month', ds) AS metric_time__month
-      , DATE_TRUNC('year', ds) AS metric_time__year
-      , COUNT(DISTINCT guest_id) AS bookers
-    FROM ***************************.fct_bookings bookings_source_src_28000
+      metric_time__day
+      , metric_time__month
+      , metric_time__year
+      , COUNT(DISTINCT bookers) AS bookers
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
-      DATE_TRUNC('day', ds)
-      , DATE_TRUNC('month', ds)
-      , DATE_TRUNC('year', ds)
-  ) subq_26
+      metric_time__day
+      , metric_time__month
+      , metric_time__year
+  ) subq_25
   ON
     (
-      subq_21.metric_time__day = subq_26.metric_time__day
+      subq_21.metric_time__day = subq_25.metric_time__day
     ) AND (
-      subq_21.metric_time__month = subq_26.metric_time__month
+      subq_21.metric_time__month = subq_25.metric_time__month
     ) AND (
-      subq_21.metric_time__year = subq_26.metric_time__year
+      subq_21.metric_time__year = subq_25.metric_time__year
     )
   GROUP BY
-    COALESCE(subq_21.metric_time__day, subq_26.metric_time__day)
-    , COALESCE(subq_21.metric_time__month, subq_26.metric_time__month)
-    , COALESCE(subq_21.metric_time__year, subq_26.metric_time__year)
-) subq_27
+    COALESCE(subq_21.metric_time__day, subq_25.metric_time__day)
+    , COALESCE(subq_21.metric_time__month, subq_25.metric_time__month)
+    , COALESCE(subq_21.metric_time__year, subq_25.metric_time__year)
+) subq_26

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_offset_window_with_agg_time_dim__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_offset_window_with_agg_time_dim__plan0_optimized.sql
@@ -3,30 +3,33 @@ test_filename: test_derived_metric_rendering.py
 sql_engine: Redshift
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS booking__ds__day
+    , 1 AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  booking__ds__day
+  booking__ds__day AS booking__ds__day
   , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_18.booking__ds__day, subq_26.booking__ds__day) AS booking__ds__day
+    COALESCE(subq_18.booking__ds__day, subq_25.booking__ds__day) AS booking__ds__day
     , MAX(subq_18.bookings) AS bookings
-    , MAX(subq_26.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+    , MAX(subq_25.bookings_2_weeks_ago) AS bookings_2_weeks_ago
   FROM (
+    -- Read From CTE For node_id=sma_28009
+    -- Pass Only Elements: ['bookings', 'booking__ds__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
       booking__ds__day
       , SUM(bookings) AS bookings
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['bookings', 'booking__ds__day']
-      SELECT
-        DATE_TRUNC('day', ds) AS booking__ds__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_16
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
       booking__ds__day
   ) subq_18
@@ -36,24 +39,18 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      subq_22.ds AS booking__ds__day
-      , SUM(subq_20.bookings) AS bookings_2_weeks_ago
-    FROM ***************************.mf_time_spine subq_22
-    INNER JOIN (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATE_TRUNC('day', ds) AS booking__ds__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_20
+      subq_21.ds AS booking__ds__day
+      , SUM(sma_28009_cte.bookings) AS bookings_2_weeks_ago
+    FROM ***************************.mf_time_spine subq_21
+    INNER JOIN
+      sma_28009_cte sma_28009_cte
     ON
-      DATEADD(day, -14, subq_22.ds) = subq_20.booking__ds__day
+      DATEADD(day, -14, subq_21.ds) = sma_28009_cte.booking__ds__day
     GROUP BY
-      subq_22.ds
-  ) subq_26
+      subq_21.ds
+  ) subq_25
   ON
-    subq_18.booking__ds__day = subq_26.booking__ds__day
+    subq_18.booking__ds__day = subq_25.booking__ds__day
   GROUP BY
-    COALESCE(subq_18.booking__ds__day, subq_26.booking__ds__day)
-) subq_27
+    COALESCE(subq_18.booking__ds__day, subq_25.booking__ds__day)
+) subq_26

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_metric_that_defines_the_same_alias_in_different_components__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_metric_that_defines_the_same_alias_in_different_components__plan0_optimized.sql
@@ -6,30 +6,34 @@ sql_engine: Snowflake
 ---
 -- Combine Aggregated Outputs
 -- Order By [] Limit 1
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    is_instant AS booking__is_instant
+    , 1 AS bookings
+    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  COALESCE(subq_18.booking__is_instant, subq_24.booking__is_instant) AS booking__is_instant
+  COALESCE(subq_18.booking__is_instant, subq_23.booking__is_instant) AS booking__is_instant
   , MAX(subq_18.derived_shared_alias_1a) AS derived_shared_alias_1a
-  , MAX(subq_24.derived_shared_alias_2) AS derived_shared_alias_2
+  , MAX(subq_23.derived_shared_alias_2) AS derived_shared_alias_2
 FROM (
   -- Compute Metrics via Expressions
   SELECT
     booking__is_instant
     , shared_alias - 10 AS derived_shared_alias_1a
   FROM (
+    -- Read From CTE For node_id=sma_28009
+    -- Pass Only Elements: ['bookings', 'booking__is_instant']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
       booking__is_instant
       , SUM(bookings) AS shared_alias
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['bookings', 'booking__is_instant']
-      SELECT
-        is_instant AS booking__is_instant
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_15
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
       booking__is_instant
   ) subq_17
@@ -40,26 +44,20 @@ FULL OUTER JOIN (
     booking__is_instant
     , shared_alias + 10 AS derived_shared_alias_2
   FROM (
+    -- Read From CTE For node_id=sma_28009
+    -- Pass Only Elements: ['instant_bookings', 'booking__is_instant']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
       booking__is_instant
       , SUM(instant_bookings) AS shared_alias
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['instant_bookings', 'booking__is_instant']
-      SELECT
-        is_instant AS booking__is_instant
-        , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_21
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
       booking__is_instant
-  ) subq_23
-) subq_24
+  ) subq_22
+) subq_23
 ON
-  subq_18.booking__is_instant = subq_24.booking__is_instant
+  subq_18.booking__is_instant = subq_23.booking__is_instant
 GROUP BY
-  COALESCE(subq_18.booking__is_instant, subq_24.booking__is_instant)
+  COALESCE(subq_18.booking__is_instant, subq_23.booking__is_instant)
 LIMIT 1

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_to_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_to_grain__plan0_optimized.sql
@@ -3,30 +3,33 @@ test_filename: test_derived_metric_rendering.py
 sql_engine: Snowflake
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , 1 AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__day
+  metric_time__day AS metric_time__day
   , bookings - bookings_at_start_of_month AS bookings_growth_since_start_of_month
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_18.metric_time__day, subq_26.metric_time__day) AS metric_time__day
+    COALESCE(subq_18.metric_time__day, subq_25.metric_time__day) AS metric_time__day
     , MAX(subq_18.bookings) AS bookings
-    , MAX(subq_26.bookings_at_start_of_month) AS bookings_at_start_of_month
+    , MAX(subq_25.bookings_at_start_of_month) AS bookings_at_start_of_month
   FROM (
+    -- Read From CTE For node_id=sma_28009
+    -- Pass Only Elements: ['bookings', 'metric_time__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
       metric_time__day
       , SUM(bookings) AS bookings
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['bookings', 'metric_time__day']
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_16
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
       metric_time__day
   ) subq_18
@@ -36,24 +39,18 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      subq_22.ds AS metric_time__day
-      , SUM(subq_20.bookings) AS bookings_at_start_of_month
-    FROM ***************************.mf_time_spine subq_22
-    INNER JOIN (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_20
+      subq_21.ds AS metric_time__day
+      , SUM(sma_28009_cte.bookings) AS bookings_at_start_of_month
+    FROM ***************************.mf_time_spine subq_21
+    INNER JOIN
+      sma_28009_cte sma_28009_cte
     ON
-      DATE_TRUNC('month', subq_22.ds) = subq_20.metric_time__day
+      DATE_TRUNC('month', subq_21.ds) = sma_28009_cte.metric_time__day
     GROUP BY
-      subq_22.ds
-  ) subq_26
+      subq_21.ds
+  ) subq_25
   ON
-    subq_18.metric_time__day = subq_26.metric_time__day
+    subq_18.metric_time__day = subq_25.metric_time__day
   GROUP BY
-    COALESCE(subq_18.metric_time__day, subq_26.metric_time__day)
-) subq_27
+    COALESCE(subq_18.metric_time__day, subq_25.metric_time__day)
+) subq_26

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_to_grain_and_granularity__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_to_grain_and_granularity__plan0_optimized.sql
@@ -3,30 +3,34 @@ test_filename: test_derived_metric_rendering.py
 sql_engine: Snowflake
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , DATE_TRUNC('week', ds) AS metric_time__week
+    , 1 AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__week
+  metric_time__week AS metric_time__week
   , bookings - bookings_at_start_of_month AS bookings_growth_since_start_of_month
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_18.metric_time__week, subq_26.metric_time__week) AS metric_time__week
+    COALESCE(subq_18.metric_time__week, subq_25.metric_time__week) AS metric_time__week
     , MAX(subq_18.bookings) AS bookings
-    , MAX(subq_26.bookings_at_start_of_month) AS bookings_at_start_of_month
+    , MAX(subq_25.bookings_at_start_of_month) AS bookings_at_start_of_month
   FROM (
+    -- Read From CTE For node_id=sma_28009
+    -- Pass Only Elements: ['bookings', 'metric_time__week']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
       metric_time__week
       , SUM(bookings) AS bookings
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['bookings', 'metric_time__week']
-      SELECT
-        DATE_TRUNC('week', ds) AS metric_time__week
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_16
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
       metric_time__week
   ) subq_18
@@ -36,25 +40,19 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      DATE_TRUNC('week', subq_22.ds) AS metric_time__week
-      , SUM(subq_20.bookings) AS bookings_at_start_of_month
-    FROM ***************************.mf_time_spine subq_22
-    INNER JOIN (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_20
+      DATE_TRUNC('week', subq_21.ds) AS metric_time__week
+      , SUM(sma_28009_cte.bookings) AS bookings_at_start_of_month
+    FROM ***************************.mf_time_spine subq_21
+    INNER JOIN
+      sma_28009_cte sma_28009_cte
     ON
-      DATE_TRUNC('month', subq_22.ds) = subq_20.metric_time__day
-    WHERE DATE_TRUNC('week', subq_22.ds) = subq_22.ds
+      DATE_TRUNC('month', subq_21.ds) = sma_28009_cte.metric_time__day
+    WHERE DATE_TRUNC('week', subq_21.ds) = subq_21.ds
     GROUP BY
-      DATE_TRUNC('week', subq_22.ds)
-  ) subq_26
+      DATE_TRUNC('week', subq_21.ds)
+  ) subq_25
   ON
-    subq_18.metric_time__week = subq_26.metric_time__week
+    subq_18.metric_time__week = subq_25.metric_time__week
   GROUP BY
-    COALESCE(subq_18.metric_time__week, subq_26.metric_time__week)
-) subq_27
+    COALESCE(subq_18.metric_time__week, subq_25.metric_time__week)
+) subq_26

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_window__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_window__plan0_optimized.sql
@@ -3,30 +3,33 @@ test_filename: test_derived_metric_rendering.py
 sql_engine: Snowflake
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , 1 AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__day
+  metric_time__day AS metric_time__day
   , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_18.metric_time__day, subq_26.metric_time__day) AS metric_time__day
+    COALESCE(subq_18.metric_time__day, subq_25.metric_time__day) AS metric_time__day
     , MAX(subq_18.bookings) AS bookings
-    , MAX(subq_26.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+    , MAX(subq_25.bookings_2_weeks_ago) AS bookings_2_weeks_ago
   FROM (
+    -- Read From CTE For node_id=sma_28009
+    -- Pass Only Elements: ['bookings', 'metric_time__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
       metric_time__day
       , SUM(bookings) AS bookings
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['bookings', 'metric_time__day']
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_16
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
       metric_time__day
   ) subq_18
@@ -36,24 +39,18 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      subq_22.ds AS metric_time__day
-      , SUM(subq_20.bookings) AS bookings_2_weeks_ago
-    FROM ***************************.mf_time_spine subq_22
-    INNER JOIN (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_20
+      subq_21.ds AS metric_time__day
+      , SUM(sma_28009_cte.bookings) AS bookings_2_weeks_ago
+    FROM ***************************.mf_time_spine subq_21
+    INNER JOIN
+      sma_28009_cte sma_28009_cte
     ON
-      DATEADD(day, -14, subq_22.ds) = subq_20.metric_time__day
+      DATEADD(day, -14, subq_21.ds) = sma_28009_cte.metric_time__day
     GROUP BY
-      subq_22.ds
-  ) subq_26
+      subq_21.ds
+  ) subq_25
   ON
-    subq_18.metric_time__day = subq_26.metric_time__day
+    subq_18.metric_time__day = subq_25.metric_time__day
   GROUP BY
-    COALESCE(subq_18.metric_time__day, subq_26.metric_time__day)
-) subq_27
+    COALESCE(subq_18.metric_time__day, subq_25.metric_time__day)
+) subq_26

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_window_and_granularity__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_window_and_granularity__plan0_optimized.sql
@@ -3,30 +3,34 @@ test_filename: test_derived_metric_rendering.py
 sql_engine: Snowflake
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , DATE_TRUNC('quarter', ds) AS metric_time__quarter
+    , 1 AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__quarter
+  metric_time__quarter AS metric_time__quarter
   , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_18.metric_time__quarter, subq_26.metric_time__quarter) AS metric_time__quarter
+    COALESCE(subq_18.metric_time__quarter, subq_25.metric_time__quarter) AS metric_time__quarter
     , MAX(subq_18.bookings) AS bookings
-    , MAX(subq_26.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+    , MAX(subq_25.bookings_2_weeks_ago) AS bookings_2_weeks_ago
   FROM (
+    -- Read From CTE For node_id=sma_28009
+    -- Pass Only Elements: ['bookings', 'metric_time__quarter']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
       metric_time__quarter
       , SUM(bookings) AS bookings
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['bookings', 'metric_time__quarter']
-      SELECT
-        DATE_TRUNC('quarter', ds) AS metric_time__quarter
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_16
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
       metric_time__quarter
   ) subq_18
@@ -36,24 +40,18 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      DATE_TRUNC('quarter', subq_22.ds) AS metric_time__quarter
-      , SUM(subq_20.bookings) AS bookings_2_weeks_ago
-    FROM ***************************.mf_time_spine subq_22
-    INNER JOIN (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_20
+      DATE_TRUNC('quarter', subq_21.ds) AS metric_time__quarter
+      , SUM(sma_28009_cte.bookings) AS bookings_2_weeks_ago
+    FROM ***************************.mf_time_spine subq_21
+    INNER JOIN
+      sma_28009_cte sma_28009_cte
     ON
-      DATEADD(day, -14, subq_22.ds) = subq_20.metric_time__day
+      DATEADD(day, -14, subq_21.ds) = sma_28009_cte.metric_time__day
     GROUP BY
-      DATE_TRUNC('quarter', subq_22.ds)
-  ) subq_26
+      DATE_TRUNC('quarter', subq_21.ds)
+  ) subq_25
   ON
-    subq_18.metric_time__quarter = subq_26.metric_time__quarter
+    subq_18.metric_time__quarter = subq_25.metric_time__quarter
   GROUP BY
-    COALESCE(subq_18.metric_time__quarter, subq_26.metric_time__quarter)
-) subq_27
+    COALESCE(subq_18.metric_time__quarter, subq_25.metric_time__quarter)
+) subq_26

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_window_and_offset_to_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_window_and_offset_to_grain__plan0_optimized.sql
@@ -3,15 +3,24 @@ test_filename: test_derived_metric_rendering.py
 sql_engine: Snowflake
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , 1 AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__day
+  metric_time__day AS metric_time__day
   , month_start_bookings - bookings_1_month_ago AS bookings_month_start_compared_to_1_month_prior
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_24.metric_time__day, subq_32.metric_time__day) AS metric_time__day
+    COALESCE(subq_24.metric_time__day, subq_31.metric_time__day) AS metric_time__day
     , MAX(subq_24.month_start_bookings) AS month_start_bookings
-    , MAX(subq_32.bookings_1_month_ago) AS bookings_1_month_ago
+    , MAX(subq_31.bookings_1_month_ago) AS bookings_1_month_ago
   FROM (
     -- Join to Time Spine Dataset
     -- Pass Only Elements: ['bookings', 'metric_time__day']
@@ -19,18 +28,12 @@ FROM (
     -- Compute Metrics via Expressions
     SELECT
       subq_20.ds AS metric_time__day
-      , SUM(subq_18.bookings) AS month_start_bookings
+      , SUM(sma_28009_cte.bookings) AS month_start_bookings
     FROM ***************************.mf_time_spine subq_20
-    INNER JOIN (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_18
+    INNER JOIN
+      sma_28009_cte sma_28009_cte
     ON
-      DATE_TRUNC('month', subq_20.ds) = subq_18.metric_time__day
+      DATE_TRUNC('month', subq_20.ds) = sma_28009_cte.metric_time__day
     GROUP BY
       subq_20.ds
   ) subq_24
@@ -40,24 +43,18 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      subq_28.ds AS metric_time__day
-      , SUM(subq_26.bookings) AS bookings_1_month_ago
-    FROM ***************************.mf_time_spine subq_28
-    INNER JOIN (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_26
+      subq_27.ds AS metric_time__day
+      , SUM(sma_28009_cte.bookings) AS bookings_1_month_ago
+    FROM ***************************.mf_time_spine subq_27
+    INNER JOIN
+      sma_28009_cte sma_28009_cte
     ON
-      DATEADD(month, -1, subq_28.ds) = subq_26.metric_time__day
+      DATEADD(month, -1, subq_27.ds) = sma_28009_cte.metric_time__day
     GROUP BY
-      subq_28.ds
-  ) subq_32
+      subq_27.ds
+  ) subq_31
   ON
-    subq_24.metric_time__day = subq_32.metric_time__day
+    subq_24.metric_time__day = subq_31.metric_time__day
   GROUP BY
-    COALESCE(subq_24.metric_time__day, subq_32.metric_time__day)
-) subq_33
+    COALESCE(subq_24.metric_time__day, subq_31.metric_time__day)
+) subq_32

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0_optimized.sql
@@ -3,15 +3,24 @@ test_filename: test_derived_metric_rendering.py
 sql_engine: Snowflake
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , 1 AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__year
+  metric_time__year AS metric_time__year
   , month_start_bookings - bookings_1_month_ago AS bookings_month_start_compared_to_1_month_prior
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_24.metric_time__year, subq_32.metric_time__year) AS metric_time__year
+    COALESCE(subq_24.metric_time__year, subq_31.metric_time__year) AS metric_time__year
     , MAX(subq_24.month_start_bookings) AS month_start_bookings
-    , MAX(subq_32.bookings_1_month_ago) AS bookings_1_month_ago
+    , MAX(subq_31.bookings_1_month_ago) AS bookings_1_month_ago
   FROM (
     -- Join to Time Spine Dataset
     -- Pass Only Elements: ['bookings', 'metric_time__year']
@@ -19,18 +28,12 @@ FROM (
     -- Compute Metrics via Expressions
     SELECT
       DATE_TRUNC('year', subq_20.ds) AS metric_time__year
-      , SUM(subq_18.bookings) AS month_start_bookings
+      , SUM(sma_28009_cte.bookings) AS month_start_bookings
     FROM ***************************.mf_time_spine subq_20
-    INNER JOIN (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_18
+    INNER JOIN
+      sma_28009_cte sma_28009_cte
     ON
-      DATE_TRUNC('month', subq_20.ds) = subq_18.metric_time__day
+      DATE_TRUNC('month', subq_20.ds) = sma_28009_cte.metric_time__day
     WHERE DATE_TRUNC('year', subq_20.ds) = subq_20.ds
     GROUP BY
       DATE_TRUNC('year', subq_20.ds)
@@ -41,24 +44,18 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      DATE_TRUNC('year', subq_28.ds) AS metric_time__year
-      , SUM(subq_26.bookings) AS bookings_1_month_ago
-    FROM ***************************.mf_time_spine subq_28
-    INNER JOIN (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_26
+      DATE_TRUNC('year', subq_27.ds) AS metric_time__year
+      , SUM(sma_28009_cte.bookings) AS bookings_1_month_ago
+    FROM ***************************.mf_time_spine subq_27
+    INNER JOIN
+      sma_28009_cte sma_28009_cte
     ON
-      DATEADD(month, -1, subq_28.ds) = subq_26.metric_time__day
+      DATEADD(month, -1, subq_27.ds) = sma_28009_cte.metric_time__day
     GROUP BY
-      DATE_TRUNC('year', subq_28.ds)
-  ) subq_32
+      DATE_TRUNC('year', subq_27.ds)
+  ) subq_31
   ON
-    subq_24.metric_time__year = subq_32.metric_time__year
+    subq_24.metric_time__year = subq_31.metric_time__year
   GROUP BY
-    COALESCE(subq_24.metric_time__year, subq_32.metric_time__year)
-) subq_33
+    COALESCE(subq_24.metric_time__year, subq_31.metric_time__year)
+) subq_32

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_window_and_time_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_window_and_time_filter__plan0_optimized.sql
@@ -3,15 +3,24 @@ test_filename: test_derived_metric_rendering.py
 sql_engine: Snowflake
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , 1 AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__day
+  metric_time__day AS metric_time__day
   , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_21.metric_time__day, subq_30.metric_time__day) AS metric_time__day
+    COALESCE(subq_21.metric_time__day, subq_29.metric_time__day) AS metric_time__day
     , MAX(subq_21.bookings) AS bookings
-    , MAX(subq_30.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+    , MAX(subq_29.bookings_2_weeks_ago) AS bookings_2_weeks_ago
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['bookings', 'metric_time__day']
@@ -21,12 +30,11 @@ FROM (
       metric_time__day
       , SUM(bookings) AS bookings
     FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
+      -- Read From CTE For node_id=sma_28009
       SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
+        metric_time__day
+        , bookings
+      FROM sma_28009_cte sma_28009_cte
     ) subq_17
     WHERE metric_time__day = '2020-01-01' or metric_time__day = '2020-01-14'
     GROUP BY
@@ -43,26 +51,20 @@ FROM (
     FROM (
       -- Join to Time Spine Dataset
       SELECT
-        subq_25.ds AS metric_time__day
-        , subq_23.bookings AS bookings
-      FROM ***************************.mf_time_spine subq_25
-      INNER JOIN (
-        -- Read Elements From Semantic Model 'bookings_source'
-        -- Metric Time Dimension 'ds'
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , 1 AS bookings
-        FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_23
+        subq_24.ds AS metric_time__day
+        , sma_28009_cte.bookings AS bookings
+      FROM ***************************.mf_time_spine subq_24
+      INNER JOIN
+        sma_28009_cte sma_28009_cte
       ON
-        DATEADD(day, -14, subq_25.ds) = subq_23.metric_time__day
-    ) subq_26
+        DATEADD(day, -14, subq_24.ds) = sma_28009_cte.metric_time__day
+    ) subq_25
     WHERE metric_time__day = '2020-01-01' or metric_time__day = '2020-01-14'
     GROUP BY
       metric_time__day
-  ) subq_30
+  ) subq_29
   ON
-    subq_21.metric_time__day = subq_30.metric_time__day
+    subq_21.metric_time__day = subq_29.metric_time__day
   GROUP BY
-    COALESCE(subq_21.metric_time__day, subq_30.metric_time__day)
-) subq_31
+    COALESCE(subq_21.metric_time__day, subq_29.metric_time__day)
+) subq_30

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_offset_metric_with_agg_time_dim__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_offset_metric_with_agg_time_dim__plan0_optimized.sql
@@ -3,15 +3,25 @@ test_filename: test_derived_metric_rendering.py
 sql_engine: Snowflake
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS booking__ds__day
+    , booking_value
+    , guest_id AS bookers
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  booking__ds__day
+  booking__ds__day AS booking__ds__day
   , booking_value * 0.05 / bookers AS booking_fees_last_week_per_booker_this_week
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_21.booking__ds__day, subq_26.booking__ds__day) AS booking__ds__day
+    COALESCE(subq_21.booking__ds__day, subq_25.booking__ds__day) AS booking__ds__day
     , MAX(subq_21.booking_value) AS booking_value
-    , MAX(subq_26.bookers) AS bookers
+    , MAX(subq_25.bookers) AS bookers
   FROM (
     -- Join to Time Spine Dataset
     -- Pass Only Elements: ['booking_value', 'booking__ds__day']
@@ -19,30 +29,29 @@ FROM (
     -- Compute Metrics via Expressions
     SELECT
       subq_17.ds AS booking__ds__day
-      , SUM(bookings_source_src_28000.booking_value) AS booking_value
+      , SUM(sma_28009_cte.booking_value) AS booking_value
     FROM ***************************.mf_time_spine subq_17
     INNER JOIN
-      ***************************.fct_bookings bookings_source_src_28000
+      sma_28009_cte sma_28009_cte
     ON
-      DATEADD(week, -1, subq_17.ds) = DATE_TRUNC('day', bookings_source_src_28000.ds)
+      DATEADD(week, -1, subq_17.ds) = sma_28009_cte.booking__ds__day
     GROUP BY
       subq_17.ds
   ) subq_21
   FULL OUTER JOIN (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28009
     -- Pass Only Elements: ['bookers', 'booking__ds__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      DATE_TRUNC('day', ds) AS booking__ds__day
-      , COUNT(DISTINCT guest_id) AS bookers
-    FROM ***************************.fct_bookings bookings_source_src_28000
+      booking__ds__day
+      , COUNT(DISTINCT bookers) AS bookers
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
-      DATE_TRUNC('day', ds)
-  ) subq_26
+      booking__ds__day
+  ) subq_25
   ON
-    subq_21.booking__ds__day = subq_26.booking__ds__day
+    subq_21.booking__ds__day = subq_25.booking__ds__day
   GROUP BY
-    COALESCE(subq_21.booking__ds__day, subq_26.booking__ds__day)
-) subq_27
+    COALESCE(subq_21.booking__ds__day, subq_25.booking__ds__day)
+) subq_26

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0_optimized.sql
@@ -3,15 +3,24 @@ test_filename: test_derived_metric_rendering.py
 sql_engine: Snowflake
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , booking_value
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__day
+  metric_time__day AS metric_time__day
   , booking_fees - booking_fees_start_of_month AS booking_fees_since_start_of_month
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_24.metric_time__day, subq_30.metric_time__day) AS metric_time__day
+    COALESCE(subq_24.metric_time__day, subq_29.metric_time__day) AS metric_time__day
     , MAX(subq_24.booking_fees_start_of_month) AS booking_fees_start_of_month
-    , MAX(subq_30.booking_fees) AS booking_fees
+    , MAX(subq_29.booking_fees) AS booking_fees
   FROM (
     -- Join to Time Spine Dataset
     SELECT
@@ -24,17 +33,16 @@ FROM (
         metric_time__day
         , booking_value * 0.05 AS booking_fees_start_of_month
       FROM (
-        -- Read Elements From Semantic Model 'bookings_source'
-        -- Metric Time Dimension 'ds'
+        -- Read From CTE For node_id=sma_28009
         -- Pass Only Elements: ['booking_value', 'metric_time__day']
         -- Aggregate Measures
         -- Compute Metrics via Expressions
         SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
+          metric_time__day
           , SUM(booking_value) AS booking_value
-        FROM ***************************.fct_bookings bookings_source_src_28000
+        FROM sma_28009_cte sma_28009_cte
         GROUP BY
-          DATE_TRUNC('day', ds)
+          metric_time__day
       ) subq_20
     ) subq_21
     ON
@@ -46,21 +54,20 @@ FROM (
       metric_time__day
       , booking_value * 0.05 AS booking_fees
     FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
+      -- Read From CTE For node_id=sma_28009
       -- Pass Only Elements: ['booking_value', 'metric_time__day']
       -- Aggregate Measures
       -- Compute Metrics via Expressions
       SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
+        metric_time__day
         , SUM(booking_value) AS booking_value
-      FROM ***************************.fct_bookings bookings_source_src_28000
+      FROM sma_28009_cte sma_28009_cte
       GROUP BY
-        DATE_TRUNC('day', ds)
-    ) subq_29
-  ) subq_30
+        metric_time__day
+    ) subq_28
+  ) subq_29
   ON
-    subq_24.metric_time__day = subq_30.metric_time__day
+    subq_24.metric_time__day = subq_29.metric_time__day
   GROUP BY
-    COALESCE(subq_24.metric_time__day, subq_30.metric_time__day)
-) subq_31
+    COALESCE(subq_24.metric_time__day, subq_29.metric_time__day)
+) subq_30

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_offset_to_grain_with_agg_time_dim__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_offset_to_grain_with_agg_time_dim__plan0_optimized.sql
@@ -3,30 +3,33 @@ test_filename: test_derived_metric_rendering.py
 sql_engine: Snowflake
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS booking__ds__day
+    , 1 AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  booking__ds__day
+  booking__ds__day AS booking__ds__day
   , bookings - bookings_at_start_of_month AS bookings_growth_since_start_of_month
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_18.booking__ds__day, subq_26.booking__ds__day) AS booking__ds__day
+    COALESCE(subq_18.booking__ds__day, subq_25.booking__ds__day) AS booking__ds__day
     , MAX(subq_18.bookings) AS bookings
-    , MAX(subq_26.bookings_at_start_of_month) AS bookings_at_start_of_month
+    , MAX(subq_25.bookings_at_start_of_month) AS bookings_at_start_of_month
   FROM (
+    -- Read From CTE For node_id=sma_28009
+    -- Pass Only Elements: ['bookings', 'booking__ds__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
       booking__ds__day
       , SUM(bookings) AS bookings
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['bookings', 'booking__ds__day']
-      SELECT
-        DATE_TRUNC('day', ds) AS booking__ds__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_16
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
       booking__ds__day
   ) subq_18
@@ -36,24 +39,18 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      subq_22.ds AS booking__ds__day
-      , SUM(subq_20.bookings) AS bookings_at_start_of_month
-    FROM ***************************.mf_time_spine subq_22
-    INNER JOIN (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATE_TRUNC('day', ds) AS booking__ds__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_20
+      subq_21.ds AS booking__ds__day
+      , SUM(sma_28009_cte.bookings) AS bookings_at_start_of_month
+    FROM ***************************.mf_time_spine subq_21
+    INNER JOIN
+      sma_28009_cte sma_28009_cte
     ON
-      DATE_TRUNC('month', subq_22.ds) = subq_20.booking__ds__day
+      DATE_TRUNC('month', subq_21.ds) = sma_28009_cte.booking__ds__day
     GROUP BY
-      subq_22.ds
-  ) subq_26
+      subq_21.ds
+  ) subq_25
   ON
-    subq_18.booking__ds__day = subq_26.booking__ds__day
+    subq_18.booking__ds__day = subq_25.booking__ds__day
   GROUP BY
-    COALESCE(subq_18.booking__ds__day, subq_26.booking__ds__day)
-) subq_27
+    COALESCE(subq_18.booking__ds__day, subq_25.booking__ds__day)
+) subq_26

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_offset_window_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_offset_window_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
@@ -5,15 +5,26 @@ docstring:
 sql_engine: Snowflake
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , DATE_TRUNC('month', ds) AS metric_time__month
+    , booking_value
+    , guest_id AS bookers
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__month
+  metric_time__month AS metric_time__month
   , booking_value * 0.05 / bookers AS booking_fees_last_week_per_booker_this_week
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_24.metric_time__month, subq_30.metric_time__month) AS metric_time__month
+    COALESCE(subq_24.metric_time__month, subq_29.metric_time__month) AS metric_time__month
     , MAX(subq_24.booking_value) AS booking_value
-    , MAX(subq_30.bookers) AS bookers
+    , MAX(subq_29.bookers) AS bookers
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['booking_value', 'metric_time__month']
@@ -27,12 +38,12 @@ FROM (
       SELECT
         subq_19.ds AS metric_time__day
         , DATE_TRUNC('month', subq_19.ds) AS metric_time__month
-        , bookings_source_src_28000.booking_value AS booking_value
+        , sma_28009_cte.booking_value AS booking_value
       FROM ***************************.mf_time_spine subq_19
       INNER JOIN
-        ***************************.fct_bookings bookings_source_src_28000
+        sma_28009_cte sma_28009_cte
       ON
-        DATEADD(week, -1, subq_19.ds) = DATE_TRUNC('day', bookings_source_src_28000.ds)
+        DATEADD(week, -1, subq_19.ds) = sma_28009_cte.metric_time__day
     ) subq_20
     WHERE metric_time__day = '2020-01-01'
     GROUP BY
@@ -47,20 +58,20 @@ FROM (
       metric_time__month
       , COUNT(DISTINCT bookers) AS bookers
     FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
+      -- Read From CTE For node_id=sma_28009
       SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , DATE_TRUNC('month', ds) AS metric_time__month
-        , guest_id AS bookers
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_26
+        metric_time__day
+        , metric_time__month
+        , booking_value
+        , bookers
+      FROM sma_28009_cte sma_28009_cte
+    ) subq_25
     WHERE metric_time__day = '2020-01-01'
     GROUP BY
       metric_time__month
-  ) subq_30
+  ) subq_29
   ON
-    subq_24.metric_time__month = subq_30.metric_time__month
+    subq_24.metric_time__month = subq_29.metric_time__month
   GROUP BY
-    COALESCE(subq_24.metric_time__month, subq_30.metric_time__month)
-) subq_31
+    COALESCE(subq_24.metric_time__month, subq_29.metric_time__month)
+) subq_30

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_offset_window_metric_multiple_granularities__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_offset_window_metric_multiple_granularities__plan0_optimized.sql
@@ -5,19 +5,31 @@ docstring:
 sql_engine: Snowflake
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , DATE_TRUNC('month', ds) AS metric_time__month
+    , DATE_TRUNC('year', ds) AS metric_time__year
+    , booking_value
+    , guest_id AS bookers
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__day
-  , metric_time__month
-  , metric_time__year
+  metric_time__day AS metric_time__day
+  , metric_time__month AS metric_time__month
+  , metric_time__year AS metric_time__year
   , booking_value * 0.05 / bookers AS booking_fees_last_week_per_booker_this_week
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_21.metric_time__day, subq_26.metric_time__day) AS metric_time__day
-    , COALESCE(subq_21.metric_time__month, subq_26.metric_time__month) AS metric_time__month
-    , COALESCE(subq_21.metric_time__year, subq_26.metric_time__year) AS metric_time__year
+    COALESCE(subq_21.metric_time__day, subq_25.metric_time__day) AS metric_time__day
+    , COALESCE(subq_21.metric_time__month, subq_25.metric_time__month) AS metric_time__month
+    , COALESCE(subq_21.metric_time__year, subq_25.metric_time__year) AS metric_time__year
     , MAX(subq_21.booking_value) AS booking_value
-    , MAX(subq_26.bookers) AS bookers
+    , MAX(subq_25.bookers) AS bookers
   FROM (
     -- Join to Time Spine Dataset
     -- Pass Only Elements: ['booking_value', 'metric_time__day', 'metric_time__month', 'metric_time__year']
@@ -27,44 +39,43 @@ FROM (
       subq_17.ds AS metric_time__day
       , DATE_TRUNC('month', subq_17.ds) AS metric_time__month
       , DATE_TRUNC('year', subq_17.ds) AS metric_time__year
-      , SUM(bookings_source_src_28000.booking_value) AS booking_value
+      , SUM(sma_28009_cte.booking_value) AS booking_value
     FROM ***************************.mf_time_spine subq_17
     INNER JOIN
-      ***************************.fct_bookings bookings_source_src_28000
+      sma_28009_cte sma_28009_cte
     ON
-      DATEADD(week, -1, subq_17.ds) = DATE_TRUNC('day', bookings_source_src_28000.ds)
+      DATEADD(week, -1, subq_17.ds) = sma_28009_cte.metric_time__day
     GROUP BY
       subq_17.ds
       , DATE_TRUNC('month', subq_17.ds)
       , DATE_TRUNC('year', subq_17.ds)
   ) subq_21
   FULL OUTER JOIN (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28009
     -- Pass Only Elements: ['bookers', 'metric_time__day', 'metric_time__month', 'metric_time__year']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      DATE_TRUNC('day', ds) AS metric_time__day
-      , DATE_TRUNC('month', ds) AS metric_time__month
-      , DATE_TRUNC('year', ds) AS metric_time__year
-      , COUNT(DISTINCT guest_id) AS bookers
-    FROM ***************************.fct_bookings bookings_source_src_28000
+      metric_time__day
+      , metric_time__month
+      , metric_time__year
+      , COUNT(DISTINCT bookers) AS bookers
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
-      DATE_TRUNC('day', ds)
-      , DATE_TRUNC('month', ds)
-      , DATE_TRUNC('year', ds)
-  ) subq_26
+      metric_time__day
+      , metric_time__month
+      , metric_time__year
+  ) subq_25
   ON
     (
-      subq_21.metric_time__day = subq_26.metric_time__day
+      subq_21.metric_time__day = subq_25.metric_time__day
     ) AND (
-      subq_21.metric_time__month = subq_26.metric_time__month
+      subq_21.metric_time__month = subq_25.metric_time__month
     ) AND (
-      subq_21.metric_time__year = subq_26.metric_time__year
+      subq_21.metric_time__year = subq_25.metric_time__year
     )
   GROUP BY
-    COALESCE(subq_21.metric_time__day, subq_26.metric_time__day)
-    , COALESCE(subq_21.metric_time__month, subq_26.metric_time__month)
-    , COALESCE(subq_21.metric_time__year, subq_26.metric_time__year)
-) subq_27
+    COALESCE(subq_21.metric_time__day, subq_25.metric_time__day)
+    , COALESCE(subq_21.metric_time__month, subq_25.metric_time__month)
+    , COALESCE(subq_21.metric_time__year, subq_25.metric_time__year)
+) subq_26

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_offset_window_with_agg_time_dim__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_offset_window_with_agg_time_dim__plan0_optimized.sql
@@ -3,30 +3,33 @@ test_filename: test_derived_metric_rendering.py
 sql_engine: Snowflake
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS booking__ds__day
+    , 1 AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  booking__ds__day
+  booking__ds__day AS booking__ds__day
   , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_18.booking__ds__day, subq_26.booking__ds__day) AS booking__ds__day
+    COALESCE(subq_18.booking__ds__day, subq_25.booking__ds__day) AS booking__ds__day
     , MAX(subq_18.bookings) AS bookings
-    , MAX(subq_26.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+    , MAX(subq_25.bookings_2_weeks_ago) AS bookings_2_weeks_ago
   FROM (
+    -- Read From CTE For node_id=sma_28009
+    -- Pass Only Elements: ['bookings', 'booking__ds__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
       booking__ds__day
       , SUM(bookings) AS bookings
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['bookings', 'booking__ds__day']
-      SELECT
-        DATE_TRUNC('day', ds) AS booking__ds__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_16
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
       booking__ds__day
   ) subq_18
@@ -36,24 +39,18 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      subq_22.ds AS booking__ds__day
-      , SUM(subq_20.bookings) AS bookings_2_weeks_ago
-    FROM ***************************.mf_time_spine subq_22
-    INNER JOIN (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATE_TRUNC('day', ds) AS booking__ds__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_20
+      subq_21.ds AS booking__ds__day
+      , SUM(sma_28009_cte.bookings) AS bookings_2_weeks_ago
+    FROM ***************************.mf_time_spine subq_21
+    INNER JOIN
+      sma_28009_cte sma_28009_cte
     ON
-      DATEADD(day, -14, subq_22.ds) = subq_20.booking__ds__day
+      DATEADD(day, -14, subq_21.ds) = sma_28009_cte.booking__ds__day
     GROUP BY
-      subq_22.ds
-  ) subq_26
+      subq_21.ds
+  ) subq_25
   ON
-    subq_18.booking__ds__day = subq_26.booking__ds__day
+    subq_18.booking__ds__day = subq_25.booking__ds__day
   GROUP BY
-    COALESCE(subq_18.booking__ds__day, subq_26.booking__ds__day)
-) subq_27
+    COALESCE(subq_18.booking__ds__day, subq_25.booking__ds__day)
+) subq_26

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_metric_that_defines_the_same_alias_in_different_components__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_metric_that_defines_the_same_alias_in_different_components__plan0_optimized.sql
@@ -6,30 +6,34 @@ sql_engine: Trino
 ---
 -- Combine Aggregated Outputs
 -- Order By [] Limit 1
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    is_instant AS booking__is_instant
+    , 1 AS bookings
+    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  COALESCE(subq_18.booking__is_instant, subq_24.booking__is_instant) AS booking__is_instant
+  COALESCE(subq_18.booking__is_instant, subq_23.booking__is_instant) AS booking__is_instant
   , MAX(subq_18.derived_shared_alias_1a) AS derived_shared_alias_1a
-  , MAX(subq_24.derived_shared_alias_2) AS derived_shared_alias_2
+  , MAX(subq_23.derived_shared_alias_2) AS derived_shared_alias_2
 FROM (
   -- Compute Metrics via Expressions
   SELECT
     booking__is_instant
     , shared_alias - 10 AS derived_shared_alias_1a
   FROM (
+    -- Read From CTE For node_id=sma_28009
+    -- Pass Only Elements: ['bookings', 'booking__is_instant']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
       booking__is_instant
       , SUM(bookings) AS shared_alias
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['bookings', 'booking__is_instant']
-      SELECT
-        is_instant AS booking__is_instant
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_15
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
       booking__is_instant
   ) subq_17
@@ -40,26 +44,20 @@ FULL OUTER JOIN (
     booking__is_instant
     , shared_alias + 10 AS derived_shared_alias_2
   FROM (
+    -- Read From CTE For node_id=sma_28009
+    -- Pass Only Elements: ['instant_bookings', 'booking__is_instant']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
       booking__is_instant
       , SUM(instant_bookings) AS shared_alias
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['instant_bookings', 'booking__is_instant']
-      SELECT
-        is_instant AS booking__is_instant
-        , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_21
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
       booking__is_instant
-  ) subq_23
-) subq_24
+  ) subq_22
+) subq_23
 ON
-  subq_18.booking__is_instant = subq_24.booking__is_instant
+  subq_18.booking__is_instant = subq_23.booking__is_instant
 GROUP BY
-  COALESCE(subq_18.booking__is_instant, subq_24.booking__is_instant)
+  COALESCE(subq_18.booking__is_instant, subq_23.booking__is_instant)
 LIMIT 1

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_metric_with_offset_to_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_metric_with_offset_to_grain__plan0_optimized.sql
@@ -3,30 +3,33 @@ test_filename: test_derived_metric_rendering.py
 sql_engine: Trino
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , 1 AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__day
+  metric_time__day AS metric_time__day
   , bookings - bookings_at_start_of_month AS bookings_growth_since_start_of_month
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_18.metric_time__day, subq_26.metric_time__day) AS metric_time__day
+    COALESCE(subq_18.metric_time__day, subq_25.metric_time__day) AS metric_time__day
     , MAX(subq_18.bookings) AS bookings
-    , MAX(subq_26.bookings_at_start_of_month) AS bookings_at_start_of_month
+    , MAX(subq_25.bookings_at_start_of_month) AS bookings_at_start_of_month
   FROM (
+    -- Read From CTE For node_id=sma_28009
+    -- Pass Only Elements: ['bookings', 'metric_time__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
       metric_time__day
       , SUM(bookings) AS bookings
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['bookings', 'metric_time__day']
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_16
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
       metric_time__day
   ) subq_18
@@ -36,24 +39,18 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      subq_22.ds AS metric_time__day
-      , SUM(subq_20.bookings) AS bookings_at_start_of_month
-    FROM ***************************.mf_time_spine subq_22
-    INNER JOIN (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_20
+      subq_21.ds AS metric_time__day
+      , SUM(sma_28009_cte.bookings) AS bookings_at_start_of_month
+    FROM ***************************.mf_time_spine subq_21
+    INNER JOIN
+      sma_28009_cte sma_28009_cte
     ON
-      DATE_TRUNC('month', subq_22.ds) = subq_20.metric_time__day
+      DATE_TRUNC('month', subq_21.ds) = sma_28009_cte.metric_time__day
     GROUP BY
-      subq_22.ds
-  ) subq_26
+      subq_21.ds
+  ) subq_25
   ON
-    subq_18.metric_time__day = subq_26.metric_time__day
+    subq_18.metric_time__day = subq_25.metric_time__day
   GROUP BY
-    COALESCE(subq_18.metric_time__day, subq_26.metric_time__day)
-) subq_27
+    COALESCE(subq_18.metric_time__day, subq_25.metric_time__day)
+) subq_26

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_metric_with_offset_to_grain_and_granularity__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_metric_with_offset_to_grain_and_granularity__plan0_optimized.sql
@@ -3,30 +3,34 @@ test_filename: test_derived_metric_rendering.py
 sql_engine: Trino
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , DATE_TRUNC('week', ds) AS metric_time__week
+    , 1 AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__week
+  metric_time__week AS metric_time__week
   , bookings - bookings_at_start_of_month AS bookings_growth_since_start_of_month
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_18.metric_time__week, subq_26.metric_time__week) AS metric_time__week
+    COALESCE(subq_18.metric_time__week, subq_25.metric_time__week) AS metric_time__week
     , MAX(subq_18.bookings) AS bookings
-    , MAX(subq_26.bookings_at_start_of_month) AS bookings_at_start_of_month
+    , MAX(subq_25.bookings_at_start_of_month) AS bookings_at_start_of_month
   FROM (
+    -- Read From CTE For node_id=sma_28009
+    -- Pass Only Elements: ['bookings', 'metric_time__week']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
       metric_time__week
       , SUM(bookings) AS bookings
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['bookings', 'metric_time__week']
-      SELECT
-        DATE_TRUNC('week', ds) AS metric_time__week
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_16
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
       metric_time__week
   ) subq_18
@@ -36,25 +40,19 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      DATE_TRUNC('week', subq_22.ds) AS metric_time__week
-      , SUM(subq_20.bookings) AS bookings_at_start_of_month
-    FROM ***************************.mf_time_spine subq_22
-    INNER JOIN (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_20
+      DATE_TRUNC('week', subq_21.ds) AS metric_time__week
+      , SUM(sma_28009_cte.bookings) AS bookings_at_start_of_month
+    FROM ***************************.mf_time_spine subq_21
+    INNER JOIN
+      sma_28009_cte sma_28009_cte
     ON
-      DATE_TRUNC('month', subq_22.ds) = subq_20.metric_time__day
-    WHERE DATE_TRUNC('week', subq_22.ds) = subq_22.ds
+      DATE_TRUNC('month', subq_21.ds) = sma_28009_cte.metric_time__day
+    WHERE DATE_TRUNC('week', subq_21.ds) = subq_21.ds
     GROUP BY
-      DATE_TRUNC('week', subq_22.ds)
-  ) subq_26
+      DATE_TRUNC('week', subq_21.ds)
+  ) subq_25
   ON
-    subq_18.metric_time__week = subq_26.metric_time__week
+    subq_18.metric_time__week = subq_25.metric_time__week
   GROUP BY
-    COALESCE(subq_18.metric_time__week, subq_26.metric_time__week)
-) subq_27
+    COALESCE(subq_18.metric_time__week, subq_25.metric_time__week)
+) subq_26

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_metric_with_offset_window__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_metric_with_offset_window__plan0_optimized.sql
@@ -3,30 +3,33 @@ test_filename: test_derived_metric_rendering.py
 sql_engine: Trino
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , 1 AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__day
+  metric_time__day AS metric_time__day
   , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_18.metric_time__day, subq_26.metric_time__day) AS metric_time__day
+    COALESCE(subq_18.metric_time__day, subq_25.metric_time__day) AS metric_time__day
     , MAX(subq_18.bookings) AS bookings
-    , MAX(subq_26.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+    , MAX(subq_25.bookings_2_weeks_ago) AS bookings_2_weeks_ago
   FROM (
+    -- Read From CTE For node_id=sma_28009
+    -- Pass Only Elements: ['bookings', 'metric_time__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
       metric_time__day
       , SUM(bookings) AS bookings
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['bookings', 'metric_time__day']
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_16
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
       metric_time__day
   ) subq_18
@@ -36,24 +39,18 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      subq_22.ds AS metric_time__day
-      , SUM(subq_20.bookings) AS bookings_2_weeks_ago
-    FROM ***************************.mf_time_spine subq_22
-    INNER JOIN (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_20
+      subq_21.ds AS metric_time__day
+      , SUM(sma_28009_cte.bookings) AS bookings_2_weeks_ago
+    FROM ***************************.mf_time_spine subq_21
+    INNER JOIN
+      sma_28009_cte sma_28009_cte
     ON
-      DATE_ADD('day', -14, subq_22.ds) = subq_20.metric_time__day
+      DATE_ADD('day', -14, subq_21.ds) = sma_28009_cte.metric_time__day
     GROUP BY
-      subq_22.ds
-  ) subq_26
+      subq_21.ds
+  ) subq_25
   ON
-    subq_18.metric_time__day = subq_26.metric_time__day
+    subq_18.metric_time__day = subq_25.metric_time__day
   GROUP BY
-    COALESCE(subq_18.metric_time__day, subq_26.metric_time__day)
-) subq_27
+    COALESCE(subq_18.metric_time__day, subq_25.metric_time__day)
+) subq_26

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_metric_with_offset_window_and_granularity__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_metric_with_offset_window_and_granularity__plan0_optimized.sql
@@ -3,30 +3,34 @@ test_filename: test_derived_metric_rendering.py
 sql_engine: Trino
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , DATE_TRUNC('quarter', ds) AS metric_time__quarter
+    , 1 AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__quarter
+  metric_time__quarter AS metric_time__quarter
   , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_18.metric_time__quarter, subq_26.metric_time__quarter) AS metric_time__quarter
+    COALESCE(subq_18.metric_time__quarter, subq_25.metric_time__quarter) AS metric_time__quarter
     , MAX(subq_18.bookings) AS bookings
-    , MAX(subq_26.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+    , MAX(subq_25.bookings_2_weeks_ago) AS bookings_2_weeks_ago
   FROM (
+    -- Read From CTE For node_id=sma_28009
+    -- Pass Only Elements: ['bookings', 'metric_time__quarter']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
       metric_time__quarter
       , SUM(bookings) AS bookings
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['bookings', 'metric_time__quarter']
-      SELECT
-        DATE_TRUNC('quarter', ds) AS metric_time__quarter
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_16
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
       metric_time__quarter
   ) subq_18
@@ -36,24 +40,18 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      DATE_TRUNC('quarter', subq_22.ds) AS metric_time__quarter
-      , SUM(subq_20.bookings) AS bookings_2_weeks_ago
-    FROM ***************************.mf_time_spine subq_22
-    INNER JOIN (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_20
+      DATE_TRUNC('quarter', subq_21.ds) AS metric_time__quarter
+      , SUM(sma_28009_cte.bookings) AS bookings_2_weeks_ago
+    FROM ***************************.mf_time_spine subq_21
+    INNER JOIN
+      sma_28009_cte sma_28009_cte
     ON
-      DATE_ADD('day', -14, subq_22.ds) = subq_20.metric_time__day
+      DATE_ADD('day', -14, subq_21.ds) = sma_28009_cte.metric_time__day
     GROUP BY
-      DATE_TRUNC('quarter', subq_22.ds)
-  ) subq_26
+      DATE_TRUNC('quarter', subq_21.ds)
+  ) subq_25
   ON
-    subq_18.metric_time__quarter = subq_26.metric_time__quarter
+    subq_18.metric_time__quarter = subq_25.metric_time__quarter
   GROUP BY
-    COALESCE(subq_18.metric_time__quarter, subq_26.metric_time__quarter)
-) subq_27
+    COALESCE(subq_18.metric_time__quarter, subq_25.metric_time__quarter)
+) subq_26

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_metric_with_offset_window_and_offset_to_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_metric_with_offset_window_and_offset_to_grain__plan0_optimized.sql
@@ -3,15 +3,24 @@ test_filename: test_derived_metric_rendering.py
 sql_engine: Trino
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , 1 AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__day
+  metric_time__day AS metric_time__day
   , month_start_bookings - bookings_1_month_ago AS bookings_month_start_compared_to_1_month_prior
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_24.metric_time__day, subq_32.metric_time__day) AS metric_time__day
+    COALESCE(subq_24.metric_time__day, subq_31.metric_time__day) AS metric_time__day
     , MAX(subq_24.month_start_bookings) AS month_start_bookings
-    , MAX(subq_32.bookings_1_month_ago) AS bookings_1_month_ago
+    , MAX(subq_31.bookings_1_month_ago) AS bookings_1_month_ago
   FROM (
     -- Join to Time Spine Dataset
     -- Pass Only Elements: ['bookings', 'metric_time__day']
@@ -19,18 +28,12 @@ FROM (
     -- Compute Metrics via Expressions
     SELECT
       subq_20.ds AS metric_time__day
-      , SUM(subq_18.bookings) AS month_start_bookings
+      , SUM(sma_28009_cte.bookings) AS month_start_bookings
     FROM ***************************.mf_time_spine subq_20
-    INNER JOIN (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_18
+    INNER JOIN
+      sma_28009_cte sma_28009_cte
     ON
-      DATE_TRUNC('month', subq_20.ds) = subq_18.metric_time__day
+      DATE_TRUNC('month', subq_20.ds) = sma_28009_cte.metric_time__day
     GROUP BY
       subq_20.ds
   ) subq_24
@@ -40,24 +43,18 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      subq_28.ds AS metric_time__day
-      , SUM(subq_26.bookings) AS bookings_1_month_ago
-    FROM ***************************.mf_time_spine subq_28
-    INNER JOIN (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_26
+      subq_27.ds AS metric_time__day
+      , SUM(sma_28009_cte.bookings) AS bookings_1_month_ago
+    FROM ***************************.mf_time_spine subq_27
+    INNER JOIN
+      sma_28009_cte sma_28009_cte
     ON
-      DATE_ADD('month', -1, subq_28.ds) = subq_26.metric_time__day
+      DATE_ADD('month', -1, subq_27.ds) = sma_28009_cte.metric_time__day
     GROUP BY
-      subq_28.ds
-  ) subq_32
+      subq_27.ds
+  ) subq_31
   ON
-    subq_24.metric_time__day = subq_32.metric_time__day
+    subq_24.metric_time__day = subq_31.metric_time__day
   GROUP BY
-    COALESCE(subq_24.metric_time__day, subq_32.metric_time__day)
-) subq_33
+    COALESCE(subq_24.metric_time__day, subq_31.metric_time__day)
+) subq_32

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0_optimized.sql
@@ -3,15 +3,24 @@ test_filename: test_derived_metric_rendering.py
 sql_engine: Trino
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , 1 AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__year
+  metric_time__year AS metric_time__year
   , month_start_bookings - bookings_1_month_ago AS bookings_month_start_compared_to_1_month_prior
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_24.metric_time__year, subq_32.metric_time__year) AS metric_time__year
+    COALESCE(subq_24.metric_time__year, subq_31.metric_time__year) AS metric_time__year
     , MAX(subq_24.month_start_bookings) AS month_start_bookings
-    , MAX(subq_32.bookings_1_month_ago) AS bookings_1_month_ago
+    , MAX(subq_31.bookings_1_month_ago) AS bookings_1_month_ago
   FROM (
     -- Join to Time Spine Dataset
     -- Pass Only Elements: ['bookings', 'metric_time__year']
@@ -19,18 +28,12 @@ FROM (
     -- Compute Metrics via Expressions
     SELECT
       DATE_TRUNC('year', subq_20.ds) AS metric_time__year
-      , SUM(subq_18.bookings) AS month_start_bookings
+      , SUM(sma_28009_cte.bookings) AS month_start_bookings
     FROM ***************************.mf_time_spine subq_20
-    INNER JOIN (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_18
+    INNER JOIN
+      sma_28009_cte sma_28009_cte
     ON
-      DATE_TRUNC('month', subq_20.ds) = subq_18.metric_time__day
+      DATE_TRUNC('month', subq_20.ds) = sma_28009_cte.metric_time__day
     WHERE DATE_TRUNC('year', subq_20.ds) = subq_20.ds
     GROUP BY
       DATE_TRUNC('year', subq_20.ds)
@@ -41,24 +44,18 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      DATE_TRUNC('year', subq_28.ds) AS metric_time__year
-      , SUM(subq_26.bookings) AS bookings_1_month_ago
-    FROM ***************************.mf_time_spine subq_28
-    INNER JOIN (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_26
+      DATE_TRUNC('year', subq_27.ds) AS metric_time__year
+      , SUM(sma_28009_cte.bookings) AS bookings_1_month_ago
+    FROM ***************************.mf_time_spine subq_27
+    INNER JOIN
+      sma_28009_cte sma_28009_cte
     ON
-      DATE_ADD('month', -1, subq_28.ds) = subq_26.metric_time__day
+      DATE_ADD('month', -1, subq_27.ds) = sma_28009_cte.metric_time__day
     GROUP BY
-      DATE_TRUNC('year', subq_28.ds)
-  ) subq_32
+      DATE_TRUNC('year', subq_27.ds)
+  ) subq_31
   ON
-    subq_24.metric_time__year = subq_32.metric_time__year
+    subq_24.metric_time__year = subq_31.metric_time__year
   GROUP BY
-    COALESCE(subq_24.metric_time__year, subq_32.metric_time__year)
-) subq_33
+    COALESCE(subq_24.metric_time__year, subq_31.metric_time__year)
+) subq_32

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_metric_with_offset_window_and_time_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_metric_with_offset_window_and_time_filter__plan0_optimized.sql
@@ -3,15 +3,24 @@ test_filename: test_derived_metric_rendering.py
 sql_engine: Trino
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , 1 AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__day
+  metric_time__day AS metric_time__day
   , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_21.metric_time__day, subq_30.metric_time__day) AS metric_time__day
+    COALESCE(subq_21.metric_time__day, subq_29.metric_time__day) AS metric_time__day
     , MAX(subq_21.bookings) AS bookings
-    , MAX(subq_30.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+    , MAX(subq_29.bookings_2_weeks_ago) AS bookings_2_weeks_ago
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['bookings', 'metric_time__day']
@@ -21,12 +30,11 @@ FROM (
       metric_time__day
       , SUM(bookings) AS bookings
     FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
+      -- Read From CTE For node_id=sma_28009
       SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
+        metric_time__day
+        , bookings
+      FROM sma_28009_cte sma_28009_cte
     ) subq_17
     WHERE metric_time__day = '2020-01-01' or metric_time__day = '2020-01-14'
     GROUP BY
@@ -43,26 +51,20 @@ FROM (
     FROM (
       -- Join to Time Spine Dataset
       SELECT
-        subq_25.ds AS metric_time__day
-        , subq_23.bookings AS bookings
-      FROM ***************************.mf_time_spine subq_25
-      INNER JOIN (
-        -- Read Elements From Semantic Model 'bookings_source'
-        -- Metric Time Dimension 'ds'
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , 1 AS bookings
-        FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_23
+        subq_24.ds AS metric_time__day
+        , sma_28009_cte.bookings AS bookings
+      FROM ***************************.mf_time_spine subq_24
+      INNER JOIN
+        sma_28009_cte sma_28009_cte
       ON
-        DATE_ADD('day', -14, subq_25.ds) = subq_23.metric_time__day
-    ) subq_26
+        DATE_ADD('day', -14, subq_24.ds) = sma_28009_cte.metric_time__day
+    ) subq_25
     WHERE metric_time__day = '2020-01-01' or metric_time__day = '2020-01-14'
     GROUP BY
       metric_time__day
-  ) subq_30
+  ) subq_29
   ON
-    subq_21.metric_time__day = subq_30.metric_time__day
+    subq_21.metric_time__day = subq_29.metric_time__day
   GROUP BY
-    COALESCE(subq_21.metric_time__day, subq_30.metric_time__day)
-) subq_31
+    COALESCE(subq_21.metric_time__day, subq_29.metric_time__day)
+) subq_30

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_offset_metric_with_agg_time_dim__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_offset_metric_with_agg_time_dim__plan0_optimized.sql
@@ -3,15 +3,25 @@ test_filename: test_derived_metric_rendering.py
 sql_engine: Trino
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS booking__ds__day
+    , booking_value
+    , guest_id AS bookers
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  booking__ds__day
+  booking__ds__day AS booking__ds__day
   , booking_value * 0.05 / bookers AS booking_fees_last_week_per_booker_this_week
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_21.booking__ds__day, subq_26.booking__ds__day) AS booking__ds__day
+    COALESCE(subq_21.booking__ds__day, subq_25.booking__ds__day) AS booking__ds__day
     , MAX(subq_21.booking_value) AS booking_value
-    , MAX(subq_26.bookers) AS bookers
+    , MAX(subq_25.bookers) AS bookers
   FROM (
     -- Join to Time Spine Dataset
     -- Pass Only Elements: ['booking_value', 'booking__ds__day']
@@ -19,30 +29,29 @@ FROM (
     -- Compute Metrics via Expressions
     SELECT
       subq_17.ds AS booking__ds__day
-      , SUM(bookings_source_src_28000.booking_value) AS booking_value
+      , SUM(sma_28009_cte.booking_value) AS booking_value
     FROM ***************************.mf_time_spine subq_17
     INNER JOIN
-      ***************************.fct_bookings bookings_source_src_28000
+      sma_28009_cte sma_28009_cte
     ON
-      DATE_ADD('week', -1, subq_17.ds) = DATE_TRUNC('day', bookings_source_src_28000.ds)
+      DATE_ADD('week', -1, subq_17.ds) = sma_28009_cte.booking__ds__day
     GROUP BY
       subq_17.ds
   ) subq_21
   FULL OUTER JOIN (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28009
     -- Pass Only Elements: ['bookers', 'booking__ds__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      DATE_TRUNC('day', ds) AS booking__ds__day
-      , COUNT(DISTINCT guest_id) AS bookers
-    FROM ***************************.fct_bookings bookings_source_src_28000
+      booking__ds__day
+      , COUNT(DISTINCT bookers) AS bookers
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
-      DATE_TRUNC('day', ds)
-  ) subq_26
+      booking__ds__day
+  ) subq_25
   ON
-    subq_21.booking__ds__day = subq_26.booking__ds__day
+    subq_21.booking__ds__day = subq_25.booking__ds__day
   GROUP BY
-    COALESCE(subq_21.booking__ds__day, subq_26.booking__ds__day)
-) subq_27
+    COALESCE(subq_21.booking__ds__day, subq_25.booking__ds__day)
+) subq_26

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0_optimized.sql
@@ -3,15 +3,24 @@ test_filename: test_derived_metric_rendering.py
 sql_engine: Trino
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , booking_value
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__day
+  metric_time__day AS metric_time__day
   , booking_fees - booking_fees_start_of_month AS booking_fees_since_start_of_month
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_24.metric_time__day, subq_30.metric_time__day) AS metric_time__day
+    COALESCE(subq_24.metric_time__day, subq_29.metric_time__day) AS metric_time__day
     , MAX(subq_24.booking_fees_start_of_month) AS booking_fees_start_of_month
-    , MAX(subq_30.booking_fees) AS booking_fees
+    , MAX(subq_29.booking_fees) AS booking_fees
   FROM (
     -- Join to Time Spine Dataset
     SELECT
@@ -24,17 +33,16 @@ FROM (
         metric_time__day
         , booking_value * 0.05 AS booking_fees_start_of_month
       FROM (
-        -- Read Elements From Semantic Model 'bookings_source'
-        -- Metric Time Dimension 'ds'
+        -- Read From CTE For node_id=sma_28009
         -- Pass Only Elements: ['booking_value', 'metric_time__day']
         -- Aggregate Measures
         -- Compute Metrics via Expressions
         SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
+          metric_time__day
           , SUM(booking_value) AS booking_value
-        FROM ***************************.fct_bookings bookings_source_src_28000
+        FROM sma_28009_cte sma_28009_cte
         GROUP BY
-          DATE_TRUNC('day', ds)
+          metric_time__day
       ) subq_20
     ) subq_21
     ON
@@ -46,21 +54,20 @@ FROM (
       metric_time__day
       , booking_value * 0.05 AS booking_fees
     FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
+      -- Read From CTE For node_id=sma_28009
       -- Pass Only Elements: ['booking_value', 'metric_time__day']
       -- Aggregate Measures
       -- Compute Metrics via Expressions
       SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
+        metric_time__day
         , SUM(booking_value) AS booking_value
-      FROM ***************************.fct_bookings bookings_source_src_28000
+      FROM sma_28009_cte sma_28009_cte
       GROUP BY
-        DATE_TRUNC('day', ds)
-    ) subq_29
-  ) subq_30
+        metric_time__day
+    ) subq_28
+  ) subq_29
   ON
-    subq_24.metric_time__day = subq_30.metric_time__day
+    subq_24.metric_time__day = subq_29.metric_time__day
   GROUP BY
-    COALESCE(subq_24.metric_time__day, subq_30.metric_time__day)
-) subq_31
+    COALESCE(subq_24.metric_time__day, subq_29.metric_time__day)
+) subq_30

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_offset_to_grain_with_agg_time_dim__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_offset_to_grain_with_agg_time_dim__plan0_optimized.sql
@@ -3,30 +3,33 @@ test_filename: test_derived_metric_rendering.py
 sql_engine: Trino
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS booking__ds__day
+    , 1 AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  booking__ds__day
+  booking__ds__day AS booking__ds__day
   , bookings - bookings_at_start_of_month AS bookings_growth_since_start_of_month
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_18.booking__ds__day, subq_26.booking__ds__day) AS booking__ds__day
+    COALESCE(subq_18.booking__ds__day, subq_25.booking__ds__day) AS booking__ds__day
     , MAX(subq_18.bookings) AS bookings
-    , MAX(subq_26.bookings_at_start_of_month) AS bookings_at_start_of_month
+    , MAX(subq_25.bookings_at_start_of_month) AS bookings_at_start_of_month
   FROM (
+    -- Read From CTE For node_id=sma_28009
+    -- Pass Only Elements: ['bookings', 'booking__ds__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
       booking__ds__day
       , SUM(bookings) AS bookings
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['bookings', 'booking__ds__day']
-      SELECT
-        DATE_TRUNC('day', ds) AS booking__ds__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_16
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
       booking__ds__day
   ) subq_18
@@ -36,24 +39,18 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      subq_22.ds AS booking__ds__day
-      , SUM(subq_20.bookings) AS bookings_at_start_of_month
-    FROM ***************************.mf_time_spine subq_22
-    INNER JOIN (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATE_TRUNC('day', ds) AS booking__ds__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_20
+      subq_21.ds AS booking__ds__day
+      , SUM(sma_28009_cte.bookings) AS bookings_at_start_of_month
+    FROM ***************************.mf_time_spine subq_21
+    INNER JOIN
+      sma_28009_cte sma_28009_cte
     ON
-      DATE_TRUNC('month', subq_22.ds) = subq_20.booking__ds__day
+      DATE_TRUNC('month', subq_21.ds) = sma_28009_cte.booking__ds__day
     GROUP BY
-      subq_22.ds
-  ) subq_26
+      subq_21.ds
+  ) subq_25
   ON
-    subq_18.booking__ds__day = subq_26.booking__ds__day
+    subq_18.booking__ds__day = subq_25.booking__ds__day
   GROUP BY
-    COALESCE(subq_18.booking__ds__day, subq_26.booking__ds__day)
-) subq_27
+    COALESCE(subq_18.booking__ds__day, subq_25.booking__ds__day)
+) subq_26

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_offset_window_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_offset_window_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
@@ -5,15 +5,26 @@ docstring:
 sql_engine: Trino
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , DATE_TRUNC('month', ds) AS metric_time__month
+    , booking_value
+    , guest_id AS bookers
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__month
+  metric_time__month AS metric_time__month
   , booking_value * 0.05 / bookers AS booking_fees_last_week_per_booker_this_week
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_24.metric_time__month, subq_30.metric_time__month) AS metric_time__month
+    COALESCE(subq_24.metric_time__month, subq_29.metric_time__month) AS metric_time__month
     , MAX(subq_24.booking_value) AS booking_value
-    , MAX(subq_30.bookers) AS bookers
+    , MAX(subq_29.bookers) AS bookers
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['booking_value', 'metric_time__month']
@@ -27,12 +38,12 @@ FROM (
       SELECT
         subq_19.ds AS metric_time__day
         , DATE_TRUNC('month', subq_19.ds) AS metric_time__month
-        , bookings_source_src_28000.booking_value AS booking_value
+        , sma_28009_cte.booking_value AS booking_value
       FROM ***************************.mf_time_spine subq_19
       INNER JOIN
-        ***************************.fct_bookings bookings_source_src_28000
+        sma_28009_cte sma_28009_cte
       ON
-        DATE_ADD('week', -1, subq_19.ds) = DATE_TRUNC('day', bookings_source_src_28000.ds)
+        DATE_ADD('week', -1, subq_19.ds) = sma_28009_cte.metric_time__day
     ) subq_20
     WHERE metric_time__day = '2020-01-01'
     GROUP BY
@@ -47,20 +58,20 @@ FROM (
       metric_time__month
       , COUNT(DISTINCT bookers) AS bookers
     FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
+      -- Read From CTE For node_id=sma_28009
       SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , DATE_TRUNC('month', ds) AS metric_time__month
-        , guest_id AS bookers
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_26
+        metric_time__day
+        , metric_time__month
+        , booking_value
+        , bookers
+      FROM sma_28009_cte sma_28009_cte
+    ) subq_25
     WHERE metric_time__day = '2020-01-01'
     GROUP BY
       metric_time__month
-  ) subq_30
+  ) subq_29
   ON
-    subq_24.metric_time__month = subq_30.metric_time__month
+    subq_24.metric_time__month = subq_29.metric_time__month
   GROUP BY
-    COALESCE(subq_24.metric_time__month, subq_30.metric_time__month)
-) subq_31
+    COALESCE(subq_24.metric_time__month, subq_29.metric_time__month)
+) subq_30

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_offset_window_metric_multiple_granularities__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_offset_window_metric_multiple_granularities__plan0_optimized.sql
@@ -5,19 +5,31 @@ docstring:
 sql_engine: Trino
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , DATE_TRUNC('month', ds) AS metric_time__month
+    , DATE_TRUNC('year', ds) AS metric_time__year
+    , booking_value
+    , guest_id AS bookers
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__day
-  , metric_time__month
-  , metric_time__year
+  metric_time__day AS metric_time__day
+  , metric_time__month AS metric_time__month
+  , metric_time__year AS metric_time__year
   , booking_value * 0.05 / bookers AS booking_fees_last_week_per_booker_this_week
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_21.metric_time__day, subq_26.metric_time__day) AS metric_time__day
-    , COALESCE(subq_21.metric_time__month, subq_26.metric_time__month) AS metric_time__month
-    , COALESCE(subq_21.metric_time__year, subq_26.metric_time__year) AS metric_time__year
+    COALESCE(subq_21.metric_time__day, subq_25.metric_time__day) AS metric_time__day
+    , COALESCE(subq_21.metric_time__month, subq_25.metric_time__month) AS metric_time__month
+    , COALESCE(subq_21.metric_time__year, subq_25.metric_time__year) AS metric_time__year
     , MAX(subq_21.booking_value) AS booking_value
-    , MAX(subq_26.bookers) AS bookers
+    , MAX(subq_25.bookers) AS bookers
   FROM (
     -- Join to Time Spine Dataset
     -- Pass Only Elements: ['booking_value', 'metric_time__day', 'metric_time__month', 'metric_time__year']
@@ -27,44 +39,43 @@ FROM (
       subq_17.ds AS metric_time__day
       , DATE_TRUNC('month', subq_17.ds) AS metric_time__month
       , DATE_TRUNC('year', subq_17.ds) AS metric_time__year
-      , SUM(bookings_source_src_28000.booking_value) AS booking_value
+      , SUM(sma_28009_cte.booking_value) AS booking_value
     FROM ***************************.mf_time_spine subq_17
     INNER JOIN
-      ***************************.fct_bookings bookings_source_src_28000
+      sma_28009_cte sma_28009_cte
     ON
-      DATE_ADD('week', -1, subq_17.ds) = DATE_TRUNC('day', bookings_source_src_28000.ds)
+      DATE_ADD('week', -1, subq_17.ds) = sma_28009_cte.metric_time__day
     GROUP BY
       subq_17.ds
       , DATE_TRUNC('month', subq_17.ds)
       , DATE_TRUNC('year', subq_17.ds)
   ) subq_21
   FULL OUTER JOIN (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28009
     -- Pass Only Elements: ['bookers', 'metric_time__day', 'metric_time__month', 'metric_time__year']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      DATE_TRUNC('day', ds) AS metric_time__day
-      , DATE_TRUNC('month', ds) AS metric_time__month
-      , DATE_TRUNC('year', ds) AS metric_time__year
-      , COUNT(DISTINCT guest_id) AS bookers
-    FROM ***************************.fct_bookings bookings_source_src_28000
+      metric_time__day
+      , metric_time__month
+      , metric_time__year
+      , COUNT(DISTINCT bookers) AS bookers
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
-      DATE_TRUNC('day', ds)
-      , DATE_TRUNC('month', ds)
-      , DATE_TRUNC('year', ds)
-  ) subq_26
+      metric_time__day
+      , metric_time__month
+      , metric_time__year
+  ) subq_25
   ON
     (
-      subq_21.metric_time__day = subq_26.metric_time__day
+      subq_21.metric_time__day = subq_25.metric_time__day
     ) AND (
-      subq_21.metric_time__month = subq_26.metric_time__month
+      subq_21.metric_time__month = subq_25.metric_time__month
     ) AND (
-      subq_21.metric_time__year = subq_26.metric_time__year
+      subq_21.metric_time__year = subq_25.metric_time__year
     )
   GROUP BY
-    COALESCE(subq_21.metric_time__day, subq_26.metric_time__day)
-    , COALESCE(subq_21.metric_time__month, subq_26.metric_time__month)
-    , COALESCE(subq_21.metric_time__year, subq_26.metric_time__year)
-) subq_27
+    COALESCE(subq_21.metric_time__day, subq_25.metric_time__day)
+    , COALESCE(subq_21.metric_time__month, subq_25.metric_time__month)
+    , COALESCE(subq_21.metric_time__year, subq_25.metric_time__year)
+) subq_26

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_offset_window_with_agg_time_dim__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_offset_window_with_agg_time_dim__plan0_optimized.sql
@@ -3,30 +3,33 @@ test_filename: test_derived_metric_rendering.py
 sql_engine: Trino
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS booking__ds__day
+    , 1 AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  booking__ds__day
+  booking__ds__day AS booking__ds__day
   , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_18.booking__ds__day, subq_26.booking__ds__day) AS booking__ds__day
+    COALESCE(subq_18.booking__ds__day, subq_25.booking__ds__day) AS booking__ds__day
     , MAX(subq_18.bookings) AS bookings
-    , MAX(subq_26.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+    , MAX(subq_25.bookings_2_weeks_ago) AS bookings_2_weeks_ago
   FROM (
+    -- Read From CTE For node_id=sma_28009
+    -- Pass Only Elements: ['bookings', 'booking__ds__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
       booking__ds__day
       , SUM(bookings) AS bookings
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['bookings', 'booking__ds__day']
-      SELECT
-        DATE_TRUNC('day', ds) AS booking__ds__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_16
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
       booking__ds__day
   ) subq_18
@@ -36,24 +39,18 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      subq_22.ds AS booking__ds__day
-      , SUM(subq_20.bookings) AS bookings_2_weeks_ago
-    FROM ***************************.mf_time_spine subq_22
-    INNER JOIN (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATE_TRUNC('day', ds) AS booking__ds__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_20
+      subq_21.ds AS booking__ds__day
+      , SUM(sma_28009_cte.bookings) AS bookings_2_weeks_ago
+    FROM ***************************.mf_time_spine subq_21
+    INNER JOIN
+      sma_28009_cte sma_28009_cte
     ON
-      DATE_ADD('day', -14, subq_22.ds) = subq_20.booking__ds__day
+      DATE_ADD('day', -14, subq_21.ds) = sma_28009_cte.booking__ds__day
     GROUP BY
-      subq_22.ds
-  ) subq_26
+      subq_21.ds
+  ) subq_25
   ON
-    subq_18.booking__ds__day = subq_26.booking__ds__day
+    subq_18.booking__ds__day = subq_25.booking__ds__day
   GROUP BY
-    COALESCE(subq_18.booking__ds__day, subq_26.booking__ds__day)
-) subq_27
+    COALESCE(subq_18.booking__ds__day, subq_25.booking__ds__day)
+) subq_26

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/BigQuery/test_derived_fill_nulls_for_one_input_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/BigQuery/test_derived_fill_nulls_for_one_input_metric__plan0_optimized.sql
@@ -3,15 +3,24 @@ test_filename: test_fill_nulls_with_rendering.py
 sql_engine: BigQuery
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATETIME_TRUNC(ds, day) AS metric_time__day
+    , 1 AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__day
+  metric_time__day AS metric_time__day
   , bookings_fill_nulls_with_0 - bookings_2_weeks_ago AS bookings_growth_2_weeks_fill_nulls_with_0_for_non_offset
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_24.metric_time__day, subq_32.metric_time__day) AS metric_time__day
+    COALESCE(subq_24.metric_time__day, subq_31.metric_time__day) AS metric_time__day
     , COALESCE(MAX(subq_24.bookings_fill_nulls_with_0), 0) AS bookings_fill_nulls_with_0
-    , MAX(subq_32.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+    , MAX(subq_31.bookings_2_weeks_ago) AS bookings_2_weeks_ago
   FROM (
     -- Compute Metrics via Expressions
     SELECT
@@ -24,19 +33,13 @@ FROM (
         , subq_20.bookings AS bookings
       FROM ***************************.mf_time_spine subq_22
       LEFT OUTER JOIN (
+        -- Read From CTE For node_id=sma_28009
+        -- Pass Only Elements: ['bookings', 'metric_time__day']
         -- Aggregate Measures
         SELECT
           metric_time__day
           , SUM(bookings) AS bookings
-        FROM (
-          -- Read Elements From Semantic Model 'bookings_source'
-          -- Metric Time Dimension 'ds'
-          -- Pass Only Elements: ['bookings', 'metric_time__day']
-          SELECT
-            DATETIME_TRUNC(ds, day) AS metric_time__day
-            , 1 AS bookings
-          FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_19
+        FROM sma_28009_cte sma_28009_cte
         GROUP BY
           metric_time__day
       ) subq_20
@@ -50,24 +53,18 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      subq_28.ds AS metric_time__day
-      , SUM(subq_26.bookings) AS bookings_2_weeks_ago
-    FROM ***************************.mf_time_spine subq_28
-    INNER JOIN (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATETIME_TRUNC(ds, day) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_26
+      subq_27.ds AS metric_time__day
+      , SUM(sma_28009_cte.bookings) AS bookings_2_weeks_ago
+    FROM ***************************.mf_time_spine subq_27
+    INNER JOIN
+      sma_28009_cte sma_28009_cte
     ON
-      DATE_SUB(CAST(subq_28.ds AS DATETIME), INTERVAL 14 day) = subq_26.metric_time__day
+      DATE_SUB(CAST(subq_27.ds AS DATETIME), INTERVAL 14 day) = sma_28009_cte.metric_time__day
     GROUP BY
       metric_time__day
-  ) subq_32
+  ) subq_31
   ON
-    subq_24.metric_time__day = subq_32.metric_time__day
+    subq_24.metric_time__day = subq_31.metric_time__day
   GROUP BY
     metric_time__day
-) subq_33
+) subq_32

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Databricks/test_derived_fill_nulls_for_one_input_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Databricks/test_derived_fill_nulls_for_one_input_metric__plan0_optimized.sql
@@ -3,15 +3,24 @@ test_filename: test_fill_nulls_with_rendering.py
 sql_engine: Databricks
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , 1 AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__day
+  metric_time__day AS metric_time__day
   , bookings_fill_nulls_with_0 - bookings_2_weeks_ago AS bookings_growth_2_weeks_fill_nulls_with_0_for_non_offset
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_24.metric_time__day, subq_32.metric_time__day) AS metric_time__day
+    COALESCE(subq_24.metric_time__day, subq_31.metric_time__day) AS metric_time__day
     , COALESCE(MAX(subq_24.bookings_fill_nulls_with_0), 0) AS bookings_fill_nulls_with_0
-    , MAX(subq_32.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+    , MAX(subq_31.bookings_2_weeks_ago) AS bookings_2_weeks_ago
   FROM (
     -- Compute Metrics via Expressions
     SELECT
@@ -24,19 +33,13 @@ FROM (
         , subq_20.bookings AS bookings
       FROM ***************************.mf_time_spine subq_22
       LEFT OUTER JOIN (
+        -- Read From CTE For node_id=sma_28009
+        -- Pass Only Elements: ['bookings', 'metric_time__day']
         -- Aggregate Measures
         SELECT
           metric_time__day
           , SUM(bookings) AS bookings
-        FROM (
-          -- Read Elements From Semantic Model 'bookings_source'
-          -- Metric Time Dimension 'ds'
-          -- Pass Only Elements: ['bookings', 'metric_time__day']
-          SELECT
-            DATE_TRUNC('day', ds) AS metric_time__day
-            , 1 AS bookings
-          FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_19
+        FROM sma_28009_cte sma_28009_cte
         GROUP BY
           metric_time__day
       ) subq_20
@@ -50,24 +53,18 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      subq_28.ds AS metric_time__day
-      , SUM(subq_26.bookings) AS bookings_2_weeks_ago
-    FROM ***************************.mf_time_spine subq_28
-    INNER JOIN (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_26
+      subq_27.ds AS metric_time__day
+      , SUM(sma_28009_cte.bookings) AS bookings_2_weeks_ago
+    FROM ***************************.mf_time_spine subq_27
+    INNER JOIN
+      sma_28009_cte sma_28009_cte
     ON
-      DATEADD(day, -14, subq_28.ds) = subq_26.metric_time__day
+      DATEADD(day, -14, subq_27.ds) = sma_28009_cte.metric_time__day
     GROUP BY
-      subq_28.ds
-  ) subq_32
+      subq_27.ds
+  ) subq_31
   ON
-    subq_24.metric_time__day = subq_32.metric_time__day
+    subq_24.metric_time__day = subq_31.metric_time__day
   GROUP BY
-    COALESCE(subq_24.metric_time__day, subq_32.metric_time__day)
-) subq_33
+    COALESCE(subq_24.metric_time__day, subq_31.metric_time__day)
+) subq_32

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/DuckDB/test_derived_fill_nulls_for_one_input_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/DuckDB/test_derived_fill_nulls_for_one_input_metric__plan0_optimized.sql
@@ -3,15 +3,24 @@ test_filename: test_fill_nulls_with_rendering.py
 sql_engine: DuckDB
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , 1 AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__day
+  metric_time__day AS metric_time__day
   , bookings_fill_nulls_with_0 - bookings_2_weeks_ago AS bookings_growth_2_weeks_fill_nulls_with_0_for_non_offset
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_24.metric_time__day, subq_32.metric_time__day) AS metric_time__day
+    COALESCE(subq_24.metric_time__day, subq_31.metric_time__day) AS metric_time__day
     , COALESCE(MAX(subq_24.bookings_fill_nulls_with_0), 0) AS bookings_fill_nulls_with_0
-    , MAX(subq_32.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+    , MAX(subq_31.bookings_2_weeks_ago) AS bookings_2_weeks_ago
   FROM (
     -- Compute Metrics via Expressions
     SELECT
@@ -24,19 +33,13 @@ FROM (
         , subq_20.bookings AS bookings
       FROM ***************************.mf_time_spine subq_22
       LEFT OUTER JOIN (
+        -- Read From CTE For node_id=sma_28009
+        -- Pass Only Elements: ['bookings', 'metric_time__day']
         -- Aggregate Measures
         SELECT
           metric_time__day
           , SUM(bookings) AS bookings
-        FROM (
-          -- Read Elements From Semantic Model 'bookings_source'
-          -- Metric Time Dimension 'ds'
-          -- Pass Only Elements: ['bookings', 'metric_time__day']
-          SELECT
-            DATE_TRUNC('day', ds) AS metric_time__day
-            , 1 AS bookings
-          FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_19
+        FROM sma_28009_cte sma_28009_cte
         GROUP BY
           metric_time__day
       ) subq_20
@@ -50,24 +53,18 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      subq_28.ds AS metric_time__day
-      , SUM(subq_26.bookings) AS bookings_2_weeks_ago
-    FROM ***************************.mf_time_spine subq_28
-    INNER JOIN (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_26
+      subq_27.ds AS metric_time__day
+      , SUM(sma_28009_cte.bookings) AS bookings_2_weeks_ago
+    FROM ***************************.mf_time_spine subq_27
+    INNER JOIN
+      sma_28009_cte sma_28009_cte
     ON
-      subq_28.ds - INTERVAL 14 day = subq_26.metric_time__day
+      subq_27.ds - INTERVAL 14 day = sma_28009_cte.metric_time__day
     GROUP BY
-      subq_28.ds
-  ) subq_32
+      subq_27.ds
+  ) subq_31
   ON
-    subq_24.metric_time__day = subq_32.metric_time__day
+    subq_24.metric_time__day = subq_31.metric_time__day
   GROUP BY
-    COALESCE(subq_24.metric_time__day, subq_32.metric_time__day)
-) subq_33
+    COALESCE(subq_24.metric_time__day, subq_31.metric_time__day)
+) subq_32

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Postgres/test_derived_fill_nulls_for_one_input_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Postgres/test_derived_fill_nulls_for_one_input_metric__plan0_optimized.sql
@@ -3,15 +3,24 @@ test_filename: test_fill_nulls_with_rendering.py
 sql_engine: Postgres
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , 1 AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__day
+  metric_time__day AS metric_time__day
   , bookings_fill_nulls_with_0 - bookings_2_weeks_ago AS bookings_growth_2_weeks_fill_nulls_with_0_for_non_offset
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_24.metric_time__day, subq_32.metric_time__day) AS metric_time__day
+    COALESCE(subq_24.metric_time__day, subq_31.metric_time__day) AS metric_time__day
     , COALESCE(MAX(subq_24.bookings_fill_nulls_with_0), 0) AS bookings_fill_nulls_with_0
-    , MAX(subq_32.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+    , MAX(subq_31.bookings_2_weeks_ago) AS bookings_2_weeks_ago
   FROM (
     -- Compute Metrics via Expressions
     SELECT
@@ -24,19 +33,13 @@ FROM (
         , subq_20.bookings AS bookings
       FROM ***************************.mf_time_spine subq_22
       LEFT OUTER JOIN (
+        -- Read From CTE For node_id=sma_28009
+        -- Pass Only Elements: ['bookings', 'metric_time__day']
         -- Aggregate Measures
         SELECT
           metric_time__day
           , SUM(bookings) AS bookings
-        FROM (
-          -- Read Elements From Semantic Model 'bookings_source'
-          -- Metric Time Dimension 'ds'
-          -- Pass Only Elements: ['bookings', 'metric_time__day']
-          SELECT
-            DATE_TRUNC('day', ds) AS metric_time__day
-            , 1 AS bookings
-          FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_19
+        FROM sma_28009_cte sma_28009_cte
         GROUP BY
           metric_time__day
       ) subq_20
@@ -50,24 +53,18 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      subq_28.ds AS metric_time__day
-      , SUM(subq_26.bookings) AS bookings_2_weeks_ago
-    FROM ***************************.mf_time_spine subq_28
-    INNER JOIN (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_26
+      subq_27.ds AS metric_time__day
+      , SUM(sma_28009_cte.bookings) AS bookings_2_weeks_ago
+    FROM ***************************.mf_time_spine subq_27
+    INNER JOIN
+      sma_28009_cte sma_28009_cte
     ON
-      subq_28.ds - MAKE_INTERVAL(days => 14) = subq_26.metric_time__day
+      subq_27.ds - MAKE_INTERVAL(days => 14) = sma_28009_cte.metric_time__day
     GROUP BY
-      subq_28.ds
-  ) subq_32
+      subq_27.ds
+  ) subq_31
   ON
-    subq_24.metric_time__day = subq_32.metric_time__day
+    subq_24.metric_time__day = subq_31.metric_time__day
   GROUP BY
-    COALESCE(subq_24.metric_time__day, subq_32.metric_time__day)
-) subq_33
+    COALESCE(subq_24.metric_time__day, subq_31.metric_time__day)
+) subq_32

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Snowflake/test_derived_fill_nulls_for_one_input_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Snowflake/test_derived_fill_nulls_for_one_input_metric__plan0_optimized.sql
@@ -3,15 +3,24 @@ test_filename: test_fill_nulls_with_rendering.py
 sql_engine: Snowflake
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , 1 AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__day
+  metric_time__day AS metric_time__day
   , bookings_fill_nulls_with_0 - bookings_2_weeks_ago AS bookings_growth_2_weeks_fill_nulls_with_0_for_non_offset
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_24.metric_time__day, subq_32.metric_time__day) AS metric_time__day
+    COALESCE(subq_24.metric_time__day, subq_31.metric_time__day) AS metric_time__day
     , COALESCE(MAX(subq_24.bookings_fill_nulls_with_0), 0) AS bookings_fill_nulls_with_0
-    , MAX(subq_32.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+    , MAX(subq_31.bookings_2_weeks_ago) AS bookings_2_weeks_ago
   FROM (
     -- Compute Metrics via Expressions
     SELECT
@@ -24,19 +33,13 @@ FROM (
         , subq_20.bookings AS bookings
       FROM ***************************.mf_time_spine subq_22
       LEFT OUTER JOIN (
+        -- Read From CTE For node_id=sma_28009
+        -- Pass Only Elements: ['bookings', 'metric_time__day']
         -- Aggregate Measures
         SELECT
           metric_time__day
           , SUM(bookings) AS bookings
-        FROM (
-          -- Read Elements From Semantic Model 'bookings_source'
-          -- Metric Time Dimension 'ds'
-          -- Pass Only Elements: ['bookings', 'metric_time__day']
-          SELECT
-            DATE_TRUNC('day', ds) AS metric_time__day
-            , 1 AS bookings
-          FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_19
+        FROM sma_28009_cte sma_28009_cte
         GROUP BY
           metric_time__day
       ) subq_20
@@ -50,24 +53,18 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      subq_28.ds AS metric_time__day
-      , SUM(subq_26.bookings) AS bookings_2_weeks_ago
-    FROM ***************************.mf_time_spine subq_28
-    INNER JOIN (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_26
+      subq_27.ds AS metric_time__day
+      , SUM(sma_28009_cte.bookings) AS bookings_2_weeks_ago
+    FROM ***************************.mf_time_spine subq_27
+    INNER JOIN
+      sma_28009_cte sma_28009_cte
     ON
-      DATEADD(day, -14, subq_28.ds) = subq_26.metric_time__day
+      DATEADD(day, -14, subq_27.ds) = sma_28009_cte.metric_time__day
     GROUP BY
-      subq_28.ds
-  ) subq_32
+      subq_27.ds
+  ) subq_31
   ON
-    subq_24.metric_time__day = subq_32.metric_time__day
+    subq_24.metric_time__day = subq_31.metric_time__day
   GROUP BY
-    COALESCE(subq_24.metric_time__day, subq_32.metric_time__day)
-) subq_33
+    COALESCE(subq_24.metric_time__day, subq_31.metric_time__day)
+) subq_32

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Trino/test_derived_fill_nulls_for_one_input_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Trino/test_derived_fill_nulls_for_one_input_metric__plan0_optimized.sql
@@ -3,15 +3,24 @@ test_filename: test_fill_nulls_with_rendering.py
 sql_engine: Trino
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , 1 AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__day
+  metric_time__day AS metric_time__day
   , bookings_fill_nulls_with_0 - bookings_2_weeks_ago AS bookings_growth_2_weeks_fill_nulls_with_0_for_non_offset
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_24.metric_time__day, subq_32.metric_time__day) AS metric_time__day
+    COALESCE(subq_24.metric_time__day, subq_31.metric_time__day) AS metric_time__day
     , COALESCE(MAX(subq_24.bookings_fill_nulls_with_0), 0) AS bookings_fill_nulls_with_0
-    , MAX(subq_32.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+    , MAX(subq_31.bookings_2_weeks_ago) AS bookings_2_weeks_ago
   FROM (
     -- Compute Metrics via Expressions
     SELECT
@@ -24,19 +33,13 @@ FROM (
         , subq_20.bookings AS bookings
       FROM ***************************.mf_time_spine subq_22
       LEFT OUTER JOIN (
+        -- Read From CTE For node_id=sma_28009
+        -- Pass Only Elements: ['bookings', 'metric_time__day']
         -- Aggregate Measures
         SELECT
           metric_time__day
           , SUM(bookings) AS bookings
-        FROM (
-          -- Read Elements From Semantic Model 'bookings_source'
-          -- Metric Time Dimension 'ds'
-          -- Pass Only Elements: ['bookings', 'metric_time__day']
-          SELECT
-            DATE_TRUNC('day', ds) AS metric_time__day
-            , 1 AS bookings
-          FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_19
+        FROM sma_28009_cte sma_28009_cte
         GROUP BY
           metric_time__day
       ) subq_20
@@ -50,24 +53,18 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      subq_28.ds AS metric_time__day
-      , SUM(subq_26.bookings) AS bookings_2_weeks_ago
-    FROM ***************************.mf_time_spine subq_28
-    INNER JOIN (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_26
+      subq_27.ds AS metric_time__day
+      , SUM(sma_28009_cte.bookings) AS bookings_2_weeks_ago
+    FROM ***************************.mf_time_spine subq_27
+    INNER JOIN
+      sma_28009_cte sma_28009_cte
     ON
-      DATE_ADD('day', -14, subq_28.ds) = subq_26.metric_time__day
+      DATE_ADD('day', -14, subq_27.ds) = sma_28009_cte.metric_time__day
     GROUP BY
-      subq_28.ds
-  ) subq_32
+      subq_27.ds
+  ) subq_31
   ON
-    subq_24.metric_time__day = subq_32.metric_time__day
+    subq_24.metric_time__day = subq_31.metric_time__day
   GROUP BY
-    COALESCE(subq_24.metric_time__day, subq_32.metric_time__day)
-) subq_33
+    COALESCE(subq_24.metric_time__day, subq_31.metric_time__day)
+) subq_32

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/BigQuery/test_offset_window_with_date_part__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/BigQuery/test_offset_window_with_date_part__plan0_optimized.sql
@@ -3,30 +3,34 @@ test_filename: test_granularity_date_part_rendering.py
 sql_engine: BigQuery
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATETIME_TRUNC(ds, day) AS metric_time__day
+    , IF(EXTRACT(dayofweek FROM ds) = 1, 7, EXTRACT(dayofweek FROM ds) - 1) AS metric_time__extract_dow
+    , 1 AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__extract_dow
+  metric_time__extract_dow AS metric_time__extract_dow
   , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_18.metric_time__extract_dow, subq_26.metric_time__extract_dow) AS metric_time__extract_dow
+    COALESCE(subq_18.metric_time__extract_dow, subq_25.metric_time__extract_dow) AS metric_time__extract_dow
     , MAX(subq_18.bookings) AS bookings
-    , MAX(subq_26.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+    , MAX(subq_25.bookings_2_weeks_ago) AS bookings_2_weeks_ago
   FROM (
+    -- Read From CTE For node_id=sma_28009
+    -- Pass Only Elements: ['bookings', 'metric_time__extract_dow']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
       metric_time__extract_dow
       , SUM(bookings) AS bookings
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['bookings', 'metric_time__extract_dow']
-      SELECT
-        IF(EXTRACT(dayofweek FROM ds) = 1, 7, EXTRACT(dayofweek FROM ds) - 1) AS metric_time__extract_dow
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_16
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
       metric_time__extract_dow
   ) subq_18
@@ -36,24 +40,18 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      IF(EXTRACT(dayofweek FROM subq_22.ds) = 1, 7, EXTRACT(dayofweek FROM subq_22.ds) - 1) AS metric_time__extract_dow
-      , SUM(subq_20.bookings) AS bookings_2_weeks_ago
-    FROM ***************************.mf_time_spine subq_22
-    INNER JOIN (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATETIME_TRUNC(ds, day) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_20
+      IF(EXTRACT(dayofweek FROM subq_21.ds) = 1, 7, EXTRACT(dayofweek FROM subq_21.ds) - 1) AS metric_time__extract_dow
+      , SUM(sma_28009_cte.bookings) AS bookings_2_weeks_ago
+    FROM ***************************.mf_time_spine subq_21
+    INNER JOIN
+      sma_28009_cte sma_28009_cte
     ON
-      DATE_SUB(CAST(subq_22.ds AS DATETIME), INTERVAL 14 day) = subq_20.metric_time__day
+      DATE_SUB(CAST(subq_21.ds AS DATETIME), INTERVAL 14 day) = sma_28009_cte.metric_time__day
     GROUP BY
       metric_time__extract_dow
-  ) subq_26
+  ) subq_25
   ON
-    subq_18.metric_time__extract_dow = subq_26.metric_time__extract_dow
+    subq_18.metric_time__extract_dow = subq_25.metric_time__extract_dow
   GROUP BY
     metric_time__extract_dow
-) subq_27
+) subq_26

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Databricks/test_offset_window_with_date_part__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Databricks/test_offset_window_with_date_part__plan0_optimized.sql
@@ -3,30 +3,34 @@ test_filename: test_granularity_date_part_rendering.py
 sql_engine: Databricks
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , EXTRACT(DAYOFWEEK_ISO FROM ds) AS metric_time__extract_dow
+    , 1 AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__extract_dow
+  metric_time__extract_dow AS metric_time__extract_dow
   , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_18.metric_time__extract_dow, subq_26.metric_time__extract_dow) AS metric_time__extract_dow
+    COALESCE(subq_18.metric_time__extract_dow, subq_25.metric_time__extract_dow) AS metric_time__extract_dow
     , MAX(subq_18.bookings) AS bookings
-    , MAX(subq_26.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+    , MAX(subq_25.bookings_2_weeks_ago) AS bookings_2_weeks_ago
   FROM (
+    -- Read From CTE For node_id=sma_28009
+    -- Pass Only Elements: ['bookings', 'metric_time__extract_dow']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
       metric_time__extract_dow
       , SUM(bookings) AS bookings
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['bookings', 'metric_time__extract_dow']
-      SELECT
-        EXTRACT(DAYOFWEEK_ISO FROM ds) AS metric_time__extract_dow
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_16
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
       metric_time__extract_dow
   ) subq_18
@@ -36,24 +40,18 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      EXTRACT(DAYOFWEEK_ISO FROM subq_22.ds) AS metric_time__extract_dow
-      , SUM(subq_20.bookings) AS bookings_2_weeks_ago
-    FROM ***************************.mf_time_spine subq_22
-    INNER JOIN (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_20
+      EXTRACT(DAYOFWEEK_ISO FROM subq_21.ds) AS metric_time__extract_dow
+      , SUM(sma_28009_cte.bookings) AS bookings_2_weeks_ago
+    FROM ***************************.mf_time_spine subq_21
+    INNER JOIN
+      sma_28009_cte sma_28009_cte
     ON
-      DATEADD(day, -14, subq_22.ds) = subq_20.metric_time__day
+      DATEADD(day, -14, subq_21.ds) = sma_28009_cte.metric_time__day
     GROUP BY
-      EXTRACT(DAYOFWEEK_ISO FROM subq_22.ds)
-  ) subq_26
+      EXTRACT(DAYOFWEEK_ISO FROM subq_21.ds)
+  ) subq_25
   ON
-    subq_18.metric_time__extract_dow = subq_26.metric_time__extract_dow
+    subq_18.metric_time__extract_dow = subq_25.metric_time__extract_dow
   GROUP BY
-    COALESCE(subq_18.metric_time__extract_dow, subq_26.metric_time__extract_dow)
-) subq_27
+    COALESCE(subq_18.metric_time__extract_dow, subq_25.metric_time__extract_dow)
+) subq_26

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/DuckDB/test_offset_window_with_date_part__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/DuckDB/test_offset_window_with_date_part__plan0_optimized.sql
@@ -3,30 +3,34 @@ test_filename: test_granularity_date_part_rendering.py
 sql_engine: DuckDB
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , EXTRACT(isodow FROM ds) AS metric_time__extract_dow
+    , 1 AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__extract_dow
+  metric_time__extract_dow AS metric_time__extract_dow
   , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_18.metric_time__extract_dow, subq_26.metric_time__extract_dow) AS metric_time__extract_dow
+    COALESCE(subq_18.metric_time__extract_dow, subq_25.metric_time__extract_dow) AS metric_time__extract_dow
     , MAX(subq_18.bookings) AS bookings
-    , MAX(subq_26.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+    , MAX(subq_25.bookings_2_weeks_ago) AS bookings_2_weeks_ago
   FROM (
+    -- Read From CTE For node_id=sma_28009
+    -- Pass Only Elements: ['bookings', 'metric_time__extract_dow']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
       metric_time__extract_dow
       , SUM(bookings) AS bookings
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['bookings', 'metric_time__extract_dow']
-      SELECT
-        EXTRACT(isodow FROM ds) AS metric_time__extract_dow
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_16
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
       metric_time__extract_dow
   ) subq_18
@@ -36,24 +40,18 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      EXTRACT(isodow FROM subq_22.ds) AS metric_time__extract_dow
-      , SUM(subq_20.bookings) AS bookings_2_weeks_ago
-    FROM ***************************.mf_time_spine subq_22
-    INNER JOIN (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_20
+      EXTRACT(isodow FROM subq_21.ds) AS metric_time__extract_dow
+      , SUM(sma_28009_cte.bookings) AS bookings_2_weeks_ago
+    FROM ***************************.mf_time_spine subq_21
+    INNER JOIN
+      sma_28009_cte sma_28009_cte
     ON
-      subq_22.ds - INTERVAL 14 day = subq_20.metric_time__day
+      subq_21.ds - INTERVAL 14 day = sma_28009_cte.metric_time__day
     GROUP BY
-      EXTRACT(isodow FROM subq_22.ds)
-  ) subq_26
+      EXTRACT(isodow FROM subq_21.ds)
+  ) subq_25
   ON
-    subq_18.metric_time__extract_dow = subq_26.metric_time__extract_dow
+    subq_18.metric_time__extract_dow = subq_25.metric_time__extract_dow
   GROUP BY
-    COALESCE(subq_18.metric_time__extract_dow, subq_26.metric_time__extract_dow)
-) subq_27
+    COALESCE(subq_18.metric_time__extract_dow, subq_25.metric_time__extract_dow)
+) subq_26

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Postgres/test_offset_window_with_date_part__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Postgres/test_offset_window_with_date_part__plan0_optimized.sql
@@ -3,30 +3,34 @@ test_filename: test_granularity_date_part_rendering.py
 sql_engine: Postgres
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , EXTRACT(isodow FROM ds) AS metric_time__extract_dow
+    , 1 AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__extract_dow
+  metric_time__extract_dow AS metric_time__extract_dow
   , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_18.metric_time__extract_dow, subq_26.metric_time__extract_dow) AS metric_time__extract_dow
+    COALESCE(subq_18.metric_time__extract_dow, subq_25.metric_time__extract_dow) AS metric_time__extract_dow
     , MAX(subq_18.bookings) AS bookings
-    , MAX(subq_26.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+    , MAX(subq_25.bookings_2_weeks_ago) AS bookings_2_weeks_ago
   FROM (
+    -- Read From CTE For node_id=sma_28009
+    -- Pass Only Elements: ['bookings', 'metric_time__extract_dow']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
       metric_time__extract_dow
       , SUM(bookings) AS bookings
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['bookings', 'metric_time__extract_dow']
-      SELECT
-        EXTRACT(isodow FROM ds) AS metric_time__extract_dow
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_16
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
       metric_time__extract_dow
   ) subq_18
@@ -36,24 +40,18 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      EXTRACT(isodow FROM subq_22.ds) AS metric_time__extract_dow
-      , SUM(subq_20.bookings) AS bookings_2_weeks_ago
-    FROM ***************************.mf_time_spine subq_22
-    INNER JOIN (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_20
+      EXTRACT(isodow FROM subq_21.ds) AS metric_time__extract_dow
+      , SUM(sma_28009_cte.bookings) AS bookings_2_weeks_ago
+    FROM ***************************.mf_time_spine subq_21
+    INNER JOIN
+      sma_28009_cte sma_28009_cte
     ON
-      subq_22.ds - MAKE_INTERVAL(days => 14) = subq_20.metric_time__day
+      subq_21.ds - MAKE_INTERVAL(days => 14) = sma_28009_cte.metric_time__day
     GROUP BY
-      EXTRACT(isodow FROM subq_22.ds)
-  ) subq_26
+      EXTRACT(isodow FROM subq_21.ds)
+  ) subq_25
   ON
-    subq_18.metric_time__extract_dow = subq_26.metric_time__extract_dow
+    subq_18.metric_time__extract_dow = subq_25.metric_time__extract_dow
   GROUP BY
-    COALESCE(subq_18.metric_time__extract_dow, subq_26.metric_time__extract_dow)
-) subq_27
+    COALESCE(subq_18.metric_time__extract_dow, subq_25.metric_time__extract_dow)
+) subq_26

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Redshift/test_offset_window_with_date_part__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Redshift/test_offset_window_with_date_part__plan0_optimized.sql
@@ -3,30 +3,34 @@ test_filename: test_granularity_date_part_rendering.py
 sql_engine: Redshift
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , CASE WHEN EXTRACT(dow FROM ds) = 0 THEN EXTRACT(dow FROM ds) + 7 ELSE EXTRACT(dow FROM ds) END AS metric_time__extract_dow
+    , 1 AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__extract_dow
+  metric_time__extract_dow AS metric_time__extract_dow
   , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_18.metric_time__extract_dow, subq_26.metric_time__extract_dow) AS metric_time__extract_dow
+    COALESCE(subq_18.metric_time__extract_dow, subq_25.metric_time__extract_dow) AS metric_time__extract_dow
     , MAX(subq_18.bookings) AS bookings
-    , MAX(subq_26.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+    , MAX(subq_25.bookings_2_weeks_ago) AS bookings_2_weeks_ago
   FROM (
+    -- Read From CTE For node_id=sma_28009
+    -- Pass Only Elements: ['bookings', 'metric_time__extract_dow']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
       metric_time__extract_dow
       , SUM(bookings) AS bookings
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['bookings', 'metric_time__extract_dow']
-      SELECT
-        CASE WHEN EXTRACT(dow FROM ds) = 0 THEN EXTRACT(dow FROM ds) + 7 ELSE EXTRACT(dow FROM ds) END AS metric_time__extract_dow
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_16
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
       metric_time__extract_dow
   ) subq_18
@@ -36,24 +40,18 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      CASE WHEN EXTRACT(dow FROM subq_22.ds) = 0 THEN EXTRACT(dow FROM subq_22.ds) + 7 ELSE EXTRACT(dow FROM subq_22.ds) END AS metric_time__extract_dow
-      , SUM(subq_20.bookings) AS bookings_2_weeks_ago
-    FROM ***************************.mf_time_spine subq_22
-    INNER JOIN (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_20
+      CASE WHEN EXTRACT(dow FROM subq_21.ds) = 0 THEN EXTRACT(dow FROM subq_21.ds) + 7 ELSE EXTRACT(dow FROM subq_21.ds) END AS metric_time__extract_dow
+      , SUM(sma_28009_cte.bookings) AS bookings_2_weeks_ago
+    FROM ***************************.mf_time_spine subq_21
+    INNER JOIN
+      sma_28009_cte sma_28009_cte
     ON
-      DATEADD(day, -14, subq_22.ds) = subq_20.metric_time__day
+      DATEADD(day, -14, subq_21.ds) = sma_28009_cte.metric_time__day
     GROUP BY
-      CASE WHEN EXTRACT(dow FROM subq_22.ds) = 0 THEN EXTRACT(dow FROM subq_22.ds) + 7 ELSE EXTRACT(dow FROM subq_22.ds) END
-  ) subq_26
+      CASE WHEN EXTRACT(dow FROM subq_21.ds) = 0 THEN EXTRACT(dow FROM subq_21.ds) + 7 ELSE EXTRACT(dow FROM subq_21.ds) END
+  ) subq_25
   ON
-    subq_18.metric_time__extract_dow = subq_26.metric_time__extract_dow
+    subq_18.metric_time__extract_dow = subq_25.metric_time__extract_dow
   GROUP BY
-    COALESCE(subq_18.metric_time__extract_dow, subq_26.metric_time__extract_dow)
-) subq_27
+    COALESCE(subq_18.metric_time__extract_dow, subq_25.metric_time__extract_dow)
+) subq_26

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Snowflake/test_offset_window_with_date_part__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Snowflake/test_offset_window_with_date_part__plan0_optimized.sql
@@ -3,30 +3,34 @@ test_filename: test_granularity_date_part_rendering.py
 sql_engine: Snowflake
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , EXTRACT(dayofweekiso FROM ds) AS metric_time__extract_dow
+    , 1 AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__extract_dow
+  metric_time__extract_dow AS metric_time__extract_dow
   , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_18.metric_time__extract_dow, subq_26.metric_time__extract_dow) AS metric_time__extract_dow
+    COALESCE(subq_18.metric_time__extract_dow, subq_25.metric_time__extract_dow) AS metric_time__extract_dow
     , MAX(subq_18.bookings) AS bookings
-    , MAX(subq_26.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+    , MAX(subq_25.bookings_2_weeks_ago) AS bookings_2_weeks_ago
   FROM (
+    -- Read From CTE For node_id=sma_28009
+    -- Pass Only Elements: ['bookings', 'metric_time__extract_dow']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
       metric_time__extract_dow
       , SUM(bookings) AS bookings
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['bookings', 'metric_time__extract_dow']
-      SELECT
-        EXTRACT(dayofweekiso FROM ds) AS metric_time__extract_dow
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_16
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
       metric_time__extract_dow
   ) subq_18
@@ -36,24 +40,18 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      EXTRACT(dayofweekiso FROM subq_22.ds) AS metric_time__extract_dow
-      , SUM(subq_20.bookings) AS bookings_2_weeks_ago
-    FROM ***************************.mf_time_spine subq_22
-    INNER JOIN (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_20
+      EXTRACT(dayofweekiso FROM subq_21.ds) AS metric_time__extract_dow
+      , SUM(sma_28009_cte.bookings) AS bookings_2_weeks_ago
+    FROM ***************************.mf_time_spine subq_21
+    INNER JOIN
+      sma_28009_cte sma_28009_cte
     ON
-      DATEADD(day, -14, subq_22.ds) = subq_20.metric_time__day
+      DATEADD(day, -14, subq_21.ds) = sma_28009_cte.metric_time__day
     GROUP BY
-      EXTRACT(dayofweekiso FROM subq_22.ds)
-  ) subq_26
+      EXTRACT(dayofweekiso FROM subq_21.ds)
+  ) subq_25
   ON
-    subq_18.metric_time__extract_dow = subq_26.metric_time__extract_dow
+    subq_18.metric_time__extract_dow = subq_25.metric_time__extract_dow
   GROUP BY
-    COALESCE(subq_18.metric_time__extract_dow, subq_26.metric_time__extract_dow)
-) subq_27
+    COALESCE(subq_18.metric_time__extract_dow, subq_25.metric_time__extract_dow)
+) subq_26

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Trino/test_offset_window_with_date_part__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Trino/test_offset_window_with_date_part__plan0_optimized.sql
@@ -3,30 +3,34 @@ test_filename: test_granularity_date_part_rendering.py
 sql_engine: Trino
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , EXTRACT(DAY_OF_WEEK FROM ds) AS metric_time__extract_dow
+    , 1 AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__extract_dow
+  metric_time__extract_dow AS metric_time__extract_dow
   , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_18.metric_time__extract_dow, subq_26.metric_time__extract_dow) AS metric_time__extract_dow
+    COALESCE(subq_18.metric_time__extract_dow, subq_25.metric_time__extract_dow) AS metric_time__extract_dow
     , MAX(subq_18.bookings) AS bookings
-    , MAX(subq_26.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+    , MAX(subq_25.bookings_2_weeks_ago) AS bookings_2_weeks_ago
   FROM (
+    -- Read From CTE For node_id=sma_28009
+    -- Pass Only Elements: ['bookings', 'metric_time__extract_dow']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
       metric_time__extract_dow
       , SUM(bookings) AS bookings
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['bookings', 'metric_time__extract_dow']
-      SELECT
-        EXTRACT(DAY_OF_WEEK FROM ds) AS metric_time__extract_dow
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_16
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
       metric_time__extract_dow
   ) subq_18
@@ -36,24 +40,18 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      EXTRACT(DAY_OF_WEEK FROM subq_22.ds) AS metric_time__extract_dow
-      , SUM(subq_20.bookings) AS bookings_2_weeks_ago
-    FROM ***************************.mf_time_spine subq_22
-    INNER JOIN (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_20
+      EXTRACT(DAY_OF_WEEK FROM subq_21.ds) AS metric_time__extract_dow
+      , SUM(sma_28009_cte.bookings) AS bookings_2_weeks_ago
+    FROM ***************************.mf_time_spine subq_21
+    INNER JOIN
+      sma_28009_cte sma_28009_cte
     ON
-      DATE_ADD('day', -14, subq_22.ds) = subq_20.metric_time__day
+      DATE_ADD('day', -14, subq_21.ds) = sma_28009_cte.metric_time__day
     GROUP BY
-      EXTRACT(DAY_OF_WEEK FROM subq_22.ds)
-  ) subq_26
+      EXTRACT(DAY_OF_WEEK FROM subq_21.ds)
+  ) subq_25
   ON
-    subq_18.metric_time__extract_dow = subq_26.metric_time__extract_dow
+    subq_18.metric_time__extract_dow = subq_25.metric_time__extract_dow
   GROUP BY
-    COALESCE(subq_18.metric_time__extract_dow, subq_26.metric_time__extract_dow)
-) subq_27
+    COALESCE(subq_18.metric_time__extract_dow, subq_25.metric_time__extract_dow)
+) subq_26

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0_optimized.sql
@@ -8,36 +8,45 @@ sql_engine: BigQuery
 -- Pass Only Elements: ['bookers',]
 -- Aggregate Measures
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    guest_id AS guest
+    , booking_value
+    , guest_id AS bookers
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
   COUNT(DISTINCT bookers) AS bookers
 FROM (
   -- Join Standard Outputs
   SELECT
-    subq_19.guest__booking_value AS guest__booking_value
+    subq_18.guest__booking_value AS guest__booking_value
     , subq_13.bookers AS bookers
   FROM (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28009
     SELECT
-      guest_id AS guest
-      , guest_id AS bookers
-    FROM ***************************.fct_bookings bookings_source_src_28000
+      guest
+      , booking_value
+      , bookers
+    FROM sma_28009_cte sma_28009_cte
   ) subq_13
   LEFT OUTER JOIN (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28009
     -- Pass Only Elements: ['booking_value', 'guest']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     -- Pass Only Elements: ['guest', 'guest__booking_value']
     SELECT
-      guest_id AS guest
+      guest
       , SUM(booking_value) AS guest__booking_value
-    FROM ***************************.fct_bookings bookings_source_src_28000
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
       guest
-  ) subq_19
+  ) subq_18
   ON
-    subq_13.guest = subq_19.guest
-) subq_20
+    subq_13.guest = subq_18.guest
+) subq_19
 WHERE guest__booking_value > 1.00

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_filter_with_conversion_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_filter_with_conversion_metric__plan0_optimized.sql
@@ -6,12 +6,22 @@ sql_engine: BigQuery
 -- Pass Only Elements: ['listings',]
 -- Aggregate Measures
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATETIME_TRUNC(ds, day) AS metric_time__day
+    , user_id AS user
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
   SUM(listings) AS listings
 FROM (
   -- Join Standard Outputs
   SELECT
-    CAST(subq_39.buys AS FLOAT64) / CAST(NULLIF(subq_39.visits, 0) AS FLOAT64) AS user__visit_buy_conversion_rate
+    CAST(subq_38.buys AS FLOAT64) / CAST(NULLIF(subq_38.visits, 0) AS FLOAT64) AS user__visit_buy_conversion_rate
     , subq_24.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
@@ -24,23 +34,17 @@ FROM (
   LEFT OUTER JOIN (
     -- Combine Aggregated Outputs
     SELECT
-      COALESCE(subq_28.user, subq_38.user) AS user
+      COALESCE(subq_28.user, subq_37.user) AS user
       , MAX(subq_28.visits) AS visits
-      , MAX(subq_38.buys) AS buys
+      , MAX(subq_37.buys) AS buys
     FROM (
+      -- Read From CTE For node_id=sma_28019
+      -- Pass Only Elements: ['visits', 'user']
       -- Aggregate Measures
       SELECT
-        subq_27.user
+        sma_28019_cte.user
         , SUM(visits) AS visits
-      FROM (
-        -- Read Elements From Semantic Model 'visits_source'
-        -- Metric Time Dimension 'ds'
-        -- Pass Only Elements: ['visits', 'user']
-        SELECT
-          user_id AS user
-          , 1 AS visits
-        FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_27
+      FROM sma_28019_cte sma_28019_cte
       GROUP BY
         user
     ) subq_28
@@ -49,47 +53,38 @@ FROM (
       -- Pass Only Elements: ['buys', 'user']
       -- Aggregate Measures
       SELECT
-        subq_35.user
+        subq_34.user
         , SUM(buys) AS buys
       FROM (
         -- Dedupe the fanout with mf_internal_uuid in the conversion data set
         SELECT DISTINCT
-          FIRST_VALUE(subq_31.visits) OVER (
+          FIRST_VALUE(sma_28019_cte.visits) OVER (
             PARTITION BY
-              subq_34.user
-              , subq_34.metric_time__day
-              , subq_34.mf_internal_uuid
-            ORDER BY subq_31.metric_time__day DESC
+              subq_33.user
+              , subq_33.metric_time__day
+              , subq_33.mf_internal_uuid
+            ORDER BY sma_28019_cte.metric_time__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS visits
-          , FIRST_VALUE(subq_31.metric_time__day) OVER (
+          , FIRST_VALUE(sma_28019_cte.metric_time__day) OVER (
             PARTITION BY
-              subq_34.user
-              , subq_34.metric_time__day
-              , subq_34.mf_internal_uuid
-            ORDER BY subq_31.metric_time__day DESC
+              subq_33.user
+              , subq_33.metric_time__day
+              , subq_33.mf_internal_uuid
+            ORDER BY sma_28019_cte.metric_time__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS metric_time__day
-          , FIRST_VALUE(subq_31.user) OVER (
+          , FIRST_VALUE(sma_28019_cte.user) OVER (
             PARTITION BY
-              subq_34.user
-              , subq_34.metric_time__day
-              , subq_34.mf_internal_uuid
-            ORDER BY subq_31.metric_time__day DESC
+              subq_33.user
+              , subq_33.metric_time__day
+              , subq_33.mf_internal_uuid
+            ORDER BY sma_28019_cte.metric_time__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS user
-          , subq_34.mf_internal_uuid AS mf_internal_uuid
-          , subq_34.buys AS buys
-        FROM (
-          -- Read Elements From Semantic Model 'visits_source'
-          -- Metric Time Dimension 'ds'
-          -- Pass Only Elements: ['visits', 'metric_time__day', 'user']
-          SELECT
-            DATETIME_TRUNC(ds, day) AS metric_time__day
-            , user_id AS user
-            , 1 AS visits
-          FROM ***************************.fct_visits visits_source_src_28000
-        ) subq_31
+          , subq_33.mf_internal_uuid AS mf_internal_uuid
+          , subq_33.buys AS buys
+        FROM sma_28019_cte sma_28019_cte
         INNER JOIN (
           -- Read Elements From Semantic Model 'buys_source'
           -- Metric Time Dimension 'ds'
@@ -100,23 +95,23 @@ FROM (
             , 1 AS buys
             , GENERATE_UUID() AS mf_internal_uuid
           FROM ***************************.fct_buys buys_source_src_28000
-        ) subq_34
+        ) subq_33
         ON
           (
-            subq_31.user = subq_34.user
+            sma_28019_cte.user = subq_33.user
           ) AND (
-            (subq_31.metric_time__day <= subq_34.metric_time__day)
+            (sma_28019_cte.metric_time__day <= subq_33.metric_time__day)
           )
-      ) subq_35
+      ) subq_34
       GROUP BY
         user
-    ) subq_38
+    ) subq_37
     ON
-      subq_28.user = subq_38.user
+      subq_28.user = subq_37.user
     GROUP BY
       user
-  ) subq_39
+  ) subq_38
   ON
-    subq_24.user = subq_39.user
-) subq_42
+    subq_24.user = subq_38.user
+) subq_41
 WHERE user__visit_buy_conversion_rate > 2

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_group_by_has_local_entity_prefix__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_group_by_has_local_entity_prefix__plan0_optimized.sql
@@ -6,21 +6,24 @@ sql_engine: BigQuery
 -- Pass Only Elements: ['listings',]
 -- Aggregate Measures
 -- Compute Metrics via Expressions
+WITH sma_28014_cte AS (
+  -- Read Elements From Semantic Model 'listings_latest'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    listing_id AS listing
+    , user_id AS user
+    , 1 AS listings
+  FROM ***************************.dim_listings_latest listings_latest_src_28000
+)
+
 SELECT
   SUM(listings) AS listings
 FROM (
   -- Join Standard Outputs
   SELECT
-    subq_27.listing__user__average_booking_value AS user__listing__user__average_booking_value
-    , subq_17.listings AS listings
-  FROM (
-    -- Read Elements From Semantic Model 'listings_latest'
-    -- Metric Time Dimension 'ds'
-    SELECT
-      user_id AS user
-      , 1 AS listings
-    FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_17
+    subq_26.listing__user__average_booking_value AS user__listing__user__average_booking_value
+    , sma_28014_cte.listings AS listings
+  FROM sma_28014_cte sma_28014_cte
   LEFT OUTER JOIN (
     -- Join Standard Outputs
     -- Pass Only Elements: ['average_booking_value', 'listing__user']
@@ -28,17 +31,17 @@ FROM (
     -- Compute Metrics via Expressions
     -- Pass Only Elements: ['listing__user', 'listing__user__average_booking_value']
     SELECT
-      listings_latest_src_28000.user_id AS listing__user
+      sma_28014_cte.user AS listing__user
       , AVG(bookings_source_src_28000.booking_value) AS listing__user__average_booking_value
     FROM ***************************.fct_bookings bookings_source_src_28000
     LEFT OUTER JOIN
-      ***************************.dim_listings_latest listings_latest_src_28000
+      sma_28014_cte sma_28014_cte
     ON
-      bookings_source_src_28000.listing_id = listings_latest_src_28000.listing_id
+      bookings_source_src_28000.listing_id = sma_28014_cte.listing
     GROUP BY
       listing__user
-  ) subq_27
+  ) subq_26
   ON
-    subq_17.user = subq_27.listing__user
-) subq_28
+    sma_28014_cte.user = subq_26.listing__user
+) subq_27
 WHERE user__listing__user__average_booking_value > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_metric_filtered_by_itself__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_metric_filtered_by_itself__plan0_optimized.sql
@@ -8,36 +8,43 @@ sql_engine: BigQuery
 -- Pass Only Elements: ['bookers',]
 -- Aggregate Measures
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    listing_id AS listing
+    , guest_id AS bookers
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
   COUNT(DISTINCT bookers) AS bookers
 FROM (
   -- Join Standard Outputs
   SELECT
-    subq_19.listing__bookers AS listing__bookers
+    subq_18.listing__bookers AS listing__bookers
     , subq_13.bookers AS bookers
   FROM (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28009
     SELECT
-      listing_id AS listing
-      , guest_id AS bookers
-    FROM ***************************.fct_bookings bookings_source_src_28000
+      listing
+      , bookers
+    FROM sma_28009_cte sma_28009_cte
   ) subq_13
   LEFT OUTER JOIN (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28009
     -- Pass Only Elements: ['bookers', 'listing']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     -- Pass Only Elements: ['listing', 'listing__bookers']
     SELECT
-      listing_id AS listing
-      , COUNT(DISTINCT guest_id) AS listing__bookers
-    FROM ***************************.fct_bookings bookings_source_src_28000
+      listing
+      , COUNT(DISTINCT bookers) AS listing__bookers
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
       listing
-  ) subq_19
+  ) subq_18
   ON
-    subq_13.listing = subq_19.listing
-) subq_20
+    subq_13.listing = subq_18.listing
+) subq_19
 WHERE listing__bookers > 1.00

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0_optimized.sql
@@ -8,36 +8,45 @@ sql_engine: Databricks
 -- Pass Only Elements: ['bookers',]
 -- Aggregate Measures
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    guest_id AS guest
+    , booking_value
+    , guest_id AS bookers
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
   COUNT(DISTINCT bookers) AS bookers
 FROM (
   -- Join Standard Outputs
   SELECT
-    subq_19.guest__booking_value AS guest__booking_value
+    subq_18.guest__booking_value AS guest__booking_value
     , subq_13.bookers AS bookers
   FROM (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28009
     SELECT
-      guest_id AS guest
-      , guest_id AS bookers
-    FROM ***************************.fct_bookings bookings_source_src_28000
+      guest
+      , booking_value
+      , bookers
+    FROM sma_28009_cte sma_28009_cte
   ) subq_13
   LEFT OUTER JOIN (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28009
     -- Pass Only Elements: ['booking_value', 'guest']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     -- Pass Only Elements: ['guest', 'guest__booking_value']
     SELECT
-      guest_id AS guest
+      guest
       , SUM(booking_value) AS guest__booking_value
-    FROM ***************************.fct_bookings bookings_source_src_28000
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
-      guest_id
-  ) subq_19
+      guest
+  ) subq_18
   ON
-    subq_13.guest = subq_19.guest
-) subq_20
+    subq_13.guest = subq_18.guest
+) subq_19
 WHERE guest__booking_value > 1.00

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_filter_with_conversion_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_filter_with_conversion_metric__plan0_optimized.sql
@@ -6,12 +6,22 @@ sql_engine: Databricks
 -- Pass Only Elements: ['listings',]
 -- Aggregate Measures
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
   SUM(listings) AS listings
 FROM (
   -- Join Standard Outputs
   SELECT
-    CAST(subq_39.buys AS DOUBLE) / CAST(NULLIF(subq_39.visits, 0) AS DOUBLE) AS user__visit_buy_conversion_rate
+    CAST(subq_38.buys AS DOUBLE) / CAST(NULLIF(subq_38.visits, 0) AS DOUBLE) AS user__visit_buy_conversion_rate
     , subq_24.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
@@ -24,72 +34,57 @@ FROM (
   LEFT OUTER JOIN (
     -- Combine Aggregated Outputs
     SELECT
-      COALESCE(subq_28.user, subq_38.user) AS user
+      COALESCE(subq_28.user, subq_37.user) AS user
       , MAX(subq_28.visits) AS visits
-      , MAX(subq_38.buys) AS buys
+      , MAX(subq_37.buys) AS buys
     FROM (
+      -- Read From CTE For node_id=sma_28019
+      -- Pass Only Elements: ['visits', 'user']
       -- Aggregate Measures
       SELECT
-        subq_27.user
+        sma_28019_cte.user
         , SUM(visits) AS visits
-      FROM (
-        -- Read Elements From Semantic Model 'visits_source'
-        -- Metric Time Dimension 'ds'
-        -- Pass Only Elements: ['visits', 'user']
-        SELECT
-          user_id AS user
-          , 1 AS visits
-        FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_27
+      FROM sma_28019_cte sma_28019_cte
       GROUP BY
-        subq_27.user
+        sma_28019_cte.user
     ) subq_28
     FULL OUTER JOIN (
       -- Find conversions for user within the range of INF
       -- Pass Only Elements: ['buys', 'user']
       -- Aggregate Measures
       SELECT
-        subq_35.user
+        subq_34.user
         , SUM(buys) AS buys
       FROM (
         -- Dedupe the fanout with mf_internal_uuid in the conversion data set
         SELECT DISTINCT
-          FIRST_VALUE(subq_31.visits) OVER (
+          FIRST_VALUE(sma_28019_cte.visits) OVER (
             PARTITION BY
-              subq_34.user
-              , subq_34.metric_time__day
-              , subq_34.mf_internal_uuid
-            ORDER BY subq_31.metric_time__day DESC
+              subq_33.user
+              , subq_33.metric_time__day
+              , subq_33.mf_internal_uuid
+            ORDER BY sma_28019_cte.metric_time__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS visits
-          , FIRST_VALUE(subq_31.metric_time__day) OVER (
+          , FIRST_VALUE(sma_28019_cte.metric_time__day) OVER (
             PARTITION BY
-              subq_34.user
-              , subq_34.metric_time__day
-              , subq_34.mf_internal_uuid
-            ORDER BY subq_31.metric_time__day DESC
+              subq_33.user
+              , subq_33.metric_time__day
+              , subq_33.mf_internal_uuid
+            ORDER BY sma_28019_cte.metric_time__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS metric_time__day
-          , FIRST_VALUE(subq_31.user) OVER (
+          , FIRST_VALUE(sma_28019_cte.user) OVER (
             PARTITION BY
-              subq_34.user
-              , subq_34.metric_time__day
-              , subq_34.mf_internal_uuid
-            ORDER BY subq_31.metric_time__day DESC
+              subq_33.user
+              , subq_33.metric_time__day
+              , subq_33.mf_internal_uuid
+            ORDER BY sma_28019_cte.metric_time__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS user
-          , subq_34.mf_internal_uuid AS mf_internal_uuid
-          , subq_34.buys AS buys
-        FROM (
-          -- Read Elements From Semantic Model 'visits_source'
-          -- Metric Time Dimension 'ds'
-          -- Pass Only Elements: ['visits', 'metric_time__day', 'user']
-          SELECT
-            DATE_TRUNC('day', ds) AS metric_time__day
-            , user_id AS user
-            , 1 AS visits
-          FROM ***************************.fct_visits visits_source_src_28000
-        ) subq_31
+          , subq_33.mf_internal_uuid AS mf_internal_uuid
+          , subq_33.buys AS buys
+        FROM sma_28019_cte sma_28019_cte
         INNER JOIN (
           -- Read Elements From Semantic Model 'buys_source'
           -- Metric Time Dimension 'ds'
@@ -100,23 +95,23 @@ FROM (
             , 1 AS buys
             , UUID() AS mf_internal_uuid
           FROM ***************************.fct_buys buys_source_src_28000
-        ) subq_34
+        ) subq_33
         ON
           (
-            subq_31.user = subq_34.user
+            sma_28019_cte.user = subq_33.user
           ) AND (
-            (subq_31.metric_time__day <= subq_34.metric_time__day)
+            (sma_28019_cte.metric_time__day <= subq_33.metric_time__day)
           )
-      ) subq_35
+      ) subq_34
       GROUP BY
-        subq_35.user
-    ) subq_38
+        subq_34.user
+    ) subq_37
     ON
-      subq_28.user = subq_38.user
+      subq_28.user = subq_37.user
     GROUP BY
-      COALESCE(subq_28.user, subq_38.user)
-  ) subq_39
+      COALESCE(subq_28.user, subq_37.user)
+  ) subq_38
   ON
-    subq_24.user = subq_39.user
-) subq_42
+    subq_24.user = subq_38.user
+) subq_41
 WHERE user__visit_buy_conversion_rate > 2

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_group_by_has_local_entity_prefix__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_group_by_has_local_entity_prefix__plan0_optimized.sql
@@ -6,21 +6,24 @@ sql_engine: Databricks
 -- Pass Only Elements: ['listings',]
 -- Aggregate Measures
 -- Compute Metrics via Expressions
+WITH sma_28014_cte AS (
+  -- Read Elements From Semantic Model 'listings_latest'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    listing_id AS listing
+    , user_id AS user
+    , 1 AS listings
+  FROM ***************************.dim_listings_latest listings_latest_src_28000
+)
+
 SELECT
   SUM(listings) AS listings
 FROM (
   -- Join Standard Outputs
   SELECT
-    subq_27.listing__user__average_booking_value AS user__listing__user__average_booking_value
-    , subq_17.listings AS listings
-  FROM (
-    -- Read Elements From Semantic Model 'listings_latest'
-    -- Metric Time Dimension 'ds'
-    SELECT
-      user_id AS user
-      , 1 AS listings
-    FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_17
+    subq_26.listing__user__average_booking_value AS user__listing__user__average_booking_value
+    , sma_28014_cte.listings AS listings
+  FROM sma_28014_cte sma_28014_cte
   LEFT OUTER JOIN (
     -- Join Standard Outputs
     -- Pass Only Elements: ['average_booking_value', 'listing__user']
@@ -28,17 +31,17 @@ FROM (
     -- Compute Metrics via Expressions
     -- Pass Only Elements: ['listing__user', 'listing__user__average_booking_value']
     SELECT
-      listings_latest_src_28000.user_id AS listing__user
+      sma_28014_cte.user AS listing__user
       , AVG(bookings_source_src_28000.booking_value) AS listing__user__average_booking_value
     FROM ***************************.fct_bookings bookings_source_src_28000
     LEFT OUTER JOIN
-      ***************************.dim_listings_latest listings_latest_src_28000
+      sma_28014_cte sma_28014_cte
     ON
-      bookings_source_src_28000.listing_id = listings_latest_src_28000.listing_id
+      bookings_source_src_28000.listing_id = sma_28014_cte.listing
     GROUP BY
-      listings_latest_src_28000.user_id
-  ) subq_27
+      sma_28014_cte.user
+  ) subq_26
   ON
-    subq_17.user = subq_27.listing__user
-) subq_28
+    sma_28014_cte.user = subq_26.listing__user
+) subq_27
 WHERE user__listing__user__average_booking_value > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_metric_filtered_by_itself__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_metric_filtered_by_itself__plan0_optimized.sql
@@ -8,36 +8,43 @@ sql_engine: Databricks
 -- Pass Only Elements: ['bookers',]
 -- Aggregate Measures
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    listing_id AS listing
+    , guest_id AS bookers
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
   COUNT(DISTINCT bookers) AS bookers
 FROM (
   -- Join Standard Outputs
   SELECT
-    subq_19.listing__bookers AS listing__bookers
+    subq_18.listing__bookers AS listing__bookers
     , subq_13.bookers AS bookers
   FROM (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28009
     SELECT
-      listing_id AS listing
-      , guest_id AS bookers
-    FROM ***************************.fct_bookings bookings_source_src_28000
+      listing
+      , bookers
+    FROM sma_28009_cte sma_28009_cte
   ) subq_13
   LEFT OUTER JOIN (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28009
     -- Pass Only Elements: ['bookers', 'listing']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     -- Pass Only Elements: ['listing', 'listing__bookers']
     SELECT
-      listing_id AS listing
-      , COUNT(DISTINCT guest_id) AS listing__bookers
-    FROM ***************************.fct_bookings bookings_source_src_28000
+      listing
+      , COUNT(DISTINCT bookers) AS listing__bookers
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
-      listing_id
-  ) subq_19
+      listing
+  ) subq_18
   ON
-    subq_13.listing = subq_19.listing
-) subq_20
+    subq_13.listing = subq_18.listing
+) subq_19
 WHERE listing__bookers > 1.00

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_query_with_multiple_metrics_in_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_query_with_multiple_metrics_in_filter__plan0_optimized.sql
@@ -8,13 +8,23 @@ sql_engine: Databricks
 -- Pass Only Elements: ['listings',]
 -- Aggregate Measures
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    listing_id AS listing
+    , 1 AS bookings
+    , guest_id AS bookers
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
   SUM(listings) AS listings
 FROM (
   -- Join Standard Outputs
   SELECT
     subq_25.listing__bookings AS listing__bookings
-    , subq_31.listing__bookers AS listing__bookers
+    , subq_30.listing__bookers AS listing__bookers
     , subq_19.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
@@ -25,41 +35,34 @@ FROM (
     FROM ***************************.dim_listings_latest listings_latest_src_28000
   ) subq_19
   LEFT OUTER JOIN (
+    -- Read From CTE For node_id=sma_28009
+    -- Pass Only Elements: ['bookings', 'listing']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     -- Pass Only Elements: ['listing', 'listing__bookings']
     SELECT
       listing
       , SUM(bookings) AS listing__bookings
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['bookings', 'listing']
-      SELECT
-        listing_id AS listing
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_22
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
       listing
   ) subq_25
   ON
     subq_19.listing = subq_25.listing
   LEFT OUTER JOIN (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28009
     -- Pass Only Elements: ['bookers', 'listing']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     -- Pass Only Elements: ['listing', 'listing__bookers']
     SELECT
-      listing_id AS listing
-      , COUNT(DISTINCT guest_id) AS listing__bookers
-    FROM ***************************.fct_bookings bookings_source_src_28000
+      listing
+      , COUNT(DISTINCT bookers) AS listing__bookers
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
-      listing_id
-  ) subq_31
+      listing
+  ) subq_30
   ON
-    subq_19.listing = subq_31.listing
-) subq_32
+    subq_19.listing = subq_30.listing
+) subq_31
 WHERE listing__bookings > 2 AND listing__bookers > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0_optimized.sql
@@ -8,36 +8,45 @@ sql_engine: DuckDB
 -- Pass Only Elements: ['bookers',]
 -- Aggregate Measures
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    guest_id AS guest
+    , booking_value
+    , guest_id AS bookers
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
   COUNT(DISTINCT bookers) AS bookers
 FROM (
   -- Join Standard Outputs
   SELECT
-    subq_19.guest__booking_value AS guest__booking_value
+    subq_18.guest__booking_value AS guest__booking_value
     , subq_13.bookers AS bookers
   FROM (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28009
     SELECT
-      guest_id AS guest
-      , guest_id AS bookers
-    FROM ***************************.fct_bookings bookings_source_src_28000
+      guest
+      , booking_value
+      , bookers
+    FROM sma_28009_cte sma_28009_cte
   ) subq_13
   LEFT OUTER JOIN (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28009
     -- Pass Only Elements: ['booking_value', 'guest']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     -- Pass Only Elements: ['guest', 'guest__booking_value']
     SELECT
-      guest_id AS guest
+      guest
       , SUM(booking_value) AS guest__booking_value
-    FROM ***************************.fct_bookings bookings_source_src_28000
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
-      guest_id
-  ) subq_19
+      guest
+  ) subq_18
   ON
-    subq_13.guest = subq_19.guest
-) subq_20
+    subq_13.guest = subq_18.guest
+) subq_19
 WHERE guest__booking_value > 1.00

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_filter_with_conversion_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_filter_with_conversion_metric__plan0_optimized.sql
@@ -6,12 +6,22 @@ sql_engine: DuckDB
 -- Pass Only Elements: ['listings',]
 -- Aggregate Measures
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
   SUM(listings) AS listings
 FROM (
   -- Join Standard Outputs
   SELECT
-    CAST(subq_39.buys AS DOUBLE) / CAST(NULLIF(subq_39.visits, 0) AS DOUBLE) AS user__visit_buy_conversion_rate
+    CAST(subq_38.buys AS DOUBLE) / CAST(NULLIF(subq_38.visits, 0) AS DOUBLE) AS user__visit_buy_conversion_rate
     , subq_24.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
@@ -24,72 +34,57 @@ FROM (
   LEFT OUTER JOIN (
     -- Combine Aggregated Outputs
     SELECT
-      COALESCE(subq_28.user, subq_38.user) AS user
+      COALESCE(subq_28.user, subq_37.user) AS user
       , MAX(subq_28.visits) AS visits
-      , MAX(subq_38.buys) AS buys
+      , MAX(subq_37.buys) AS buys
     FROM (
+      -- Read From CTE For node_id=sma_28019
+      -- Pass Only Elements: ['visits', 'user']
       -- Aggregate Measures
       SELECT
-        subq_27.user
+        sma_28019_cte.user
         , SUM(visits) AS visits
-      FROM (
-        -- Read Elements From Semantic Model 'visits_source'
-        -- Metric Time Dimension 'ds'
-        -- Pass Only Elements: ['visits', 'user']
-        SELECT
-          user_id AS user
-          , 1 AS visits
-        FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_27
+      FROM sma_28019_cte sma_28019_cte
       GROUP BY
-        subq_27.user
+        sma_28019_cte.user
     ) subq_28
     FULL OUTER JOIN (
       -- Find conversions for user within the range of INF
       -- Pass Only Elements: ['buys', 'user']
       -- Aggregate Measures
       SELECT
-        subq_35.user
+        subq_34.user
         , SUM(buys) AS buys
       FROM (
         -- Dedupe the fanout with mf_internal_uuid in the conversion data set
         SELECT DISTINCT
-          FIRST_VALUE(subq_31.visits) OVER (
+          FIRST_VALUE(sma_28019_cte.visits) OVER (
             PARTITION BY
-              subq_34.user
-              , subq_34.metric_time__day
-              , subq_34.mf_internal_uuid
-            ORDER BY subq_31.metric_time__day DESC
+              subq_33.user
+              , subq_33.metric_time__day
+              , subq_33.mf_internal_uuid
+            ORDER BY sma_28019_cte.metric_time__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS visits
-          , FIRST_VALUE(subq_31.metric_time__day) OVER (
+          , FIRST_VALUE(sma_28019_cte.metric_time__day) OVER (
             PARTITION BY
-              subq_34.user
-              , subq_34.metric_time__day
-              , subq_34.mf_internal_uuid
-            ORDER BY subq_31.metric_time__day DESC
+              subq_33.user
+              , subq_33.metric_time__day
+              , subq_33.mf_internal_uuid
+            ORDER BY sma_28019_cte.metric_time__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS metric_time__day
-          , FIRST_VALUE(subq_31.user) OVER (
+          , FIRST_VALUE(sma_28019_cte.user) OVER (
             PARTITION BY
-              subq_34.user
-              , subq_34.metric_time__day
-              , subq_34.mf_internal_uuid
-            ORDER BY subq_31.metric_time__day DESC
+              subq_33.user
+              , subq_33.metric_time__day
+              , subq_33.mf_internal_uuid
+            ORDER BY sma_28019_cte.metric_time__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS user
-          , subq_34.mf_internal_uuid AS mf_internal_uuid
-          , subq_34.buys AS buys
-        FROM (
-          -- Read Elements From Semantic Model 'visits_source'
-          -- Metric Time Dimension 'ds'
-          -- Pass Only Elements: ['visits', 'metric_time__day', 'user']
-          SELECT
-            DATE_TRUNC('day', ds) AS metric_time__day
-            , user_id AS user
-            , 1 AS visits
-          FROM ***************************.fct_visits visits_source_src_28000
-        ) subq_31
+          , subq_33.mf_internal_uuid AS mf_internal_uuid
+          , subq_33.buys AS buys
+        FROM sma_28019_cte sma_28019_cte
         INNER JOIN (
           -- Read Elements From Semantic Model 'buys_source'
           -- Metric Time Dimension 'ds'
@@ -100,23 +95,23 @@ FROM (
             , 1 AS buys
             , GEN_RANDOM_UUID() AS mf_internal_uuid
           FROM ***************************.fct_buys buys_source_src_28000
-        ) subq_34
+        ) subq_33
         ON
           (
-            subq_31.user = subq_34.user
+            sma_28019_cte.user = subq_33.user
           ) AND (
-            (subq_31.metric_time__day <= subq_34.metric_time__day)
+            (sma_28019_cte.metric_time__day <= subq_33.metric_time__day)
           )
-      ) subq_35
+      ) subq_34
       GROUP BY
-        subq_35.user
-    ) subq_38
+        subq_34.user
+    ) subq_37
     ON
-      subq_28.user = subq_38.user
+      subq_28.user = subq_37.user
     GROUP BY
-      COALESCE(subq_28.user, subq_38.user)
-  ) subq_39
+      COALESCE(subq_28.user, subq_37.user)
+  ) subq_38
   ON
-    subq_24.user = subq_39.user
-) subq_42
+    subq_24.user = subq_38.user
+) subq_41
 WHERE user__visit_buy_conversion_rate > 2

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_group_by_has_local_entity_prefix__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_group_by_has_local_entity_prefix__plan0_optimized.sql
@@ -6,21 +6,24 @@ sql_engine: DuckDB
 -- Pass Only Elements: ['listings',]
 -- Aggregate Measures
 -- Compute Metrics via Expressions
+WITH sma_28014_cte AS (
+  -- Read Elements From Semantic Model 'listings_latest'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    listing_id AS listing
+    , user_id AS user
+    , 1 AS listings
+  FROM ***************************.dim_listings_latest listings_latest_src_28000
+)
+
 SELECT
   SUM(listings) AS listings
 FROM (
   -- Join Standard Outputs
   SELECT
-    subq_27.listing__user__average_booking_value AS user__listing__user__average_booking_value
-    , subq_17.listings AS listings
-  FROM (
-    -- Read Elements From Semantic Model 'listings_latest'
-    -- Metric Time Dimension 'ds'
-    SELECT
-      user_id AS user
-      , 1 AS listings
-    FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_17
+    subq_26.listing__user__average_booking_value AS user__listing__user__average_booking_value
+    , sma_28014_cte.listings AS listings
+  FROM sma_28014_cte sma_28014_cte
   LEFT OUTER JOIN (
     -- Join Standard Outputs
     -- Pass Only Elements: ['average_booking_value', 'listing__user']
@@ -28,17 +31,17 @@ FROM (
     -- Compute Metrics via Expressions
     -- Pass Only Elements: ['listing__user', 'listing__user__average_booking_value']
     SELECT
-      listings_latest_src_28000.user_id AS listing__user
+      sma_28014_cte.user AS listing__user
       , AVG(bookings_source_src_28000.booking_value) AS listing__user__average_booking_value
     FROM ***************************.fct_bookings bookings_source_src_28000
     LEFT OUTER JOIN
-      ***************************.dim_listings_latest listings_latest_src_28000
+      sma_28014_cte sma_28014_cte
     ON
-      bookings_source_src_28000.listing_id = listings_latest_src_28000.listing_id
+      bookings_source_src_28000.listing_id = sma_28014_cte.listing
     GROUP BY
-      listings_latest_src_28000.user_id
-  ) subq_27
+      sma_28014_cte.user
+  ) subq_26
   ON
-    subq_17.user = subq_27.listing__user
-) subq_28
+    sma_28014_cte.user = subq_26.listing__user
+) subq_27
 WHERE user__listing__user__average_booking_value > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_metric_filtered_by_itself__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_metric_filtered_by_itself__plan0_optimized.sql
@@ -8,36 +8,43 @@ sql_engine: DuckDB
 -- Pass Only Elements: ['bookers',]
 -- Aggregate Measures
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    listing_id AS listing
+    , guest_id AS bookers
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
   COUNT(DISTINCT bookers) AS bookers
 FROM (
   -- Join Standard Outputs
   SELECT
-    subq_19.listing__bookers AS listing__bookers
+    subq_18.listing__bookers AS listing__bookers
     , subq_13.bookers AS bookers
   FROM (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28009
     SELECT
-      listing_id AS listing
-      , guest_id AS bookers
-    FROM ***************************.fct_bookings bookings_source_src_28000
+      listing
+      , bookers
+    FROM sma_28009_cte sma_28009_cte
   ) subq_13
   LEFT OUTER JOIN (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28009
     -- Pass Only Elements: ['bookers', 'listing']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     -- Pass Only Elements: ['listing', 'listing__bookers']
     SELECT
-      listing_id AS listing
-      , COUNT(DISTINCT guest_id) AS listing__bookers
-    FROM ***************************.fct_bookings bookings_source_src_28000
+      listing
+      , COUNT(DISTINCT bookers) AS listing__bookers
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
-      listing_id
-  ) subq_19
+      listing
+  ) subq_18
   ON
-    subq_13.listing = subq_19.listing
-) subq_20
+    subq_13.listing = subq_18.listing
+) subq_19
 WHERE listing__bookers > 1.00

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_query_with_multiple_metrics_in_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_query_with_multiple_metrics_in_filter__plan0_optimized.sql
@@ -8,13 +8,23 @@ sql_engine: DuckDB
 -- Pass Only Elements: ['listings',]
 -- Aggregate Measures
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    listing_id AS listing
+    , 1 AS bookings
+    , guest_id AS bookers
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
   SUM(listings) AS listings
 FROM (
   -- Join Standard Outputs
   SELECT
     subq_25.listing__bookings AS listing__bookings
-    , subq_31.listing__bookers AS listing__bookers
+    , subq_30.listing__bookers AS listing__bookers
     , subq_19.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
@@ -25,41 +35,34 @@ FROM (
     FROM ***************************.dim_listings_latest listings_latest_src_28000
   ) subq_19
   LEFT OUTER JOIN (
+    -- Read From CTE For node_id=sma_28009
+    -- Pass Only Elements: ['bookings', 'listing']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     -- Pass Only Elements: ['listing', 'listing__bookings']
     SELECT
       listing
       , SUM(bookings) AS listing__bookings
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['bookings', 'listing']
-      SELECT
-        listing_id AS listing
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_22
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
       listing
   ) subq_25
   ON
     subq_19.listing = subq_25.listing
   LEFT OUTER JOIN (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28009
     -- Pass Only Elements: ['bookers', 'listing']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     -- Pass Only Elements: ['listing', 'listing__bookers']
     SELECT
-      listing_id AS listing
-      , COUNT(DISTINCT guest_id) AS listing__bookers
-    FROM ***************************.fct_bookings bookings_source_src_28000
+      listing
+      , COUNT(DISTINCT bookers) AS listing__bookers
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
-      listing_id
-  ) subq_31
+      listing
+  ) subq_30
   ON
-    subq_19.listing = subq_31.listing
-) subq_32
+    subq_19.listing = subq_30.listing
+) subq_31
 WHERE listing__bookings > 2 AND listing__bookers > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0_optimized.sql
@@ -8,36 +8,45 @@ sql_engine: Postgres
 -- Pass Only Elements: ['bookers',]
 -- Aggregate Measures
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    guest_id AS guest
+    , booking_value
+    , guest_id AS bookers
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
   COUNT(DISTINCT bookers) AS bookers
 FROM (
   -- Join Standard Outputs
   SELECT
-    subq_19.guest__booking_value AS guest__booking_value
+    subq_18.guest__booking_value AS guest__booking_value
     , subq_13.bookers AS bookers
   FROM (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28009
     SELECT
-      guest_id AS guest
-      , guest_id AS bookers
-    FROM ***************************.fct_bookings bookings_source_src_28000
+      guest
+      , booking_value
+      , bookers
+    FROM sma_28009_cte sma_28009_cte
   ) subq_13
   LEFT OUTER JOIN (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28009
     -- Pass Only Elements: ['booking_value', 'guest']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     -- Pass Only Elements: ['guest', 'guest__booking_value']
     SELECT
-      guest_id AS guest
+      guest
       , SUM(booking_value) AS guest__booking_value
-    FROM ***************************.fct_bookings bookings_source_src_28000
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
-      guest_id
-  ) subq_19
+      guest
+  ) subq_18
   ON
-    subq_13.guest = subq_19.guest
-) subq_20
+    subq_13.guest = subq_18.guest
+) subq_19
 WHERE guest__booking_value > 1.00

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_filter_with_conversion_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_filter_with_conversion_metric__plan0_optimized.sql
@@ -6,12 +6,22 @@ sql_engine: Postgres
 -- Pass Only Elements: ['listings',]
 -- Aggregate Measures
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
   SUM(listings) AS listings
 FROM (
   -- Join Standard Outputs
   SELECT
-    CAST(subq_39.buys AS DOUBLE PRECISION) / CAST(NULLIF(subq_39.visits, 0) AS DOUBLE PRECISION) AS user__visit_buy_conversion_rate
+    CAST(subq_38.buys AS DOUBLE PRECISION) / CAST(NULLIF(subq_38.visits, 0) AS DOUBLE PRECISION) AS user__visit_buy_conversion_rate
     , subq_24.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
@@ -24,72 +34,57 @@ FROM (
   LEFT OUTER JOIN (
     -- Combine Aggregated Outputs
     SELECT
-      COALESCE(subq_28.user, subq_38.user) AS user
+      COALESCE(subq_28.user, subq_37.user) AS user
       , MAX(subq_28.visits) AS visits
-      , MAX(subq_38.buys) AS buys
+      , MAX(subq_37.buys) AS buys
     FROM (
+      -- Read From CTE For node_id=sma_28019
+      -- Pass Only Elements: ['visits', 'user']
       -- Aggregate Measures
       SELECT
-        subq_27.user
+        sma_28019_cte.user
         , SUM(visits) AS visits
-      FROM (
-        -- Read Elements From Semantic Model 'visits_source'
-        -- Metric Time Dimension 'ds'
-        -- Pass Only Elements: ['visits', 'user']
-        SELECT
-          user_id AS user
-          , 1 AS visits
-        FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_27
+      FROM sma_28019_cte sma_28019_cte
       GROUP BY
-        subq_27.user
+        sma_28019_cte.user
     ) subq_28
     FULL OUTER JOIN (
       -- Find conversions for user within the range of INF
       -- Pass Only Elements: ['buys', 'user']
       -- Aggregate Measures
       SELECT
-        subq_35.user
+        subq_34.user
         , SUM(buys) AS buys
       FROM (
         -- Dedupe the fanout with mf_internal_uuid in the conversion data set
         SELECT DISTINCT
-          FIRST_VALUE(subq_31.visits) OVER (
+          FIRST_VALUE(sma_28019_cte.visits) OVER (
             PARTITION BY
-              subq_34.user
-              , subq_34.metric_time__day
-              , subq_34.mf_internal_uuid
-            ORDER BY subq_31.metric_time__day DESC
+              subq_33.user
+              , subq_33.metric_time__day
+              , subq_33.mf_internal_uuid
+            ORDER BY sma_28019_cte.metric_time__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS visits
-          , FIRST_VALUE(subq_31.metric_time__day) OVER (
+          , FIRST_VALUE(sma_28019_cte.metric_time__day) OVER (
             PARTITION BY
-              subq_34.user
-              , subq_34.metric_time__day
-              , subq_34.mf_internal_uuid
-            ORDER BY subq_31.metric_time__day DESC
+              subq_33.user
+              , subq_33.metric_time__day
+              , subq_33.mf_internal_uuid
+            ORDER BY sma_28019_cte.metric_time__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS metric_time__day
-          , FIRST_VALUE(subq_31.user) OVER (
+          , FIRST_VALUE(sma_28019_cte.user) OVER (
             PARTITION BY
-              subq_34.user
-              , subq_34.metric_time__day
-              , subq_34.mf_internal_uuid
-            ORDER BY subq_31.metric_time__day DESC
+              subq_33.user
+              , subq_33.metric_time__day
+              , subq_33.mf_internal_uuid
+            ORDER BY sma_28019_cte.metric_time__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS user
-          , subq_34.mf_internal_uuid AS mf_internal_uuid
-          , subq_34.buys AS buys
-        FROM (
-          -- Read Elements From Semantic Model 'visits_source'
-          -- Metric Time Dimension 'ds'
-          -- Pass Only Elements: ['visits', 'metric_time__day', 'user']
-          SELECT
-            DATE_TRUNC('day', ds) AS metric_time__day
-            , user_id AS user
-            , 1 AS visits
-          FROM ***************************.fct_visits visits_source_src_28000
-        ) subq_31
+          , subq_33.mf_internal_uuid AS mf_internal_uuid
+          , subq_33.buys AS buys
+        FROM sma_28019_cte sma_28019_cte
         INNER JOIN (
           -- Read Elements From Semantic Model 'buys_source'
           -- Metric Time Dimension 'ds'
@@ -100,23 +95,23 @@ FROM (
             , 1 AS buys
             , GEN_RANDOM_UUID() AS mf_internal_uuid
           FROM ***************************.fct_buys buys_source_src_28000
-        ) subq_34
+        ) subq_33
         ON
           (
-            subq_31.user = subq_34.user
+            sma_28019_cte.user = subq_33.user
           ) AND (
-            (subq_31.metric_time__day <= subq_34.metric_time__day)
+            (sma_28019_cte.metric_time__day <= subq_33.metric_time__day)
           )
-      ) subq_35
+      ) subq_34
       GROUP BY
-        subq_35.user
-    ) subq_38
+        subq_34.user
+    ) subq_37
     ON
-      subq_28.user = subq_38.user
+      subq_28.user = subq_37.user
     GROUP BY
-      COALESCE(subq_28.user, subq_38.user)
-  ) subq_39
+      COALESCE(subq_28.user, subq_37.user)
+  ) subq_38
   ON
-    subq_24.user = subq_39.user
-) subq_42
+    subq_24.user = subq_38.user
+) subq_41
 WHERE user__visit_buy_conversion_rate > 2

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_group_by_has_local_entity_prefix__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_group_by_has_local_entity_prefix__plan0_optimized.sql
@@ -6,21 +6,24 @@ sql_engine: Postgres
 -- Pass Only Elements: ['listings',]
 -- Aggregate Measures
 -- Compute Metrics via Expressions
+WITH sma_28014_cte AS (
+  -- Read Elements From Semantic Model 'listings_latest'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    listing_id AS listing
+    , user_id AS user
+    , 1 AS listings
+  FROM ***************************.dim_listings_latest listings_latest_src_28000
+)
+
 SELECT
   SUM(listings) AS listings
 FROM (
   -- Join Standard Outputs
   SELECT
-    subq_27.listing__user__average_booking_value AS user__listing__user__average_booking_value
-    , subq_17.listings AS listings
-  FROM (
-    -- Read Elements From Semantic Model 'listings_latest'
-    -- Metric Time Dimension 'ds'
-    SELECT
-      user_id AS user
-      , 1 AS listings
-    FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_17
+    subq_26.listing__user__average_booking_value AS user__listing__user__average_booking_value
+    , sma_28014_cte.listings AS listings
+  FROM sma_28014_cte sma_28014_cte
   LEFT OUTER JOIN (
     -- Join Standard Outputs
     -- Pass Only Elements: ['average_booking_value', 'listing__user']
@@ -28,17 +31,17 @@ FROM (
     -- Compute Metrics via Expressions
     -- Pass Only Elements: ['listing__user', 'listing__user__average_booking_value']
     SELECT
-      listings_latest_src_28000.user_id AS listing__user
+      sma_28014_cte.user AS listing__user
       , AVG(bookings_source_src_28000.booking_value) AS listing__user__average_booking_value
     FROM ***************************.fct_bookings bookings_source_src_28000
     LEFT OUTER JOIN
-      ***************************.dim_listings_latest listings_latest_src_28000
+      sma_28014_cte sma_28014_cte
     ON
-      bookings_source_src_28000.listing_id = listings_latest_src_28000.listing_id
+      bookings_source_src_28000.listing_id = sma_28014_cte.listing
     GROUP BY
-      listings_latest_src_28000.user_id
-  ) subq_27
+      sma_28014_cte.user
+  ) subq_26
   ON
-    subq_17.user = subq_27.listing__user
-) subq_28
+    sma_28014_cte.user = subq_26.listing__user
+) subq_27
 WHERE user__listing__user__average_booking_value > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_metric_filtered_by_itself__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_metric_filtered_by_itself__plan0_optimized.sql
@@ -8,36 +8,43 @@ sql_engine: Postgres
 -- Pass Only Elements: ['bookers',]
 -- Aggregate Measures
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    listing_id AS listing
+    , guest_id AS bookers
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
   COUNT(DISTINCT bookers) AS bookers
 FROM (
   -- Join Standard Outputs
   SELECT
-    subq_19.listing__bookers AS listing__bookers
+    subq_18.listing__bookers AS listing__bookers
     , subq_13.bookers AS bookers
   FROM (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28009
     SELECT
-      listing_id AS listing
-      , guest_id AS bookers
-    FROM ***************************.fct_bookings bookings_source_src_28000
+      listing
+      , bookers
+    FROM sma_28009_cte sma_28009_cte
   ) subq_13
   LEFT OUTER JOIN (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28009
     -- Pass Only Elements: ['bookers', 'listing']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     -- Pass Only Elements: ['listing', 'listing__bookers']
     SELECT
-      listing_id AS listing
-      , COUNT(DISTINCT guest_id) AS listing__bookers
-    FROM ***************************.fct_bookings bookings_source_src_28000
+      listing
+      , COUNT(DISTINCT bookers) AS listing__bookers
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
-      listing_id
-  ) subq_19
+      listing
+  ) subq_18
   ON
-    subq_13.listing = subq_19.listing
-) subq_20
+    subq_13.listing = subq_18.listing
+) subq_19
 WHERE listing__bookers > 1.00

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_query_with_multiple_metrics_in_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_query_with_multiple_metrics_in_filter__plan0_optimized.sql
@@ -8,13 +8,23 @@ sql_engine: Postgres
 -- Pass Only Elements: ['listings',]
 -- Aggregate Measures
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    listing_id AS listing
+    , 1 AS bookings
+    , guest_id AS bookers
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
   SUM(listings) AS listings
 FROM (
   -- Join Standard Outputs
   SELECT
     subq_25.listing__bookings AS listing__bookings
-    , subq_31.listing__bookers AS listing__bookers
+    , subq_30.listing__bookers AS listing__bookers
     , subq_19.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
@@ -25,41 +35,34 @@ FROM (
     FROM ***************************.dim_listings_latest listings_latest_src_28000
   ) subq_19
   LEFT OUTER JOIN (
+    -- Read From CTE For node_id=sma_28009
+    -- Pass Only Elements: ['bookings', 'listing']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     -- Pass Only Elements: ['listing', 'listing__bookings']
     SELECT
       listing
       , SUM(bookings) AS listing__bookings
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['bookings', 'listing']
-      SELECT
-        listing_id AS listing
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_22
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
       listing
   ) subq_25
   ON
     subq_19.listing = subq_25.listing
   LEFT OUTER JOIN (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28009
     -- Pass Only Elements: ['bookers', 'listing']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     -- Pass Only Elements: ['listing', 'listing__bookers']
     SELECT
-      listing_id AS listing
-      , COUNT(DISTINCT guest_id) AS listing__bookers
-    FROM ***************************.fct_bookings bookings_source_src_28000
+      listing
+      , COUNT(DISTINCT bookers) AS listing__bookers
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
-      listing_id
-  ) subq_31
+      listing
+  ) subq_30
   ON
-    subq_19.listing = subq_31.listing
-) subq_32
+    subq_19.listing = subq_30.listing
+) subq_31
 WHERE listing__bookings > 2 AND listing__bookers > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0_optimized.sql
@@ -8,36 +8,45 @@ sql_engine: Redshift
 -- Pass Only Elements: ['bookers',]
 -- Aggregate Measures
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    guest_id AS guest
+    , booking_value
+    , guest_id AS bookers
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
   COUNT(DISTINCT bookers) AS bookers
 FROM (
   -- Join Standard Outputs
   SELECT
-    subq_19.guest__booking_value AS guest__booking_value
+    subq_18.guest__booking_value AS guest__booking_value
     , subq_13.bookers AS bookers
   FROM (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28009
     SELECT
-      guest_id AS guest
-      , guest_id AS bookers
-    FROM ***************************.fct_bookings bookings_source_src_28000
+      guest
+      , booking_value
+      , bookers
+    FROM sma_28009_cte sma_28009_cte
   ) subq_13
   LEFT OUTER JOIN (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28009
     -- Pass Only Elements: ['booking_value', 'guest']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     -- Pass Only Elements: ['guest', 'guest__booking_value']
     SELECT
-      guest_id AS guest
+      guest
       , SUM(booking_value) AS guest__booking_value
-    FROM ***************************.fct_bookings bookings_source_src_28000
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
-      guest_id
-  ) subq_19
+      guest
+  ) subq_18
   ON
-    subq_13.guest = subq_19.guest
-) subq_20
+    subq_13.guest = subq_18.guest
+) subq_19
 WHERE guest__booking_value > 1.00

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_group_by_has_local_entity_prefix__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_group_by_has_local_entity_prefix__plan0_optimized.sql
@@ -6,21 +6,24 @@ sql_engine: Redshift
 -- Pass Only Elements: ['listings',]
 -- Aggregate Measures
 -- Compute Metrics via Expressions
+WITH sma_28014_cte AS (
+  -- Read Elements From Semantic Model 'listings_latest'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    listing_id AS listing
+    , user_id AS user
+    , 1 AS listings
+  FROM ***************************.dim_listings_latest listings_latest_src_28000
+)
+
 SELECT
   SUM(listings) AS listings
 FROM (
   -- Join Standard Outputs
   SELECT
-    subq_27.listing__user__average_booking_value AS user__listing__user__average_booking_value
-    , subq_17.listings AS listings
-  FROM (
-    -- Read Elements From Semantic Model 'listings_latest'
-    -- Metric Time Dimension 'ds'
-    SELECT
-      user_id AS user
-      , 1 AS listings
-    FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_17
+    subq_26.listing__user__average_booking_value AS user__listing__user__average_booking_value
+    , sma_28014_cte.listings AS listings
+  FROM sma_28014_cte sma_28014_cte
   LEFT OUTER JOIN (
     -- Join Standard Outputs
     -- Pass Only Elements: ['average_booking_value', 'listing__user']
@@ -28,17 +31,17 @@ FROM (
     -- Compute Metrics via Expressions
     -- Pass Only Elements: ['listing__user', 'listing__user__average_booking_value']
     SELECT
-      listings_latest_src_28000.user_id AS listing__user
+      sma_28014_cte.user AS listing__user
       , AVG(bookings_source_src_28000.booking_value) AS listing__user__average_booking_value
     FROM ***************************.fct_bookings bookings_source_src_28000
     LEFT OUTER JOIN
-      ***************************.dim_listings_latest listings_latest_src_28000
+      sma_28014_cte sma_28014_cte
     ON
-      bookings_source_src_28000.listing_id = listings_latest_src_28000.listing_id
+      bookings_source_src_28000.listing_id = sma_28014_cte.listing
     GROUP BY
-      listings_latest_src_28000.user_id
-  ) subq_27
+      sma_28014_cte.user
+  ) subq_26
   ON
-    subq_17.user = subq_27.listing__user
-) subq_28
+    sma_28014_cte.user = subq_26.listing__user
+) subq_27
 WHERE user__listing__user__average_booking_value > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_metric_filtered_by_itself__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_metric_filtered_by_itself__plan0_optimized.sql
@@ -8,36 +8,43 @@ sql_engine: Redshift
 -- Pass Only Elements: ['bookers',]
 -- Aggregate Measures
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    listing_id AS listing
+    , guest_id AS bookers
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
   COUNT(DISTINCT bookers) AS bookers
 FROM (
   -- Join Standard Outputs
   SELECT
-    subq_19.listing__bookers AS listing__bookers
+    subq_18.listing__bookers AS listing__bookers
     , subq_13.bookers AS bookers
   FROM (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28009
     SELECT
-      listing_id AS listing
-      , guest_id AS bookers
-    FROM ***************************.fct_bookings bookings_source_src_28000
+      listing
+      , bookers
+    FROM sma_28009_cte sma_28009_cte
   ) subq_13
   LEFT OUTER JOIN (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28009
     -- Pass Only Elements: ['bookers', 'listing']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     -- Pass Only Elements: ['listing', 'listing__bookers']
     SELECT
-      listing_id AS listing
-      , COUNT(DISTINCT guest_id) AS listing__bookers
-    FROM ***************************.fct_bookings bookings_source_src_28000
+      listing
+      , COUNT(DISTINCT bookers) AS listing__bookers
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
-      listing_id
-  ) subq_19
+      listing
+  ) subq_18
   ON
-    subq_13.listing = subq_19.listing
-) subq_20
+    subq_13.listing = subq_18.listing
+) subq_19
 WHERE listing__bookers > 1.00

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_query_with_multiple_metrics_in_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_query_with_multiple_metrics_in_filter__plan0_optimized.sql
@@ -8,13 +8,23 @@ sql_engine: Redshift
 -- Pass Only Elements: ['listings',]
 -- Aggregate Measures
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    listing_id AS listing
+    , 1 AS bookings
+    , guest_id AS bookers
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
   SUM(listings) AS listings
 FROM (
   -- Join Standard Outputs
   SELECT
     subq_25.listing__bookings AS listing__bookings
-    , subq_31.listing__bookers AS listing__bookers
+    , subq_30.listing__bookers AS listing__bookers
     , subq_19.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
@@ -25,41 +35,34 @@ FROM (
     FROM ***************************.dim_listings_latest listings_latest_src_28000
   ) subq_19
   LEFT OUTER JOIN (
+    -- Read From CTE For node_id=sma_28009
+    -- Pass Only Elements: ['bookings', 'listing']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     -- Pass Only Elements: ['listing', 'listing__bookings']
     SELECT
       listing
       , SUM(bookings) AS listing__bookings
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['bookings', 'listing']
-      SELECT
-        listing_id AS listing
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_22
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
       listing
   ) subq_25
   ON
     subq_19.listing = subq_25.listing
   LEFT OUTER JOIN (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28009
     -- Pass Only Elements: ['bookers', 'listing']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     -- Pass Only Elements: ['listing', 'listing__bookers']
     SELECT
-      listing_id AS listing
-      , COUNT(DISTINCT guest_id) AS listing__bookers
-    FROM ***************************.fct_bookings bookings_source_src_28000
+      listing
+      , COUNT(DISTINCT bookers) AS listing__bookers
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
-      listing_id
-  ) subq_31
+      listing
+  ) subq_30
   ON
-    subq_19.listing = subq_31.listing
-) subq_32
+    subq_19.listing = subq_30.listing
+) subq_31
 WHERE listing__bookings > 2 AND listing__bookers > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0_optimized.sql
@@ -8,36 +8,45 @@ sql_engine: Snowflake
 -- Pass Only Elements: ['bookers',]
 -- Aggregate Measures
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    guest_id AS guest
+    , booking_value
+    , guest_id AS bookers
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
   COUNT(DISTINCT bookers) AS bookers
 FROM (
   -- Join Standard Outputs
   SELECT
-    subq_19.guest__booking_value AS guest__booking_value
+    subq_18.guest__booking_value AS guest__booking_value
     , subq_13.bookers AS bookers
   FROM (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28009
     SELECT
-      guest_id AS guest
-      , guest_id AS bookers
-    FROM ***************************.fct_bookings bookings_source_src_28000
+      guest
+      , booking_value
+      , bookers
+    FROM sma_28009_cte sma_28009_cte
   ) subq_13
   LEFT OUTER JOIN (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28009
     -- Pass Only Elements: ['booking_value', 'guest']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     -- Pass Only Elements: ['guest', 'guest__booking_value']
     SELECT
-      guest_id AS guest
+      guest
       , SUM(booking_value) AS guest__booking_value
-    FROM ***************************.fct_bookings bookings_source_src_28000
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
-      guest_id
-  ) subq_19
+      guest
+  ) subq_18
   ON
-    subq_13.guest = subq_19.guest
-) subq_20
+    subq_13.guest = subq_18.guest
+) subq_19
 WHERE guest__booking_value > 1.00

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_filter_with_conversion_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_filter_with_conversion_metric__plan0_optimized.sql
@@ -6,12 +6,22 @@ sql_engine: Snowflake
 -- Pass Only Elements: ['listings',]
 -- Aggregate Measures
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
   SUM(listings) AS listings
 FROM (
   -- Join Standard Outputs
   SELECT
-    CAST(subq_39.buys AS DOUBLE) / CAST(NULLIF(subq_39.visits, 0) AS DOUBLE) AS user__visit_buy_conversion_rate
+    CAST(subq_38.buys AS DOUBLE) / CAST(NULLIF(subq_38.visits, 0) AS DOUBLE) AS user__visit_buy_conversion_rate
     , subq_24.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
@@ -24,72 +34,57 @@ FROM (
   LEFT OUTER JOIN (
     -- Combine Aggregated Outputs
     SELECT
-      COALESCE(subq_28.user, subq_38.user) AS user
+      COALESCE(subq_28.user, subq_37.user) AS user
       , MAX(subq_28.visits) AS visits
-      , MAX(subq_38.buys) AS buys
+      , MAX(subq_37.buys) AS buys
     FROM (
+      -- Read From CTE For node_id=sma_28019
+      -- Pass Only Elements: ['visits', 'user']
       -- Aggregate Measures
       SELECT
-        subq_27.user
+        sma_28019_cte.user
         , SUM(visits) AS visits
-      FROM (
-        -- Read Elements From Semantic Model 'visits_source'
-        -- Metric Time Dimension 'ds'
-        -- Pass Only Elements: ['visits', 'user']
-        SELECT
-          user_id AS user
-          , 1 AS visits
-        FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_27
+      FROM sma_28019_cte sma_28019_cte
       GROUP BY
-        subq_27.user
+        sma_28019_cte.user
     ) subq_28
     FULL OUTER JOIN (
       -- Find conversions for user within the range of INF
       -- Pass Only Elements: ['buys', 'user']
       -- Aggregate Measures
       SELECT
-        subq_35.user
+        subq_34.user
         , SUM(buys) AS buys
       FROM (
         -- Dedupe the fanout with mf_internal_uuid in the conversion data set
         SELECT DISTINCT
-          FIRST_VALUE(subq_31.visits) OVER (
+          FIRST_VALUE(sma_28019_cte.visits) OVER (
             PARTITION BY
-              subq_34.user
-              , subq_34.metric_time__day
-              , subq_34.mf_internal_uuid
-            ORDER BY subq_31.metric_time__day DESC
+              subq_33.user
+              , subq_33.metric_time__day
+              , subq_33.mf_internal_uuid
+            ORDER BY sma_28019_cte.metric_time__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS visits
-          , FIRST_VALUE(subq_31.metric_time__day) OVER (
+          , FIRST_VALUE(sma_28019_cte.metric_time__day) OVER (
             PARTITION BY
-              subq_34.user
-              , subq_34.metric_time__day
-              , subq_34.mf_internal_uuid
-            ORDER BY subq_31.metric_time__day DESC
+              subq_33.user
+              , subq_33.metric_time__day
+              , subq_33.mf_internal_uuid
+            ORDER BY sma_28019_cte.metric_time__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS metric_time__day
-          , FIRST_VALUE(subq_31.user) OVER (
+          , FIRST_VALUE(sma_28019_cte.user) OVER (
             PARTITION BY
-              subq_34.user
-              , subq_34.metric_time__day
-              , subq_34.mf_internal_uuid
-            ORDER BY subq_31.metric_time__day DESC
+              subq_33.user
+              , subq_33.metric_time__day
+              , subq_33.mf_internal_uuid
+            ORDER BY sma_28019_cte.metric_time__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS user
-          , subq_34.mf_internal_uuid AS mf_internal_uuid
-          , subq_34.buys AS buys
-        FROM (
-          -- Read Elements From Semantic Model 'visits_source'
-          -- Metric Time Dimension 'ds'
-          -- Pass Only Elements: ['visits', 'metric_time__day', 'user']
-          SELECT
-            DATE_TRUNC('day', ds) AS metric_time__day
-            , user_id AS user
-            , 1 AS visits
-          FROM ***************************.fct_visits visits_source_src_28000
-        ) subq_31
+          , subq_33.mf_internal_uuid AS mf_internal_uuid
+          , subq_33.buys AS buys
+        FROM sma_28019_cte sma_28019_cte
         INNER JOIN (
           -- Read Elements From Semantic Model 'buys_source'
           -- Metric Time Dimension 'ds'
@@ -100,23 +95,23 @@ FROM (
             , 1 AS buys
             , UUID_STRING() AS mf_internal_uuid
           FROM ***************************.fct_buys buys_source_src_28000
-        ) subq_34
+        ) subq_33
         ON
           (
-            subq_31.user = subq_34.user
+            sma_28019_cte.user = subq_33.user
           ) AND (
-            (subq_31.metric_time__day <= subq_34.metric_time__day)
+            (sma_28019_cte.metric_time__day <= subq_33.metric_time__day)
           )
-      ) subq_35
+      ) subq_34
       GROUP BY
-        subq_35.user
-    ) subq_38
+        subq_34.user
+    ) subq_37
     ON
-      subq_28.user = subq_38.user
+      subq_28.user = subq_37.user
     GROUP BY
-      COALESCE(subq_28.user, subq_38.user)
-  ) subq_39
+      COALESCE(subq_28.user, subq_37.user)
+  ) subq_38
   ON
-    subq_24.user = subq_39.user
-) subq_42
+    subq_24.user = subq_38.user
+) subq_41
 WHERE user__visit_buy_conversion_rate > 2

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_group_by_has_local_entity_prefix__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_group_by_has_local_entity_prefix__plan0_optimized.sql
@@ -6,21 +6,24 @@ sql_engine: Snowflake
 -- Pass Only Elements: ['listings',]
 -- Aggregate Measures
 -- Compute Metrics via Expressions
+WITH sma_28014_cte AS (
+  -- Read Elements From Semantic Model 'listings_latest'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    listing_id AS listing
+    , user_id AS user
+    , 1 AS listings
+  FROM ***************************.dim_listings_latest listings_latest_src_28000
+)
+
 SELECT
   SUM(listings) AS listings
 FROM (
   -- Join Standard Outputs
   SELECT
-    subq_27.listing__user__average_booking_value AS user__listing__user__average_booking_value
-    , subq_17.listings AS listings
-  FROM (
-    -- Read Elements From Semantic Model 'listings_latest'
-    -- Metric Time Dimension 'ds'
-    SELECT
-      user_id AS user
-      , 1 AS listings
-    FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_17
+    subq_26.listing__user__average_booking_value AS user__listing__user__average_booking_value
+    , sma_28014_cte.listings AS listings
+  FROM sma_28014_cte sma_28014_cte
   LEFT OUTER JOIN (
     -- Join Standard Outputs
     -- Pass Only Elements: ['average_booking_value', 'listing__user']
@@ -28,17 +31,17 @@ FROM (
     -- Compute Metrics via Expressions
     -- Pass Only Elements: ['listing__user', 'listing__user__average_booking_value']
     SELECT
-      listings_latest_src_28000.user_id AS listing__user
+      sma_28014_cte.user AS listing__user
       , AVG(bookings_source_src_28000.booking_value) AS listing__user__average_booking_value
     FROM ***************************.fct_bookings bookings_source_src_28000
     LEFT OUTER JOIN
-      ***************************.dim_listings_latest listings_latest_src_28000
+      sma_28014_cte sma_28014_cte
     ON
-      bookings_source_src_28000.listing_id = listings_latest_src_28000.listing_id
+      bookings_source_src_28000.listing_id = sma_28014_cte.listing
     GROUP BY
-      listings_latest_src_28000.user_id
-  ) subq_27
+      sma_28014_cte.user
+  ) subq_26
   ON
-    subq_17.user = subq_27.listing__user
-) subq_28
+    sma_28014_cte.user = subq_26.listing__user
+) subq_27
 WHERE user__listing__user__average_booking_value > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_metric_filtered_by_itself__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_metric_filtered_by_itself__plan0_optimized.sql
@@ -8,36 +8,43 @@ sql_engine: Snowflake
 -- Pass Only Elements: ['bookers',]
 -- Aggregate Measures
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    listing_id AS listing
+    , guest_id AS bookers
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
   COUNT(DISTINCT bookers) AS bookers
 FROM (
   -- Join Standard Outputs
   SELECT
-    subq_19.listing__bookers AS listing__bookers
+    subq_18.listing__bookers AS listing__bookers
     , subq_13.bookers AS bookers
   FROM (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28009
     SELECT
-      listing_id AS listing
-      , guest_id AS bookers
-    FROM ***************************.fct_bookings bookings_source_src_28000
+      listing
+      , bookers
+    FROM sma_28009_cte sma_28009_cte
   ) subq_13
   LEFT OUTER JOIN (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28009
     -- Pass Only Elements: ['bookers', 'listing']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     -- Pass Only Elements: ['listing', 'listing__bookers']
     SELECT
-      listing_id AS listing
-      , COUNT(DISTINCT guest_id) AS listing__bookers
-    FROM ***************************.fct_bookings bookings_source_src_28000
+      listing
+      , COUNT(DISTINCT bookers) AS listing__bookers
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
-      listing_id
-  ) subq_19
+      listing
+  ) subq_18
   ON
-    subq_13.listing = subq_19.listing
-) subq_20
+    subq_13.listing = subq_18.listing
+) subq_19
 WHERE listing__bookers > 1.00

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_query_with_multiple_metrics_in_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_query_with_multiple_metrics_in_filter__plan0_optimized.sql
@@ -8,13 +8,23 @@ sql_engine: Snowflake
 -- Pass Only Elements: ['listings',]
 -- Aggregate Measures
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    listing_id AS listing
+    , 1 AS bookings
+    , guest_id AS bookers
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
   SUM(listings) AS listings
 FROM (
   -- Join Standard Outputs
   SELECT
     subq_25.listing__bookings AS listing__bookings
-    , subq_31.listing__bookers AS listing__bookers
+    , subq_30.listing__bookers AS listing__bookers
     , subq_19.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
@@ -25,41 +35,34 @@ FROM (
     FROM ***************************.dim_listings_latest listings_latest_src_28000
   ) subq_19
   LEFT OUTER JOIN (
+    -- Read From CTE For node_id=sma_28009
+    -- Pass Only Elements: ['bookings', 'listing']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     -- Pass Only Elements: ['listing', 'listing__bookings']
     SELECT
       listing
       , SUM(bookings) AS listing__bookings
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['bookings', 'listing']
-      SELECT
-        listing_id AS listing
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_22
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
       listing
   ) subq_25
   ON
     subq_19.listing = subq_25.listing
   LEFT OUTER JOIN (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28009
     -- Pass Only Elements: ['bookers', 'listing']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     -- Pass Only Elements: ['listing', 'listing__bookers']
     SELECT
-      listing_id AS listing
-      , COUNT(DISTINCT guest_id) AS listing__bookers
-    FROM ***************************.fct_bookings bookings_source_src_28000
+      listing
+      , COUNT(DISTINCT bookers) AS listing__bookers
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
-      listing_id
-  ) subq_31
+      listing
+  ) subq_30
   ON
-    subq_19.listing = subq_31.listing
-) subq_32
+    subq_19.listing = subq_30.listing
+) subq_31
 WHERE listing__bookings > 2 AND listing__bookers > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0_optimized.sql
@@ -8,36 +8,45 @@ sql_engine: Trino
 -- Pass Only Elements: ['bookers',]
 -- Aggregate Measures
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    guest_id AS guest
+    , booking_value
+    , guest_id AS bookers
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
   COUNT(DISTINCT bookers) AS bookers
 FROM (
   -- Join Standard Outputs
   SELECT
-    subq_19.guest__booking_value AS guest__booking_value
+    subq_18.guest__booking_value AS guest__booking_value
     , subq_13.bookers AS bookers
   FROM (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28009
     SELECT
-      guest_id AS guest
-      , guest_id AS bookers
-    FROM ***************************.fct_bookings bookings_source_src_28000
+      guest
+      , booking_value
+      , bookers
+    FROM sma_28009_cte sma_28009_cte
   ) subq_13
   LEFT OUTER JOIN (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28009
     -- Pass Only Elements: ['booking_value', 'guest']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     -- Pass Only Elements: ['guest', 'guest__booking_value']
     SELECT
-      guest_id AS guest
+      guest
       , SUM(booking_value) AS guest__booking_value
-    FROM ***************************.fct_bookings bookings_source_src_28000
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
-      guest_id
-  ) subq_19
+      guest
+  ) subq_18
   ON
-    subq_13.guest = subq_19.guest
-) subq_20
+    subq_13.guest = subq_18.guest
+) subq_19
 WHERE guest__booking_value > 1.00

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_filter_with_conversion_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_filter_with_conversion_metric__plan0_optimized.sql
@@ -6,12 +6,22 @@ sql_engine: Trino
 -- Pass Only Elements: ['listings',]
 -- Aggregate Measures
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
   SUM(listings) AS listings
 FROM (
   -- Join Standard Outputs
   SELECT
-    CAST(subq_39.buys AS DOUBLE) / CAST(NULLIF(subq_39.visits, 0) AS DOUBLE) AS user__visit_buy_conversion_rate
+    CAST(subq_38.buys AS DOUBLE) / CAST(NULLIF(subq_38.visits, 0) AS DOUBLE) AS user__visit_buy_conversion_rate
     , subq_24.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
@@ -24,72 +34,57 @@ FROM (
   LEFT OUTER JOIN (
     -- Combine Aggregated Outputs
     SELECT
-      COALESCE(subq_28.user, subq_38.user) AS user
+      COALESCE(subq_28.user, subq_37.user) AS user
       , MAX(subq_28.visits) AS visits
-      , MAX(subq_38.buys) AS buys
+      , MAX(subq_37.buys) AS buys
     FROM (
+      -- Read From CTE For node_id=sma_28019
+      -- Pass Only Elements: ['visits', 'user']
       -- Aggregate Measures
       SELECT
-        subq_27.user
+        sma_28019_cte.user
         , SUM(visits) AS visits
-      FROM (
-        -- Read Elements From Semantic Model 'visits_source'
-        -- Metric Time Dimension 'ds'
-        -- Pass Only Elements: ['visits', 'user']
-        SELECT
-          user_id AS user
-          , 1 AS visits
-        FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_27
+      FROM sma_28019_cte sma_28019_cte
       GROUP BY
-        subq_27.user
+        sma_28019_cte.user
     ) subq_28
     FULL OUTER JOIN (
       -- Find conversions for user within the range of INF
       -- Pass Only Elements: ['buys', 'user']
       -- Aggregate Measures
       SELECT
-        subq_35.user
+        subq_34.user
         , SUM(buys) AS buys
       FROM (
         -- Dedupe the fanout with mf_internal_uuid in the conversion data set
         SELECT DISTINCT
-          FIRST_VALUE(subq_31.visits) OVER (
+          FIRST_VALUE(sma_28019_cte.visits) OVER (
             PARTITION BY
-              subq_34.user
-              , subq_34.metric_time__day
-              , subq_34.mf_internal_uuid
-            ORDER BY subq_31.metric_time__day DESC
+              subq_33.user
+              , subq_33.metric_time__day
+              , subq_33.mf_internal_uuid
+            ORDER BY sma_28019_cte.metric_time__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS visits
-          , FIRST_VALUE(subq_31.metric_time__day) OVER (
+          , FIRST_VALUE(sma_28019_cte.metric_time__day) OVER (
             PARTITION BY
-              subq_34.user
-              , subq_34.metric_time__day
-              , subq_34.mf_internal_uuid
-            ORDER BY subq_31.metric_time__day DESC
+              subq_33.user
+              , subq_33.metric_time__day
+              , subq_33.mf_internal_uuid
+            ORDER BY sma_28019_cte.metric_time__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS metric_time__day
-          , FIRST_VALUE(subq_31.user) OVER (
+          , FIRST_VALUE(sma_28019_cte.user) OVER (
             PARTITION BY
-              subq_34.user
-              , subq_34.metric_time__day
-              , subq_34.mf_internal_uuid
-            ORDER BY subq_31.metric_time__day DESC
+              subq_33.user
+              , subq_33.metric_time__day
+              , subq_33.mf_internal_uuid
+            ORDER BY sma_28019_cte.metric_time__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS user
-          , subq_34.mf_internal_uuid AS mf_internal_uuid
-          , subq_34.buys AS buys
-        FROM (
-          -- Read Elements From Semantic Model 'visits_source'
-          -- Metric Time Dimension 'ds'
-          -- Pass Only Elements: ['visits', 'metric_time__day', 'user']
-          SELECT
-            DATE_TRUNC('day', ds) AS metric_time__day
-            , user_id AS user
-            , 1 AS visits
-          FROM ***************************.fct_visits visits_source_src_28000
-        ) subq_31
+          , subq_33.mf_internal_uuid AS mf_internal_uuid
+          , subq_33.buys AS buys
+        FROM sma_28019_cte sma_28019_cte
         INNER JOIN (
           -- Read Elements From Semantic Model 'buys_source'
           -- Metric Time Dimension 'ds'
@@ -100,23 +95,23 @@ FROM (
             , 1 AS buys
             , uuid() AS mf_internal_uuid
           FROM ***************************.fct_buys buys_source_src_28000
-        ) subq_34
+        ) subq_33
         ON
           (
-            subq_31.user = subq_34.user
+            sma_28019_cte.user = subq_33.user
           ) AND (
-            (subq_31.metric_time__day <= subq_34.metric_time__day)
+            (sma_28019_cte.metric_time__day <= subq_33.metric_time__day)
           )
-      ) subq_35
+      ) subq_34
       GROUP BY
-        subq_35.user
-    ) subq_38
+        subq_34.user
+    ) subq_37
     ON
-      subq_28.user = subq_38.user
+      subq_28.user = subq_37.user
     GROUP BY
-      COALESCE(subq_28.user, subq_38.user)
-  ) subq_39
+      COALESCE(subq_28.user, subq_37.user)
+  ) subq_38
   ON
-    subq_24.user = subq_39.user
-) subq_42
+    subq_24.user = subq_38.user
+) subq_41
 WHERE user__visit_buy_conversion_rate > 2

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_group_by_has_local_entity_prefix__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_group_by_has_local_entity_prefix__plan0_optimized.sql
@@ -6,21 +6,24 @@ sql_engine: Trino
 -- Pass Only Elements: ['listings',]
 -- Aggregate Measures
 -- Compute Metrics via Expressions
+WITH sma_28014_cte AS (
+  -- Read Elements From Semantic Model 'listings_latest'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    listing_id AS listing
+    , user_id AS user
+    , 1 AS listings
+  FROM ***************************.dim_listings_latest listings_latest_src_28000
+)
+
 SELECT
   SUM(listings) AS listings
 FROM (
   -- Join Standard Outputs
   SELECT
-    subq_27.listing__user__average_booking_value AS user__listing__user__average_booking_value
-    , subq_17.listings AS listings
-  FROM (
-    -- Read Elements From Semantic Model 'listings_latest'
-    -- Metric Time Dimension 'ds'
-    SELECT
-      user_id AS user
-      , 1 AS listings
-    FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_17
+    subq_26.listing__user__average_booking_value AS user__listing__user__average_booking_value
+    , sma_28014_cte.listings AS listings
+  FROM sma_28014_cte sma_28014_cte
   LEFT OUTER JOIN (
     -- Join Standard Outputs
     -- Pass Only Elements: ['average_booking_value', 'listing__user']
@@ -28,17 +31,17 @@ FROM (
     -- Compute Metrics via Expressions
     -- Pass Only Elements: ['listing__user', 'listing__user__average_booking_value']
     SELECT
-      listings_latest_src_28000.user_id AS listing__user
+      sma_28014_cte.user AS listing__user
       , AVG(bookings_source_src_28000.booking_value) AS listing__user__average_booking_value
     FROM ***************************.fct_bookings bookings_source_src_28000
     LEFT OUTER JOIN
-      ***************************.dim_listings_latest listings_latest_src_28000
+      sma_28014_cte sma_28014_cte
     ON
-      bookings_source_src_28000.listing_id = listings_latest_src_28000.listing_id
+      bookings_source_src_28000.listing_id = sma_28014_cte.listing
     GROUP BY
-      listings_latest_src_28000.user_id
-  ) subq_27
+      sma_28014_cte.user
+  ) subq_26
   ON
-    subq_17.user = subq_27.listing__user
-) subq_28
+    sma_28014_cte.user = subq_26.listing__user
+) subq_27
 WHERE user__listing__user__average_booking_value > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_metric_filtered_by_itself__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_metric_filtered_by_itself__plan0_optimized.sql
@@ -8,36 +8,43 @@ sql_engine: Trino
 -- Pass Only Elements: ['bookers',]
 -- Aggregate Measures
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    listing_id AS listing
+    , guest_id AS bookers
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
   COUNT(DISTINCT bookers) AS bookers
 FROM (
   -- Join Standard Outputs
   SELECT
-    subq_19.listing__bookers AS listing__bookers
+    subq_18.listing__bookers AS listing__bookers
     , subq_13.bookers AS bookers
   FROM (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28009
     SELECT
-      listing_id AS listing
-      , guest_id AS bookers
-    FROM ***************************.fct_bookings bookings_source_src_28000
+      listing
+      , bookers
+    FROM sma_28009_cte sma_28009_cte
   ) subq_13
   LEFT OUTER JOIN (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28009
     -- Pass Only Elements: ['bookers', 'listing']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     -- Pass Only Elements: ['listing', 'listing__bookers']
     SELECT
-      listing_id AS listing
-      , COUNT(DISTINCT guest_id) AS listing__bookers
-    FROM ***************************.fct_bookings bookings_source_src_28000
+      listing
+      , COUNT(DISTINCT bookers) AS listing__bookers
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
-      listing_id
-  ) subq_19
+      listing
+  ) subq_18
   ON
-    subq_13.listing = subq_19.listing
-) subq_20
+    subq_13.listing = subq_18.listing
+) subq_19
 WHERE listing__bookers > 1.00

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_query_with_multiple_metrics_in_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_query_with_multiple_metrics_in_filter__plan0_optimized.sql
@@ -8,13 +8,23 @@ sql_engine: Trino
 -- Pass Only Elements: ['listings',]
 -- Aggregate Measures
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    listing_id AS listing
+    , 1 AS bookings
+    , guest_id AS bookers
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
   SUM(listings) AS listings
 FROM (
   -- Join Standard Outputs
   SELECT
     subq_25.listing__bookings AS listing__bookings
-    , subq_31.listing__bookers AS listing__bookers
+    , subq_30.listing__bookers AS listing__bookers
     , subq_19.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
@@ -25,41 +35,34 @@ FROM (
     FROM ***************************.dim_listings_latest listings_latest_src_28000
   ) subq_19
   LEFT OUTER JOIN (
+    -- Read From CTE For node_id=sma_28009
+    -- Pass Only Elements: ['bookings', 'listing']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     -- Pass Only Elements: ['listing', 'listing__bookings']
     SELECT
       listing
       , SUM(bookings) AS listing__bookings
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['bookings', 'listing']
-      SELECT
-        listing_id AS listing
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_22
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
       listing
   ) subq_25
   ON
     subq_19.listing = subq_25.listing
   LEFT OUTER JOIN (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28009
     -- Pass Only Elements: ['bookers', 'listing']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     -- Pass Only Elements: ['listing', 'listing__bookers']
     SELECT
-      listing_id AS listing
-      , COUNT(DISTINCT guest_id) AS listing__bookers
-    FROM ***************************.fct_bookings bookings_source_src_28000
+      listing
+      , COUNT(DISTINCT bookers) AS listing__bookers
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
-      listing_id
-  ) subq_31
+      listing
+  ) subq_30
   ON
-    subq_19.listing = subq_31.listing
-) subq_32
+    subq_19.listing = subq_30.listing
+) subq_31
 WHERE listing__bookings > 2 AND listing__bookers > 1

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_conversion_metric_query_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_conversion_metric_query_filters__plan0_optimized.sql
@@ -5,17 +5,36 @@ docstring:
 sql_engine: BigQuery
 ---
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATETIME_TRUNC(ds, day) AS metric_time__day
+    , user_id AS user
+    , referrer_id AS visit__referrer_id
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
+, rss_28028_cte AS (
+  -- Read Elements From Semantic Model 'users_latest'
+  SELECT
+    home_state_latest
+    , user_id AS user
+  FROM ***************************.dim_users_latest users_latest_src_28000
+)
+
 SELECT
-  metric_time__day
-  , user__home_state_latest
+  metric_time__day AS metric_time__day
+  , user__home_state_latest AS user__home_state_latest
   , CAST(buys AS FLOAT64) / CAST(NULLIF(visits, 0) AS FLOAT64) AS visit_buy_conversion_rate_7days
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_30.metric_time__day, subq_44.metric_time__day) AS metric_time__day
-    , COALESCE(subq_30.user__home_state_latest, subq_44.user__home_state_latest) AS user__home_state_latest
+    COALESCE(subq_30.metric_time__day, subq_43.metric_time__day) AS metric_time__day
+    , COALESCE(subq_30.user__home_state_latest, subq_43.user__home_state_latest) AS user__home_state_latest
     , MAX(subq_30.visits) AS visits
-    , MAX(subq_44.buys) AS buys
+    , MAX(subq_43.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['visits', 'user__home_state_latest', 'metric_time__day']
@@ -27,24 +46,15 @@ FROM (
     FROM (
       -- Join Standard Outputs
       SELECT
-        users_latest_src_28000.home_state_latest AS user__home_state_latest
-        , subq_24.metric_time__day AS metric_time__day
-        , subq_24.visit__referrer_id AS visit__referrer_id
-        , subq_24.visits AS visits
-      FROM (
-        -- Read Elements From Semantic Model 'visits_source'
-        -- Metric Time Dimension 'ds'
-        SELECT
-          DATETIME_TRUNC(ds, day) AS metric_time__day
-          , user_id AS user
-          , referrer_id AS visit__referrer_id
-          , 1 AS visits
-        FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_24
+        rss_28028_cte.home_state_latest AS user__home_state_latest
+        , sma_28019_cte.metric_time__day AS metric_time__day
+        , sma_28019_cte.visit__referrer_id AS visit__referrer_id
+        , sma_28019_cte.visits AS visits
+      FROM sma_28019_cte sma_28019_cte
       LEFT OUTER JOIN
-        ***************************.dim_users_latest users_latest_src_28000
+        rss_28028_cte rss_28028_cte
       ON
-        subq_24.user = users_latest_src_28000.user_id
+        sma_28019_cte.user = rss_28028_cte.user
     ) subq_27
     WHERE visit__referrer_id = '123456'
     GROUP BY
@@ -62,82 +72,73 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_37.visits) OVER (
+        FIRST_VALUE(subq_36.visits) OVER (
           PARTITION BY
-            subq_40.user
-            , subq_40.metric_time__day
-            , subq_40.mf_internal_uuid
-          ORDER BY subq_37.metric_time__day DESC
+            subq_39.user
+            , subq_39.metric_time__day
+            , subq_39.mf_internal_uuid
+          ORDER BY subq_36.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_37.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_36.visit__referrer_id) OVER (
           PARTITION BY
-            subq_40.user
-            , subq_40.metric_time__day
-            , subq_40.mf_internal_uuid
-          ORDER BY subq_37.metric_time__day DESC
+            subq_39.user
+            , subq_39.metric_time__day
+            , subq_39.mf_internal_uuid
+          ORDER BY subq_36.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_37.user__home_state_latest) OVER (
+        , FIRST_VALUE(subq_36.user__home_state_latest) OVER (
           PARTITION BY
-            subq_40.user
-            , subq_40.metric_time__day
-            , subq_40.mf_internal_uuid
-          ORDER BY subq_37.metric_time__day DESC
+            subq_39.user
+            , subq_39.metric_time__day
+            , subq_39.mf_internal_uuid
+          ORDER BY subq_36.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user__home_state_latest
-        , FIRST_VALUE(subq_37.metric_time__day) OVER (
+        , FIRST_VALUE(subq_36.metric_time__day) OVER (
           PARTITION BY
-            subq_40.user
-            , subq_40.metric_time__day
-            , subq_40.mf_internal_uuid
-          ORDER BY subq_37.metric_time__day DESC
+            subq_39.user
+            , subq_39.metric_time__day
+            , subq_39.mf_internal_uuid
+          ORDER BY subq_36.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_37.user) OVER (
+        , FIRST_VALUE(subq_36.user) OVER (
           PARTITION BY
-            subq_40.user
-            , subq_40.metric_time__day
-            , subq_40.mf_internal_uuid
-          ORDER BY subq_37.metric_time__day DESC
+            subq_39.user
+            , subq_39.metric_time__day
+            , subq_39.mf_internal_uuid
+          ORDER BY subq_36.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_40.mf_internal_uuid AS mf_internal_uuid
-        , subq_40.buys AS buys
+        , subq_39.mf_internal_uuid AS mf_internal_uuid
+        , subq_39.buys AS buys
       FROM (
         -- Constrain Output with WHERE
         -- Pass Only Elements: ['visits', 'visit__referrer_id', 'user__home_state_latest', 'metric_time__day', 'user']
         SELECT
           metric_time__day
-          , subq_35.user
+          , subq_34.user
           , visit__referrer_id
           , user__home_state_latest
           , visits
         FROM (
           -- Join Standard Outputs
           SELECT
-            users_latest_src_28000.home_state_latest AS user__home_state_latest
-            , subq_32.metric_time__day AS metric_time__day
-            , subq_32.user AS user
-            , subq_32.visit__referrer_id AS visit__referrer_id
-            , subq_32.visits AS visits
-          FROM (
-            -- Read Elements From Semantic Model 'visits_source'
-            -- Metric Time Dimension 'ds'
-            SELECT
-              DATETIME_TRUNC(ds, day) AS metric_time__day
-              , user_id AS user
-              , referrer_id AS visit__referrer_id
-              , 1 AS visits
-            FROM ***************************.fct_visits visits_source_src_28000
-          ) subq_32
+            rss_28028_cte.home_state_latest AS user__home_state_latest
+            , sma_28019_cte.metric_time__day AS metric_time__day
+            , sma_28019_cte.user AS user
+            , sma_28019_cte.visit__referrer_id AS visit__referrer_id
+            , sma_28019_cte.visits AS visits
+          FROM sma_28019_cte sma_28019_cte
           LEFT OUTER JOIN
-            ***************************.dim_users_latest users_latest_src_28000
+            rss_28028_cte rss_28028_cte
           ON
-            subq_32.user = users_latest_src_28000.user_id
-        ) subq_35
+            sma_28019_cte.user = rss_28028_cte.user
+        ) subq_34
         WHERE visit__referrer_id = '123456'
-      ) subq_37
+      ) subq_36
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -148,29 +149,29 @@ FROM (
           , 1 AS buys
           , GENERATE_UUID() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_40
+      ) subq_39
       ON
         (
-          subq_37.user = subq_40.user
+          subq_36.user = subq_39.user
         ) AND (
           (
-            subq_37.metric_time__day <= subq_40.metric_time__day
+            subq_36.metric_time__day <= subq_39.metric_time__day
           ) AND (
-            subq_37.metric_time__day > DATE_SUB(CAST(subq_40.metric_time__day AS DATETIME), INTERVAL 7 day)
+            subq_36.metric_time__day > DATE_SUB(CAST(subq_39.metric_time__day AS DATETIME), INTERVAL 7 day)
           )
         )
-    ) subq_41
+    ) subq_40
     GROUP BY
       metric_time__day
       , user__home_state_latest
-  ) subq_44
+  ) subq_43
   ON
     (
-      subq_30.user__home_state_latest = subq_44.user__home_state_latest
+      subq_30.user__home_state_latest = subq_43.user__home_state_latest
     ) AND (
-      subq_30.metric_time__day = subq_44.metric_time__day
+      subq_30.metric_time__day = subq_43.metric_time__day
     )
   GROUP BY
     metric_time__day
     , user__home_state_latest
-) subq_45
+) subq_44

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_different_filters_on_same_measure_source_categorical_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_different_filters_on_same_measure_source_categorical_dimension__plan0_optimized.sql
@@ -13,15 +13,26 @@ docstring:
 sql_engine: BigQuery
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATETIME_TRUNC(ds, day) AS metric_time__day
+    , is_instant AS booking__is_instant
+    , booking_value AS max_booking_value
+    , booking_value AS average_booking_value
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__day
+  metric_time__day AS metric_time__day
   , CAST(average_booking_value AS FLOAT64) / CAST(NULLIF(max_booking_value, 0) AS FLOAT64) AS instant_booking_fraction_of_max_value
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_17.metric_time__day, subq_22.metric_time__day) AS metric_time__day
+    COALESCE(subq_17.metric_time__day, subq_21.metric_time__day) AS metric_time__day
     , MAX(subq_17.average_booking_value) AS average_booking_value
-    , MAX(subq_22.max_booking_value) AS max_booking_value
+    , MAX(subq_21.max_booking_value) AS max_booking_value
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['average_booking_value', 'metric_time__day']
@@ -31,33 +42,32 @@ FROM (
       metric_time__day
       , AVG(average_booking_value) AS average_booking_value
     FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
+      -- Read From CTE For node_id=sma_28009
       SELECT
-        DATETIME_TRUNC(ds, day) AS metric_time__day
-        , is_instant AS booking__is_instant
-        , booking_value AS average_booking_value
-      FROM ***************************.fct_bookings bookings_source_src_28000
+        metric_time__day
+        , booking__is_instant
+        , max_booking_value
+        , average_booking_value
+      FROM sma_28009_cte sma_28009_cte
     ) subq_13
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
   ) subq_17
   FULL OUTER JOIN (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28009
     -- Pass Only Elements: ['max_booking_value', 'metric_time__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      DATETIME_TRUNC(ds, day) AS metric_time__day
-      , MAX(booking_value) AS max_booking_value
-    FROM ***************************.fct_bookings bookings_source_src_28000
+      metric_time__day
+      , MAX(max_booking_value) AS max_booking_value
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
       metric_time__day
-  ) subq_22
+  ) subq_21
   ON
-    subq_17.metric_time__day = subq_22.metric_time__day
+    subq_17.metric_time__day = subq_21.metric_time__day
   GROUP BY
     metric_time__day
-) subq_23
+) subq_22

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0_optimized.sql
@@ -7,17 +7,37 @@ docstring:
 sql_engine: BigQuery
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATETIME_TRUNC(ds, day) AS metric_time__day
+    , listing_id AS listing
+    , is_instant AS booking__is_instant
+    , 1 AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
+, sma_28014_cte AS (
+  -- Read Elements From Semantic Model 'listings_latest'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    listing_id AS listing
+    , country AS country_latest
+  FROM ***************************.dim_listings_latest listings_latest_src_28000
+)
+
 SELECT
-  metric_time__day
-  , listing__country_latest
+  metric_time__day AS metric_time__day
+  , listing__country_latest AS listing__country_latest
   , bookings_fill_nulls_with_0 - bookings_2_weeks_ago AS bookings_growth_2_weeks_fill_nulls_with_0
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_42.metric_time__day, subq_58.metric_time__day) AS metric_time__day
-    , COALESCE(subq_42.listing__country_latest, subq_58.listing__country_latest) AS listing__country_latest
+    COALESCE(subq_42.metric_time__day, subq_56.metric_time__day) AS metric_time__day
+    , COALESCE(subq_42.listing__country_latest, subq_56.listing__country_latest) AS listing__country_latest
     , COALESCE(MAX(subq_42.bookings_fill_nulls_with_0), 0) AS bookings_fill_nulls_with_0
-    , COALESCE(MAX(subq_58.bookings_2_weeks_ago), 0) AS bookings_2_weeks_ago
+    , COALESCE(MAX(subq_56.bookings_2_weeks_ago), 0) AS bookings_2_weeks_ago
   FROM (
     -- Compute Metrics via Expressions
     SELECT
@@ -42,24 +62,15 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            listings_latest_src_28000.country AS listing__country_latest
-            , subq_31.metric_time__day AS metric_time__day
-            , subq_31.booking__is_instant AS booking__is_instant
-            , subq_31.bookings AS bookings
-          FROM (
-            -- Read Elements From Semantic Model 'bookings_source'
-            -- Metric Time Dimension 'ds'
-            SELECT
-              DATETIME_TRUNC(ds, day) AS metric_time__day
-              , listing_id AS listing
-              , is_instant AS booking__is_instant
-              , 1 AS bookings
-            FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_31
+            sma_28014_cte.country_latest AS listing__country_latest
+            , sma_28009_cte.metric_time__day AS metric_time__day
+            , sma_28009_cte.booking__is_instant AS booking__is_instant
+            , sma_28009_cte.bookings AS bookings
+          FROM sma_28009_cte sma_28009_cte
           LEFT OUTER JOIN
-            ***************************.dim_listings_latest listings_latest_src_28000
+            sma_28014_cte sma_28014_cte
           ON
-            subq_31.listing = listings_latest_src_28000.listing_id
+            sma_28009_cte.listing = sma_28014_cte.listing
         ) subq_35
         WHERE booking__is_instant
         GROUP BY
@@ -79,10 +90,10 @@ FROM (
     FROM (
       -- Join to Time Spine Dataset
       SELECT
-        subq_56.ds AS metric_time__day
-        , subq_54.listing__country_latest AS listing__country_latest
-        , subq_54.bookings AS bookings
-      FROM ***************************.mf_time_spine subq_56
+        subq_54.ds AS metric_time__day
+        , subq_52.listing__country_latest AS listing__country_latest
+        , subq_52.bookings AS bookings
+      FROM ***************************.mf_time_spine subq_54
       LEFT OUTER JOIN (
         -- Constrain Output with WHERE
         -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
@@ -94,52 +105,44 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            listings_latest_src_28000.country AS listing__country_latest
-            , subq_47.metric_time__day AS metric_time__day
-            , subq_47.booking__is_instant AS booking__is_instant
-            , subq_47.bookings AS bookings
+            sma_28014_cte.country_latest AS listing__country_latest
+            , subq_46.metric_time__day AS metric_time__day
+            , subq_46.booking__is_instant AS booking__is_instant
+            , subq_46.bookings AS bookings
           FROM (
             -- Join to Time Spine Dataset
             SELECT
-              subq_46.ds AS metric_time__day
-              , subq_44.listing AS listing
-              , subq_44.booking__is_instant AS booking__is_instant
-              , subq_44.bookings AS bookings
-            FROM ***************************.mf_time_spine subq_46
-            INNER JOIN (
-              -- Read Elements From Semantic Model 'bookings_source'
-              -- Metric Time Dimension 'ds'
-              SELECT
-                DATETIME_TRUNC(ds, day) AS metric_time__day
-                , listing_id AS listing
-                , is_instant AS booking__is_instant
-                , 1 AS bookings
-              FROM ***************************.fct_bookings bookings_source_src_28000
-            ) subq_44
+              subq_45.ds AS metric_time__day
+              , sma_28009_cte.listing AS listing
+              , sma_28009_cte.booking__is_instant AS booking__is_instant
+              , sma_28009_cte.bookings AS bookings
+            FROM ***************************.mf_time_spine subq_45
+            INNER JOIN
+              sma_28009_cte sma_28009_cte
             ON
-              DATE_SUB(CAST(subq_46.ds AS DATETIME), INTERVAL 14 day) = subq_44.metric_time__day
-          ) subq_47
+              DATE_SUB(CAST(subq_45.ds AS DATETIME), INTERVAL 14 day) = sma_28009_cte.metric_time__day
+          ) subq_46
           LEFT OUTER JOIN
-            ***************************.dim_listings_latest listings_latest_src_28000
+            sma_28014_cte sma_28014_cte
           ON
-            subq_47.listing = listings_latest_src_28000.listing_id
-        ) subq_51
+            subq_46.listing = sma_28014_cte.listing
+        ) subq_49
         WHERE booking__is_instant
         GROUP BY
           metric_time__day
           , listing__country_latest
-      ) subq_54
+      ) subq_52
       ON
-        subq_56.ds = subq_54.metric_time__day
-    ) subq_57
-  ) subq_58
+        subq_54.ds = subq_52.metric_time__day
+    ) subq_55
+  ) subq_56
   ON
     (
-      subq_42.listing__country_latest = subq_58.listing__country_latest
+      subq_42.listing__country_latest = subq_56.listing__country_latest
     ) AND (
-      subq_42.metric_time__day = subq_58.metric_time__day
+      subq_42.metric_time__day = subq_56.metric_time__day
     )
   GROUP BY
     metric_time__day
     , listing__country_latest
-) subq_59
+) subq_57

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_offset_metric_with_query_time_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_offset_metric_with_query_time_filters__plan0_optimized.sql
@@ -7,17 +7,37 @@ docstring:
 sql_engine: BigQuery
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATETIME_TRUNC(ds, day) AS metric_time__day
+    , listing_id AS listing
+    , is_instant AS booking__is_instant
+    , 1 AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
+, sma_28014_cte AS (
+  -- Read Elements From Semantic Model 'listings_latest'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    listing_id AS listing
+    , country AS country_latest
+  FROM ***************************.dim_listings_latest listings_latest_src_28000
+)
+
 SELECT
-  metric_time__day
-  , listing__country_latest
+  metric_time__day AS metric_time__day
+  , listing__country_latest AS listing__country_latest
   , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_33.metric_time__day, subq_46.metric_time__day) AS metric_time__day
-    , COALESCE(subq_33.listing__country_latest, subq_46.listing__country_latest) AS listing__country_latest
+    COALESCE(subq_33.metric_time__day, subq_44.metric_time__day) AS metric_time__day
+    , COALESCE(subq_33.listing__country_latest, subq_44.listing__country_latest) AS listing__country_latest
     , MAX(subq_33.bookings) AS bookings
-    , MAX(subq_46.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+    , MAX(subq_44.bookings_2_weeks_ago) AS bookings_2_weeks_ago
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
@@ -30,24 +50,15 @@ FROM (
     FROM (
       -- Join Standard Outputs
       SELECT
-        listings_latest_src_28000.country AS listing__country_latest
-        , subq_25.metric_time__day AS metric_time__day
-        , subq_25.booking__is_instant AS booking__is_instant
-        , subq_25.bookings AS bookings
-      FROM (
-        -- Read Elements From Semantic Model 'bookings_source'
-        -- Metric Time Dimension 'ds'
-        SELECT
-          DATETIME_TRUNC(ds, day) AS metric_time__day
-          , listing_id AS listing
-          , is_instant AS booking__is_instant
-          , 1 AS bookings
-        FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_25
+        sma_28014_cte.country_latest AS listing__country_latest
+        , sma_28009_cte.metric_time__day AS metric_time__day
+        , sma_28009_cte.booking__is_instant AS booking__is_instant
+        , sma_28009_cte.bookings AS bookings
+      FROM sma_28009_cte sma_28009_cte
       LEFT OUTER JOIN
-        ***************************.dim_listings_latest listings_latest_src_28000
+        sma_28014_cte sma_28014_cte
       ON
-        subq_25.listing = listings_latest_src_28000.listing_id
+        sma_28009_cte.listing = sma_28014_cte.listing
     ) subq_29
     WHERE booking__is_instant
     GROUP BY
@@ -66,48 +77,40 @@ FROM (
     FROM (
       -- Join Standard Outputs
       SELECT
-        listings_latest_src_28000.country AS listing__country_latest
-        , subq_38.metric_time__day AS metric_time__day
-        , subq_38.booking__is_instant AS booking__is_instant
-        , subq_38.bookings AS bookings
+        sma_28014_cte.country_latest AS listing__country_latest
+        , subq_37.metric_time__day AS metric_time__day
+        , subq_37.booking__is_instant AS booking__is_instant
+        , subq_37.bookings AS bookings
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_37.ds AS metric_time__day
-          , subq_35.listing AS listing
-          , subq_35.booking__is_instant AS booking__is_instant
-          , subq_35.bookings AS bookings
-        FROM ***************************.mf_time_spine subq_37
-        INNER JOIN (
-          -- Read Elements From Semantic Model 'bookings_source'
-          -- Metric Time Dimension 'ds'
-          SELECT
-            DATETIME_TRUNC(ds, day) AS metric_time__day
-            , listing_id AS listing
-            , is_instant AS booking__is_instant
-            , 1 AS bookings
-          FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_35
+          subq_36.ds AS metric_time__day
+          , sma_28009_cte.listing AS listing
+          , sma_28009_cte.booking__is_instant AS booking__is_instant
+          , sma_28009_cte.bookings AS bookings
+        FROM ***************************.mf_time_spine subq_36
+        INNER JOIN
+          sma_28009_cte sma_28009_cte
         ON
-          DATE_SUB(CAST(subq_37.ds AS DATETIME), INTERVAL 14 day) = subq_35.metric_time__day
-      ) subq_38
+          DATE_SUB(CAST(subq_36.ds AS DATETIME), INTERVAL 14 day) = sma_28009_cte.metric_time__day
+      ) subq_37
       LEFT OUTER JOIN
-        ***************************.dim_listings_latest listings_latest_src_28000
+        sma_28014_cte sma_28014_cte
       ON
-        subq_38.listing = listings_latest_src_28000.listing_id
-    ) subq_42
+        subq_37.listing = sma_28014_cte.listing
+    ) subq_40
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
       , listing__country_latest
-  ) subq_46
+  ) subq_44
   ON
     (
-      subq_33.listing__country_latest = subq_46.listing__country_latest
+      subq_33.listing__country_latest = subq_44.listing__country_latest
     ) AND (
-      subq_33.metric_time__day = subq_46.metric_time__day
+      subq_33.metric_time__day = subq_44.metric_time__day
     )
   GROUP BY
     metric_time__day
     , listing__country_latest
-) subq_47
+) subq_45

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_saved_query_with_metric_joins_and_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_saved_query_with_metric_joins_and_filter__plan0_optimized.sql
@@ -7,12 +7,7 @@ docstring:
 sql_engine: BigQuery
 ---
 -- Combine Aggregated Outputs
-SELECT
-  COALESCE(subq_51.listing__capacity_latest, subq_61.listing__capacity_latest, subq_82.listing__capacity_latest) AS listing__capacity_latest
-  , MAX(subq_51.bookings) AS bookings
-  , MAX(subq_61.views) AS views
-  , MAX(CAST(subq_82.bookings AS FLOAT64) / CAST(NULLIF(subq_82.views, 0) AS FLOAT64)) AS bookings_per_view
-FROM (
+WITH cm_6_cte AS (
   -- Constrain Output with WHERE
   -- Pass Only Elements: ['bookings', 'listing__capacity_latest']
   -- Aggregate Measures
@@ -44,8 +39,9 @@ FROM (
   WHERE (listing__is_lux_latest) AND (metric_time__day >= '2020-01-02')
   GROUP BY
     listing__capacity_latest
-) subq_51
-FULL OUTER JOIN (
+)
+
+, cm_7_cte AS (
   -- Constrain Output with WHERE
   -- Pass Only Elements: ['views', 'listing__capacity_latest']
   -- Aggregate Measures
@@ -77,87 +73,33 @@ FULL OUTER JOIN (
   WHERE (listing__is_lux_latest) AND (metric_time__day >= '2020-01-02')
   GROUP BY
     listing__capacity_latest
-) subq_61
+)
+
+SELECT
+  COALESCE(cm_6_cte.listing__capacity_latest, cm_7_cte.listing__capacity_latest, subq_64.listing__capacity_latest) AS listing__capacity_latest
+  , MAX(cm_6_cte.bookings) AS bookings
+  , MAX(cm_7_cte.views) AS views
+  , MAX(CAST(subq_64.bookings AS FLOAT64) / CAST(NULLIF(subq_64.views, 0) AS FLOAT64)) AS bookings_per_view
+FROM cm_6_cte cm_6_cte
+FULL OUTER JOIN
+  cm_7_cte cm_7_cte
 ON
-  subq_51.listing__capacity_latest = subq_61.listing__capacity_latest
+  cm_6_cte.listing__capacity_latest = cm_7_cte.listing__capacity_latest
 FULL OUTER JOIN (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_71.listing__capacity_latest, subq_81.listing__capacity_latest) AS listing__capacity_latest
-    , MAX(subq_71.bookings) AS bookings
-    , MAX(subq_81.views) AS views
-  FROM (
-    -- Constrain Output with WHERE
-    -- Pass Only Elements: ['bookings', 'listing__capacity_latest']
-    -- Aggregate Measures
-    -- Compute Metrics via Expressions
-    SELECT
-      listing__capacity_latest
-      , SUM(bookings) AS bookings
-    FROM (
-      -- Join Standard Outputs
-      SELECT
-        listings_latest_src_28000.is_lux AS listing__is_lux_latest
-        , listings_latest_src_28000.capacity AS listing__capacity_latest
-        , subq_63.metric_time__day AS metric_time__day
-        , subq_63.bookings AS bookings
-      FROM (
-        -- Read Elements From Semantic Model 'bookings_source'
-        -- Metric Time Dimension 'ds'
-        SELECT
-          DATETIME_TRUNC(ds, day) AS metric_time__day
-          , listing_id AS listing
-          , 1 AS bookings
-        FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_63
-      LEFT OUTER JOIN
-        ***************************.dim_listings_latest listings_latest_src_28000
-      ON
-        subq_63.listing = listings_latest_src_28000.listing_id
-    ) subq_67
-    WHERE (listing__is_lux_latest) AND (metric_time__day >= '2020-01-02')
-    GROUP BY
-      listing__capacity_latest
-  ) subq_71
-  FULL OUTER JOIN (
-    -- Constrain Output with WHERE
-    -- Pass Only Elements: ['views', 'listing__capacity_latest']
-    -- Aggregate Measures
-    -- Compute Metrics via Expressions
-    SELECT
-      listing__capacity_latest
-      , SUM(views) AS views
-    FROM (
-      -- Join Standard Outputs
-      SELECT
-        listings_latest_src_28000.is_lux AS listing__is_lux_latest
-        , listings_latest_src_28000.capacity AS listing__capacity_latest
-        , subq_73.metric_time__day AS metric_time__day
-        , subq_73.views AS views
-      FROM (
-        -- Read Elements From Semantic Model 'views_source'
-        -- Metric Time Dimension 'ds'
-        SELECT
-          DATETIME_TRUNC(ds, day) AS metric_time__day
-          , listing_id AS listing
-          , 1 AS views
-        FROM ***************************.fct_views views_source_src_28000
-      ) subq_73
-      LEFT OUTER JOIN
-        ***************************.dim_listings_latest listings_latest_src_28000
-      ON
-        subq_73.listing = listings_latest_src_28000.listing_id
-    ) subq_77
-    WHERE (listing__is_lux_latest) AND (metric_time__day >= '2020-01-02')
-    GROUP BY
-      listing__capacity_latest
-  ) subq_81
+    COALESCE(cm_6_cte.listing__capacity_latest, cm_7_cte.listing__capacity_latest) AS listing__capacity_latest
+    , MAX(cm_6_cte.bookings) AS bookings
+    , MAX(cm_7_cte.views) AS views
+  FROM cm_6_cte cm_6_cte
+  FULL OUTER JOIN
+    cm_7_cte cm_7_cte
   ON
-    subq_71.listing__capacity_latest = subq_81.listing__capacity_latest
+    cm_6_cte.listing__capacity_latest = cm_7_cte.listing__capacity_latest
   GROUP BY
     listing__capacity_latest
-) subq_82
+) subq_64
 ON
-  COALESCE(subq_51.listing__capacity_latest, subq_61.listing__capacity_latest) = subq_82.listing__capacity_latest
+  COALESCE(cm_6_cte.listing__capacity_latest, cm_7_cte.listing__capacity_latest) = subq_64.listing__capacity_latest
 GROUP BY
   listing__capacity_latest

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_conversion_metric_query_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_conversion_metric_query_filters__plan0_optimized.sql
@@ -5,17 +5,36 @@ docstring:
 sql_engine: Databricks
 ---
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , referrer_id AS visit__referrer_id
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
+, rss_28028_cte AS (
+  -- Read Elements From Semantic Model 'users_latest'
+  SELECT
+    home_state_latest
+    , user_id AS user
+  FROM ***************************.dim_users_latest users_latest_src_28000
+)
+
 SELECT
-  metric_time__day
-  , user__home_state_latest
+  metric_time__day AS metric_time__day
+  , user__home_state_latest AS user__home_state_latest
   , CAST(buys AS DOUBLE) / CAST(NULLIF(visits, 0) AS DOUBLE) AS visit_buy_conversion_rate_7days
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_30.metric_time__day, subq_44.metric_time__day) AS metric_time__day
-    , COALESCE(subq_30.user__home_state_latest, subq_44.user__home_state_latest) AS user__home_state_latest
+    COALESCE(subq_30.metric_time__day, subq_43.metric_time__day) AS metric_time__day
+    , COALESCE(subq_30.user__home_state_latest, subq_43.user__home_state_latest) AS user__home_state_latest
     , MAX(subq_30.visits) AS visits
-    , MAX(subq_44.buys) AS buys
+    , MAX(subq_43.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['visits', 'user__home_state_latest', 'metric_time__day']
@@ -27,24 +46,15 @@ FROM (
     FROM (
       -- Join Standard Outputs
       SELECT
-        users_latest_src_28000.home_state_latest AS user__home_state_latest
-        , subq_24.metric_time__day AS metric_time__day
-        , subq_24.visit__referrer_id AS visit__referrer_id
-        , subq_24.visits AS visits
-      FROM (
-        -- Read Elements From Semantic Model 'visits_source'
-        -- Metric Time Dimension 'ds'
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , user_id AS user
-          , referrer_id AS visit__referrer_id
-          , 1 AS visits
-        FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_24
+        rss_28028_cte.home_state_latest AS user__home_state_latest
+        , sma_28019_cte.metric_time__day AS metric_time__day
+        , sma_28019_cte.visit__referrer_id AS visit__referrer_id
+        , sma_28019_cte.visits AS visits
+      FROM sma_28019_cte sma_28019_cte
       LEFT OUTER JOIN
-        ***************************.dim_users_latest users_latest_src_28000
+        rss_28028_cte rss_28028_cte
       ON
-        subq_24.user = users_latest_src_28000.user_id
+        sma_28019_cte.user = rss_28028_cte.user
     ) subq_27
     WHERE visit__referrer_id = '123456'
     GROUP BY
@@ -62,82 +72,73 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_37.visits) OVER (
+        FIRST_VALUE(subq_36.visits) OVER (
           PARTITION BY
-            subq_40.user
-            , subq_40.metric_time__day
-            , subq_40.mf_internal_uuid
-          ORDER BY subq_37.metric_time__day DESC
+            subq_39.user
+            , subq_39.metric_time__day
+            , subq_39.mf_internal_uuid
+          ORDER BY subq_36.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_37.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_36.visit__referrer_id) OVER (
           PARTITION BY
-            subq_40.user
-            , subq_40.metric_time__day
-            , subq_40.mf_internal_uuid
-          ORDER BY subq_37.metric_time__day DESC
+            subq_39.user
+            , subq_39.metric_time__day
+            , subq_39.mf_internal_uuid
+          ORDER BY subq_36.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_37.user__home_state_latest) OVER (
+        , FIRST_VALUE(subq_36.user__home_state_latest) OVER (
           PARTITION BY
-            subq_40.user
-            , subq_40.metric_time__day
-            , subq_40.mf_internal_uuid
-          ORDER BY subq_37.metric_time__day DESC
+            subq_39.user
+            , subq_39.metric_time__day
+            , subq_39.mf_internal_uuid
+          ORDER BY subq_36.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user__home_state_latest
-        , FIRST_VALUE(subq_37.metric_time__day) OVER (
+        , FIRST_VALUE(subq_36.metric_time__day) OVER (
           PARTITION BY
-            subq_40.user
-            , subq_40.metric_time__day
-            , subq_40.mf_internal_uuid
-          ORDER BY subq_37.metric_time__day DESC
+            subq_39.user
+            , subq_39.metric_time__day
+            , subq_39.mf_internal_uuid
+          ORDER BY subq_36.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_37.user) OVER (
+        , FIRST_VALUE(subq_36.user) OVER (
           PARTITION BY
-            subq_40.user
-            , subq_40.metric_time__day
-            , subq_40.mf_internal_uuid
-          ORDER BY subq_37.metric_time__day DESC
+            subq_39.user
+            , subq_39.metric_time__day
+            , subq_39.mf_internal_uuid
+          ORDER BY subq_36.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_40.mf_internal_uuid AS mf_internal_uuid
-        , subq_40.buys AS buys
+        , subq_39.mf_internal_uuid AS mf_internal_uuid
+        , subq_39.buys AS buys
       FROM (
         -- Constrain Output with WHERE
         -- Pass Only Elements: ['visits', 'visit__referrer_id', 'user__home_state_latest', 'metric_time__day', 'user']
         SELECT
           metric_time__day
-          , subq_35.user
+          , subq_34.user
           , visit__referrer_id
           , user__home_state_latest
           , visits
         FROM (
           -- Join Standard Outputs
           SELECT
-            users_latest_src_28000.home_state_latest AS user__home_state_latest
-            , subq_32.metric_time__day AS metric_time__day
-            , subq_32.user AS user
-            , subq_32.visit__referrer_id AS visit__referrer_id
-            , subq_32.visits AS visits
-          FROM (
-            -- Read Elements From Semantic Model 'visits_source'
-            -- Metric Time Dimension 'ds'
-            SELECT
-              DATE_TRUNC('day', ds) AS metric_time__day
-              , user_id AS user
-              , referrer_id AS visit__referrer_id
-              , 1 AS visits
-            FROM ***************************.fct_visits visits_source_src_28000
-          ) subq_32
+            rss_28028_cte.home_state_latest AS user__home_state_latest
+            , sma_28019_cte.metric_time__day AS metric_time__day
+            , sma_28019_cte.user AS user
+            , sma_28019_cte.visit__referrer_id AS visit__referrer_id
+            , sma_28019_cte.visits AS visits
+          FROM sma_28019_cte sma_28019_cte
           LEFT OUTER JOIN
-            ***************************.dim_users_latest users_latest_src_28000
+            rss_28028_cte rss_28028_cte
           ON
-            subq_32.user = users_latest_src_28000.user_id
-        ) subq_35
+            sma_28019_cte.user = rss_28028_cte.user
+        ) subq_34
         WHERE visit__referrer_id = '123456'
-      ) subq_37
+      ) subq_36
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -148,29 +149,29 @@ FROM (
           , 1 AS buys
           , UUID() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_40
+      ) subq_39
       ON
         (
-          subq_37.user = subq_40.user
+          subq_36.user = subq_39.user
         ) AND (
           (
-            subq_37.metric_time__day <= subq_40.metric_time__day
+            subq_36.metric_time__day <= subq_39.metric_time__day
           ) AND (
-            subq_37.metric_time__day > DATEADD(day, -7, subq_40.metric_time__day)
+            subq_36.metric_time__day > DATEADD(day, -7, subq_39.metric_time__day)
           )
         )
-    ) subq_41
+    ) subq_40
     GROUP BY
       metric_time__day
       , user__home_state_latest
-  ) subq_44
+  ) subq_43
   ON
     (
-      subq_30.user__home_state_latest = subq_44.user__home_state_latest
+      subq_30.user__home_state_latest = subq_43.user__home_state_latest
     ) AND (
-      subq_30.metric_time__day = subq_44.metric_time__day
+      subq_30.metric_time__day = subq_43.metric_time__day
     )
   GROUP BY
-    COALESCE(subq_30.metric_time__day, subq_44.metric_time__day)
-    , COALESCE(subq_30.user__home_state_latest, subq_44.user__home_state_latest)
-) subq_45
+    COALESCE(subq_30.metric_time__day, subq_43.metric_time__day)
+    , COALESCE(subq_30.user__home_state_latest, subq_43.user__home_state_latest)
+) subq_44

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_different_filters_on_same_measure_source_categorical_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_different_filters_on_same_measure_source_categorical_dimension__plan0_optimized.sql
@@ -13,15 +13,26 @@ docstring:
 sql_engine: Databricks
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , is_instant AS booking__is_instant
+    , booking_value AS max_booking_value
+    , booking_value AS average_booking_value
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__day
+  metric_time__day AS metric_time__day
   , CAST(average_booking_value AS DOUBLE) / CAST(NULLIF(max_booking_value, 0) AS DOUBLE) AS instant_booking_fraction_of_max_value
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_17.metric_time__day, subq_22.metric_time__day) AS metric_time__day
+    COALESCE(subq_17.metric_time__day, subq_21.metric_time__day) AS metric_time__day
     , MAX(subq_17.average_booking_value) AS average_booking_value
-    , MAX(subq_22.max_booking_value) AS max_booking_value
+    , MAX(subq_21.max_booking_value) AS max_booking_value
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['average_booking_value', 'metric_time__day']
@@ -31,33 +42,32 @@ FROM (
       metric_time__day
       , AVG(average_booking_value) AS average_booking_value
     FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
+      -- Read From CTE For node_id=sma_28009
       SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , is_instant AS booking__is_instant
-        , booking_value AS average_booking_value
-      FROM ***************************.fct_bookings bookings_source_src_28000
+        metric_time__day
+        , booking__is_instant
+        , max_booking_value
+        , average_booking_value
+      FROM sma_28009_cte sma_28009_cte
     ) subq_13
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
   ) subq_17
   FULL OUTER JOIN (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28009
     -- Pass Only Elements: ['max_booking_value', 'metric_time__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      DATE_TRUNC('day', ds) AS metric_time__day
-      , MAX(booking_value) AS max_booking_value
-    FROM ***************************.fct_bookings bookings_source_src_28000
+      metric_time__day
+      , MAX(max_booking_value) AS max_booking_value
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
-      DATE_TRUNC('day', ds)
-  ) subq_22
+      metric_time__day
+  ) subq_21
   ON
-    subq_17.metric_time__day = subq_22.metric_time__day
+    subq_17.metric_time__day = subq_21.metric_time__day
   GROUP BY
-    COALESCE(subq_17.metric_time__day, subq_22.metric_time__day)
-) subq_23
+    COALESCE(subq_17.metric_time__day, subq_21.metric_time__day)
+) subq_22

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_offset_metric_with_query_time_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_offset_metric_with_query_time_filters__plan0_optimized.sql
@@ -7,17 +7,37 @@ docstring:
 sql_engine: Databricks
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , listing_id AS listing
+    , is_instant AS booking__is_instant
+    , 1 AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
+, sma_28014_cte AS (
+  -- Read Elements From Semantic Model 'listings_latest'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    listing_id AS listing
+    , country AS country_latest
+  FROM ***************************.dim_listings_latest listings_latest_src_28000
+)
+
 SELECT
-  metric_time__day
-  , listing__country_latest
+  metric_time__day AS metric_time__day
+  , listing__country_latest AS listing__country_latest
   , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_33.metric_time__day, subq_46.metric_time__day) AS metric_time__day
-    , COALESCE(subq_33.listing__country_latest, subq_46.listing__country_latest) AS listing__country_latest
+    COALESCE(subq_33.metric_time__day, subq_44.metric_time__day) AS metric_time__day
+    , COALESCE(subq_33.listing__country_latest, subq_44.listing__country_latest) AS listing__country_latest
     , MAX(subq_33.bookings) AS bookings
-    , MAX(subq_46.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+    , MAX(subq_44.bookings_2_weeks_ago) AS bookings_2_weeks_ago
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
@@ -30,24 +50,15 @@ FROM (
     FROM (
       -- Join Standard Outputs
       SELECT
-        listings_latest_src_28000.country AS listing__country_latest
-        , subq_25.metric_time__day AS metric_time__day
-        , subq_25.booking__is_instant AS booking__is_instant
-        , subq_25.bookings AS bookings
-      FROM (
-        -- Read Elements From Semantic Model 'bookings_source'
-        -- Metric Time Dimension 'ds'
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , listing_id AS listing
-          , is_instant AS booking__is_instant
-          , 1 AS bookings
-        FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_25
+        sma_28014_cte.country_latest AS listing__country_latest
+        , sma_28009_cte.metric_time__day AS metric_time__day
+        , sma_28009_cte.booking__is_instant AS booking__is_instant
+        , sma_28009_cte.bookings AS bookings
+      FROM sma_28009_cte sma_28009_cte
       LEFT OUTER JOIN
-        ***************************.dim_listings_latest listings_latest_src_28000
+        sma_28014_cte sma_28014_cte
       ON
-        subq_25.listing = listings_latest_src_28000.listing_id
+        sma_28009_cte.listing = sma_28014_cte.listing
     ) subq_29
     WHERE booking__is_instant
     GROUP BY
@@ -66,48 +77,40 @@ FROM (
     FROM (
       -- Join Standard Outputs
       SELECT
-        listings_latest_src_28000.country AS listing__country_latest
-        , subq_38.metric_time__day AS metric_time__day
-        , subq_38.booking__is_instant AS booking__is_instant
-        , subq_38.bookings AS bookings
+        sma_28014_cte.country_latest AS listing__country_latest
+        , subq_37.metric_time__day AS metric_time__day
+        , subq_37.booking__is_instant AS booking__is_instant
+        , subq_37.bookings AS bookings
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_37.ds AS metric_time__day
-          , subq_35.listing AS listing
-          , subq_35.booking__is_instant AS booking__is_instant
-          , subq_35.bookings AS bookings
-        FROM ***************************.mf_time_spine subq_37
-        INNER JOIN (
-          -- Read Elements From Semantic Model 'bookings_source'
-          -- Metric Time Dimension 'ds'
-          SELECT
-            DATE_TRUNC('day', ds) AS metric_time__day
-            , listing_id AS listing
-            , is_instant AS booking__is_instant
-            , 1 AS bookings
-          FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_35
+          subq_36.ds AS metric_time__day
+          , sma_28009_cte.listing AS listing
+          , sma_28009_cte.booking__is_instant AS booking__is_instant
+          , sma_28009_cte.bookings AS bookings
+        FROM ***************************.mf_time_spine subq_36
+        INNER JOIN
+          sma_28009_cte sma_28009_cte
         ON
-          DATEADD(day, -14, subq_37.ds) = subq_35.metric_time__day
-      ) subq_38
+          DATEADD(day, -14, subq_36.ds) = sma_28009_cte.metric_time__day
+      ) subq_37
       LEFT OUTER JOIN
-        ***************************.dim_listings_latest listings_latest_src_28000
+        sma_28014_cte sma_28014_cte
       ON
-        subq_38.listing = listings_latest_src_28000.listing_id
-    ) subq_42
+        subq_37.listing = sma_28014_cte.listing
+    ) subq_40
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
       , listing__country_latest
-  ) subq_46
+  ) subq_44
   ON
     (
-      subq_33.listing__country_latest = subq_46.listing__country_latest
+      subq_33.listing__country_latest = subq_44.listing__country_latest
     ) AND (
-      subq_33.metric_time__day = subq_46.metric_time__day
+      subq_33.metric_time__day = subq_44.metric_time__day
     )
   GROUP BY
-    COALESCE(subq_33.metric_time__day, subq_46.metric_time__day)
-    , COALESCE(subq_33.listing__country_latest, subq_46.listing__country_latest)
-) subq_47
+    COALESCE(subq_33.metric_time__day, subq_44.metric_time__day)
+    , COALESCE(subq_33.listing__country_latest, subq_44.listing__country_latest)
+) subq_45

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_different_filters_on_same_measure_source_categorical_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_different_filters_on_same_measure_source_categorical_dimension__plan0_optimized.sql
@@ -13,15 +13,26 @@ docstring:
 sql_engine: DuckDB
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , is_instant AS booking__is_instant
+    , booking_value AS max_booking_value
+    , booking_value AS average_booking_value
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__day
+  metric_time__day AS metric_time__day
   , CAST(average_booking_value AS DOUBLE) / CAST(NULLIF(max_booking_value, 0) AS DOUBLE) AS instant_booking_fraction_of_max_value
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_17.metric_time__day, subq_22.metric_time__day) AS metric_time__day
+    COALESCE(subq_17.metric_time__day, subq_21.metric_time__day) AS metric_time__day
     , MAX(subq_17.average_booking_value) AS average_booking_value
-    , MAX(subq_22.max_booking_value) AS max_booking_value
+    , MAX(subq_21.max_booking_value) AS max_booking_value
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['average_booking_value', 'metric_time__day']
@@ -31,33 +42,32 @@ FROM (
       metric_time__day
       , AVG(average_booking_value) AS average_booking_value
     FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
+      -- Read From CTE For node_id=sma_28009
       SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , is_instant AS booking__is_instant
-        , booking_value AS average_booking_value
-      FROM ***************************.fct_bookings bookings_source_src_28000
+        metric_time__day
+        , booking__is_instant
+        , max_booking_value
+        , average_booking_value
+      FROM sma_28009_cte sma_28009_cte
     ) subq_13
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
   ) subq_17
   FULL OUTER JOIN (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28009
     -- Pass Only Elements: ['max_booking_value', 'metric_time__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      DATE_TRUNC('day', ds) AS metric_time__day
-      , MAX(booking_value) AS max_booking_value
-    FROM ***************************.fct_bookings bookings_source_src_28000
+      metric_time__day
+      , MAX(max_booking_value) AS max_booking_value
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
-      DATE_TRUNC('day', ds)
-  ) subq_22
+      metric_time__day
+  ) subq_21
   ON
-    subq_17.metric_time__day = subq_22.metric_time__day
+    subq_17.metric_time__day = subq_21.metric_time__day
   GROUP BY
-    COALESCE(subq_17.metric_time__day, subq_22.metric_time__day)
-) subq_23
+    COALESCE(subq_17.metric_time__day, subq_21.metric_time__day)
+) subq_22

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0_optimized.sql
@@ -7,17 +7,37 @@ docstring:
 sql_engine: DuckDB
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , listing_id AS listing
+    , is_instant AS booking__is_instant
+    , 1 AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
+, sma_28014_cte AS (
+  -- Read Elements From Semantic Model 'listings_latest'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    listing_id AS listing
+    , country AS country_latest
+  FROM ***************************.dim_listings_latest listings_latest_src_28000
+)
+
 SELECT
-  metric_time__day
-  , listing__country_latest
+  metric_time__day AS metric_time__day
+  , listing__country_latest AS listing__country_latest
   , bookings_fill_nulls_with_0 - bookings_2_weeks_ago AS bookings_growth_2_weeks_fill_nulls_with_0
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_42.metric_time__day, subq_58.metric_time__day) AS metric_time__day
-    , COALESCE(subq_42.listing__country_latest, subq_58.listing__country_latest) AS listing__country_latest
+    COALESCE(subq_42.metric_time__day, subq_56.metric_time__day) AS metric_time__day
+    , COALESCE(subq_42.listing__country_latest, subq_56.listing__country_latest) AS listing__country_latest
     , COALESCE(MAX(subq_42.bookings_fill_nulls_with_0), 0) AS bookings_fill_nulls_with_0
-    , COALESCE(MAX(subq_58.bookings_2_weeks_ago), 0) AS bookings_2_weeks_ago
+    , COALESCE(MAX(subq_56.bookings_2_weeks_ago), 0) AS bookings_2_weeks_ago
   FROM (
     -- Compute Metrics via Expressions
     SELECT
@@ -42,24 +62,15 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            listings_latest_src_28000.country AS listing__country_latest
-            , subq_31.metric_time__day AS metric_time__day
-            , subq_31.booking__is_instant AS booking__is_instant
-            , subq_31.bookings AS bookings
-          FROM (
-            -- Read Elements From Semantic Model 'bookings_source'
-            -- Metric Time Dimension 'ds'
-            SELECT
-              DATE_TRUNC('day', ds) AS metric_time__day
-              , listing_id AS listing
-              , is_instant AS booking__is_instant
-              , 1 AS bookings
-            FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_31
+            sma_28014_cte.country_latest AS listing__country_latest
+            , sma_28009_cte.metric_time__day AS metric_time__day
+            , sma_28009_cte.booking__is_instant AS booking__is_instant
+            , sma_28009_cte.bookings AS bookings
+          FROM sma_28009_cte sma_28009_cte
           LEFT OUTER JOIN
-            ***************************.dim_listings_latest listings_latest_src_28000
+            sma_28014_cte sma_28014_cte
           ON
-            subq_31.listing = listings_latest_src_28000.listing_id
+            sma_28009_cte.listing = sma_28014_cte.listing
         ) subq_35
         WHERE booking__is_instant
         GROUP BY
@@ -79,10 +90,10 @@ FROM (
     FROM (
       -- Join to Time Spine Dataset
       SELECT
-        subq_56.ds AS metric_time__day
-        , subq_54.listing__country_latest AS listing__country_latest
-        , subq_54.bookings AS bookings
-      FROM ***************************.mf_time_spine subq_56
+        subq_54.ds AS metric_time__day
+        , subq_52.listing__country_latest AS listing__country_latest
+        , subq_52.bookings AS bookings
+      FROM ***************************.mf_time_spine subq_54
       LEFT OUTER JOIN (
         -- Constrain Output with WHERE
         -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
@@ -94,52 +105,44 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            listings_latest_src_28000.country AS listing__country_latest
-            , subq_47.metric_time__day AS metric_time__day
-            , subq_47.booking__is_instant AS booking__is_instant
-            , subq_47.bookings AS bookings
+            sma_28014_cte.country_latest AS listing__country_latest
+            , subq_46.metric_time__day AS metric_time__day
+            , subq_46.booking__is_instant AS booking__is_instant
+            , subq_46.bookings AS bookings
           FROM (
             -- Join to Time Spine Dataset
             SELECT
-              subq_46.ds AS metric_time__day
-              , subq_44.listing AS listing
-              , subq_44.booking__is_instant AS booking__is_instant
-              , subq_44.bookings AS bookings
-            FROM ***************************.mf_time_spine subq_46
-            INNER JOIN (
-              -- Read Elements From Semantic Model 'bookings_source'
-              -- Metric Time Dimension 'ds'
-              SELECT
-                DATE_TRUNC('day', ds) AS metric_time__day
-                , listing_id AS listing
-                , is_instant AS booking__is_instant
-                , 1 AS bookings
-              FROM ***************************.fct_bookings bookings_source_src_28000
-            ) subq_44
+              subq_45.ds AS metric_time__day
+              , sma_28009_cte.listing AS listing
+              , sma_28009_cte.booking__is_instant AS booking__is_instant
+              , sma_28009_cte.bookings AS bookings
+            FROM ***************************.mf_time_spine subq_45
+            INNER JOIN
+              sma_28009_cte sma_28009_cte
             ON
-              subq_46.ds - INTERVAL 14 day = subq_44.metric_time__day
-          ) subq_47
+              subq_45.ds - INTERVAL 14 day = sma_28009_cte.metric_time__day
+          ) subq_46
           LEFT OUTER JOIN
-            ***************************.dim_listings_latest listings_latest_src_28000
+            sma_28014_cte sma_28014_cte
           ON
-            subq_47.listing = listings_latest_src_28000.listing_id
-        ) subq_51
+            subq_46.listing = sma_28014_cte.listing
+        ) subq_49
         WHERE booking__is_instant
         GROUP BY
           metric_time__day
           , listing__country_latest
-      ) subq_54
+      ) subq_52
       ON
-        subq_56.ds = subq_54.metric_time__day
-    ) subq_57
-  ) subq_58
+        subq_54.ds = subq_52.metric_time__day
+    ) subq_55
+  ) subq_56
   ON
     (
-      subq_42.listing__country_latest = subq_58.listing__country_latest
+      subq_42.listing__country_latest = subq_56.listing__country_latest
     ) AND (
-      subq_42.metric_time__day = subq_58.metric_time__day
+      subq_42.metric_time__day = subq_56.metric_time__day
     )
   GROUP BY
-    COALESCE(subq_42.metric_time__day, subq_58.metric_time__day)
-    , COALESCE(subq_42.listing__country_latest, subq_58.listing__country_latest)
-) subq_59
+    COALESCE(subq_42.metric_time__day, subq_56.metric_time__day)
+    , COALESCE(subq_42.listing__country_latest, subq_56.listing__country_latest)
+) subq_57

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_saved_query_with_metric_joins_and_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_saved_query_with_metric_joins_and_filter__plan0_optimized.sql
@@ -7,12 +7,7 @@ docstring:
 sql_engine: DuckDB
 ---
 -- Combine Aggregated Outputs
-SELECT
-  COALESCE(subq_51.listing__capacity_latest, subq_61.listing__capacity_latest, subq_82.listing__capacity_latest) AS listing__capacity_latest
-  , MAX(subq_51.bookings) AS bookings
-  , MAX(subq_61.views) AS views
-  , MAX(CAST(subq_82.bookings AS DOUBLE) / CAST(NULLIF(subq_82.views, 0) AS DOUBLE)) AS bookings_per_view
-FROM (
+WITH cm_6_cte AS (
   -- Constrain Output with WHERE
   -- Pass Only Elements: ['bookings', 'listing__capacity_latest']
   -- Aggregate Measures
@@ -44,8 +39,9 @@ FROM (
   WHERE (listing__is_lux_latest) AND (metric_time__day >= '2020-01-02')
   GROUP BY
     listing__capacity_latest
-) subq_51
-FULL OUTER JOIN (
+)
+
+, cm_7_cte AS (
   -- Constrain Output with WHERE
   -- Pass Only Elements: ['views', 'listing__capacity_latest']
   -- Aggregate Measures
@@ -77,87 +73,33 @@ FULL OUTER JOIN (
   WHERE (listing__is_lux_latest) AND (metric_time__day >= '2020-01-02')
   GROUP BY
     listing__capacity_latest
-) subq_61
+)
+
+SELECT
+  COALESCE(cm_6_cte.listing__capacity_latest, cm_7_cte.listing__capacity_latest, subq_64.listing__capacity_latest) AS listing__capacity_latest
+  , MAX(cm_6_cte.bookings) AS bookings
+  , MAX(cm_7_cte.views) AS views
+  , MAX(CAST(subq_64.bookings AS DOUBLE) / CAST(NULLIF(subq_64.views, 0) AS DOUBLE)) AS bookings_per_view
+FROM cm_6_cte cm_6_cte
+FULL OUTER JOIN
+  cm_7_cte cm_7_cte
 ON
-  subq_51.listing__capacity_latest = subq_61.listing__capacity_latest
+  cm_6_cte.listing__capacity_latest = cm_7_cte.listing__capacity_latest
 FULL OUTER JOIN (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_71.listing__capacity_latest, subq_81.listing__capacity_latest) AS listing__capacity_latest
-    , MAX(subq_71.bookings) AS bookings
-    , MAX(subq_81.views) AS views
-  FROM (
-    -- Constrain Output with WHERE
-    -- Pass Only Elements: ['bookings', 'listing__capacity_latest']
-    -- Aggregate Measures
-    -- Compute Metrics via Expressions
-    SELECT
-      listing__capacity_latest
-      , SUM(bookings) AS bookings
-    FROM (
-      -- Join Standard Outputs
-      SELECT
-        listings_latest_src_28000.is_lux AS listing__is_lux_latest
-        , listings_latest_src_28000.capacity AS listing__capacity_latest
-        , subq_63.metric_time__day AS metric_time__day
-        , subq_63.bookings AS bookings
-      FROM (
-        -- Read Elements From Semantic Model 'bookings_source'
-        -- Metric Time Dimension 'ds'
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , listing_id AS listing
-          , 1 AS bookings
-        FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_63
-      LEFT OUTER JOIN
-        ***************************.dim_listings_latest listings_latest_src_28000
-      ON
-        subq_63.listing = listings_latest_src_28000.listing_id
-    ) subq_67
-    WHERE (listing__is_lux_latest) AND (metric_time__day >= '2020-01-02')
-    GROUP BY
-      listing__capacity_latest
-  ) subq_71
-  FULL OUTER JOIN (
-    -- Constrain Output with WHERE
-    -- Pass Only Elements: ['views', 'listing__capacity_latest']
-    -- Aggregate Measures
-    -- Compute Metrics via Expressions
-    SELECT
-      listing__capacity_latest
-      , SUM(views) AS views
-    FROM (
-      -- Join Standard Outputs
-      SELECT
-        listings_latest_src_28000.is_lux AS listing__is_lux_latest
-        , listings_latest_src_28000.capacity AS listing__capacity_latest
-        , subq_73.metric_time__day AS metric_time__day
-        , subq_73.views AS views
-      FROM (
-        -- Read Elements From Semantic Model 'views_source'
-        -- Metric Time Dimension 'ds'
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , listing_id AS listing
-          , 1 AS views
-        FROM ***************************.fct_views views_source_src_28000
-      ) subq_73
-      LEFT OUTER JOIN
-        ***************************.dim_listings_latest listings_latest_src_28000
-      ON
-        subq_73.listing = listings_latest_src_28000.listing_id
-    ) subq_77
-    WHERE (listing__is_lux_latest) AND (metric_time__day >= '2020-01-02')
-    GROUP BY
-      listing__capacity_latest
-  ) subq_81
+    COALESCE(cm_6_cte.listing__capacity_latest, cm_7_cte.listing__capacity_latest) AS listing__capacity_latest
+    , MAX(cm_6_cte.bookings) AS bookings
+    , MAX(cm_7_cte.views) AS views
+  FROM cm_6_cte cm_6_cte
+  FULL OUTER JOIN
+    cm_7_cte cm_7_cte
   ON
-    subq_71.listing__capacity_latest = subq_81.listing__capacity_latest
+    cm_6_cte.listing__capacity_latest = cm_7_cte.listing__capacity_latest
   GROUP BY
-    COALESCE(subq_71.listing__capacity_latest, subq_81.listing__capacity_latest)
-) subq_82
+    COALESCE(cm_6_cte.listing__capacity_latest, cm_7_cte.listing__capacity_latest)
+) subq_64
 ON
-  COALESCE(subq_51.listing__capacity_latest, subq_61.listing__capacity_latest) = subq_82.listing__capacity_latest
+  COALESCE(cm_6_cte.listing__capacity_latest, cm_7_cte.listing__capacity_latest) = subq_64.listing__capacity_latest
 GROUP BY
-  COALESCE(subq_51.listing__capacity_latest, subq_61.listing__capacity_latest, subq_82.listing__capacity_latest)
+  COALESCE(cm_6_cte.listing__capacity_latest, cm_7_cte.listing__capacity_latest, subq_64.listing__capacity_latest)

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_conversion_metric_query_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_conversion_metric_query_filters__plan0_optimized.sql
@@ -5,17 +5,36 @@ docstring:
 sql_engine: Postgres
 ---
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , referrer_id AS visit__referrer_id
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
+, rss_28028_cte AS (
+  -- Read Elements From Semantic Model 'users_latest'
+  SELECT
+    home_state_latest
+    , user_id AS user
+  FROM ***************************.dim_users_latest users_latest_src_28000
+)
+
 SELECT
-  metric_time__day
-  , user__home_state_latest
+  metric_time__day AS metric_time__day
+  , user__home_state_latest AS user__home_state_latest
   , CAST(buys AS DOUBLE PRECISION) / CAST(NULLIF(visits, 0) AS DOUBLE PRECISION) AS visit_buy_conversion_rate_7days
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_30.metric_time__day, subq_44.metric_time__day) AS metric_time__day
-    , COALESCE(subq_30.user__home_state_latest, subq_44.user__home_state_latest) AS user__home_state_latest
+    COALESCE(subq_30.metric_time__day, subq_43.metric_time__day) AS metric_time__day
+    , COALESCE(subq_30.user__home_state_latest, subq_43.user__home_state_latest) AS user__home_state_latest
     , MAX(subq_30.visits) AS visits
-    , MAX(subq_44.buys) AS buys
+    , MAX(subq_43.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['visits', 'user__home_state_latest', 'metric_time__day']
@@ -27,24 +46,15 @@ FROM (
     FROM (
       -- Join Standard Outputs
       SELECT
-        users_latest_src_28000.home_state_latest AS user__home_state_latest
-        , subq_24.metric_time__day AS metric_time__day
-        , subq_24.visit__referrer_id AS visit__referrer_id
-        , subq_24.visits AS visits
-      FROM (
-        -- Read Elements From Semantic Model 'visits_source'
-        -- Metric Time Dimension 'ds'
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , user_id AS user
-          , referrer_id AS visit__referrer_id
-          , 1 AS visits
-        FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_24
+        rss_28028_cte.home_state_latest AS user__home_state_latest
+        , sma_28019_cte.metric_time__day AS metric_time__day
+        , sma_28019_cte.visit__referrer_id AS visit__referrer_id
+        , sma_28019_cte.visits AS visits
+      FROM sma_28019_cte sma_28019_cte
       LEFT OUTER JOIN
-        ***************************.dim_users_latest users_latest_src_28000
+        rss_28028_cte rss_28028_cte
       ON
-        subq_24.user = users_latest_src_28000.user_id
+        sma_28019_cte.user = rss_28028_cte.user
     ) subq_27
     WHERE visit__referrer_id = '123456'
     GROUP BY
@@ -62,82 +72,73 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_37.visits) OVER (
+        FIRST_VALUE(subq_36.visits) OVER (
           PARTITION BY
-            subq_40.user
-            , subq_40.metric_time__day
-            , subq_40.mf_internal_uuid
-          ORDER BY subq_37.metric_time__day DESC
+            subq_39.user
+            , subq_39.metric_time__day
+            , subq_39.mf_internal_uuid
+          ORDER BY subq_36.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_37.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_36.visit__referrer_id) OVER (
           PARTITION BY
-            subq_40.user
-            , subq_40.metric_time__day
-            , subq_40.mf_internal_uuid
-          ORDER BY subq_37.metric_time__day DESC
+            subq_39.user
+            , subq_39.metric_time__day
+            , subq_39.mf_internal_uuid
+          ORDER BY subq_36.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_37.user__home_state_latest) OVER (
+        , FIRST_VALUE(subq_36.user__home_state_latest) OVER (
           PARTITION BY
-            subq_40.user
-            , subq_40.metric_time__day
-            , subq_40.mf_internal_uuid
-          ORDER BY subq_37.metric_time__day DESC
+            subq_39.user
+            , subq_39.metric_time__day
+            , subq_39.mf_internal_uuid
+          ORDER BY subq_36.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user__home_state_latest
-        , FIRST_VALUE(subq_37.metric_time__day) OVER (
+        , FIRST_VALUE(subq_36.metric_time__day) OVER (
           PARTITION BY
-            subq_40.user
-            , subq_40.metric_time__day
-            , subq_40.mf_internal_uuid
-          ORDER BY subq_37.metric_time__day DESC
+            subq_39.user
+            , subq_39.metric_time__day
+            , subq_39.mf_internal_uuid
+          ORDER BY subq_36.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_37.user) OVER (
+        , FIRST_VALUE(subq_36.user) OVER (
           PARTITION BY
-            subq_40.user
-            , subq_40.metric_time__day
-            , subq_40.mf_internal_uuid
-          ORDER BY subq_37.metric_time__day DESC
+            subq_39.user
+            , subq_39.metric_time__day
+            , subq_39.mf_internal_uuid
+          ORDER BY subq_36.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_40.mf_internal_uuid AS mf_internal_uuid
-        , subq_40.buys AS buys
+        , subq_39.mf_internal_uuid AS mf_internal_uuid
+        , subq_39.buys AS buys
       FROM (
         -- Constrain Output with WHERE
         -- Pass Only Elements: ['visits', 'visit__referrer_id', 'user__home_state_latest', 'metric_time__day', 'user']
         SELECT
           metric_time__day
-          , subq_35.user
+          , subq_34.user
           , visit__referrer_id
           , user__home_state_latest
           , visits
         FROM (
           -- Join Standard Outputs
           SELECT
-            users_latest_src_28000.home_state_latest AS user__home_state_latest
-            , subq_32.metric_time__day AS metric_time__day
-            , subq_32.user AS user
-            , subq_32.visit__referrer_id AS visit__referrer_id
-            , subq_32.visits AS visits
-          FROM (
-            -- Read Elements From Semantic Model 'visits_source'
-            -- Metric Time Dimension 'ds'
-            SELECT
-              DATE_TRUNC('day', ds) AS metric_time__day
-              , user_id AS user
-              , referrer_id AS visit__referrer_id
-              , 1 AS visits
-            FROM ***************************.fct_visits visits_source_src_28000
-          ) subq_32
+            rss_28028_cte.home_state_latest AS user__home_state_latest
+            , sma_28019_cte.metric_time__day AS metric_time__day
+            , sma_28019_cte.user AS user
+            , sma_28019_cte.visit__referrer_id AS visit__referrer_id
+            , sma_28019_cte.visits AS visits
+          FROM sma_28019_cte sma_28019_cte
           LEFT OUTER JOIN
-            ***************************.dim_users_latest users_latest_src_28000
+            rss_28028_cte rss_28028_cte
           ON
-            subq_32.user = users_latest_src_28000.user_id
-        ) subq_35
+            sma_28019_cte.user = rss_28028_cte.user
+        ) subq_34
         WHERE visit__referrer_id = '123456'
-      ) subq_37
+      ) subq_36
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -148,29 +149,29 @@ FROM (
           , 1 AS buys
           , GEN_RANDOM_UUID() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_40
+      ) subq_39
       ON
         (
-          subq_37.user = subq_40.user
+          subq_36.user = subq_39.user
         ) AND (
           (
-            subq_37.metric_time__day <= subq_40.metric_time__day
+            subq_36.metric_time__day <= subq_39.metric_time__day
           ) AND (
-            subq_37.metric_time__day > subq_40.metric_time__day - MAKE_INTERVAL(days => 7)
+            subq_36.metric_time__day > subq_39.metric_time__day - MAKE_INTERVAL(days => 7)
           )
         )
-    ) subq_41
+    ) subq_40
     GROUP BY
       metric_time__day
       , user__home_state_latest
-  ) subq_44
+  ) subq_43
   ON
     (
-      subq_30.user__home_state_latest = subq_44.user__home_state_latest
+      subq_30.user__home_state_latest = subq_43.user__home_state_latest
     ) AND (
-      subq_30.metric_time__day = subq_44.metric_time__day
+      subq_30.metric_time__day = subq_43.metric_time__day
     )
   GROUP BY
-    COALESCE(subq_30.metric_time__day, subq_44.metric_time__day)
-    , COALESCE(subq_30.user__home_state_latest, subq_44.user__home_state_latest)
-) subq_45
+    COALESCE(subq_30.metric_time__day, subq_43.metric_time__day)
+    , COALESCE(subq_30.user__home_state_latest, subq_43.user__home_state_latest)
+) subq_44

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_different_filters_on_same_measure_source_categorical_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_different_filters_on_same_measure_source_categorical_dimension__plan0_optimized.sql
@@ -13,15 +13,26 @@ docstring:
 sql_engine: Postgres
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , is_instant AS booking__is_instant
+    , booking_value AS max_booking_value
+    , booking_value AS average_booking_value
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__day
+  metric_time__day AS metric_time__day
   , CAST(average_booking_value AS DOUBLE PRECISION) / CAST(NULLIF(max_booking_value, 0) AS DOUBLE PRECISION) AS instant_booking_fraction_of_max_value
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_17.metric_time__day, subq_22.metric_time__day) AS metric_time__day
+    COALESCE(subq_17.metric_time__day, subq_21.metric_time__day) AS metric_time__day
     , MAX(subq_17.average_booking_value) AS average_booking_value
-    , MAX(subq_22.max_booking_value) AS max_booking_value
+    , MAX(subq_21.max_booking_value) AS max_booking_value
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['average_booking_value', 'metric_time__day']
@@ -31,33 +42,32 @@ FROM (
       metric_time__day
       , AVG(average_booking_value) AS average_booking_value
     FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
+      -- Read From CTE For node_id=sma_28009
       SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , is_instant AS booking__is_instant
-        , booking_value AS average_booking_value
-      FROM ***************************.fct_bookings bookings_source_src_28000
+        metric_time__day
+        , booking__is_instant
+        , max_booking_value
+        , average_booking_value
+      FROM sma_28009_cte sma_28009_cte
     ) subq_13
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
   ) subq_17
   FULL OUTER JOIN (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28009
     -- Pass Only Elements: ['max_booking_value', 'metric_time__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      DATE_TRUNC('day', ds) AS metric_time__day
-      , MAX(booking_value) AS max_booking_value
-    FROM ***************************.fct_bookings bookings_source_src_28000
+      metric_time__day
+      , MAX(max_booking_value) AS max_booking_value
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
-      DATE_TRUNC('day', ds)
-  ) subq_22
+      metric_time__day
+  ) subq_21
   ON
-    subq_17.metric_time__day = subq_22.metric_time__day
+    subq_17.metric_time__day = subq_21.metric_time__day
   GROUP BY
-    COALESCE(subq_17.metric_time__day, subq_22.metric_time__day)
-) subq_23
+    COALESCE(subq_17.metric_time__day, subq_21.metric_time__day)
+) subq_22

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0_optimized.sql
@@ -7,17 +7,37 @@ docstring:
 sql_engine: Postgres
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , listing_id AS listing
+    , is_instant AS booking__is_instant
+    , 1 AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
+, sma_28014_cte AS (
+  -- Read Elements From Semantic Model 'listings_latest'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    listing_id AS listing
+    , country AS country_latest
+  FROM ***************************.dim_listings_latest listings_latest_src_28000
+)
+
 SELECT
-  metric_time__day
-  , listing__country_latest
+  metric_time__day AS metric_time__day
+  , listing__country_latest AS listing__country_latest
   , bookings_fill_nulls_with_0 - bookings_2_weeks_ago AS bookings_growth_2_weeks_fill_nulls_with_0
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_42.metric_time__day, subq_58.metric_time__day) AS metric_time__day
-    , COALESCE(subq_42.listing__country_latest, subq_58.listing__country_latest) AS listing__country_latest
+    COALESCE(subq_42.metric_time__day, subq_56.metric_time__day) AS metric_time__day
+    , COALESCE(subq_42.listing__country_latest, subq_56.listing__country_latest) AS listing__country_latest
     , COALESCE(MAX(subq_42.bookings_fill_nulls_with_0), 0) AS bookings_fill_nulls_with_0
-    , COALESCE(MAX(subq_58.bookings_2_weeks_ago), 0) AS bookings_2_weeks_ago
+    , COALESCE(MAX(subq_56.bookings_2_weeks_ago), 0) AS bookings_2_weeks_ago
   FROM (
     -- Compute Metrics via Expressions
     SELECT
@@ -42,24 +62,15 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            listings_latest_src_28000.country AS listing__country_latest
-            , subq_31.metric_time__day AS metric_time__day
-            , subq_31.booking__is_instant AS booking__is_instant
-            , subq_31.bookings AS bookings
-          FROM (
-            -- Read Elements From Semantic Model 'bookings_source'
-            -- Metric Time Dimension 'ds'
-            SELECT
-              DATE_TRUNC('day', ds) AS metric_time__day
-              , listing_id AS listing
-              , is_instant AS booking__is_instant
-              , 1 AS bookings
-            FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_31
+            sma_28014_cte.country_latest AS listing__country_latest
+            , sma_28009_cte.metric_time__day AS metric_time__day
+            , sma_28009_cte.booking__is_instant AS booking__is_instant
+            , sma_28009_cte.bookings AS bookings
+          FROM sma_28009_cte sma_28009_cte
           LEFT OUTER JOIN
-            ***************************.dim_listings_latest listings_latest_src_28000
+            sma_28014_cte sma_28014_cte
           ON
-            subq_31.listing = listings_latest_src_28000.listing_id
+            sma_28009_cte.listing = sma_28014_cte.listing
         ) subq_35
         WHERE booking__is_instant
         GROUP BY
@@ -79,10 +90,10 @@ FROM (
     FROM (
       -- Join to Time Spine Dataset
       SELECT
-        subq_56.ds AS metric_time__day
-        , subq_54.listing__country_latest AS listing__country_latest
-        , subq_54.bookings AS bookings
-      FROM ***************************.mf_time_spine subq_56
+        subq_54.ds AS metric_time__day
+        , subq_52.listing__country_latest AS listing__country_latest
+        , subq_52.bookings AS bookings
+      FROM ***************************.mf_time_spine subq_54
       LEFT OUTER JOIN (
         -- Constrain Output with WHERE
         -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
@@ -94,52 +105,44 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            listings_latest_src_28000.country AS listing__country_latest
-            , subq_47.metric_time__day AS metric_time__day
-            , subq_47.booking__is_instant AS booking__is_instant
-            , subq_47.bookings AS bookings
+            sma_28014_cte.country_latest AS listing__country_latest
+            , subq_46.metric_time__day AS metric_time__day
+            , subq_46.booking__is_instant AS booking__is_instant
+            , subq_46.bookings AS bookings
           FROM (
             -- Join to Time Spine Dataset
             SELECT
-              subq_46.ds AS metric_time__day
-              , subq_44.listing AS listing
-              , subq_44.booking__is_instant AS booking__is_instant
-              , subq_44.bookings AS bookings
-            FROM ***************************.mf_time_spine subq_46
-            INNER JOIN (
-              -- Read Elements From Semantic Model 'bookings_source'
-              -- Metric Time Dimension 'ds'
-              SELECT
-                DATE_TRUNC('day', ds) AS metric_time__day
-                , listing_id AS listing
-                , is_instant AS booking__is_instant
-                , 1 AS bookings
-              FROM ***************************.fct_bookings bookings_source_src_28000
-            ) subq_44
+              subq_45.ds AS metric_time__day
+              , sma_28009_cte.listing AS listing
+              , sma_28009_cte.booking__is_instant AS booking__is_instant
+              , sma_28009_cte.bookings AS bookings
+            FROM ***************************.mf_time_spine subq_45
+            INNER JOIN
+              sma_28009_cte sma_28009_cte
             ON
-              subq_46.ds - MAKE_INTERVAL(days => 14) = subq_44.metric_time__day
-          ) subq_47
+              subq_45.ds - MAKE_INTERVAL(days => 14) = sma_28009_cte.metric_time__day
+          ) subq_46
           LEFT OUTER JOIN
-            ***************************.dim_listings_latest listings_latest_src_28000
+            sma_28014_cte sma_28014_cte
           ON
-            subq_47.listing = listings_latest_src_28000.listing_id
-        ) subq_51
+            subq_46.listing = sma_28014_cte.listing
+        ) subq_49
         WHERE booking__is_instant
         GROUP BY
           metric_time__day
           , listing__country_latest
-      ) subq_54
+      ) subq_52
       ON
-        subq_56.ds = subq_54.metric_time__day
-    ) subq_57
-  ) subq_58
+        subq_54.ds = subq_52.metric_time__day
+    ) subq_55
+  ) subq_56
   ON
     (
-      subq_42.listing__country_latest = subq_58.listing__country_latest
+      subq_42.listing__country_latest = subq_56.listing__country_latest
     ) AND (
-      subq_42.metric_time__day = subq_58.metric_time__day
+      subq_42.metric_time__day = subq_56.metric_time__day
     )
   GROUP BY
-    COALESCE(subq_42.metric_time__day, subq_58.metric_time__day)
-    , COALESCE(subq_42.listing__country_latest, subq_58.listing__country_latest)
-) subq_59
+    COALESCE(subq_42.metric_time__day, subq_56.metric_time__day)
+    , COALESCE(subq_42.listing__country_latest, subq_56.listing__country_latest)
+) subq_57

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_offset_metric_with_query_time_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_offset_metric_with_query_time_filters__plan0_optimized.sql
@@ -7,17 +7,37 @@ docstring:
 sql_engine: Postgres
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , listing_id AS listing
+    , is_instant AS booking__is_instant
+    , 1 AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
+, sma_28014_cte AS (
+  -- Read Elements From Semantic Model 'listings_latest'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    listing_id AS listing
+    , country AS country_latest
+  FROM ***************************.dim_listings_latest listings_latest_src_28000
+)
+
 SELECT
-  metric_time__day
-  , listing__country_latest
+  metric_time__day AS metric_time__day
+  , listing__country_latest AS listing__country_latest
   , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_33.metric_time__day, subq_46.metric_time__day) AS metric_time__day
-    , COALESCE(subq_33.listing__country_latest, subq_46.listing__country_latest) AS listing__country_latest
+    COALESCE(subq_33.metric_time__day, subq_44.metric_time__day) AS metric_time__day
+    , COALESCE(subq_33.listing__country_latest, subq_44.listing__country_latest) AS listing__country_latest
     , MAX(subq_33.bookings) AS bookings
-    , MAX(subq_46.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+    , MAX(subq_44.bookings_2_weeks_ago) AS bookings_2_weeks_ago
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
@@ -30,24 +50,15 @@ FROM (
     FROM (
       -- Join Standard Outputs
       SELECT
-        listings_latest_src_28000.country AS listing__country_latest
-        , subq_25.metric_time__day AS metric_time__day
-        , subq_25.booking__is_instant AS booking__is_instant
-        , subq_25.bookings AS bookings
-      FROM (
-        -- Read Elements From Semantic Model 'bookings_source'
-        -- Metric Time Dimension 'ds'
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , listing_id AS listing
-          , is_instant AS booking__is_instant
-          , 1 AS bookings
-        FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_25
+        sma_28014_cte.country_latest AS listing__country_latest
+        , sma_28009_cte.metric_time__day AS metric_time__day
+        , sma_28009_cte.booking__is_instant AS booking__is_instant
+        , sma_28009_cte.bookings AS bookings
+      FROM sma_28009_cte sma_28009_cte
       LEFT OUTER JOIN
-        ***************************.dim_listings_latest listings_latest_src_28000
+        sma_28014_cte sma_28014_cte
       ON
-        subq_25.listing = listings_latest_src_28000.listing_id
+        sma_28009_cte.listing = sma_28014_cte.listing
     ) subq_29
     WHERE booking__is_instant
     GROUP BY
@@ -66,48 +77,40 @@ FROM (
     FROM (
       -- Join Standard Outputs
       SELECT
-        listings_latest_src_28000.country AS listing__country_latest
-        , subq_38.metric_time__day AS metric_time__day
-        , subq_38.booking__is_instant AS booking__is_instant
-        , subq_38.bookings AS bookings
+        sma_28014_cte.country_latest AS listing__country_latest
+        , subq_37.metric_time__day AS metric_time__day
+        , subq_37.booking__is_instant AS booking__is_instant
+        , subq_37.bookings AS bookings
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_37.ds AS metric_time__day
-          , subq_35.listing AS listing
-          , subq_35.booking__is_instant AS booking__is_instant
-          , subq_35.bookings AS bookings
-        FROM ***************************.mf_time_spine subq_37
-        INNER JOIN (
-          -- Read Elements From Semantic Model 'bookings_source'
-          -- Metric Time Dimension 'ds'
-          SELECT
-            DATE_TRUNC('day', ds) AS metric_time__day
-            , listing_id AS listing
-            , is_instant AS booking__is_instant
-            , 1 AS bookings
-          FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_35
+          subq_36.ds AS metric_time__day
+          , sma_28009_cte.listing AS listing
+          , sma_28009_cte.booking__is_instant AS booking__is_instant
+          , sma_28009_cte.bookings AS bookings
+        FROM ***************************.mf_time_spine subq_36
+        INNER JOIN
+          sma_28009_cte sma_28009_cte
         ON
-          subq_37.ds - MAKE_INTERVAL(days => 14) = subq_35.metric_time__day
-      ) subq_38
+          subq_36.ds - MAKE_INTERVAL(days => 14) = sma_28009_cte.metric_time__day
+      ) subq_37
       LEFT OUTER JOIN
-        ***************************.dim_listings_latest listings_latest_src_28000
+        sma_28014_cte sma_28014_cte
       ON
-        subq_38.listing = listings_latest_src_28000.listing_id
-    ) subq_42
+        subq_37.listing = sma_28014_cte.listing
+    ) subq_40
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
       , listing__country_latest
-  ) subq_46
+  ) subq_44
   ON
     (
-      subq_33.listing__country_latest = subq_46.listing__country_latest
+      subq_33.listing__country_latest = subq_44.listing__country_latest
     ) AND (
-      subq_33.metric_time__day = subq_46.metric_time__day
+      subq_33.metric_time__day = subq_44.metric_time__day
     )
   GROUP BY
-    COALESCE(subq_33.metric_time__day, subq_46.metric_time__day)
-    , COALESCE(subq_33.listing__country_latest, subq_46.listing__country_latest)
-) subq_47
+    COALESCE(subq_33.metric_time__day, subq_44.metric_time__day)
+    , COALESCE(subq_33.listing__country_latest, subq_44.listing__country_latest)
+) subq_45

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_saved_query_with_metric_joins_and_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_saved_query_with_metric_joins_and_filter__plan0_optimized.sql
@@ -7,12 +7,7 @@ docstring:
 sql_engine: Postgres
 ---
 -- Combine Aggregated Outputs
-SELECT
-  COALESCE(subq_51.listing__capacity_latest, subq_61.listing__capacity_latest, subq_82.listing__capacity_latest) AS listing__capacity_latest
-  , MAX(subq_51.bookings) AS bookings
-  , MAX(subq_61.views) AS views
-  , MAX(CAST(subq_82.bookings AS DOUBLE PRECISION) / CAST(NULLIF(subq_82.views, 0) AS DOUBLE PRECISION)) AS bookings_per_view
-FROM (
+WITH cm_6_cte AS (
   -- Constrain Output with WHERE
   -- Pass Only Elements: ['bookings', 'listing__capacity_latest']
   -- Aggregate Measures
@@ -44,8 +39,9 @@ FROM (
   WHERE (listing__is_lux_latest) AND (metric_time__day >= '2020-01-02')
   GROUP BY
     listing__capacity_latest
-) subq_51
-FULL OUTER JOIN (
+)
+
+, cm_7_cte AS (
   -- Constrain Output with WHERE
   -- Pass Only Elements: ['views', 'listing__capacity_latest']
   -- Aggregate Measures
@@ -77,87 +73,33 @@ FULL OUTER JOIN (
   WHERE (listing__is_lux_latest) AND (metric_time__day >= '2020-01-02')
   GROUP BY
     listing__capacity_latest
-) subq_61
+)
+
+SELECT
+  COALESCE(cm_6_cte.listing__capacity_latest, cm_7_cte.listing__capacity_latest, subq_64.listing__capacity_latest) AS listing__capacity_latest
+  , MAX(cm_6_cte.bookings) AS bookings
+  , MAX(cm_7_cte.views) AS views
+  , MAX(CAST(subq_64.bookings AS DOUBLE PRECISION) / CAST(NULLIF(subq_64.views, 0) AS DOUBLE PRECISION)) AS bookings_per_view
+FROM cm_6_cte cm_6_cte
+FULL OUTER JOIN
+  cm_7_cte cm_7_cte
 ON
-  subq_51.listing__capacity_latest = subq_61.listing__capacity_latest
+  cm_6_cte.listing__capacity_latest = cm_7_cte.listing__capacity_latest
 FULL OUTER JOIN (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_71.listing__capacity_latest, subq_81.listing__capacity_latest) AS listing__capacity_latest
-    , MAX(subq_71.bookings) AS bookings
-    , MAX(subq_81.views) AS views
-  FROM (
-    -- Constrain Output with WHERE
-    -- Pass Only Elements: ['bookings', 'listing__capacity_latest']
-    -- Aggregate Measures
-    -- Compute Metrics via Expressions
-    SELECT
-      listing__capacity_latest
-      , SUM(bookings) AS bookings
-    FROM (
-      -- Join Standard Outputs
-      SELECT
-        listings_latest_src_28000.is_lux AS listing__is_lux_latest
-        , listings_latest_src_28000.capacity AS listing__capacity_latest
-        , subq_63.metric_time__day AS metric_time__day
-        , subq_63.bookings AS bookings
-      FROM (
-        -- Read Elements From Semantic Model 'bookings_source'
-        -- Metric Time Dimension 'ds'
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , listing_id AS listing
-          , 1 AS bookings
-        FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_63
-      LEFT OUTER JOIN
-        ***************************.dim_listings_latest listings_latest_src_28000
-      ON
-        subq_63.listing = listings_latest_src_28000.listing_id
-    ) subq_67
-    WHERE (listing__is_lux_latest) AND (metric_time__day >= '2020-01-02')
-    GROUP BY
-      listing__capacity_latest
-  ) subq_71
-  FULL OUTER JOIN (
-    -- Constrain Output with WHERE
-    -- Pass Only Elements: ['views', 'listing__capacity_latest']
-    -- Aggregate Measures
-    -- Compute Metrics via Expressions
-    SELECT
-      listing__capacity_latest
-      , SUM(views) AS views
-    FROM (
-      -- Join Standard Outputs
-      SELECT
-        listings_latest_src_28000.is_lux AS listing__is_lux_latest
-        , listings_latest_src_28000.capacity AS listing__capacity_latest
-        , subq_73.metric_time__day AS metric_time__day
-        , subq_73.views AS views
-      FROM (
-        -- Read Elements From Semantic Model 'views_source'
-        -- Metric Time Dimension 'ds'
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , listing_id AS listing
-          , 1 AS views
-        FROM ***************************.fct_views views_source_src_28000
-      ) subq_73
-      LEFT OUTER JOIN
-        ***************************.dim_listings_latest listings_latest_src_28000
-      ON
-        subq_73.listing = listings_latest_src_28000.listing_id
-    ) subq_77
-    WHERE (listing__is_lux_latest) AND (metric_time__day >= '2020-01-02')
-    GROUP BY
-      listing__capacity_latest
-  ) subq_81
+    COALESCE(cm_6_cte.listing__capacity_latest, cm_7_cte.listing__capacity_latest) AS listing__capacity_latest
+    , MAX(cm_6_cte.bookings) AS bookings
+    , MAX(cm_7_cte.views) AS views
+  FROM cm_6_cte cm_6_cte
+  FULL OUTER JOIN
+    cm_7_cte cm_7_cte
   ON
-    subq_71.listing__capacity_latest = subq_81.listing__capacity_latest
+    cm_6_cte.listing__capacity_latest = cm_7_cte.listing__capacity_latest
   GROUP BY
-    COALESCE(subq_71.listing__capacity_latest, subq_81.listing__capacity_latest)
-) subq_82
+    COALESCE(cm_6_cte.listing__capacity_latest, cm_7_cte.listing__capacity_latest)
+) subq_64
 ON
-  COALESCE(subq_51.listing__capacity_latest, subq_61.listing__capacity_latest) = subq_82.listing__capacity_latest
+  COALESCE(cm_6_cte.listing__capacity_latest, cm_7_cte.listing__capacity_latest) = subq_64.listing__capacity_latest
 GROUP BY
-  COALESCE(subq_51.listing__capacity_latest, subq_61.listing__capacity_latest, subq_82.listing__capacity_latest)
+  COALESCE(cm_6_cte.listing__capacity_latest, cm_7_cte.listing__capacity_latest, subq_64.listing__capacity_latest)

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_conversion_metric_query_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_conversion_metric_query_filters__plan0_optimized.sql
@@ -5,17 +5,36 @@ docstring:
 sql_engine: Redshift
 ---
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , referrer_id AS visit__referrer_id
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
+, rss_28028_cte AS (
+  -- Read Elements From Semantic Model 'users_latest'
+  SELECT
+    home_state_latest
+    , user_id AS user
+  FROM ***************************.dim_users_latest users_latest_src_28000
+)
+
 SELECT
-  metric_time__day
-  , user__home_state_latest
+  metric_time__day AS metric_time__day
+  , user__home_state_latest AS user__home_state_latest
   , CAST(buys AS DOUBLE PRECISION) / CAST(NULLIF(visits, 0) AS DOUBLE PRECISION) AS visit_buy_conversion_rate_7days
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_30.metric_time__day, subq_44.metric_time__day) AS metric_time__day
-    , COALESCE(subq_30.user__home_state_latest, subq_44.user__home_state_latest) AS user__home_state_latest
+    COALESCE(subq_30.metric_time__day, subq_43.metric_time__day) AS metric_time__day
+    , COALESCE(subq_30.user__home_state_latest, subq_43.user__home_state_latest) AS user__home_state_latest
     , MAX(subq_30.visits) AS visits
-    , MAX(subq_44.buys) AS buys
+    , MAX(subq_43.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['visits', 'user__home_state_latest', 'metric_time__day']
@@ -27,24 +46,15 @@ FROM (
     FROM (
       -- Join Standard Outputs
       SELECT
-        users_latest_src_28000.home_state_latest AS user__home_state_latest
-        , subq_24.metric_time__day AS metric_time__day
-        , subq_24.visit__referrer_id AS visit__referrer_id
-        , subq_24.visits AS visits
-      FROM (
-        -- Read Elements From Semantic Model 'visits_source'
-        -- Metric Time Dimension 'ds'
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , user_id AS user
-          , referrer_id AS visit__referrer_id
-          , 1 AS visits
-        FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_24
+        rss_28028_cte.home_state_latest AS user__home_state_latest
+        , sma_28019_cte.metric_time__day AS metric_time__day
+        , sma_28019_cte.visit__referrer_id AS visit__referrer_id
+        , sma_28019_cte.visits AS visits
+      FROM sma_28019_cte sma_28019_cte
       LEFT OUTER JOIN
-        ***************************.dim_users_latest users_latest_src_28000
+        rss_28028_cte rss_28028_cte
       ON
-        subq_24.user = users_latest_src_28000.user_id
+        sma_28019_cte.user = rss_28028_cte.user
     ) subq_27
     WHERE visit__referrer_id = '123456'
     GROUP BY
@@ -62,82 +72,73 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_37.visits) OVER (
+        FIRST_VALUE(subq_36.visits) OVER (
           PARTITION BY
-            subq_40.user
-            , subq_40.metric_time__day
-            , subq_40.mf_internal_uuid
-          ORDER BY subq_37.metric_time__day DESC
+            subq_39.user
+            , subq_39.metric_time__day
+            , subq_39.mf_internal_uuid
+          ORDER BY subq_36.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_37.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_36.visit__referrer_id) OVER (
           PARTITION BY
-            subq_40.user
-            , subq_40.metric_time__day
-            , subq_40.mf_internal_uuid
-          ORDER BY subq_37.metric_time__day DESC
+            subq_39.user
+            , subq_39.metric_time__day
+            , subq_39.mf_internal_uuid
+          ORDER BY subq_36.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_37.user__home_state_latest) OVER (
+        , FIRST_VALUE(subq_36.user__home_state_latest) OVER (
           PARTITION BY
-            subq_40.user
-            , subq_40.metric_time__day
-            , subq_40.mf_internal_uuid
-          ORDER BY subq_37.metric_time__day DESC
+            subq_39.user
+            , subq_39.metric_time__day
+            , subq_39.mf_internal_uuid
+          ORDER BY subq_36.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user__home_state_latest
-        , FIRST_VALUE(subq_37.metric_time__day) OVER (
+        , FIRST_VALUE(subq_36.metric_time__day) OVER (
           PARTITION BY
-            subq_40.user
-            , subq_40.metric_time__day
-            , subq_40.mf_internal_uuid
-          ORDER BY subq_37.metric_time__day DESC
+            subq_39.user
+            , subq_39.metric_time__day
+            , subq_39.mf_internal_uuid
+          ORDER BY subq_36.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_37.user) OVER (
+        , FIRST_VALUE(subq_36.user) OVER (
           PARTITION BY
-            subq_40.user
-            , subq_40.metric_time__day
-            , subq_40.mf_internal_uuid
-          ORDER BY subq_37.metric_time__day DESC
+            subq_39.user
+            , subq_39.metric_time__day
+            , subq_39.mf_internal_uuid
+          ORDER BY subq_36.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_40.mf_internal_uuid AS mf_internal_uuid
-        , subq_40.buys AS buys
+        , subq_39.mf_internal_uuid AS mf_internal_uuid
+        , subq_39.buys AS buys
       FROM (
         -- Constrain Output with WHERE
         -- Pass Only Elements: ['visits', 'visit__referrer_id', 'user__home_state_latest', 'metric_time__day', 'user']
         SELECT
           metric_time__day
-          , subq_35.user
+          , subq_34.user
           , visit__referrer_id
           , user__home_state_latest
           , visits
         FROM (
           -- Join Standard Outputs
           SELECT
-            users_latest_src_28000.home_state_latest AS user__home_state_latest
-            , subq_32.metric_time__day AS metric_time__day
-            , subq_32.user AS user
-            , subq_32.visit__referrer_id AS visit__referrer_id
-            , subq_32.visits AS visits
-          FROM (
-            -- Read Elements From Semantic Model 'visits_source'
-            -- Metric Time Dimension 'ds'
-            SELECT
-              DATE_TRUNC('day', ds) AS metric_time__day
-              , user_id AS user
-              , referrer_id AS visit__referrer_id
-              , 1 AS visits
-            FROM ***************************.fct_visits visits_source_src_28000
-          ) subq_32
+            rss_28028_cte.home_state_latest AS user__home_state_latest
+            , sma_28019_cte.metric_time__day AS metric_time__day
+            , sma_28019_cte.user AS user
+            , sma_28019_cte.visit__referrer_id AS visit__referrer_id
+            , sma_28019_cte.visits AS visits
+          FROM sma_28019_cte sma_28019_cte
           LEFT OUTER JOIN
-            ***************************.dim_users_latest users_latest_src_28000
+            rss_28028_cte rss_28028_cte
           ON
-            subq_32.user = users_latest_src_28000.user_id
-        ) subq_35
+            sma_28019_cte.user = rss_28028_cte.user
+        ) subq_34
         WHERE visit__referrer_id = '123456'
-      ) subq_37
+      ) subq_36
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -148,29 +149,29 @@ FROM (
           , 1 AS buys
           , CONCAT(CAST(RANDOM()*100000000 AS INT)::VARCHAR,CAST(RANDOM()*100000000 AS INT)::VARCHAR) AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_40
+      ) subq_39
       ON
         (
-          subq_37.user = subq_40.user
+          subq_36.user = subq_39.user
         ) AND (
           (
-            subq_37.metric_time__day <= subq_40.metric_time__day
+            subq_36.metric_time__day <= subq_39.metric_time__day
           ) AND (
-            subq_37.metric_time__day > DATEADD(day, -7, subq_40.metric_time__day)
+            subq_36.metric_time__day > DATEADD(day, -7, subq_39.metric_time__day)
           )
         )
-    ) subq_41
+    ) subq_40
     GROUP BY
       metric_time__day
       , user__home_state_latest
-  ) subq_44
+  ) subq_43
   ON
     (
-      subq_30.user__home_state_latest = subq_44.user__home_state_latest
+      subq_30.user__home_state_latest = subq_43.user__home_state_latest
     ) AND (
-      subq_30.metric_time__day = subq_44.metric_time__day
+      subq_30.metric_time__day = subq_43.metric_time__day
     )
   GROUP BY
-    COALESCE(subq_30.metric_time__day, subq_44.metric_time__day)
-    , COALESCE(subq_30.user__home_state_latest, subq_44.user__home_state_latest)
-) subq_45
+    COALESCE(subq_30.metric_time__day, subq_43.metric_time__day)
+    , COALESCE(subq_30.user__home_state_latest, subq_43.user__home_state_latest)
+) subq_44

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_different_filters_on_same_measure_source_categorical_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_different_filters_on_same_measure_source_categorical_dimension__plan0_optimized.sql
@@ -13,15 +13,26 @@ docstring:
 sql_engine: Redshift
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , is_instant AS booking__is_instant
+    , booking_value AS max_booking_value
+    , booking_value AS average_booking_value
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__day
+  metric_time__day AS metric_time__day
   , CAST(average_booking_value AS DOUBLE PRECISION) / CAST(NULLIF(max_booking_value, 0) AS DOUBLE PRECISION) AS instant_booking_fraction_of_max_value
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_17.metric_time__day, subq_22.metric_time__day) AS metric_time__day
+    COALESCE(subq_17.metric_time__day, subq_21.metric_time__day) AS metric_time__day
     , MAX(subq_17.average_booking_value) AS average_booking_value
-    , MAX(subq_22.max_booking_value) AS max_booking_value
+    , MAX(subq_21.max_booking_value) AS max_booking_value
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['average_booking_value', 'metric_time__day']
@@ -31,33 +42,32 @@ FROM (
       metric_time__day
       , AVG(average_booking_value) AS average_booking_value
     FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
+      -- Read From CTE For node_id=sma_28009
       SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , is_instant AS booking__is_instant
-        , booking_value AS average_booking_value
-      FROM ***************************.fct_bookings bookings_source_src_28000
+        metric_time__day
+        , booking__is_instant
+        , max_booking_value
+        , average_booking_value
+      FROM sma_28009_cte sma_28009_cte
     ) subq_13
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
   ) subq_17
   FULL OUTER JOIN (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28009
     -- Pass Only Elements: ['max_booking_value', 'metric_time__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      DATE_TRUNC('day', ds) AS metric_time__day
-      , MAX(booking_value) AS max_booking_value
-    FROM ***************************.fct_bookings bookings_source_src_28000
+      metric_time__day
+      , MAX(max_booking_value) AS max_booking_value
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
-      DATE_TRUNC('day', ds)
-  ) subq_22
+      metric_time__day
+  ) subq_21
   ON
-    subq_17.metric_time__day = subq_22.metric_time__day
+    subq_17.metric_time__day = subq_21.metric_time__day
   GROUP BY
-    COALESCE(subq_17.metric_time__day, subq_22.metric_time__day)
-) subq_23
+    COALESCE(subq_17.metric_time__day, subq_21.metric_time__day)
+) subq_22

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0_optimized.sql
@@ -7,17 +7,37 @@ docstring:
 sql_engine: Redshift
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , listing_id AS listing
+    , is_instant AS booking__is_instant
+    , 1 AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
+, sma_28014_cte AS (
+  -- Read Elements From Semantic Model 'listings_latest'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    listing_id AS listing
+    , country AS country_latest
+  FROM ***************************.dim_listings_latest listings_latest_src_28000
+)
+
 SELECT
-  metric_time__day
-  , listing__country_latest
+  metric_time__day AS metric_time__day
+  , listing__country_latest AS listing__country_latest
   , bookings_fill_nulls_with_0 - bookings_2_weeks_ago AS bookings_growth_2_weeks_fill_nulls_with_0
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_42.metric_time__day, subq_58.metric_time__day) AS metric_time__day
-    , COALESCE(subq_42.listing__country_latest, subq_58.listing__country_latest) AS listing__country_latest
+    COALESCE(subq_42.metric_time__day, subq_56.metric_time__day) AS metric_time__day
+    , COALESCE(subq_42.listing__country_latest, subq_56.listing__country_latest) AS listing__country_latest
     , COALESCE(MAX(subq_42.bookings_fill_nulls_with_0), 0) AS bookings_fill_nulls_with_0
-    , COALESCE(MAX(subq_58.bookings_2_weeks_ago), 0) AS bookings_2_weeks_ago
+    , COALESCE(MAX(subq_56.bookings_2_weeks_ago), 0) AS bookings_2_weeks_ago
   FROM (
     -- Compute Metrics via Expressions
     SELECT
@@ -42,24 +62,15 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            listings_latest_src_28000.country AS listing__country_latest
-            , subq_31.metric_time__day AS metric_time__day
-            , subq_31.booking__is_instant AS booking__is_instant
-            , subq_31.bookings AS bookings
-          FROM (
-            -- Read Elements From Semantic Model 'bookings_source'
-            -- Metric Time Dimension 'ds'
-            SELECT
-              DATE_TRUNC('day', ds) AS metric_time__day
-              , listing_id AS listing
-              , is_instant AS booking__is_instant
-              , 1 AS bookings
-            FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_31
+            sma_28014_cte.country_latest AS listing__country_latest
+            , sma_28009_cte.metric_time__day AS metric_time__day
+            , sma_28009_cte.booking__is_instant AS booking__is_instant
+            , sma_28009_cte.bookings AS bookings
+          FROM sma_28009_cte sma_28009_cte
           LEFT OUTER JOIN
-            ***************************.dim_listings_latest listings_latest_src_28000
+            sma_28014_cte sma_28014_cte
           ON
-            subq_31.listing = listings_latest_src_28000.listing_id
+            sma_28009_cte.listing = sma_28014_cte.listing
         ) subq_35
         WHERE booking__is_instant
         GROUP BY
@@ -79,10 +90,10 @@ FROM (
     FROM (
       -- Join to Time Spine Dataset
       SELECT
-        subq_56.ds AS metric_time__day
-        , subq_54.listing__country_latest AS listing__country_latest
-        , subq_54.bookings AS bookings
-      FROM ***************************.mf_time_spine subq_56
+        subq_54.ds AS metric_time__day
+        , subq_52.listing__country_latest AS listing__country_latest
+        , subq_52.bookings AS bookings
+      FROM ***************************.mf_time_spine subq_54
       LEFT OUTER JOIN (
         -- Constrain Output with WHERE
         -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
@@ -94,52 +105,44 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            listings_latest_src_28000.country AS listing__country_latest
-            , subq_47.metric_time__day AS metric_time__day
-            , subq_47.booking__is_instant AS booking__is_instant
-            , subq_47.bookings AS bookings
+            sma_28014_cte.country_latest AS listing__country_latest
+            , subq_46.metric_time__day AS metric_time__day
+            , subq_46.booking__is_instant AS booking__is_instant
+            , subq_46.bookings AS bookings
           FROM (
             -- Join to Time Spine Dataset
             SELECT
-              subq_46.ds AS metric_time__day
-              , subq_44.listing AS listing
-              , subq_44.booking__is_instant AS booking__is_instant
-              , subq_44.bookings AS bookings
-            FROM ***************************.mf_time_spine subq_46
-            INNER JOIN (
-              -- Read Elements From Semantic Model 'bookings_source'
-              -- Metric Time Dimension 'ds'
-              SELECT
-                DATE_TRUNC('day', ds) AS metric_time__day
-                , listing_id AS listing
-                , is_instant AS booking__is_instant
-                , 1 AS bookings
-              FROM ***************************.fct_bookings bookings_source_src_28000
-            ) subq_44
+              subq_45.ds AS metric_time__day
+              , sma_28009_cte.listing AS listing
+              , sma_28009_cte.booking__is_instant AS booking__is_instant
+              , sma_28009_cte.bookings AS bookings
+            FROM ***************************.mf_time_spine subq_45
+            INNER JOIN
+              sma_28009_cte sma_28009_cte
             ON
-              DATEADD(day, -14, subq_46.ds) = subq_44.metric_time__day
-          ) subq_47
+              DATEADD(day, -14, subq_45.ds) = sma_28009_cte.metric_time__day
+          ) subq_46
           LEFT OUTER JOIN
-            ***************************.dim_listings_latest listings_latest_src_28000
+            sma_28014_cte sma_28014_cte
           ON
-            subq_47.listing = listings_latest_src_28000.listing_id
-        ) subq_51
+            subq_46.listing = sma_28014_cte.listing
+        ) subq_49
         WHERE booking__is_instant
         GROUP BY
           metric_time__day
           , listing__country_latest
-      ) subq_54
+      ) subq_52
       ON
-        subq_56.ds = subq_54.metric_time__day
-    ) subq_57
-  ) subq_58
+        subq_54.ds = subq_52.metric_time__day
+    ) subq_55
+  ) subq_56
   ON
     (
-      subq_42.listing__country_latest = subq_58.listing__country_latest
+      subq_42.listing__country_latest = subq_56.listing__country_latest
     ) AND (
-      subq_42.metric_time__day = subq_58.metric_time__day
+      subq_42.metric_time__day = subq_56.metric_time__day
     )
   GROUP BY
-    COALESCE(subq_42.metric_time__day, subq_58.metric_time__day)
-    , COALESCE(subq_42.listing__country_latest, subq_58.listing__country_latest)
-) subq_59
+    COALESCE(subq_42.metric_time__day, subq_56.metric_time__day)
+    , COALESCE(subq_42.listing__country_latest, subq_56.listing__country_latest)
+) subq_57

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_offset_metric_with_query_time_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_offset_metric_with_query_time_filters__plan0_optimized.sql
@@ -7,17 +7,37 @@ docstring:
 sql_engine: Redshift
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , listing_id AS listing
+    , is_instant AS booking__is_instant
+    , 1 AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
+, sma_28014_cte AS (
+  -- Read Elements From Semantic Model 'listings_latest'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    listing_id AS listing
+    , country AS country_latest
+  FROM ***************************.dim_listings_latest listings_latest_src_28000
+)
+
 SELECT
-  metric_time__day
-  , listing__country_latest
+  metric_time__day AS metric_time__day
+  , listing__country_latest AS listing__country_latest
   , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_33.metric_time__day, subq_46.metric_time__day) AS metric_time__day
-    , COALESCE(subq_33.listing__country_latest, subq_46.listing__country_latest) AS listing__country_latest
+    COALESCE(subq_33.metric_time__day, subq_44.metric_time__day) AS metric_time__day
+    , COALESCE(subq_33.listing__country_latest, subq_44.listing__country_latest) AS listing__country_latest
     , MAX(subq_33.bookings) AS bookings
-    , MAX(subq_46.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+    , MAX(subq_44.bookings_2_weeks_ago) AS bookings_2_weeks_ago
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
@@ -30,24 +50,15 @@ FROM (
     FROM (
       -- Join Standard Outputs
       SELECT
-        listings_latest_src_28000.country AS listing__country_latest
-        , subq_25.metric_time__day AS metric_time__day
-        , subq_25.booking__is_instant AS booking__is_instant
-        , subq_25.bookings AS bookings
-      FROM (
-        -- Read Elements From Semantic Model 'bookings_source'
-        -- Metric Time Dimension 'ds'
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , listing_id AS listing
-          , is_instant AS booking__is_instant
-          , 1 AS bookings
-        FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_25
+        sma_28014_cte.country_latest AS listing__country_latest
+        , sma_28009_cte.metric_time__day AS metric_time__day
+        , sma_28009_cte.booking__is_instant AS booking__is_instant
+        , sma_28009_cte.bookings AS bookings
+      FROM sma_28009_cte sma_28009_cte
       LEFT OUTER JOIN
-        ***************************.dim_listings_latest listings_latest_src_28000
+        sma_28014_cte sma_28014_cte
       ON
-        subq_25.listing = listings_latest_src_28000.listing_id
+        sma_28009_cte.listing = sma_28014_cte.listing
     ) subq_29
     WHERE booking__is_instant
     GROUP BY
@@ -66,48 +77,40 @@ FROM (
     FROM (
       -- Join Standard Outputs
       SELECT
-        listings_latest_src_28000.country AS listing__country_latest
-        , subq_38.metric_time__day AS metric_time__day
-        , subq_38.booking__is_instant AS booking__is_instant
-        , subq_38.bookings AS bookings
+        sma_28014_cte.country_latest AS listing__country_latest
+        , subq_37.metric_time__day AS metric_time__day
+        , subq_37.booking__is_instant AS booking__is_instant
+        , subq_37.bookings AS bookings
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_37.ds AS metric_time__day
-          , subq_35.listing AS listing
-          , subq_35.booking__is_instant AS booking__is_instant
-          , subq_35.bookings AS bookings
-        FROM ***************************.mf_time_spine subq_37
-        INNER JOIN (
-          -- Read Elements From Semantic Model 'bookings_source'
-          -- Metric Time Dimension 'ds'
-          SELECT
-            DATE_TRUNC('day', ds) AS metric_time__day
-            , listing_id AS listing
-            , is_instant AS booking__is_instant
-            , 1 AS bookings
-          FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_35
+          subq_36.ds AS metric_time__day
+          , sma_28009_cte.listing AS listing
+          , sma_28009_cte.booking__is_instant AS booking__is_instant
+          , sma_28009_cte.bookings AS bookings
+        FROM ***************************.mf_time_spine subq_36
+        INNER JOIN
+          sma_28009_cte sma_28009_cte
         ON
-          DATEADD(day, -14, subq_37.ds) = subq_35.metric_time__day
-      ) subq_38
+          DATEADD(day, -14, subq_36.ds) = sma_28009_cte.metric_time__day
+      ) subq_37
       LEFT OUTER JOIN
-        ***************************.dim_listings_latest listings_latest_src_28000
+        sma_28014_cte sma_28014_cte
       ON
-        subq_38.listing = listings_latest_src_28000.listing_id
-    ) subq_42
+        subq_37.listing = sma_28014_cte.listing
+    ) subq_40
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
       , listing__country_latest
-  ) subq_46
+  ) subq_44
   ON
     (
-      subq_33.listing__country_latest = subq_46.listing__country_latest
+      subq_33.listing__country_latest = subq_44.listing__country_latest
     ) AND (
-      subq_33.metric_time__day = subq_46.metric_time__day
+      subq_33.metric_time__day = subq_44.metric_time__day
     )
   GROUP BY
-    COALESCE(subq_33.metric_time__day, subq_46.metric_time__day)
-    , COALESCE(subq_33.listing__country_latest, subq_46.listing__country_latest)
-) subq_47
+    COALESCE(subq_33.metric_time__day, subq_44.metric_time__day)
+    , COALESCE(subq_33.listing__country_latest, subq_44.listing__country_latest)
+) subq_45

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_saved_query_with_metric_joins_and_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_saved_query_with_metric_joins_and_filter__plan0_optimized.sql
@@ -7,12 +7,7 @@ docstring:
 sql_engine: Redshift
 ---
 -- Combine Aggregated Outputs
-SELECT
-  COALESCE(subq_51.listing__capacity_latest, subq_61.listing__capacity_latest, subq_82.listing__capacity_latest) AS listing__capacity_latest
-  , MAX(subq_51.bookings) AS bookings
-  , MAX(subq_61.views) AS views
-  , MAX(CAST(subq_82.bookings AS DOUBLE PRECISION) / CAST(NULLIF(subq_82.views, 0) AS DOUBLE PRECISION)) AS bookings_per_view
-FROM (
+WITH cm_6_cte AS (
   -- Constrain Output with WHERE
   -- Pass Only Elements: ['bookings', 'listing__capacity_latest']
   -- Aggregate Measures
@@ -44,8 +39,9 @@ FROM (
   WHERE (listing__is_lux_latest) AND (metric_time__day >= '2020-01-02')
   GROUP BY
     listing__capacity_latest
-) subq_51
-FULL OUTER JOIN (
+)
+
+, cm_7_cte AS (
   -- Constrain Output with WHERE
   -- Pass Only Elements: ['views', 'listing__capacity_latest']
   -- Aggregate Measures
@@ -77,87 +73,33 @@ FULL OUTER JOIN (
   WHERE (listing__is_lux_latest) AND (metric_time__day >= '2020-01-02')
   GROUP BY
     listing__capacity_latest
-) subq_61
+)
+
+SELECT
+  COALESCE(cm_6_cte.listing__capacity_latest, cm_7_cte.listing__capacity_latest, subq_64.listing__capacity_latest) AS listing__capacity_latest
+  , MAX(cm_6_cte.bookings) AS bookings
+  , MAX(cm_7_cte.views) AS views
+  , MAX(CAST(subq_64.bookings AS DOUBLE PRECISION) / CAST(NULLIF(subq_64.views, 0) AS DOUBLE PRECISION)) AS bookings_per_view
+FROM cm_6_cte cm_6_cte
+FULL OUTER JOIN
+  cm_7_cte cm_7_cte
 ON
-  subq_51.listing__capacity_latest = subq_61.listing__capacity_latest
+  cm_6_cte.listing__capacity_latest = cm_7_cte.listing__capacity_latest
 FULL OUTER JOIN (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_71.listing__capacity_latest, subq_81.listing__capacity_latest) AS listing__capacity_latest
-    , MAX(subq_71.bookings) AS bookings
-    , MAX(subq_81.views) AS views
-  FROM (
-    -- Constrain Output with WHERE
-    -- Pass Only Elements: ['bookings', 'listing__capacity_latest']
-    -- Aggregate Measures
-    -- Compute Metrics via Expressions
-    SELECT
-      listing__capacity_latest
-      , SUM(bookings) AS bookings
-    FROM (
-      -- Join Standard Outputs
-      SELECT
-        listings_latest_src_28000.is_lux AS listing__is_lux_latest
-        , listings_latest_src_28000.capacity AS listing__capacity_latest
-        , subq_63.metric_time__day AS metric_time__day
-        , subq_63.bookings AS bookings
-      FROM (
-        -- Read Elements From Semantic Model 'bookings_source'
-        -- Metric Time Dimension 'ds'
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , listing_id AS listing
-          , 1 AS bookings
-        FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_63
-      LEFT OUTER JOIN
-        ***************************.dim_listings_latest listings_latest_src_28000
-      ON
-        subq_63.listing = listings_latest_src_28000.listing_id
-    ) subq_67
-    WHERE (listing__is_lux_latest) AND (metric_time__day >= '2020-01-02')
-    GROUP BY
-      listing__capacity_latest
-  ) subq_71
-  FULL OUTER JOIN (
-    -- Constrain Output with WHERE
-    -- Pass Only Elements: ['views', 'listing__capacity_latest']
-    -- Aggregate Measures
-    -- Compute Metrics via Expressions
-    SELECT
-      listing__capacity_latest
-      , SUM(views) AS views
-    FROM (
-      -- Join Standard Outputs
-      SELECT
-        listings_latest_src_28000.is_lux AS listing__is_lux_latest
-        , listings_latest_src_28000.capacity AS listing__capacity_latest
-        , subq_73.metric_time__day AS metric_time__day
-        , subq_73.views AS views
-      FROM (
-        -- Read Elements From Semantic Model 'views_source'
-        -- Metric Time Dimension 'ds'
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , listing_id AS listing
-          , 1 AS views
-        FROM ***************************.fct_views views_source_src_28000
-      ) subq_73
-      LEFT OUTER JOIN
-        ***************************.dim_listings_latest listings_latest_src_28000
-      ON
-        subq_73.listing = listings_latest_src_28000.listing_id
-    ) subq_77
-    WHERE (listing__is_lux_latest) AND (metric_time__day >= '2020-01-02')
-    GROUP BY
-      listing__capacity_latest
-  ) subq_81
+    COALESCE(cm_6_cte.listing__capacity_latest, cm_7_cte.listing__capacity_latest) AS listing__capacity_latest
+    , MAX(cm_6_cte.bookings) AS bookings
+    , MAX(cm_7_cte.views) AS views
+  FROM cm_6_cte cm_6_cte
+  FULL OUTER JOIN
+    cm_7_cte cm_7_cte
   ON
-    subq_71.listing__capacity_latest = subq_81.listing__capacity_latest
+    cm_6_cte.listing__capacity_latest = cm_7_cte.listing__capacity_latest
   GROUP BY
-    COALESCE(subq_71.listing__capacity_latest, subq_81.listing__capacity_latest)
-) subq_82
+    COALESCE(cm_6_cte.listing__capacity_latest, cm_7_cte.listing__capacity_latest)
+) subq_64
 ON
-  COALESCE(subq_51.listing__capacity_latest, subq_61.listing__capacity_latest) = subq_82.listing__capacity_latest
+  COALESCE(cm_6_cte.listing__capacity_latest, cm_7_cte.listing__capacity_latest) = subq_64.listing__capacity_latest
 GROUP BY
-  COALESCE(subq_51.listing__capacity_latest, subq_61.listing__capacity_latest, subq_82.listing__capacity_latest)
+  COALESCE(cm_6_cte.listing__capacity_latest, cm_7_cte.listing__capacity_latest, subq_64.listing__capacity_latest)

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_conversion_metric_query_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_conversion_metric_query_filters__plan0_optimized.sql
@@ -5,17 +5,36 @@ docstring:
 sql_engine: Snowflake
 ---
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , referrer_id AS visit__referrer_id
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
+, rss_28028_cte AS (
+  -- Read Elements From Semantic Model 'users_latest'
+  SELECT
+    home_state_latest
+    , user_id AS user
+  FROM ***************************.dim_users_latest users_latest_src_28000
+)
+
 SELECT
-  metric_time__day
-  , user__home_state_latest
+  metric_time__day AS metric_time__day
+  , user__home_state_latest AS user__home_state_latest
   , CAST(buys AS DOUBLE) / CAST(NULLIF(visits, 0) AS DOUBLE) AS visit_buy_conversion_rate_7days
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_30.metric_time__day, subq_44.metric_time__day) AS metric_time__day
-    , COALESCE(subq_30.user__home_state_latest, subq_44.user__home_state_latest) AS user__home_state_latest
+    COALESCE(subq_30.metric_time__day, subq_43.metric_time__day) AS metric_time__day
+    , COALESCE(subq_30.user__home_state_latest, subq_43.user__home_state_latest) AS user__home_state_latest
     , MAX(subq_30.visits) AS visits
-    , MAX(subq_44.buys) AS buys
+    , MAX(subq_43.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['visits', 'user__home_state_latest', 'metric_time__day']
@@ -27,24 +46,15 @@ FROM (
     FROM (
       -- Join Standard Outputs
       SELECT
-        users_latest_src_28000.home_state_latest AS user__home_state_latest
-        , subq_24.metric_time__day AS metric_time__day
-        , subq_24.visit__referrer_id AS visit__referrer_id
-        , subq_24.visits AS visits
-      FROM (
-        -- Read Elements From Semantic Model 'visits_source'
-        -- Metric Time Dimension 'ds'
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , user_id AS user
-          , referrer_id AS visit__referrer_id
-          , 1 AS visits
-        FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_24
+        rss_28028_cte.home_state_latest AS user__home_state_latest
+        , sma_28019_cte.metric_time__day AS metric_time__day
+        , sma_28019_cte.visit__referrer_id AS visit__referrer_id
+        , sma_28019_cte.visits AS visits
+      FROM sma_28019_cte sma_28019_cte
       LEFT OUTER JOIN
-        ***************************.dim_users_latest users_latest_src_28000
+        rss_28028_cte rss_28028_cte
       ON
-        subq_24.user = users_latest_src_28000.user_id
+        sma_28019_cte.user = rss_28028_cte.user
     ) subq_27
     WHERE visit__referrer_id = '123456'
     GROUP BY
@@ -62,82 +72,73 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_37.visits) OVER (
+        FIRST_VALUE(subq_36.visits) OVER (
           PARTITION BY
-            subq_40.user
-            , subq_40.metric_time__day
-            , subq_40.mf_internal_uuid
-          ORDER BY subq_37.metric_time__day DESC
+            subq_39.user
+            , subq_39.metric_time__day
+            , subq_39.mf_internal_uuid
+          ORDER BY subq_36.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_37.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_36.visit__referrer_id) OVER (
           PARTITION BY
-            subq_40.user
-            , subq_40.metric_time__day
-            , subq_40.mf_internal_uuid
-          ORDER BY subq_37.metric_time__day DESC
+            subq_39.user
+            , subq_39.metric_time__day
+            , subq_39.mf_internal_uuid
+          ORDER BY subq_36.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_37.user__home_state_latest) OVER (
+        , FIRST_VALUE(subq_36.user__home_state_latest) OVER (
           PARTITION BY
-            subq_40.user
-            , subq_40.metric_time__day
-            , subq_40.mf_internal_uuid
-          ORDER BY subq_37.metric_time__day DESC
+            subq_39.user
+            , subq_39.metric_time__day
+            , subq_39.mf_internal_uuid
+          ORDER BY subq_36.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user__home_state_latest
-        , FIRST_VALUE(subq_37.metric_time__day) OVER (
+        , FIRST_VALUE(subq_36.metric_time__day) OVER (
           PARTITION BY
-            subq_40.user
-            , subq_40.metric_time__day
-            , subq_40.mf_internal_uuid
-          ORDER BY subq_37.metric_time__day DESC
+            subq_39.user
+            , subq_39.metric_time__day
+            , subq_39.mf_internal_uuid
+          ORDER BY subq_36.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_37.user) OVER (
+        , FIRST_VALUE(subq_36.user) OVER (
           PARTITION BY
-            subq_40.user
-            , subq_40.metric_time__day
-            , subq_40.mf_internal_uuid
-          ORDER BY subq_37.metric_time__day DESC
+            subq_39.user
+            , subq_39.metric_time__day
+            , subq_39.mf_internal_uuid
+          ORDER BY subq_36.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_40.mf_internal_uuid AS mf_internal_uuid
-        , subq_40.buys AS buys
+        , subq_39.mf_internal_uuid AS mf_internal_uuid
+        , subq_39.buys AS buys
       FROM (
         -- Constrain Output with WHERE
         -- Pass Only Elements: ['visits', 'visit__referrer_id', 'user__home_state_latest', 'metric_time__day', 'user']
         SELECT
           metric_time__day
-          , subq_35.user
+          , subq_34.user
           , visit__referrer_id
           , user__home_state_latest
           , visits
         FROM (
           -- Join Standard Outputs
           SELECT
-            users_latest_src_28000.home_state_latest AS user__home_state_latest
-            , subq_32.metric_time__day AS metric_time__day
-            , subq_32.user AS user
-            , subq_32.visit__referrer_id AS visit__referrer_id
-            , subq_32.visits AS visits
-          FROM (
-            -- Read Elements From Semantic Model 'visits_source'
-            -- Metric Time Dimension 'ds'
-            SELECT
-              DATE_TRUNC('day', ds) AS metric_time__day
-              , user_id AS user
-              , referrer_id AS visit__referrer_id
-              , 1 AS visits
-            FROM ***************************.fct_visits visits_source_src_28000
-          ) subq_32
+            rss_28028_cte.home_state_latest AS user__home_state_latest
+            , sma_28019_cte.metric_time__day AS metric_time__day
+            , sma_28019_cte.user AS user
+            , sma_28019_cte.visit__referrer_id AS visit__referrer_id
+            , sma_28019_cte.visits AS visits
+          FROM sma_28019_cte sma_28019_cte
           LEFT OUTER JOIN
-            ***************************.dim_users_latest users_latest_src_28000
+            rss_28028_cte rss_28028_cte
           ON
-            subq_32.user = users_latest_src_28000.user_id
-        ) subq_35
+            sma_28019_cte.user = rss_28028_cte.user
+        ) subq_34
         WHERE visit__referrer_id = '123456'
-      ) subq_37
+      ) subq_36
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -148,29 +149,29 @@ FROM (
           , 1 AS buys
           , UUID_STRING() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_40
+      ) subq_39
       ON
         (
-          subq_37.user = subq_40.user
+          subq_36.user = subq_39.user
         ) AND (
           (
-            subq_37.metric_time__day <= subq_40.metric_time__day
+            subq_36.metric_time__day <= subq_39.metric_time__day
           ) AND (
-            subq_37.metric_time__day > DATEADD(day, -7, subq_40.metric_time__day)
+            subq_36.metric_time__day > DATEADD(day, -7, subq_39.metric_time__day)
           )
         )
-    ) subq_41
+    ) subq_40
     GROUP BY
       metric_time__day
       , user__home_state_latest
-  ) subq_44
+  ) subq_43
   ON
     (
-      subq_30.user__home_state_latest = subq_44.user__home_state_latest
+      subq_30.user__home_state_latest = subq_43.user__home_state_latest
     ) AND (
-      subq_30.metric_time__day = subq_44.metric_time__day
+      subq_30.metric_time__day = subq_43.metric_time__day
     )
   GROUP BY
-    COALESCE(subq_30.metric_time__day, subq_44.metric_time__day)
-    , COALESCE(subq_30.user__home_state_latest, subq_44.user__home_state_latest)
-) subq_45
+    COALESCE(subq_30.metric_time__day, subq_43.metric_time__day)
+    , COALESCE(subq_30.user__home_state_latest, subq_43.user__home_state_latest)
+) subq_44

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_different_filters_on_same_measure_source_categorical_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_different_filters_on_same_measure_source_categorical_dimension__plan0_optimized.sql
@@ -13,15 +13,26 @@ docstring:
 sql_engine: Snowflake
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , is_instant AS booking__is_instant
+    , booking_value AS max_booking_value
+    , booking_value AS average_booking_value
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__day
+  metric_time__day AS metric_time__day
   , CAST(average_booking_value AS DOUBLE) / CAST(NULLIF(max_booking_value, 0) AS DOUBLE) AS instant_booking_fraction_of_max_value
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_17.metric_time__day, subq_22.metric_time__day) AS metric_time__day
+    COALESCE(subq_17.metric_time__day, subq_21.metric_time__day) AS metric_time__day
     , MAX(subq_17.average_booking_value) AS average_booking_value
-    , MAX(subq_22.max_booking_value) AS max_booking_value
+    , MAX(subq_21.max_booking_value) AS max_booking_value
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['average_booking_value', 'metric_time__day']
@@ -31,33 +42,32 @@ FROM (
       metric_time__day
       , AVG(average_booking_value) AS average_booking_value
     FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
+      -- Read From CTE For node_id=sma_28009
       SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , is_instant AS booking__is_instant
-        , booking_value AS average_booking_value
-      FROM ***************************.fct_bookings bookings_source_src_28000
+        metric_time__day
+        , booking__is_instant
+        , max_booking_value
+        , average_booking_value
+      FROM sma_28009_cte sma_28009_cte
     ) subq_13
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
   ) subq_17
   FULL OUTER JOIN (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28009
     -- Pass Only Elements: ['max_booking_value', 'metric_time__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      DATE_TRUNC('day', ds) AS metric_time__day
-      , MAX(booking_value) AS max_booking_value
-    FROM ***************************.fct_bookings bookings_source_src_28000
+      metric_time__day
+      , MAX(max_booking_value) AS max_booking_value
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
-      DATE_TRUNC('day', ds)
-  ) subq_22
+      metric_time__day
+  ) subq_21
   ON
-    subq_17.metric_time__day = subq_22.metric_time__day
+    subq_17.metric_time__day = subq_21.metric_time__day
   GROUP BY
-    COALESCE(subq_17.metric_time__day, subq_22.metric_time__day)
-) subq_23
+    COALESCE(subq_17.metric_time__day, subq_21.metric_time__day)
+) subq_22

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0_optimized.sql
@@ -7,17 +7,37 @@ docstring:
 sql_engine: Snowflake
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , listing_id AS listing
+    , is_instant AS booking__is_instant
+    , 1 AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
+, sma_28014_cte AS (
+  -- Read Elements From Semantic Model 'listings_latest'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    listing_id AS listing
+    , country AS country_latest
+  FROM ***************************.dim_listings_latest listings_latest_src_28000
+)
+
 SELECT
-  metric_time__day
-  , listing__country_latest
+  metric_time__day AS metric_time__day
+  , listing__country_latest AS listing__country_latest
   , bookings_fill_nulls_with_0 - bookings_2_weeks_ago AS bookings_growth_2_weeks_fill_nulls_with_0
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_42.metric_time__day, subq_58.metric_time__day) AS metric_time__day
-    , COALESCE(subq_42.listing__country_latest, subq_58.listing__country_latest) AS listing__country_latest
+    COALESCE(subq_42.metric_time__day, subq_56.metric_time__day) AS metric_time__day
+    , COALESCE(subq_42.listing__country_latest, subq_56.listing__country_latest) AS listing__country_latest
     , COALESCE(MAX(subq_42.bookings_fill_nulls_with_0), 0) AS bookings_fill_nulls_with_0
-    , COALESCE(MAX(subq_58.bookings_2_weeks_ago), 0) AS bookings_2_weeks_ago
+    , COALESCE(MAX(subq_56.bookings_2_weeks_ago), 0) AS bookings_2_weeks_ago
   FROM (
     -- Compute Metrics via Expressions
     SELECT
@@ -42,24 +62,15 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            listings_latest_src_28000.country AS listing__country_latest
-            , subq_31.metric_time__day AS metric_time__day
-            , subq_31.booking__is_instant AS booking__is_instant
-            , subq_31.bookings AS bookings
-          FROM (
-            -- Read Elements From Semantic Model 'bookings_source'
-            -- Metric Time Dimension 'ds'
-            SELECT
-              DATE_TRUNC('day', ds) AS metric_time__day
-              , listing_id AS listing
-              , is_instant AS booking__is_instant
-              , 1 AS bookings
-            FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_31
+            sma_28014_cte.country_latest AS listing__country_latest
+            , sma_28009_cte.metric_time__day AS metric_time__day
+            , sma_28009_cte.booking__is_instant AS booking__is_instant
+            , sma_28009_cte.bookings AS bookings
+          FROM sma_28009_cte sma_28009_cte
           LEFT OUTER JOIN
-            ***************************.dim_listings_latest listings_latest_src_28000
+            sma_28014_cte sma_28014_cte
           ON
-            subq_31.listing = listings_latest_src_28000.listing_id
+            sma_28009_cte.listing = sma_28014_cte.listing
         ) subq_35
         WHERE booking__is_instant
         GROUP BY
@@ -79,10 +90,10 @@ FROM (
     FROM (
       -- Join to Time Spine Dataset
       SELECT
-        subq_56.ds AS metric_time__day
-        , subq_54.listing__country_latest AS listing__country_latest
-        , subq_54.bookings AS bookings
-      FROM ***************************.mf_time_spine subq_56
+        subq_54.ds AS metric_time__day
+        , subq_52.listing__country_latest AS listing__country_latest
+        , subq_52.bookings AS bookings
+      FROM ***************************.mf_time_spine subq_54
       LEFT OUTER JOIN (
         -- Constrain Output with WHERE
         -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
@@ -94,52 +105,44 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            listings_latest_src_28000.country AS listing__country_latest
-            , subq_47.metric_time__day AS metric_time__day
-            , subq_47.booking__is_instant AS booking__is_instant
-            , subq_47.bookings AS bookings
+            sma_28014_cte.country_latest AS listing__country_latest
+            , subq_46.metric_time__day AS metric_time__day
+            , subq_46.booking__is_instant AS booking__is_instant
+            , subq_46.bookings AS bookings
           FROM (
             -- Join to Time Spine Dataset
             SELECT
-              subq_46.ds AS metric_time__day
-              , subq_44.listing AS listing
-              , subq_44.booking__is_instant AS booking__is_instant
-              , subq_44.bookings AS bookings
-            FROM ***************************.mf_time_spine subq_46
-            INNER JOIN (
-              -- Read Elements From Semantic Model 'bookings_source'
-              -- Metric Time Dimension 'ds'
-              SELECT
-                DATE_TRUNC('day', ds) AS metric_time__day
-                , listing_id AS listing
-                , is_instant AS booking__is_instant
-                , 1 AS bookings
-              FROM ***************************.fct_bookings bookings_source_src_28000
-            ) subq_44
+              subq_45.ds AS metric_time__day
+              , sma_28009_cte.listing AS listing
+              , sma_28009_cte.booking__is_instant AS booking__is_instant
+              , sma_28009_cte.bookings AS bookings
+            FROM ***************************.mf_time_spine subq_45
+            INNER JOIN
+              sma_28009_cte sma_28009_cte
             ON
-              DATEADD(day, -14, subq_46.ds) = subq_44.metric_time__day
-          ) subq_47
+              DATEADD(day, -14, subq_45.ds) = sma_28009_cte.metric_time__day
+          ) subq_46
           LEFT OUTER JOIN
-            ***************************.dim_listings_latest listings_latest_src_28000
+            sma_28014_cte sma_28014_cte
           ON
-            subq_47.listing = listings_latest_src_28000.listing_id
-        ) subq_51
+            subq_46.listing = sma_28014_cte.listing
+        ) subq_49
         WHERE booking__is_instant
         GROUP BY
           metric_time__day
           , listing__country_latest
-      ) subq_54
+      ) subq_52
       ON
-        subq_56.ds = subq_54.metric_time__day
-    ) subq_57
-  ) subq_58
+        subq_54.ds = subq_52.metric_time__day
+    ) subq_55
+  ) subq_56
   ON
     (
-      subq_42.listing__country_latest = subq_58.listing__country_latest
+      subq_42.listing__country_latest = subq_56.listing__country_latest
     ) AND (
-      subq_42.metric_time__day = subq_58.metric_time__day
+      subq_42.metric_time__day = subq_56.metric_time__day
     )
   GROUP BY
-    COALESCE(subq_42.metric_time__day, subq_58.metric_time__day)
-    , COALESCE(subq_42.listing__country_latest, subq_58.listing__country_latest)
-) subq_59
+    COALESCE(subq_42.metric_time__day, subq_56.metric_time__day)
+    , COALESCE(subq_42.listing__country_latest, subq_56.listing__country_latest)
+) subq_57

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_offset_metric_with_query_time_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_offset_metric_with_query_time_filters__plan0_optimized.sql
@@ -7,17 +7,37 @@ docstring:
 sql_engine: Snowflake
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , listing_id AS listing
+    , is_instant AS booking__is_instant
+    , 1 AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
+, sma_28014_cte AS (
+  -- Read Elements From Semantic Model 'listings_latest'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    listing_id AS listing
+    , country AS country_latest
+  FROM ***************************.dim_listings_latest listings_latest_src_28000
+)
+
 SELECT
-  metric_time__day
-  , listing__country_latest
+  metric_time__day AS metric_time__day
+  , listing__country_latest AS listing__country_latest
   , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_33.metric_time__day, subq_46.metric_time__day) AS metric_time__day
-    , COALESCE(subq_33.listing__country_latest, subq_46.listing__country_latest) AS listing__country_latest
+    COALESCE(subq_33.metric_time__day, subq_44.metric_time__day) AS metric_time__day
+    , COALESCE(subq_33.listing__country_latest, subq_44.listing__country_latest) AS listing__country_latest
     , MAX(subq_33.bookings) AS bookings
-    , MAX(subq_46.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+    , MAX(subq_44.bookings_2_weeks_ago) AS bookings_2_weeks_ago
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
@@ -30,24 +50,15 @@ FROM (
     FROM (
       -- Join Standard Outputs
       SELECT
-        listings_latest_src_28000.country AS listing__country_latest
-        , subq_25.metric_time__day AS metric_time__day
-        , subq_25.booking__is_instant AS booking__is_instant
-        , subq_25.bookings AS bookings
-      FROM (
-        -- Read Elements From Semantic Model 'bookings_source'
-        -- Metric Time Dimension 'ds'
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , listing_id AS listing
-          , is_instant AS booking__is_instant
-          , 1 AS bookings
-        FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_25
+        sma_28014_cte.country_latest AS listing__country_latest
+        , sma_28009_cte.metric_time__day AS metric_time__day
+        , sma_28009_cte.booking__is_instant AS booking__is_instant
+        , sma_28009_cte.bookings AS bookings
+      FROM sma_28009_cte sma_28009_cte
       LEFT OUTER JOIN
-        ***************************.dim_listings_latest listings_latest_src_28000
+        sma_28014_cte sma_28014_cte
       ON
-        subq_25.listing = listings_latest_src_28000.listing_id
+        sma_28009_cte.listing = sma_28014_cte.listing
     ) subq_29
     WHERE booking__is_instant
     GROUP BY
@@ -66,48 +77,40 @@ FROM (
     FROM (
       -- Join Standard Outputs
       SELECT
-        listings_latest_src_28000.country AS listing__country_latest
-        , subq_38.metric_time__day AS metric_time__day
-        , subq_38.booking__is_instant AS booking__is_instant
-        , subq_38.bookings AS bookings
+        sma_28014_cte.country_latest AS listing__country_latest
+        , subq_37.metric_time__day AS metric_time__day
+        , subq_37.booking__is_instant AS booking__is_instant
+        , subq_37.bookings AS bookings
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_37.ds AS metric_time__day
-          , subq_35.listing AS listing
-          , subq_35.booking__is_instant AS booking__is_instant
-          , subq_35.bookings AS bookings
-        FROM ***************************.mf_time_spine subq_37
-        INNER JOIN (
-          -- Read Elements From Semantic Model 'bookings_source'
-          -- Metric Time Dimension 'ds'
-          SELECT
-            DATE_TRUNC('day', ds) AS metric_time__day
-            , listing_id AS listing
-            , is_instant AS booking__is_instant
-            , 1 AS bookings
-          FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_35
+          subq_36.ds AS metric_time__day
+          , sma_28009_cte.listing AS listing
+          , sma_28009_cte.booking__is_instant AS booking__is_instant
+          , sma_28009_cte.bookings AS bookings
+        FROM ***************************.mf_time_spine subq_36
+        INNER JOIN
+          sma_28009_cte sma_28009_cte
         ON
-          DATEADD(day, -14, subq_37.ds) = subq_35.metric_time__day
-      ) subq_38
+          DATEADD(day, -14, subq_36.ds) = sma_28009_cte.metric_time__day
+      ) subq_37
       LEFT OUTER JOIN
-        ***************************.dim_listings_latest listings_latest_src_28000
+        sma_28014_cte sma_28014_cte
       ON
-        subq_38.listing = listings_latest_src_28000.listing_id
-    ) subq_42
+        subq_37.listing = sma_28014_cte.listing
+    ) subq_40
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
       , listing__country_latest
-  ) subq_46
+  ) subq_44
   ON
     (
-      subq_33.listing__country_latest = subq_46.listing__country_latest
+      subq_33.listing__country_latest = subq_44.listing__country_latest
     ) AND (
-      subq_33.metric_time__day = subq_46.metric_time__day
+      subq_33.metric_time__day = subq_44.metric_time__day
     )
   GROUP BY
-    COALESCE(subq_33.metric_time__day, subq_46.metric_time__day)
-    , COALESCE(subq_33.listing__country_latest, subq_46.listing__country_latest)
-) subq_47
+    COALESCE(subq_33.metric_time__day, subq_44.metric_time__day)
+    , COALESCE(subq_33.listing__country_latest, subq_44.listing__country_latest)
+) subq_45

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_saved_query_with_metric_joins_and_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_saved_query_with_metric_joins_and_filter__plan0_optimized.sql
@@ -7,12 +7,7 @@ docstring:
 sql_engine: Snowflake
 ---
 -- Combine Aggregated Outputs
-SELECT
-  COALESCE(subq_51.listing__capacity_latest, subq_61.listing__capacity_latest, subq_82.listing__capacity_latest) AS listing__capacity_latest
-  , MAX(subq_51.bookings) AS bookings
-  , MAX(subq_61.views) AS views
-  , MAX(CAST(subq_82.bookings AS DOUBLE) / CAST(NULLIF(subq_82.views, 0) AS DOUBLE)) AS bookings_per_view
-FROM (
+WITH cm_6_cte AS (
   -- Constrain Output with WHERE
   -- Pass Only Elements: ['bookings', 'listing__capacity_latest']
   -- Aggregate Measures
@@ -44,8 +39,9 @@ FROM (
   WHERE (listing__is_lux_latest) AND (metric_time__day >= '2020-01-02')
   GROUP BY
     listing__capacity_latest
-) subq_51
-FULL OUTER JOIN (
+)
+
+, cm_7_cte AS (
   -- Constrain Output with WHERE
   -- Pass Only Elements: ['views', 'listing__capacity_latest']
   -- Aggregate Measures
@@ -77,87 +73,33 @@ FULL OUTER JOIN (
   WHERE (listing__is_lux_latest) AND (metric_time__day >= '2020-01-02')
   GROUP BY
     listing__capacity_latest
-) subq_61
+)
+
+SELECT
+  COALESCE(cm_6_cte.listing__capacity_latest, cm_7_cte.listing__capacity_latest, subq_64.listing__capacity_latest) AS listing__capacity_latest
+  , MAX(cm_6_cte.bookings) AS bookings
+  , MAX(cm_7_cte.views) AS views
+  , MAX(CAST(subq_64.bookings AS DOUBLE) / CAST(NULLIF(subq_64.views, 0) AS DOUBLE)) AS bookings_per_view
+FROM cm_6_cte cm_6_cte
+FULL OUTER JOIN
+  cm_7_cte cm_7_cte
 ON
-  subq_51.listing__capacity_latest = subq_61.listing__capacity_latest
+  cm_6_cte.listing__capacity_latest = cm_7_cte.listing__capacity_latest
 FULL OUTER JOIN (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_71.listing__capacity_latest, subq_81.listing__capacity_latest) AS listing__capacity_latest
-    , MAX(subq_71.bookings) AS bookings
-    , MAX(subq_81.views) AS views
-  FROM (
-    -- Constrain Output with WHERE
-    -- Pass Only Elements: ['bookings', 'listing__capacity_latest']
-    -- Aggregate Measures
-    -- Compute Metrics via Expressions
-    SELECT
-      listing__capacity_latest
-      , SUM(bookings) AS bookings
-    FROM (
-      -- Join Standard Outputs
-      SELECT
-        listings_latest_src_28000.is_lux AS listing__is_lux_latest
-        , listings_latest_src_28000.capacity AS listing__capacity_latest
-        , subq_63.metric_time__day AS metric_time__day
-        , subq_63.bookings AS bookings
-      FROM (
-        -- Read Elements From Semantic Model 'bookings_source'
-        -- Metric Time Dimension 'ds'
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , listing_id AS listing
-          , 1 AS bookings
-        FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_63
-      LEFT OUTER JOIN
-        ***************************.dim_listings_latest listings_latest_src_28000
-      ON
-        subq_63.listing = listings_latest_src_28000.listing_id
-    ) subq_67
-    WHERE (listing__is_lux_latest) AND (metric_time__day >= '2020-01-02')
-    GROUP BY
-      listing__capacity_latest
-  ) subq_71
-  FULL OUTER JOIN (
-    -- Constrain Output with WHERE
-    -- Pass Only Elements: ['views', 'listing__capacity_latest']
-    -- Aggregate Measures
-    -- Compute Metrics via Expressions
-    SELECT
-      listing__capacity_latest
-      , SUM(views) AS views
-    FROM (
-      -- Join Standard Outputs
-      SELECT
-        listings_latest_src_28000.is_lux AS listing__is_lux_latest
-        , listings_latest_src_28000.capacity AS listing__capacity_latest
-        , subq_73.metric_time__day AS metric_time__day
-        , subq_73.views AS views
-      FROM (
-        -- Read Elements From Semantic Model 'views_source'
-        -- Metric Time Dimension 'ds'
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , listing_id AS listing
-          , 1 AS views
-        FROM ***************************.fct_views views_source_src_28000
-      ) subq_73
-      LEFT OUTER JOIN
-        ***************************.dim_listings_latest listings_latest_src_28000
-      ON
-        subq_73.listing = listings_latest_src_28000.listing_id
-    ) subq_77
-    WHERE (listing__is_lux_latest) AND (metric_time__day >= '2020-01-02')
-    GROUP BY
-      listing__capacity_latest
-  ) subq_81
+    COALESCE(cm_6_cte.listing__capacity_latest, cm_7_cte.listing__capacity_latest) AS listing__capacity_latest
+    , MAX(cm_6_cte.bookings) AS bookings
+    , MAX(cm_7_cte.views) AS views
+  FROM cm_6_cte cm_6_cte
+  FULL OUTER JOIN
+    cm_7_cte cm_7_cte
   ON
-    subq_71.listing__capacity_latest = subq_81.listing__capacity_latest
+    cm_6_cte.listing__capacity_latest = cm_7_cte.listing__capacity_latest
   GROUP BY
-    COALESCE(subq_71.listing__capacity_latest, subq_81.listing__capacity_latest)
-) subq_82
+    COALESCE(cm_6_cte.listing__capacity_latest, cm_7_cte.listing__capacity_latest)
+) subq_64
 ON
-  COALESCE(subq_51.listing__capacity_latest, subq_61.listing__capacity_latest) = subq_82.listing__capacity_latest
+  COALESCE(cm_6_cte.listing__capacity_latest, cm_7_cte.listing__capacity_latest) = subq_64.listing__capacity_latest
 GROUP BY
-  COALESCE(subq_51.listing__capacity_latest, subq_61.listing__capacity_latest, subq_82.listing__capacity_latest)
+  COALESCE(cm_6_cte.listing__capacity_latest, cm_7_cte.listing__capacity_latest, subq_64.listing__capacity_latest)

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_conversion_metric_query_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_conversion_metric_query_filters__plan0_optimized.sql
@@ -5,17 +5,36 @@ docstring:
 sql_engine: Trino
 ---
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , referrer_id AS visit__referrer_id
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
+, rss_28028_cte AS (
+  -- Read Elements From Semantic Model 'users_latest'
+  SELECT
+    home_state_latest
+    , user_id AS user
+  FROM ***************************.dim_users_latest users_latest_src_28000
+)
+
 SELECT
-  metric_time__day
-  , user__home_state_latest
+  metric_time__day AS metric_time__day
+  , user__home_state_latest AS user__home_state_latest
   , CAST(buys AS DOUBLE) / CAST(NULLIF(visits, 0) AS DOUBLE) AS visit_buy_conversion_rate_7days
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_30.metric_time__day, subq_44.metric_time__day) AS metric_time__day
-    , COALESCE(subq_30.user__home_state_latest, subq_44.user__home_state_latest) AS user__home_state_latest
+    COALESCE(subq_30.metric_time__day, subq_43.metric_time__day) AS metric_time__day
+    , COALESCE(subq_30.user__home_state_latest, subq_43.user__home_state_latest) AS user__home_state_latest
     , MAX(subq_30.visits) AS visits
-    , MAX(subq_44.buys) AS buys
+    , MAX(subq_43.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['visits', 'user__home_state_latest', 'metric_time__day']
@@ -27,24 +46,15 @@ FROM (
     FROM (
       -- Join Standard Outputs
       SELECT
-        users_latest_src_28000.home_state_latest AS user__home_state_latest
-        , subq_24.metric_time__day AS metric_time__day
-        , subq_24.visit__referrer_id AS visit__referrer_id
-        , subq_24.visits AS visits
-      FROM (
-        -- Read Elements From Semantic Model 'visits_source'
-        -- Metric Time Dimension 'ds'
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , user_id AS user
-          , referrer_id AS visit__referrer_id
-          , 1 AS visits
-        FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_24
+        rss_28028_cte.home_state_latest AS user__home_state_latest
+        , sma_28019_cte.metric_time__day AS metric_time__day
+        , sma_28019_cte.visit__referrer_id AS visit__referrer_id
+        , sma_28019_cte.visits AS visits
+      FROM sma_28019_cte sma_28019_cte
       LEFT OUTER JOIN
-        ***************************.dim_users_latest users_latest_src_28000
+        rss_28028_cte rss_28028_cte
       ON
-        subq_24.user = users_latest_src_28000.user_id
+        sma_28019_cte.user = rss_28028_cte.user
     ) subq_27
     WHERE visit__referrer_id = '123456'
     GROUP BY
@@ -62,82 +72,73 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_37.visits) OVER (
+        FIRST_VALUE(subq_36.visits) OVER (
           PARTITION BY
-            subq_40.user
-            , subq_40.metric_time__day
-            , subq_40.mf_internal_uuid
-          ORDER BY subq_37.metric_time__day DESC
+            subq_39.user
+            , subq_39.metric_time__day
+            , subq_39.mf_internal_uuid
+          ORDER BY subq_36.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_37.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_36.visit__referrer_id) OVER (
           PARTITION BY
-            subq_40.user
-            , subq_40.metric_time__day
-            , subq_40.mf_internal_uuid
-          ORDER BY subq_37.metric_time__day DESC
+            subq_39.user
+            , subq_39.metric_time__day
+            , subq_39.mf_internal_uuid
+          ORDER BY subq_36.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_37.user__home_state_latest) OVER (
+        , FIRST_VALUE(subq_36.user__home_state_latest) OVER (
           PARTITION BY
-            subq_40.user
-            , subq_40.metric_time__day
-            , subq_40.mf_internal_uuid
-          ORDER BY subq_37.metric_time__day DESC
+            subq_39.user
+            , subq_39.metric_time__day
+            , subq_39.mf_internal_uuid
+          ORDER BY subq_36.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user__home_state_latest
-        , FIRST_VALUE(subq_37.metric_time__day) OVER (
+        , FIRST_VALUE(subq_36.metric_time__day) OVER (
           PARTITION BY
-            subq_40.user
-            , subq_40.metric_time__day
-            , subq_40.mf_internal_uuid
-          ORDER BY subq_37.metric_time__day DESC
+            subq_39.user
+            , subq_39.metric_time__day
+            , subq_39.mf_internal_uuid
+          ORDER BY subq_36.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_37.user) OVER (
+        , FIRST_VALUE(subq_36.user) OVER (
           PARTITION BY
-            subq_40.user
-            , subq_40.metric_time__day
-            , subq_40.mf_internal_uuid
-          ORDER BY subq_37.metric_time__day DESC
+            subq_39.user
+            , subq_39.metric_time__day
+            , subq_39.mf_internal_uuid
+          ORDER BY subq_36.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_40.mf_internal_uuid AS mf_internal_uuid
-        , subq_40.buys AS buys
+        , subq_39.mf_internal_uuid AS mf_internal_uuid
+        , subq_39.buys AS buys
       FROM (
         -- Constrain Output with WHERE
         -- Pass Only Elements: ['visits', 'visit__referrer_id', 'user__home_state_latest', 'metric_time__day', 'user']
         SELECT
           metric_time__day
-          , subq_35.user
+          , subq_34.user
           , visit__referrer_id
           , user__home_state_latest
           , visits
         FROM (
           -- Join Standard Outputs
           SELECT
-            users_latest_src_28000.home_state_latest AS user__home_state_latest
-            , subq_32.metric_time__day AS metric_time__day
-            , subq_32.user AS user
-            , subq_32.visit__referrer_id AS visit__referrer_id
-            , subq_32.visits AS visits
-          FROM (
-            -- Read Elements From Semantic Model 'visits_source'
-            -- Metric Time Dimension 'ds'
-            SELECT
-              DATE_TRUNC('day', ds) AS metric_time__day
-              , user_id AS user
-              , referrer_id AS visit__referrer_id
-              , 1 AS visits
-            FROM ***************************.fct_visits visits_source_src_28000
-          ) subq_32
+            rss_28028_cte.home_state_latest AS user__home_state_latest
+            , sma_28019_cte.metric_time__day AS metric_time__day
+            , sma_28019_cte.user AS user
+            , sma_28019_cte.visit__referrer_id AS visit__referrer_id
+            , sma_28019_cte.visits AS visits
+          FROM sma_28019_cte sma_28019_cte
           LEFT OUTER JOIN
-            ***************************.dim_users_latest users_latest_src_28000
+            rss_28028_cte rss_28028_cte
           ON
-            subq_32.user = users_latest_src_28000.user_id
-        ) subq_35
+            sma_28019_cte.user = rss_28028_cte.user
+        ) subq_34
         WHERE visit__referrer_id = '123456'
-      ) subq_37
+      ) subq_36
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -148,29 +149,29 @@ FROM (
           , 1 AS buys
           , uuid() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_40
+      ) subq_39
       ON
         (
-          subq_37.user = subq_40.user
+          subq_36.user = subq_39.user
         ) AND (
           (
-            subq_37.metric_time__day <= subq_40.metric_time__day
+            subq_36.metric_time__day <= subq_39.metric_time__day
           ) AND (
-            subq_37.metric_time__day > DATE_ADD('day', -7, subq_40.metric_time__day)
+            subq_36.metric_time__day > DATE_ADD('day', -7, subq_39.metric_time__day)
           )
         )
-    ) subq_41
+    ) subq_40
     GROUP BY
       metric_time__day
       , user__home_state_latest
-  ) subq_44
+  ) subq_43
   ON
     (
-      subq_30.user__home_state_latest = subq_44.user__home_state_latest
+      subq_30.user__home_state_latest = subq_43.user__home_state_latest
     ) AND (
-      subq_30.metric_time__day = subq_44.metric_time__day
+      subq_30.metric_time__day = subq_43.metric_time__day
     )
   GROUP BY
-    COALESCE(subq_30.metric_time__day, subq_44.metric_time__day)
-    , COALESCE(subq_30.user__home_state_latest, subq_44.user__home_state_latest)
-) subq_45
+    COALESCE(subq_30.metric_time__day, subq_43.metric_time__day)
+    , COALESCE(subq_30.user__home_state_latest, subq_43.user__home_state_latest)
+) subq_44

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_different_filters_on_same_measure_source_categorical_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_different_filters_on_same_measure_source_categorical_dimension__plan0_optimized.sql
@@ -13,15 +13,26 @@ docstring:
 sql_engine: Trino
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , is_instant AS booking__is_instant
+    , booking_value AS max_booking_value
+    , booking_value AS average_booking_value
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__day
+  metric_time__day AS metric_time__day
   , CAST(average_booking_value AS DOUBLE) / CAST(NULLIF(max_booking_value, 0) AS DOUBLE) AS instant_booking_fraction_of_max_value
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_17.metric_time__day, subq_22.metric_time__day) AS metric_time__day
+    COALESCE(subq_17.metric_time__day, subq_21.metric_time__day) AS metric_time__day
     , MAX(subq_17.average_booking_value) AS average_booking_value
-    , MAX(subq_22.max_booking_value) AS max_booking_value
+    , MAX(subq_21.max_booking_value) AS max_booking_value
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['average_booking_value', 'metric_time__day']
@@ -31,33 +42,32 @@ FROM (
       metric_time__day
       , AVG(average_booking_value) AS average_booking_value
     FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
+      -- Read From CTE For node_id=sma_28009
       SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , is_instant AS booking__is_instant
-        , booking_value AS average_booking_value
-      FROM ***************************.fct_bookings bookings_source_src_28000
+        metric_time__day
+        , booking__is_instant
+        , max_booking_value
+        , average_booking_value
+      FROM sma_28009_cte sma_28009_cte
     ) subq_13
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
   ) subq_17
   FULL OUTER JOIN (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28009
     -- Pass Only Elements: ['max_booking_value', 'metric_time__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      DATE_TRUNC('day', ds) AS metric_time__day
-      , MAX(booking_value) AS max_booking_value
-    FROM ***************************.fct_bookings bookings_source_src_28000
+      metric_time__day
+      , MAX(max_booking_value) AS max_booking_value
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
-      DATE_TRUNC('day', ds)
-  ) subq_22
+      metric_time__day
+  ) subq_21
   ON
-    subq_17.metric_time__day = subq_22.metric_time__day
+    subq_17.metric_time__day = subq_21.metric_time__day
   GROUP BY
-    COALESCE(subq_17.metric_time__day, subq_22.metric_time__day)
-) subq_23
+    COALESCE(subq_17.metric_time__day, subq_21.metric_time__day)
+) subq_22

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0_optimized.sql
@@ -7,17 +7,37 @@ docstring:
 sql_engine: Trino
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , listing_id AS listing
+    , is_instant AS booking__is_instant
+    , 1 AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
+, sma_28014_cte AS (
+  -- Read Elements From Semantic Model 'listings_latest'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    listing_id AS listing
+    , country AS country_latest
+  FROM ***************************.dim_listings_latest listings_latest_src_28000
+)
+
 SELECT
-  metric_time__day
-  , listing__country_latest
+  metric_time__day AS metric_time__day
+  , listing__country_latest AS listing__country_latest
   , bookings_fill_nulls_with_0 - bookings_2_weeks_ago AS bookings_growth_2_weeks_fill_nulls_with_0
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_42.metric_time__day, subq_58.metric_time__day) AS metric_time__day
-    , COALESCE(subq_42.listing__country_latest, subq_58.listing__country_latest) AS listing__country_latest
+    COALESCE(subq_42.metric_time__day, subq_56.metric_time__day) AS metric_time__day
+    , COALESCE(subq_42.listing__country_latest, subq_56.listing__country_latest) AS listing__country_latest
     , COALESCE(MAX(subq_42.bookings_fill_nulls_with_0), 0) AS bookings_fill_nulls_with_0
-    , COALESCE(MAX(subq_58.bookings_2_weeks_ago), 0) AS bookings_2_weeks_ago
+    , COALESCE(MAX(subq_56.bookings_2_weeks_ago), 0) AS bookings_2_weeks_ago
   FROM (
     -- Compute Metrics via Expressions
     SELECT
@@ -42,24 +62,15 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            listings_latest_src_28000.country AS listing__country_latest
-            , subq_31.metric_time__day AS metric_time__day
-            , subq_31.booking__is_instant AS booking__is_instant
-            , subq_31.bookings AS bookings
-          FROM (
-            -- Read Elements From Semantic Model 'bookings_source'
-            -- Metric Time Dimension 'ds'
-            SELECT
-              DATE_TRUNC('day', ds) AS metric_time__day
-              , listing_id AS listing
-              , is_instant AS booking__is_instant
-              , 1 AS bookings
-            FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_31
+            sma_28014_cte.country_latest AS listing__country_latest
+            , sma_28009_cte.metric_time__day AS metric_time__day
+            , sma_28009_cte.booking__is_instant AS booking__is_instant
+            , sma_28009_cte.bookings AS bookings
+          FROM sma_28009_cte sma_28009_cte
           LEFT OUTER JOIN
-            ***************************.dim_listings_latest listings_latest_src_28000
+            sma_28014_cte sma_28014_cte
           ON
-            subq_31.listing = listings_latest_src_28000.listing_id
+            sma_28009_cte.listing = sma_28014_cte.listing
         ) subq_35
         WHERE booking__is_instant
         GROUP BY
@@ -79,10 +90,10 @@ FROM (
     FROM (
       -- Join to Time Spine Dataset
       SELECT
-        subq_56.ds AS metric_time__day
-        , subq_54.listing__country_latest AS listing__country_latest
-        , subq_54.bookings AS bookings
-      FROM ***************************.mf_time_spine subq_56
+        subq_54.ds AS metric_time__day
+        , subq_52.listing__country_latest AS listing__country_latest
+        , subq_52.bookings AS bookings
+      FROM ***************************.mf_time_spine subq_54
       LEFT OUTER JOIN (
         -- Constrain Output with WHERE
         -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
@@ -94,52 +105,44 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            listings_latest_src_28000.country AS listing__country_latest
-            , subq_47.metric_time__day AS metric_time__day
-            , subq_47.booking__is_instant AS booking__is_instant
-            , subq_47.bookings AS bookings
+            sma_28014_cte.country_latest AS listing__country_latest
+            , subq_46.metric_time__day AS metric_time__day
+            , subq_46.booking__is_instant AS booking__is_instant
+            , subq_46.bookings AS bookings
           FROM (
             -- Join to Time Spine Dataset
             SELECT
-              subq_46.ds AS metric_time__day
-              , subq_44.listing AS listing
-              , subq_44.booking__is_instant AS booking__is_instant
-              , subq_44.bookings AS bookings
-            FROM ***************************.mf_time_spine subq_46
-            INNER JOIN (
-              -- Read Elements From Semantic Model 'bookings_source'
-              -- Metric Time Dimension 'ds'
-              SELECT
-                DATE_TRUNC('day', ds) AS metric_time__day
-                , listing_id AS listing
-                , is_instant AS booking__is_instant
-                , 1 AS bookings
-              FROM ***************************.fct_bookings bookings_source_src_28000
-            ) subq_44
+              subq_45.ds AS metric_time__day
+              , sma_28009_cte.listing AS listing
+              , sma_28009_cte.booking__is_instant AS booking__is_instant
+              , sma_28009_cte.bookings AS bookings
+            FROM ***************************.mf_time_spine subq_45
+            INNER JOIN
+              sma_28009_cte sma_28009_cte
             ON
-              DATE_ADD('day', -14, subq_46.ds) = subq_44.metric_time__day
-          ) subq_47
+              DATE_ADD('day', -14, subq_45.ds) = sma_28009_cte.metric_time__day
+          ) subq_46
           LEFT OUTER JOIN
-            ***************************.dim_listings_latest listings_latest_src_28000
+            sma_28014_cte sma_28014_cte
           ON
-            subq_47.listing = listings_latest_src_28000.listing_id
-        ) subq_51
+            subq_46.listing = sma_28014_cte.listing
+        ) subq_49
         WHERE booking__is_instant
         GROUP BY
           metric_time__day
           , listing__country_latest
-      ) subq_54
+      ) subq_52
       ON
-        subq_56.ds = subq_54.metric_time__day
-    ) subq_57
-  ) subq_58
+        subq_54.ds = subq_52.metric_time__day
+    ) subq_55
+  ) subq_56
   ON
     (
-      subq_42.listing__country_latest = subq_58.listing__country_latest
+      subq_42.listing__country_latest = subq_56.listing__country_latest
     ) AND (
-      subq_42.metric_time__day = subq_58.metric_time__day
+      subq_42.metric_time__day = subq_56.metric_time__day
     )
   GROUP BY
-    COALESCE(subq_42.metric_time__day, subq_58.metric_time__day)
-    , COALESCE(subq_42.listing__country_latest, subq_58.listing__country_latest)
-) subq_59
+    COALESCE(subq_42.metric_time__day, subq_56.metric_time__day)
+    , COALESCE(subq_42.listing__country_latest, subq_56.listing__country_latest)
+) subq_57

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_offset_metric_with_query_time_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_offset_metric_with_query_time_filters__plan0_optimized.sql
@@ -7,17 +7,37 @@ docstring:
 sql_engine: Trino
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , listing_id AS listing
+    , is_instant AS booking__is_instant
+    , 1 AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
+, sma_28014_cte AS (
+  -- Read Elements From Semantic Model 'listings_latest'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    listing_id AS listing
+    , country AS country_latest
+  FROM ***************************.dim_listings_latest listings_latest_src_28000
+)
+
 SELECT
-  metric_time__day
-  , listing__country_latest
+  metric_time__day AS metric_time__day
+  , listing__country_latest AS listing__country_latest
   , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_33.metric_time__day, subq_46.metric_time__day) AS metric_time__day
-    , COALESCE(subq_33.listing__country_latest, subq_46.listing__country_latest) AS listing__country_latest
+    COALESCE(subq_33.metric_time__day, subq_44.metric_time__day) AS metric_time__day
+    , COALESCE(subq_33.listing__country_latest, subq_44.listing__country_latest) AS listing__country_latest
     , MAX(subq_33.bookings) AS bookings
-    , MAX(subq_46.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+    , MAX(subq_44.bookings_2_weeks_ago) AS bookings_2_weeks_ago
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
@@ -30,24 +50,15 @@ FROM (
     FROM (
       -- Join Standard Outputs
       SELECT
-        listings_latest_src_28000.country AS listing__country_latest
-        , subq_25.metric_time__day AS metric_time__day
-        , subq_25.booking__is_instant AS booking__is_instant
-        , subq_25.bookings AS bookings
-      FROM (
-        -- Read Elements From Semantic Model 'bookings_source'
-        -- Metric Time Dimension 'ds'
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , listing_id AS listing
-          , is_instant AS booking__is_instant
-          , 1 AS bookings
-        FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_25
+        sma_28014_cte.country_latest AS listing__country_latest
+        , sma_28009_cte.metric_time__day AS metric_time__day
+        , sma_28009_cte.booking__is_instant AS booking__is_instant
+        , sma_28009_cte.bookings AS bookings
+      FROM sma_28009_cte sma_28009_cte
       LEFT OUTER JOIN
-        ***************************.dim_listings_latest listings_latest_src_28000
+        sma_28014_cte sma_28014_cte
       ON
-        subq_25.listing = listings_latest_src_28000.listing_id
+        sma_28009_cte.listing = sma_28014_cte.listing
     ) subq_29
     WHERE booking__is_instant
     GROUP BY
@@ -66,48 +77,40 @@ FROM (
     FROM (
       -- Join Standard Outputs
       SELECT
-        listings_latest_src_28000.country AS listing__country_latest
-        , subq_38.metric_time__day AS metric_time__day
-        , subq_38.booking__is_instant AS booking__is_instant
-        , subq_38.bookings AS bookings
+        sma_28014_cte.country_latest AS listing__country_latest
+        , subq_37.metric_time__day AS metric_time__day
+        , subq_37.booking__is_instant AS booking__is_instant
+        , subq_37.bookings AS bookings
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_37.ds AS metric_time__day
-          , subq_35.listing AS listing
-          , subq_35.booking__is_instant AS booking__is_instant
-          , subq_35.bookings AS bookings
-        FROM ***************************.mf_time_spine subq_37
-        INNER JOIN (
-          -- Read Elements From Semantic Model 'bookings_source'
-          -- Metric Time Dimension 'ds'
-          SELECT
-            DATE_TRUNC('day', ds) AS metric_time__day
-            , listing_id AS listing
-            , is_instant AS booking__is_instant
-            , 1 AS bookings
-          FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_35
+          subq_36.ds AS metric_time__day
+          , sma_28009_cte.listing AS listing
+          , sma_28009_cte.booking__is_instant AS booking__is_instant
+          , sma_28009_cte.bookings AS bookings
+        FROM ***************************.mf_time_spine subq_36
+        INNER JOIN
+          sma_28009_cte sma_28009_cte
         ON
-          DATE_ADD('day', -14, subq_37.ds) = subq_35.metric_time__day
-      ) subq_38
+          DATE_ADD('day', -14, subq_36.ds) = sma_28009_cte.metric_time__day
+      ) subq_37
       LEFT OUTER JOIN
-        ***************************.dim_listings_latest listings_latest_src_28000
+        sma_28014_cte sma_28014_cte
       ON
-        subq_38.listing = listings_latest_src_28000.listing_id
-    ) subq_42
+        subq_37.listing = sma_28014_cte.listing
+    ) subq_40
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
       , listing__country_latest
-  ) subq_46
+  ) subq_44
   ON
     (
-      subq_33.listing__country_latest = subq_46.listing__country_latest
+      subq_33.listing__country_latest = subq_44.listing__country_latest
     ) AND (
-      subq_33.metric_time__day = subq_46.metric_time__day
+      subq_33.metric_time__day = subq_44.metric_time__day
     )
   GROUP BY
-    COALESCE(subq_33.metric_time__day, subq_46.metric_time__day)
-    , COALESCE(subq_33.listing__country_latest, subq_46.listing__country_latest)
-) subq_47
+    COALESCE(subq_33.metric_time__day, subq_44.metric_time__day)
+    , COALESCE(subq_33.listing__country_latest, subq_44.listing__country_latest)
+) subq_45

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_saved_query_with_metric_joins_and_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_saved_query_with_metric_joins_and_filter__plan0_optimized.sql
@@ -7,12 +7,7 @@ docstring:
 sql_engine: Trino
 ---
 -- Combine Aggregated Outputs
-SELECT
-  COALESCE(subq_51.listing__capacity_latest, subq_61.listing__capacity_latest, subq_82.listing__capacity_latest) AS listing__capacity_latest
-  , MAX(subq_51.bookings) AS bookings
-  , MAX(subq_61.views) AS views
-  , MAX(CAST(subq_82.bookings AS DOUBLE) / CAST(NULLIF(subq_82.views, 0) AS DOUBLE)) AS bookings_per_view
-FROM (
+WITH cm_6_cte AS (
   -- Constrain Output with WHERE
   -- Pass Only Elements: ['bookings', 'listing__capacity_latest']
   -- Aggregate Measures
@@ -44,8 +39,9 @@ FROM (
   WHERE (listing__is_lux_latest) AND (metric_time__day >= '2020-01-02')
   GROUP BY
     listing__capacity_latest
-) subq_51
-FULL OUTER JOIN (
+)
+
+, cm_7_cte AS (
   -- Constrain Output with WHERE
   -- Pass Only Elements: ['views', 'listing__capacity_latest']
   -- Aggregate Measures
@@ -77,87 +73,33 @@ FULL OUTER JOIN (
   WHERE (listing__is_lux_latest) AND (metric_time__day >= '2020-01-02')
   GROUP BY
     listing__capacity_latest
-) subq_61
+)
+
+SELECT
+  COALESCE(cm_6_cte.listing__capacity_latest, cm_7_cte.listing__capacity_latest, subq_64.listing__capacity_latest) AS listing__capacity_latest
+  , MAX(cm_6_cte.bookings) AS bookings
+  , MAX(cm_7_cte.views) AS views
+  , MAX(CAST(subq_64.bookings AS DOUBLE) / CAST(NULLIF(subq_64.views, 0) AS DOUBLE)) AS bookings_per_view
+FROM cm_6_cte cm_6_cte
+FULL OUTER JOIN
+  cm_7_cte cm_7_cte
 ON
-  subq_51.listing__capacity_latest = subq_61.listing__capacity_latest
+  cm_6_cte.listing__capacity_latest = cm_7_cte.listing__capacity_latest
 FULL OUTER JOIN (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_71.listing__capacity_latest, subq_81.listing__capacity_latest) AS listing__capacity_latest
-    , MAX(subq_71.bookings) AS bookings
-    , MAX(subq_81.views) AS views
-  FROM (
-    -- Constrain Output with WHERE
-    -- Pass Only Elements: ['bookings', 'listing__capacity_latest']
-    -- Aggregate Measures
-    -- Compute Metrics via Expressions
-    SELECT
-      listing__capacity_latest
-      , SUM(bookings) AS bookings
-    FROM (
-      -- Join Standard Outputs
-      SELECT
-        listings_latest_src_28000.is_lux AS listing__is_lux_latest
-        , listings_latest_src_28000.capacity AS listing__capacity_latest
-        , subq_63.metric_time__day AS metric_time__day
-        , subq_63.bookings AS bookings
-      FROM (
-        -- Read Elements From Semantic Model 'bookings_source'
-        -- Metric Time Dimension 'ds'
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , listing_id AS listing
-          , 1 AS bookings
-        FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_63
-      LEFT OUTER JOIN
-        ***************************.dim_listings_latest listings_latest_src_28000
-      ON
-        subq_63.listing = listings_latest_src_28000.listing_id
-    ) subq_67
-    WHERE (listing__is_lux_latest) AND (metric_time__day >= '2020-01-02')
-    GROUP BY
-      listing__capacity_latest
-  ) subq_71
-  FULL OUTER JOIN (
-    -- Constrain Output with WHERE
-    -- Pass Only Elements: ['views', 'listing__capacity_latest']
-    -- Aggregate Measures
-    -- Compute Metrics via Expressions
-    SELECT
-      listing__capacity_latest
-      , SUM(views) AS views
-    FROM (
-      -- Join Standard Outputs
-      SELECT
-        listings_latest_src_28000.is_lux AS listing__is_lux_latest
-        , listings_latest_src_28000.capacity AS listing__capacity_latest
-        , subq_73.metric_time__day AS metric_time__day
-        , subq_73.views AS views
-      FROM (
-        -- Read Elements From Semantic Model 'views_source'
-        -- Metric Time Dimension 'ds'
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , listing_id AS listing
-          , 1 AS views
-        FROM ***************************.fct_views views_source_src_28000
-      ) subq_73
-      LEFT OUTER JOIN
-        ***************************.dim_listings_latest listings_latest_src_28000
-      ON
-        subq_73.listing = listings_latest_src_28000.listing_id
-    ) subq_77
-    WHERE (listing__is_lux_latest) AND (metric_time__day >= '2020-01-02')
-    GROUP BY
-      listing__capacity_latest
-  ) subq_81
+    COALESCE(cm_6_cte.listing__capacity_latest, cm_7_cte.listing__capacity_latest) AS listing__capacity_latest
+    , MAX(cm_6_cte.bookings) AS bookings
+    , MAX(cm_7_cte.views) AS views
+  FROM cm_6_cte cm_6_cte
+  FULL OUTER JOIN
+    cm_7_cte cm_7_cte
   ON
-    subq_71.listing__capacity_latest = subq_81.listing__capacity_latest
+    cm_6_cte.listing__capacity_latest = cm_7_cte.listing__capacity_latest
   GROUP BY
-    COALESCE(subq_71.listing__capacity_latest, subq_81.listing__capacity_latest)
-) subq_82
+    COALESCE(cm_6_cte.listing__capacity_latest, cm_7_cte.listing__capacity_latest)
+) subq_64
 ON
-  COALESCE(subq_51.listing__capacity_latest, subq_61.listing__capacity_latest) = subq_82.listing__capacity_latest
+  COALESCE(cm_6_cte.listing__capacity_latest, cm_7_cte.listing__capacity_latest) = subq_64.listing__capacity_latest
 GROUP BY
-  COALESCE(subq_51.listing__capacity_latest, subq_61.listing__capacity_latest, subq_82.listing__capacity_latest)
+  COALESCE(cm_6_cte.listing__capacity_latest, cm_7_cte.listing__capacity_latest, subq_64.listing__capacity_latest)

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_measure_constraint_with_reused_measure__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_measure_constraint_with_reused_measure__plan0_optimized.sql
@@ -3,15 +3,25 @@ test_filename: test_query_rendering.py
 sql_engine: BigQuery
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATETIME_TRUNC(ds, day) AS metric_time__day
+    , is_instant AS booking__is_instant
+    , booking_value
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__day
+  metric_time__day AS metric_time__day
   , CAST(booking_value_with_is_instant_constraint AS FLOAT64) / CAST(NULLIF(booking_value, 0) AS FLOAT64) AS instant_booking_value_ratio
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_17.metric_time__day, subq_22.metric_time__day) AS metric_time__day
+    COALESCE(subq_17.metric_time__day, subq_21.metric_time__day) AS metric_time__day
     , MAX(subq_17.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
-    , MAX(subq_22.booking_value) AS booking_value
+    , MAX(subq_21.booking_value) AS booking_value
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['booking_value', 'metric_time__day']
@@ -21,33 +31,31 @@ FROM (
       metric_time__day
       , SUM(booking_value) AS booking_value_with_is_instant_constraint
     FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
+      -- Read From CTE For node_id=sma_28009
       SELECT
-        DATETIME_TRUNC(ds, day) AS metric_time__day
-        , is_instant AS booking__is_instant
+        metric_time__day
+        , booking__is_instant
         , booking_value
-      FROM ***************************.fct_bookings bookings_source_src_28000
+      FROM sma_28009_cte sma_28009_cte
     ) subq_13
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
   ) subq_17
   FULL OUTER JOIN (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28009
     -- Pass Only Elements: ['booking_value', 'metric_time__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      DATETIME_TRUNC(ds, day) AS metric_time__day
+      metric_time__day
       , SUM(booking_value) AS booking_value
-    FROM ***************************.fct_bookings bookings_source_src_28000
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
       metric_time__day
-  ) subq_22
+  ) subq_21
   ON
-    subq_17.metric_time__day = subq_22.metric_time__day
+    subq_17.metric_time__day = subq_21.metric_time__day
   GROUP BY
     metric_time__day
-) subq_23
+) subq_22

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_measure_constraint_with_reused_measure__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_measure_constraint_with_reused_measure__plan0_optimized.sql
@@ -3,15 +3,25 @@ test_filename: test_query_rendering.py
 sql_engine: Databricks
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , is_instant AS booking__is_instant
+    , booking_value
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__day
+  metric_time__day AS metric_time__day
   , CAST(booking_value_with_is_instant_constraint AS DOUBLE) / CAST(NULLIF(booking_value, 0) AS DOUBLE) AS instant_booking_value_ratio
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_17.metric_time__day, subq_22.metric_time__day) AS metric_time__day
+    COALESCE(subq_17.metric_time__day, subq_21.metric_time__day) AS metric_time__day
     , MAX(subq_17.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
-    , MAX(subq_22.booking_value) AS booking_value
+    , MAX(subq_21.booking_value) AS booking_value
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['booking_value', 'metric_time__day']
@@ -21,33 +31,31 @@ FROM (
       metric_time__day
       , SUM(booking_value) AS booking_value_with_is_instant_constraint
     FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
+      -- Read From CTE For node_id=sma_28009
       SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , is_instant AS booking__is_instant
+        metric_time__day
+        , booking__is_instant
         , booking_value
-      FROM ***************************.fct_bookings bookings_source_src_28000
+      FROM sma_28009_cte sma_28009_cte
     ) subq_13
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
   ) subq_17
   FULL OUTER JOIN (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28009
     -- Pass Only Elements: ['booking_value', 'metric_time__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      DATE_TRUNC('day', ds) AS metric_time__day
+      metric_time__day
       , SUM(booking_value) AS booking_value
-    FROM ***************************.fct_bookings bookings_source_src_28000
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
-      DATE_TRUNC('day', ds)
-  ) subq_22
+      metric_time__day
+  ) subq_21
   ON
-    subq_17.metric_time__day = subq_22.metric_time__day
+    subq_17.metric_time__day = subq_21.metric_time__day
   GROUP BY
-    COALESCE(subq_17.metric_time__day, subq_22.metric_time__day)
-) subq_23
+    COALESCE(subq_17.metric_time__day, subq_21.metric_time__day)
+) subq_22

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_measure_constraint_with_reused_measure__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_measure_constraint_with_reused_measure__plan0_optimized.sql
@@ -3,15 +3,25 @@ test_filename: test_query_rendering.py
 sql_engine: DuckDB
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , is_instant AS booking__is_instant
+    , booking_value
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__day
+  metric_time__day AS metric_time__day
   , CAST(booking_value_with_is_instant_constraint AS DOUBLE) / CAST(NULLIF(booking_value, 0) AS DOUBLE) AS instant_booking_value_ratio
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_17.metric_time__day, subq_22.metric_time__day) AS metric_time__day
+    COALESCE(subq_17.metric_time__day, subq_21.metric_time__day) AS metric_time__day
     , MAX(subq_17.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
-    , MAX(subq_22.booking_value) AS booking_value
+    , MAX(subq_21.booking_value) AS booking_value
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['booking_value', 'metric_time__day']
@@ -21,33 +31,31 @@ FROM (
       metric_time__day
       , SUM(booking_value) AS booking_value_with_is_instant_constraint
     FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
+      -- Read From CTE For node_id=sma_28009
       SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , is_instant AS booking__is_instant
+        metric_time__day
+        , booking__is_instant
         , booking_value
-      FROM ***************************.fct_bookings bookings_source_src_28000
+      FROM sma_28009_cte sma_28009_cte
     ) subq_13
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
   ) subq_17
   FULL OUTER JOIN (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28009
     -- Pass Only Elements: ['booking_value', 'metric_time__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      DATE_TRUNC('day', ds) AS metric_time__day
+      metric_time__day
       , SUM(booking_value) AS booking_value
-    FROM ***************************.fct_bookings bookings_source_src_28000
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
-      DATE_TRUNC('day', ds)
-  ) subq_22
+      metric_time__day
+  ) subq_21
   ON
-    subq_17.metric_time__day = subq_22.metric_time__day
+    subq_17.metric_time__day = subq_21.metric_time__day
   GROUP BY
-    COALESCE(subq_17.metric_time__day, subq_22.metric_time__day)
-) subq_23
+    COALESCE(subq_17.metric_time__day, subq_21.metric_time__day)
+) subq_22

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_measure_constraint_with_reused_measure__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_measure_constraint_with_reused_measure__plan0_optimized.sql
@@ -3,15 +3,25 @@ test_filename: test_query_rendering.py
 sql_engine: Postgres
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , is_instant AS booking__is_instant
+    , booking_value
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__day
+  metric_time__day AS metric_time__day
   , CAST(booking_value_with_is_instant_constraint AS DOUBLE PRECISION) / CAST(NULLIF(booking_value, 0) AS DOUBLE PRECISION) AS instant_booking_value_ratio
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_17.metric_time__day, subq_22.metric_time__day) AS metric_time__day
+    COALESCE(subq_17.metric_time__day, subq_21.metric_time__day) AS metric_time__day
     , MAX(subq_17.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
-    , MAX(subq_22.booking_value) AS booking_value
+    , MAX(subq_21.booking_value) AS booking_value
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['booking_value', 'metric_time__day']
@@ -21,33 +31,31 @@ FROM (
       metric_time__day
       , SUM(booking_value) AS booking_value_with_is_instant_constraint
     FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
+      -- Read From CTE For node_id=sma_28009
       SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , is_instant AS booking__is_instant
+        metric_time__day
+        , booking__is_instant
         , booking_value
-      FROM ***************************.fct_bookings bookings_source_src_28000
+      FROM sma_28009_cte sma_28009_cte
     ) subq_13
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
   ) subq_17
   FULL OUTER JOIN (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28009
     -- Pass Only Elements: ['booking_value', 'metric_time__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      DATE_TRUNC('day', ds) AS metric_time__day
+      metric_time__day
       , SUM(booking_value) AS booking_value
-    FROM ***************************.fct_bookings bookings_source_src_28000
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
-      DATE_TRUNC('day', ds)
-  ) subq_22
+      metric_time__day
+  ) subq_21
   ON
-    subq_17.metric_time__day = subq_22.metric_time__day
+    subq_17.metric_time__day = subq_21.metric_time__day
   GROUP BY
-    COALESCE(subq_17.metric_time__day, subq_22.metric_time__day)
-) subq_23
+    COALESCE(subq_17.metric_time__day, subq_21.metric_time__day)
+) subq_22

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_measure_constraint_with_reused_measure__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_measure_constraint_with_reused_measure__plan0_optimized.sql
@@ -3,15 +3,25 @@ test_filename: test_query_rendering.py
 sql_engine: Redshift
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , is_instant AS booking__is_instant
+    , booking_value
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__day
+  metric_time__day AS metric_time__day
   , CAST(booking_value_with_is_instant_constraint AS DOUBLE PRECISION) / CAST(NULLIF(booking_value, 0) AS DOUBLE PRECISION) AS instant_booking_value_ratio
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_17.metric_time__day, subq_22.metric_time__day) AS metric_time__day
+    COALESCE(subq_17.metric_time__day, subq_21.metric_time__day) AS metric_time__day
     , MAX(subq_17.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
-    , MAX(subq_22.booking_value) AS booking_value
+    , MAX(subq_21.booking_value) AS booking_value
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['booking_value', 'metric_time__day']
@@ -21,33 +31,31 @@ FROM (
       metric_time__day
       , SUM(booking_value) AS booking_value_with_is_instant_constraint
     FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
+      -- Read From CTE For node_id=sma_28009
       SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , is_instant AS booking__is_instant
+        metric_time__day
+        , booking__is_instant
         , booking_value
-      FROM ***************************.fct_bookings bookings_source_src_28000
+      FROM sma_28009_cte sma_28009_cte
     ) subq_13
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
   ) subq_17
   FULL OUTER JOIN (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28009
     -- Pass Only Elements: ['booking_value', 'metric_time__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      DATE_TRUNC('day', ds) AS metric_time__day
+      metric_time__day
       , SUM(booking_value) AS booking_value
-    FROM ***************************.fct_bookings bookings_source_src_28000
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
-      DATE_TRUNC('day', ds)
-  ) subq_22
+      metric_time__day
+  ) subq_21
   ON
-    subq_17.metric_time__day = subq_22.metric_time__day
+    subq_17.metric_time__day = subq_21.metric_time__day
   GROUP BY
-    COALESCE(subq_17.metric_time__day, subq_22.metric_time__day)
-) subq_23
+    COALESCE(subq_17.metric_time__day, subq_21.metric_time__day)
+) subq_22

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_measure_constraint_with_reused_measure__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_measure_constraint_with_reused_measure__plan0_optimized.sql
@@ -3,15 +3,25 @@ test_filename: test_query_rendering.py
 sql_engine: Snowflake
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , is_instant AS booking__is_instant
+    , booking_value
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__day
+  metric_time__day AS metric_time__day
   , CAST(booking_value_with_is_instant_constraint AS DOUBLE) / CAST(NULLIF(booking_value, 0) AS DOUBLE) AS instant_booking_value_ratio
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_17.metric_time__day, subq_22.metric_time__day) AS metric_time__day
+    COALESCE(subq_17.metric_time__day, subq_21.metric_time__day) AS metric_time__day
     , MAX(subq_17.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
-    , MAX(subq_22.booking_value) AS booking_value
+    , MAX(subq_21.booking_value) AS booking_value
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['booking_value', 'metric_time__day']
@@ -21,33 +31,31 @@ FROM (
       metric_time__day
       , SUM(booking_value) AS booking_value_with_is_instant_constraint
     FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
+      -- Read From CTE For node_id=sma_28009
       SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , is_instant AS booking__is_instant
+        metric_time__day
+        , booking__is_instant
         , booking_value
-      FROM ***************************.fct_bookings bookings_source_src_28000
+      FROM sma_28009_cte sma_28009_cte
     ) subq_13
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
   ) subq_17
   FULL OUTER JOIN (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28009
     -- Pass Only Elements: ['booking_value', 'metric_time__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      DATE_TRUNC('day', ds) AS metric_time__day
+      metric_time__day
       , SUM(booking_value) AS booking_value
-    FROM ***************************.fct_bookings bookings_source_src_28000
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
-      DATE_TRUNC('day', ds)
-  ) subq_22
+      metric_time__day
+  ) subq_21
   ON
-    subq_17.metric_time__day = subq_22.metric_time__day
+    subq_17.metric_time__day = subq_21.metric_time__day
   GROUP BY
-    COALESCE(subq_17.metric_time__day, subq_22.metric_time__day)
-) subq_23
+    COALESCE(subq_17.metric_time__day, subq_21.metric_time__day)
+) subq_22

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_measure_constraint_with_reused_measure__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_measure_constraint_with_reused_measure__plan0_optimized.sql
@@ -3,15 +3,25 @@ test_filename: test_query_rendering.py
 sql_engine: Trino
 ---
 -- Compute Metrics via Expressions
+WITH sma_28009_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , is_instant AS booking__is_instant
+    , booking_value
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
-  metric_time__day
+  metric_time__day AS metric_time__day
   , CAST(booking_value_with_is_instant_constraint AS DOUBLE) / CAST(NULLIF(booking_value, 0) AS DOUBLE) AS instant_booking_value_ratio
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_17.metric_time__day, subq_22.metric_time__day) AS metric_time__day
+    COALESCE(subq_17.metric_time__day, subq_21.metric_time__day) AS metric_time__day
     , MAX(subq_17.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
-    , MAX(subq_22.booking_value) AS booking_value
+    , MAX(subq_21.booking_value) AS booking_value
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['booking_value', 'metric_time__day']
@@ -21,33 +31,31 @@ FROM (
       metric_time__day
       , SUM(booking_value) AS booking_value_with_is_instant_constraint
     FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
+      -- Read From CTE For node_id=sma_28009
       SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , is_instant AS booking__is_instant
+        metric_time__day
+        , booking__is_instant
         , booking_value
-      FROM ***************************.fct_bookings bookings_source_src_28000
+      FROM sma_28009_cte sma_28009_cte
     ) subq_13
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
   ) subq_17
   FULL OUTER JOIN (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Metric Time Dimension 'ds'
+    -- Read From CTE For node_id=sma_28009
     -- Pass Only Elements: ['booking_value', 'metric_time__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      DATE_TRUNC('day', ds) AS metric_time__day
+      metric_time__day
       , SUM(booking_value) AS booking_value
-    FROM ***************************.fct_bookings bookings_source_src_28000
+    FROM sma_28009_cte sma_28009_cte
     GROUP BY
-      DATE_TRUNC('day', ds)
-  ) subq_22
+      metric_time__day
+  ) subq_21
   ON
-    subq_17.metric_time__day = subq_22.metric_time__day
+    subq_17.metric_time__day = subq_21.metric_time__day
   GROUP BY
-    COALESCE(subq_17.metric_time__day, subq_22.metric_time__day)
-) subq_23
+    COALESCE(subq_17.metric_time__day, subq_21.metric_time__day)
+) subq_22

--- a/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_2_metrics_from_1_semantic_model__dfpo_0.xml
+++ b/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_2_metrics_from_1_semantic_model__dfpo_0.xml
@@ -16,12 +16,12 @@ docstring:
             <!-- metric_spec = MetricSpec(element_name='booking_value', filter_spec_set=WhereFilterSpecSet()) -->
             <AggregateMeasuresNode>
                 <!-- description = 'Aggregate Measures' -->
-                <!-- node_id = NodeId(id_str='am_4') -->
+                <!-- node_id = NodeId(id_str='am_2') -->
                 <FilterElementsNode>
                     <!-- description =                                                                      -->
                     <!--   ("Pass Only Elements: ['bookings', 'booking_value', 'listing__country_latest', " -->
                     <!--    "'metric_time__day']")                                                          -->
-                    <!-- node_id = NodeId(id_str='pfe_9') -->
+                    <!-- node_id = NodeId(id_str='pfe_5') -->
                     <!-- include_spec = MeasureSpec(element_name='bookings') -->
                     <!-- include_spec = MeasureSpec(element_name='booking_value') -->
                     <!-- include_spec =                                               -->
@@ -37,36 +37,36 @@ docstring:
                     <!-- distinct = False -->
                     <JoinOnEntitiesNode>
                         <!-- description = 'Join Standard Outputs' -->
-                        <!-- node_id = NodeId(id_str='jso_4') -->
-                        <!-- join0_for_node_id_pfe_8 =                                      -->
+                        <!-- node_id = NodeId(id_str='jso_2') -->
+                        <!-- join0_for_node_id_pfe_4 =                                      -->
                         <!--   JoinDescription(                                             -->
-                        <!--     join_node=FilterElementsNode(node_id=pfe_8),               -->
+                        <!--     join_node=FilterElementsNode(node_id=pfe_4),               -->
                         <!--     join_on_entity=LinklessEntitySpec(element_name='listing'), -->
                         <!--     join_type=LEFT_OUTER,                                      -->
                         <!--   )                                                            -->
                         <MetricTimeDimensionTransformNode>
                             <!-- description = "Metric Time Dimension 'ds'" -->
-                            <!-- node_id = NodeId(id_str='sma_4') -->
+                            <!-- node_id = NodeId(id_str='sma_0') -->
                             <!-- aggregation_time_dimension = 'ds' -->
                             <ReadSqlSourceNode>
                                 <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
-                                <!-- node_id = NodeId(id_str='rss_4') -->
+                                <!-- node_id = NodeId(id_str='rss_0') -->
                                 <!-- data_set = SemanticModelDataSet('bookings_source') -->
                             </ReadSqlSourceNode>
                         </MetricTimeDimensionTransformNode>
                         <FilterElementsNode>
                             <!-- description = "Pass Only Elements: ['country_latest', 'listing']" -->
-                            <!-- node_id = NodeId(id_str='pfe_8') -->
+                            <!-- node_id = NodeId(id_str='pfe_4') -->
                             <!-- include_spec = DimensionSpec(element_name='country_latest') -->
                             <!-- include_spec = LinklessEntitySpec(element_name='listing') -->
                             <!-- distinct = False -->
                             <MetricTimeDimensionTransformNode>
                                 <!-- description = "Metric Time Dimension 'ds'" -->
-                                <!-- node_id = NodeId(id_str='sma_5') -->
+                                <!-- node_id = NodeId(id_str='sma_1') -->
                                 <!-- aggregation_time_dimension = 'ds' -->
                                 <ReadSqlSourceNode>
                                     <!-- description = "Read From SemanticModelDataSet('listings_latest')" -->
-                                    <!-- node_id = NodeId(id_str='rss_5') -->
+                                    <!-- node_id = NodeId(id_str='rss_1') -->
                                     <!-- data_set = SemanticModelDataSet('listings_latest') -->
                                 </ReadSqlSourceNode>
                             </MetricTimeDimensionTransformNode>

--- a/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_2_metrics_from_2_semantic_models__dfpo_0.xml
+++ b/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_2_metrics_from_2_semantic_models__dfpo_0.xml
@@ -16,10 +16,10 @@ docstring:
                 <!-- metric_spec = MetricSpec(element_name='bookings', filter_spec_set=WhereFilterSpecSet()) -->
                 <AggregateMeasuresNode>
                     <!-- description = 'Aggregate Measures' -->
-                    <!-- node_id = NodeId(id_str='am_2') -->
+                    <!-- node_id = NodeId(id_str='am_0') -->
                     <FilterElementsNode>
                         <!-- description = "Pass Only Elements: ['bookings', 'metric_time__day']" -->
-                        <!-- node_id = NodeId(id_str='pfe_2') -->
+                        <!-- node_id = NodeId(id_str='pfe_0') -->
                         <!-- include_spec = MeasureSpec(element_name='bookings') -->
                         <!-- include_spec =                                                                  -->
                         <!--   TimeDimensionSpec(                                                            -->
@@ -29,11 +29,11 @@ docstring:
                         <!-- distinct = False -->
                         <MetricTimeDimensionTransformNode>
                             <!-- description = "Metric Time Dimension 'ds'" -->
-                            <!-- node_id = NodeId(id_str='sma_0') -->
+                            <!-- node_id = NodeId(id_str='sma_28009') -->
                             <!-- aggregation_time_dimension = 'ds' -->
                             <ReadSqlSourceNode>
                                 <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
-                                <!-- node_id = NodeId(id_str='rss_0') -->
+                                <!-- node_id = NodeId(id_str='rss_28020') -->
                                 <!-- data_set = SemanticModelDataSet('bookings_source') -->
                             </ReadSqlSourceNode>
                         </MetricTimeDimensionTransformNode>
@@ -46,10 +46,10 @@ docstring:
                 <!-- metric_spec = MetricSpec(element_name='listings', filter_spec_set=WhereFilterSpecSet()) -->
                 <AggregateMeasuresNode>
                     <!-- description = 'Aggregate Measures' -->
-                    <!-- node_id = NodeId(id_str='am_3') -->
+                    <!-- node_id = NodeId(id_str='am_1') -->
                     <FilterElementsNode>
                         <!-- description = "Pass Only Elements: ['listings', 'metric_time__day']" -->
-                        <!-- node_id = NodeId(id_str='pfe_3') -->
+                        <!-- node_id = NodeId(id_str='pfe_1') -->
                         <!-- include_spec = MeasureSpec(element_name='listings') -->
                         <!-- include_spec =                                                                  -->
                         <!--   TimeDimensionSpec(                                                            -->
@@ -59,11 +59,11 @@ docstring:
                         <!-- distinct = False -->
                         <MetricTimeDimensionTransformNode>
                             <!-- description = "Metric Time Dimension 'ds'" -->
-                            <!-- node_id = NodeId(id_str='sma_1') -->
+                            <!-- node_id = NodeId(id_str='sma_28014') -->
                             <!-- aggregation_time_dimension = 'ds' -->
                             <ReadSqlSourceNode>
                                 <!-- description = "Read From SemanticModelDataSet('listings_latest')" -->
-                                <!-- node_id = NodeId(id_str='rss_1') -->
+                                <!-- node_id = NodeId(id_str='rss_28024') -->
                                 <!-- data_set = SemanticModelDataSet('listings_latest') -->
                             </ReadSqlSourceNode>
                         </MetricTimeDimensionTransformNode>

--- a/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_2_ratio_metrics_from_1_semantic_model__dfpo_0.xml
+++ b/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_2_ratio_metrics_from_1_semantic_model__dfpo_0.xml
@@ -9,22 +9,22 @@ docstring:
         <!-- node_id = NodeId(id_str='wrd_1') -->
         <ComputeMetricsNode>
             <!-- description = 'Compute Metrics via Expressions' -->
-            <!-- node_id = NodeId(id_str='cm_14') -->
+            <!-- node_id = NodeId(id_str='cm_13') -->
             <!-- metric_spec = MetricSpec(element_name='bookings_per_booker', filter_spec_set=WhereFilterSpecSet()) -->
             <!-- metric_spec = MetricSpec(element_name='bookings_per_dollar', filter_spec_set=WhereFilterSpecSet()) -->
             <ComputeMetricsNode>
                 <!-- description = 'Compute Metrics via Expressions' -->
-                <!-- node_id = NodeId(id_str='cm_13') -->
+                <!-- node_id = NodeId(id_str='cm_12') -->
                 <!-- metric_spec = MetricSpec(element_name='bookings', filter_spec_set=WhereFilterSpecSet()) -->
                 <!-- metric_spec = MetricSpec(element_name='bookers', filter_spec_set=WhereFilterSpecSet()) -->
                 <!-- metric_spec = MetricSpec(element_name='booking_value', filter_spec_set=WhereFilterSpecSet()) -->
                 <AggregateMeasuresNode>
                     <!-- description = 'Aggregate Measures' -->
-                    <!-- node_id = NodeId(id_str='am_9') -->
+                    <!-- node_id = NodeId(id_str='am_5') -->
                     <FilterElementsNode>
                         <!-- description =                                                                        -->
                         <!--   "Pass Only Elements: ['bookings', 'bookers', 'booking_value', 'metric_time__day']" -->
-                        <!-- node_id = NodeId(id_str='pfe_9') -->
+                        <!-- node_id = NodeId(id_str='pfe_5') -->
                         <!-- include_spec = MeasureSpec(element_name='bookings') -->
                         <!-- include_spec = MeasureSpec(element_name='bookers') -->
                         <!-- include_spec = MeasureSpec(element_name='booking_value') -->
@@ -36,11 +36,11 @@ docstring:
                         <!-- distinct = False -->
                         <MetricTimeDimensionTransformNode>
                             <!-- description = "Metric Time Dimension 'ds'" -->
-                            <!-- node_id = NodeId(id_str='sma_6') -->
+                            <!-- node_id = NodeId(id_str='sma_2') -->
                             <!-- aggregation_time_dimension = 'ds' -->
                             <ReadSqlSourceNode>
                                 <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
-                                <!-- node_id = NodeId(id_str='rss_6') -->
+                                <!-- node_id = NodeId(id_str='rss_2') -->
                                 <!-- data_set = SemanticModelDataSet('bookings_source') -->
                             </ReadSqlSourceNode>
                         </MetricTimeDimensionTransformNode>

--- a/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_3_metrics_from_2_semantic_models__dfpo_0.xml
+++ b/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_3_metrics_from_2_semantic_models__dfpo_0.xml
@@ -17,10 +17,10 @@ docstring:
                 <!-- metric_spec = MetricSpec(element_name='booking_value', filter_spec_set=WhereFilterSpecSet()) -->
                 <AggregateMeasuresNode>
                     <!-- description = 'Aggregate Measures' -->
-                    <!-- node_id = NodeId(id_str='am_6') -->
+                    <!-- node_id = NodeId(id_str='am_3') -->
                     <FilterElementsNode>
                         <!-- description = "Pass Only Elements: ['bookings', 'booking_value', 'metric_time__day']" -->
-                        <!-- node_id = NodeId(id_str='pfe_6') -->
+                        <!-- node_id = NodeId(id_str='pfe_3') -->
                         <!-- include_spec = MeasureSpec(element_name='bookings') -->
                         <!-- include_spec = MeasureSpec(element_name='booking_value') -->
                         <!-- include_spec =                                                                  -->
@@ -31,11 +31,11 @@ docstring:
                         <!-- distinct = False -->
                         <MetricTimeDimensionTransformNode>
                             <!-- description = "Metric Time Dimension 'ds'" -->
-                            <!-- node_id = NodeId(id_str='sma_3') -->
+                            <!-- node_id = NodeId(id_str='sma_0') -->
                             <!-- aggregation_time_dimension = 'ds' -->
                             <ReadSqlSourceNode>
                                 <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
-                                <!-- node_id = NodeId(id_str='rss_3') -->
+                                <!-- node_id = NodeId(id_str='rss_0') -->
                                 <!-- data_set = SemanticModelDataSet('bookings_source') -->
                             </ReadSqlSourceNode>
                         </MetricTimeDimensionTransformNode>
@@ -48,10 +48,10 @@ docstring:
                 <!-- metric_spec = MetricSpec(element_name='listings', filter_spec_set=WhereFilterSpecSet()) -->
                 <AggregateMeasuresNode>
                     <!-- description = 'Aggregate Measures' -->
-                    <!-- node_id = NodeId(id_str='am_5') -->
+                    <!-- node_id = NodeId(id_str='am_2') -->
                     <FilterElementsNode>
                         <!-- description = "Pass Only Elements: ['listings', 'metric_time__day']" -->
-                        <!-- node_id = NodeId(id_str='pfe_5') -->
+                        <!-- node_id = NodeId(id_str='pfe_2') -->
                         <!-- include_spec = MeasureSpec(element_name='listings') -->
                         <!-- include_spec =                                                                  -->
                         <!--   TimeDimensionSpec(                                                            -->
@@ -61,11 +61,11 @@ docstring:
                         <!-- distinct = False -->
                         <MetricTimeDimensionTransformNode>
                             <!-- description = "Metric Time Dimension 'ds'" -->
-                            <!-- node_id = NodeId(id_str='sma_2') -->
+                            <!-- node_id = NodeId(id_str='sma_28014') -->
                             <!-- aggregation_time_dimension = 'ds' -->
                             <ReadSqlSourceNode>
                                 <!-- description = "Read From SemanticModelDataSet('listings_latest')" -->
-                                <!-- node_id = NodeId(id_str='rss_2') -->
+                                <!-- node_id = NodeId(id_str='rss_28024') -->
                                 <!-- data_set = SemanticModelDataSet('listings_latest') -->
                             </ReadSqlSourceNode>
                         </MetricTimeDimensionTransformNode>

--- a/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_constrained_metric_not_combined__dfpo_0.xml
+++ b/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_constrained_metric_not_combined__dfpo_0.xml
@@ -19,10 +19,10 @@ docstring:
                 <!-- metric_spec = MetricSpec(element_name='booking_value', filter_spec_set=WhereFilterSpecSet()) -->
                 <AggregateMeasuresNode>
                     <!-- description = 'Aggregate Measures' -->
-                    <!-- node_id = NodeId(id_str='am_2') -->
+                    <!-- node_id = NodeId(id_str='am_0') -->
                     <FilterElementsNode>
                         <!-- description = "Pass Only Elements: ['booking_value', 'metric_time__day']" -->
-                        <!-- node_id = NodeId(id_str='pfe_2') -->
+                        <!-- node_id = NodeId(id_str='pfe_0') -->
                         <!-- include_spec = MeasureSpec(element_name='booking_value') -->
                         <!-- include_spec =                                                                  -->
                         <!--   TimeDimensionSpec(                                                            -->
@@ -32,11 +32,11 @@ docstring:
                         <!-- distinct = False -->
                         <MetricTimeDimensionTransformNode>
                             <!-- description = "Metric Time Dimension 'ds'" -->
-                            <!-- node_id = NodeId(id_str='sma_0') -->
+                            <!-- node_id = NodeId(id_str='sma_28009') -->
                             <!-- aggregation_time_dimension = 'ds' -->
                             <ReadSqlSourceNode>
                                 <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
-                                <!-- node_id = NodeId(id_str='rss_0') -->
+                                <!-- node_id = NodeId(id_str='rss_28020') -->
                                 <!-- data_set = SemanticModelDataSet('bookings_source') -->
                             </ReadSqlSourceNode>
                         </MetricTimeDimensionTransformNode>
@@ -50,10 +50,10 @@ docstring:
                 <!--   MetricSpec(element_name='instant_booking_value', filter_spec_set=WhereFilterSpecSet()) -->
                 <AggregateMeasuresNode>
                     <!-- description = 'Aggregate Measures' -->
-                    <!-- node_id = NodeId(id_str='am_3') -->
+                    <!-- node_id = NodeId(id_str='am_1') -->
                     <FilterElementsNode>
                         <!-- description = "Pass Only Elements: ['booking_value', 'metric_time__day']" -->
-                        <!-- node_id = NodeId(id_str='pfe_3') -->
+                        <!-- node_id = NodeId(id_str='pfe_1') -->
                         <!-- include_spec = MeasureSpec(element_name='booking_value') -->
                         <!-- include_spec =                                                                  -->
                         <!--   TimeDimensionSpec(                                                            -->
@@ -63,7 +63,7 @@ docstring:
                         <!-- distinct = False -->
                         <WhereConstraintNode>
                             <!-- description = 'Constrain Output with WHERE' -->
-                            <!-- node_id = NodeId(id_str='wcc_1') -->
+                            <!-- node_id = NodeId(id_str='wcc_0') -->
                             <!-- where_condition =                                                 -->
                             <!--   WhereFilterSpec(                                                -->
                             <!--     where_sql='booking__is_instant',                              -->
@@ -105,11 +105,11 @@ docstring:
                             <!--   )                                                               -->
                             <MetricTimeDimensionTransformNode>
                                 <!-- description = "Metric Time Dimension 'ds'" -->
-                                <!-- node_id = NodeId(id_str='sma_1') -->
+                                <!-- node_id = NodeId(id_str='sma_28009') -->
                                 <!-- aggregation_time_dimension = 'ds' -->
                                 <ReadSqlSourceNode>
                                     <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
-                                    <!-- node_id = NodeId(id_str='rss_1') -->
+                                    <!-- node_id = NodeId(id_str='rss_28020') -->
                                     <!-- data_set = SemanticModelDataSet('bookings_source') -->
                                 </ReadSqlSourceNode>
                             </MetricTimeDimensionTransformNode>

--- a/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_derived_metric__dfpo_0.xml
+++ b/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_derived_metric__dfpo_0.xml
@@ -26,10 +26,10 @@ docstring:
                 <!-- metric_spec = MetricSpec(element_name='bookings', filter_spec_set=WhereFilterSpecSet()) -->
                 <AggregateMeasuresNode>
                     <!-- description = 'Aggregate Measures' -->
-                    <!-- node_id = NodeId(id_str='am_4') -->
+                    <!-- node_id = NodeId(id_str='am_2') -->
                     <FilterElementsNode>
                         <!-- description = "Pass Only Elements: ['referred_bookings', 'bookings', 'metric_time__day']" -->
-                        <!-- node_id = NodeId(id_str='pfe_4') -->
+                        <!-- node_id = NodeId(id_str='pfe_2') -->
                         <!-- include_spec = MeasureSpec(element_name='referred_bookings') -->
                         <!-- include_spec = MeasureSpec(element_name='bookings') -->
                         <!-- include_spec =                                                                  -->
@@ -40,11 +40,11 @@ docstring:
                         <!-- distinct = False -->
                         <MetricTimeDimensionTransformNode>
                             <!-- description = "Metric Time Dimension 'ds'" -->
-                            <!-- node_id = NodeId(id_str='sma_2') -->
+                            <!-- node_id = NodeId(id_str='sma_0') -->
                             <!-- aggregation_time_dimension = 'ds' -->
                             <ReadSqlSourceNode>
                                 <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
-                                <!-- node_id = NodeId(id_str='rss_2') -->
+                                <!-- node_id = NodeId(id_str='rss_0') -->
                                 <!-- data_set = SemanticModelDataSet('bookings_source') -->
                             </ReadSqlSourceNode>
                         </MetricTimeDimensionTransformNode>

--- a/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_derived_metric_same_alias_components_combined__dfpo_0.xml
+++ b/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_derived_metric_same_alias_components_combined__dfpo_0.xml
@@ -12,20 +12,20 @@ docstring:
         <!-- node_id = NodeId(id_str='wrd_1') -->
         <ComputeMetricsNode>
             <!-- description = 'Compute Metrics via Expressions' -->
-            <!-- node_id = NodeId(id_str='cm_8') -->
+            <!-- node_id = NodeId(id_str='cm_7') -->
             <!-- metric_spec = MetricSpec(element_name='derived_shared_alias_1a', filter_spec_set=WhereFilterSpecSet()) -->
             <!-- metric_spec = MetricSpec(element_name='derived_shared_alias_1b', filter_spec_set=WhereFilterSpecSet()) -->
             <ComputeMetricsNode>
                 <!-- description = 'Compute Metrics via Expressions' -->
-                <!-- node_id = NodeId(id_str='cm_7') -->
+                <!-- node_id = NodeId(id_str='cm_6') -->
                 <!-- metric_spec =                                                                                     -->
                 <!--   MetricSpec(element_name='bookings', filter_spec_set=WhereFilterSpecSet(), alias='shared_alias') -->
                 <AggregateMeasuresNode>
                     <!-- description = 'Aggregate Measures' -->
-                    <!-- node_id = NodeId(id_str='am_3') -->
+                    <!-- node_id = NodeId(id_str='am_1') -->
                     <FilterElementsNode>
                         <!-- description = "Pass Only Elements: ['bookings', 'booking__is_instant']" -->
-                        <!-- node_id = NodeId(id_str='pfe_3') -->
+                        <!-- node_id = NodeId(id_str='pfe_1') -->
                         <!-- include_spec = MeasureSpec(element_name='bookings') -->
                         <!-- include_spec =                                               -->
                         <!--   DimensionSpec(                                             -->
@@ -35,11 +35,11 @@ docstring:
                         <!-- distinct = False -->
                         <MetricTimeDimensionTransformNode>
                             <!-- description = "Metric Time Dimension 'ds'" -->
-                            <!-- node_id = NodeId(id_str='sma_2') -->
+                            <!-- node_id = NodeId(id_str='sma_0') -->
                             <!-- aggregation_time_dimension = 'ds' -->
                             <ReadSqlSourceNode>
                                 <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
-                                <!-- node_id = NodeId(id_str='rss_2') -->
+                                <!-- node_id = NodeId(id_str='rss_0') -->
                                 <!-- data_set = SemanticModelDataSet('bookings_source') -->
                             </ReadSqlSourceNode>
                         </MetricTimeDimensionTransformNode>

--- a/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_derived_metric_same_alias_components_not_combined__dfpo_0.xml
+++ b/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_derived_metric_same_alias_components_not_combined__dfpo_0.xml
@@ -25,10 +25,10 @@ docstring:
                     <!--   MetricSpec(element_name='bookings', filter_spec_set=WhereFilterSpecSet(), alias='shared_alias') -->
                     <AggregateMeasuresNode>
                         <!-- description = 'Aggregate Measures' -->
-                        <!-- node_id = NodeId(id_str='am_2') -->
+                        <!-- node_id = NodeId(id_str='am_0') -->
                         <FilterElementsNode>
                             <!-- description = "Pass Only Elements: ['bookings', 'booking__is_instant']" -->
-                            <!-- node_id = NodeId(id_str='pfe_2') -->
+                            <!-- node_id = NodeId(id_str='pfe_0') -->
                             <!-- include_spec = MeasureSpec(element_name='bookings') -->
                             <!-- include_spec =                                               -->
                             <!--   DimensionSpec(                                             -->
@@ -38,11 +38,11 @@ docstring:
                             <!-- distinct = False -->
                             <MetricTimeDimensionTransformNode>
                                 <!-- description = "Metric Time Dimension 'ds'" -->
-                                <!-- node_id = NodeId(id_str='sma_0') -->
+                                <!-- node_id = NodeId(id_str='sma_28009') -->
                                 <!-- aggregation_time_dimension = 'ds' -->
                                 <ReadSqlSourceNode>
                                     <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
-                                    <!-- node_id = NodeId(id_str='rss_0') -->
+                                    <!-- node_id = NodeId(id_str='rss_28020') -->
                                     <!-- data_set = SemanticModelDataSet('bookings_source') -->
                                 </ReadSqlSourceNode>
                             </MetricTimeDimensionTransformNode>
@@ -66,10 +66,10 @@ docstring:
                     <!--   )                                       -->
                     <AggregateMeasuresNode>
                         <!-- description = 'Aggregate Measures' -->
-                        <!-- node_id = NodeId(id_str='am_3') -->
+                        <!-- node_id = NodeId(id_str='am_1') -->
                         <FilterElementsNode>
                             <!-- description = "Pass Only Elements: ['instant_bookings', 'booking__is_instant']" -->
-                            <!-- node_id = NodeId(id_str='pfe_3') -->
+                            <!-- node_id = NodeId(id_str='pfe_1') -->
                             <!-- include_spec = MeasureSpec(element_name='instant_bookings') -->
                             <!-- include_spec =                                               -->
                             <!--   DimensionSpec(                                             -->
@@ -79,11 +79,11 @@ docstring:
                             <!-- distinct = False -->
                             <MetricTimeDimensionTransformNode>
                                 <!-- description = "Metric Time Dimension 'ds'" -->
-                                <!-- node_id = NodeId(id_str='sma_1') -->
+                                <!-- node_id = NodeId(id_str='sma_28009') -->
                                 <!-- aggregation_time_dimension = 'ds' -->
                                 <ReadSqlSourceNode>
                                     <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
-                                    <!-- node_id = NodeId(id_str='rss_1') -->
+                                    <!-- node_id = NodeId(id_str='rss_28020') -->
                                     <!-- data_set = SemanticModelDataSet('bookings_source') -->
                                 </ReadSqlSourceNode>
                             </MetricTimeDimensionTransformNode>

--- a/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_derived_metric_with_non_derived_metric__dfpo_0.xml
+++ b/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_derived_metric_with_non_derived_metric__dfpo_0.xml
@@ -24,10 +24,10 @@ docstring:
                 <!-- metric_spec = MetricSpec(element_name='booking_value', filter_spec_set=WhereFilterSpecSet()) -->
                 <AggregateMeasuresNode>
                     <!-- description = 'Aggregate Measures' -->
-                    <!-- node_id = NodeId(id_str='am_3') -->
+                    <!-- node_id = NodeId(id_str='am_0') -->
                     <FilterElementsNode>
                         <!-- description = "Pass Only Elements: ['booking_value', 'metric_time__day']" -->
-                        <!-- node_id = NodeId(id_str='pfe_3') -->
+                        <!-- node_id = NodeId(id_str='pfe_0') -->
                         <!-- include_spec = MeasureSpec(element_name='booking_value') -->
                         <!-- include_spec =                                                                  -->
                         <!--   TimeDimensionSpec(                                                            -->
@@ -37,11 +37,11 @@ docstring:
                         <!-- distinct = False -->
                         <MetricTimeDimensionTransformNode>
                             <!-- description = "Metric Time Dimension 'ds'" -->
-                            <!-- node_id = NodeId(id_str='sma_0') -->
+                            <!-- node_id = NodeId(id_str='sma_28009') -->
                             <!-- aggregation_time_dimension = 'ds' -->
                             <ReadSqlSourceNode>
                                 <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
-                                <!-- node_id = NodeId(id_str='rss_0') -->
+                                <!-- node_id = NodeId(id_str='rss_28020') -->
                                 <!-- data_set = SemanticModelDataSet('bookings_source') -->
                             </ReadSqlSourceNode>
                         </MetricTimeDimensionTransformNode>
@@ -65,11 +65,11 @@ docstring:
                     <!-- metric_spec = MetricSpec(element_name='bookings', filter_spec_set=WhereFilterSpecSet()) -->
                     <AggregateMeasuresNode>
                         <!-- description = 'Aggregate Measures' -->
-                        <!-- node_id = NodeId(id_str='am_6') -->
+                        <!-- node_id = NodeId(id_str='am_3') -->
                         <FilterElementsNode>
                             <!-- description =                                                                 -->
                             <!--   "Pass Only Elements: ['referred_bookings', 'bookings', 'metric_time__day']" -->
-                            <!-- node_id = NodeId(id_str='pfe_6') -->
+                            <!-- node_id = NodeId(id_str='pfe_3') -->
                             <!-- include_spec = MeasureSpec(element_name='referred_bookings') -->
                             <!-- include_spec = MeasureSpec(element_name='bookings') -->
                             <!-- include_spec =                                                                  -->
@@ -80,11 +80,11 @@ docstring:
                             <!-- distinct = False -->
                             <MetricTimeDimensionTransformNode>
                                 <!-- description = "Metric Time Dimension 'ds'" -->
-                                <!-- node_id = NodeId(id_str='sma_3') -->
+                                <!-- node_id = NodeId(id_str='sma_0') -->
                                 <!-- aggregation_time_dimension = 'ds' -->
                                 <ReadSqlSourceNode>
                                     <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
-                                    <!-- node_id = NodeId(id_str='rss_3') -->
+                                    <!-- node_id = NodeId(id_str='rss_0') -->
                                     <!-- data_set = SemanticModelDataSet('bookings_source') -->
                                 </ReadSqlSourceNode>
                             </MetricTimeDimensionTransformNode>

--- a/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_duplicate_measures__dfpo_0.xml
+++ b/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_duplicate_measures__dfpo_0.xml
@@ -9,19 +9,19 @@ docstring:
         <!-- node_id = NodeId(id_str='wrd_1') -->
         <ComputeMetricsNode>
             <!-- description = 'Compute Metrics via Expressions' -->
-            <!-- node_id = NodeId(id_str='cm_8') -->
+            <!-- node_id = NodeId(id_str='cm_7') -->
             <!-- metric_spec = MetricSpec(element_name='derived_bookings_0', filter_spec_set=WhereFilterSpecSet()) -->
             <!-- metric_spec = MetricSpec(element_name='derived_bookings_1', filter_spec_set=WhereFilterSpecSet()) -->
             <ComputeMetricsNode>
                 <!-- description = 'Compute Metrics via Expressions' -->
-                <!-- node_id = NodeId(id_str='cm_7') -->
+                <!-- node_id = NodeId(id_str='cm_6') -->
                 <!-- metric_spec = MetricSpec(element_name='bookings', filter_spec_set=WhereFilterSpecSet()) -->
                 <AggregateMeasuresNode>
                     <!-- description = 'Aggregate Measures' -->
-                    <!-- node_id = NodeId(id_str='am_3') -->
+                    <!-- node_id = NodeId(id_str='am_1') -->
                     <FilterElementsNode>
                         <!-- description = "Pass Only Elements: ['bookings', 'metric_time__day']" -->
-                        <!-- node_id = NodeId(id_str='pfe_3') -->
+                        <!-- node_id = NodeId(id_str='pfe_1') -->
                         <!-- include_spec = MeasureSpec(element_name='bookings') -->
                         <!-- include_spec =                                                                  -->
                         <!--   TimeDimensionSpec(                                                            -->
@@ -31,11 +31,11 @@ docstring:
                         <!-- distinct = False -->
                         <MetricTimeDimensionTransformNode>
                             <!-- description = "Metric Time Dimension 'ds'" -->
-                            <!-- node_id = NodeId(id_str='sma_2') -->
+                            <!-- node_id = NodeId(id_str='sma_0') -->
                             <!-- aggregation_time_dimension = 'ds' -->
                             <ReadSqlSourceNode>
                                 <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
-                                <!-- node_id = NodeId(id_str='rss_2') -->
+                                <!-- node_id = NodeId(id_str='rss_0') -->
                                 <!-- data_set = SemanticModelDataSet('bookings_source') -->
                             </ReadSqlSourceNode>
                         </MetricTimeDimensionTransformNode>

--- a/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_nested_derived_metric__dfpo_0.xml
+++ b/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_nested_derived_metric__dfpo_0.xml
@@ -12,7 +12,7 @@ docstring:
         <!-- node_id = NodeId(id_str='wrd_1') -->
         <ComputeMetricsNode>
             <!-- description = 'Compute Metrics via Expressions' -->
-            <!-- node_id = NodeId(id_str='cm_12') -->
+            <!-- node_id = NodeId(id_str='cm_11') -->
             <!-- metric_spec =                                                                                             -->
             <!--   MetricSpec(element_name='instant_plus_non_referred_bookings_pct', filter_spec_set=WhereFilterSpecSet()) -->
             <CombineAggregatedOutputsNode>
@@ -39,11 +39,11 @@ docstring:
                         <!-- metric_spec = MetricSpec(element_name='bookings', filter_spec_set=WhereFilterSpecSet()) -->
                         <AggregateMeasuresNode>
                             <!-- description = 'Aggregate Measures' -->
-                            <!-- node_id = NodeId(id_str='am_5') -->
+                            <!-- node_id = NodeId(id_str='am_3') -->
                             <FilterElementsNode>
                                 <!-- description =                                                                 -->
                                 <!--   "Pass Only Elements: ['referred_bookings', 'bookings', 'metric_time__day']" -->
-                                <!-- node_id = NodeId(id_str='pfe_5') -->
+                                <!-- node_id = NodeId(id_str='pfe_3') -->
                                 <!-- include_spec = MeasureSpec(element_name='referred_bookings') -->
                                 <!-- include_spec = MeasureSpec(element_name='bookings') -->
                                 <!-- include_spec =                                                                  -->
@@ -54,11 +54,11 @@ docstring:
                                 <!-- distinct = False -->
                                 <MetricTimeDimensionTransformNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->
-                                    <!-- node_id = NodeId(id_str='sma_2') -->
+                                    <!-- node_id = NodeId(id_str='sma_0') -->
                                     <!-- aggregation_time_dimension = 'ds' -->
                                     <ReadSqlSourceNode>
                                         <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
-                                        <!-- node_id = NodeId(id_str='rss_2') -->
+                                        <!-- node_id = NodeId(id_str='rss_0') -->
                                         <!-- data_set = SemanticModelDataSet('bookings_source') -->
                                     </ReadSqlSourceNode>
                                 </MetricTimeDimensionTransformNode>
@@ -68,7 +68,7 @@ docstring:
                 </ComputeMetricsNode>
                 <ComputeMetricsNode>
                     <!-- description = 'Compute Metrics via Expressions' -->
-                    <!-- node_id = NodeId(id_str='cm_11') -->
+                    <!-- node_id = NodeId(id_str='cm_10') -->
                     <!-- metric_spec =                             -->
                     <!--   MetricSpec(                             -->
                     <!--     element_name='instant_bookings',      -->
@@ -78,11 +78,11 @@ docstring:
                     <!-- metric_spec = MetricSpec(element_name='bookings', filter_spec_set=WhereFilterSpecSet()) -->
                     <AggregateMeasuresNode>
                         <!-- description = 'Aggregate Measures' -->
-                        <!-- node_id = NodeId(id_str='am_8') -->
+                        <!-- node_id = NodeId(id_str='am_4') -->
                         <FilterElementsNode>
                             <!-- description =                                                                -->
                             <!--   "Pass Only Elements: ['instant_bookings', 'bookings', 'metric_time__day']" -->
-                            <!-- node_id = NodeId(id_str='pfe_8') -->
+                            <!-- node_id = NodeId(id_str='pfe_4') -->
                             <!-- include_spec = MeasureSpec(element_name='instant_bookings') -->
                             <!-- include_spec = MeasureSpec(element_name='bookings') -->
                             <!-- include_spec =                                                                  -->
@@ -93,11 +93,11 @@ docstring:
                             <!-- distinct = False -->
                             <MetricTimeDimensionTransformNode>
                                 <!-- description = "Metric Time Dimension 'ds'" -->
-                                <!-- node_id = NodeId(id_str='sma_5') -->
+                                <!-- node_id = NodeId(id_str='sma_1') -->
                                 <!-- aggregation_time_dimension = 'ds' -->
                                 <ReadSqlSourceNode>
                                     <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
-                                    <!-- node_id = NodeId(id_str='rss_5') -->
+                                    <!-- node_id = NodeId(id_str='rss_1') -->
                                     <!-- data_set = SemanticModelDataSet('bookings_source') -->
                                 </ReadSqlSourceNode>
                             </MetricTimeDimensionTransformNode>


### PR DESCRIPTION
Generation of CTEs is determined by identical nodes in the dataflow plan. Previously, the `SourceScanOptimizer` would create new nodes whenever it was able to optimize a branch. In addition, it would create new nodes in some cases where it was not necessary.

This PR updates `SourceScanOptimizer` to memoize results so that identical nodes are used in cases where the dataflow branch is the same.

This results in snapshot changes for tests where the optimizer previously prevented CTEs from being used - please view by commit.