### PR TITLE
Add marker for DuckDb-only tests

### DIFF
--- a/tests_metricflow/test_pytest_markers.py
+++ b/tests_metricflow/test_pytest_markers.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from metricflow.protocols.sql_client import SqlClient, SqlEngine
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.duckdb_only
+def test_duckdb_only(sql_client: SqlClient) -> None:
+    """Check that the `duckdb_only` skips tests when the tests are run with another SQL engine.
+
+    This depends on auto-using of the `skip_if_not_duck_db` fixture.
+    """
+    duckdb_engine_type = SqlEngine.DUCKDB
+    engine_type_under_test = sql_client.sql_engine_type
+    assert engine_type_under_test is duckdb_engine_type, (
+        f"This test should have only been run when using {duckdb_engine_type}, but the engine type under test is"
+        f" {engine_type_under_test}"
+    )


### PR DESCRIPTION
This PR adds a `pytest` marker that allows tests to only be run when testing using DuckDB. This is useful in integration test cases where engine-specific SQL rendering is not being tested. This can help to reduce test suite runtimes and to reduce the number of snapshots.