### PR TITLE
Add tags to SavedQueries

### DIFF
--- a/.changes/unreleased/Features-20241210-172725.yaml
+++ b/.changes/unreleased/Features-20241210-172725.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Adds tags to SavedQueries
+time: 2024-12-10T17:27:25.368395-08:00
+custom:
+    Author: theyostalservice
+    Issue: None

--- a/metricflow/engine/models.py
+++ b/metricflow/engine/models.py
@@ -183,6 +183,7 @@ class SavedQuery:
     query_params: SavedQueryQueryParams
     metadata: Optional[Metadata]
     exports: Sequence[Export]
+    tags: Sequence[str]
 
     @classmethod
     def from_pydantic(cls, pydantic_saved_query: SemanticManifestSavedQuery) -> SavedQuery:
@@ -194,4 +195,5 @@ class SavedQuery:
             query_params=pydantic_saved_query.query_params,
             metadata=pydantic_saved_query.metadata,
             exports=pydantic_saved_query.exports,
+            tags=pydantic_saved_query.tags,
         )


### PR DESCRIPTION
Adds tags to saved queries.  This is modeled off of [this](https://github.com/dbt-labs/metricflow/pull/1334/files) PR.