### PR TITLE
Implement `Mergeable` for `SqlExpressionTreeLineage`

### DIFF
--- a/metricflow/sql/optimizer/rewriting_sub_query_reducer.py
+++ b/metricflow/sql/optimizer/rewriting_sub_query_reducer.py
@@ -122,7 +122,7 @@ class SqlRewritingSubQueryReducerVisitor(SqlQueryPlanNodeVisitor[SqlQueryPlanNod
 
     @staticmethod
     def _statement_contains_difficult_expressions(node: SqlSelectStatementNode) -> bool:
-        combined_lineage = SqlExpressionTreeLineage.combine(
+        combined_lineage = SqlExpressionTreeLineage.merge_iterable(
             tuple(x.expr.lineage for x in node.select_columns)
             + ((node.where.lineage,) if node.where else ())
             + tuple(x.expr.lineage for x in node.group_bys)
@@ -133,7 +133,7 @@ class SqlRewritingSubQueryReducerVisitor(SqlQueryPlanNodeVisitor[SqlQueryPlanNod
 
     @staticmethod
     def _select_columns_contain_string_expressions(select_columns: Tuple[SqlSelectColumn, ...]) -> bool:
-        combined_lineage = SqlExpressionTreeLineage.combine(tuple(x.expr.lineage for x in select_columns))
+        combined_lineage = SqlExpressionTreeLineage.merge_iterable(tuple(x.expr.lineage for x in select_columns))
 
         return len(combined_lineage.string_exprs) > 0
 

--- a/metricflow/sql/optimizer/tag_required_column_aliases.py
+++ b/metricflow/sql/optimizer/tag_required_column_aliases.py
@@ -102,7 +102,7 @@ class SqlMapRequiredColumnAliasesVisitor(SqlQueryPlanNodeVisitor[None]):
         if select_node.where:
             all_expr_search_results.append(select_node.where.lineage)
 
-        return SqlExpressionTreeLineage.combine(all_expr_search_results)
+        return SqlExpressionTreeLineage.merge_iterable(all_expr_search_results)
 
     @override
     def visit_cte_node(self, node: SqlCteNode) -> None:

--- a/metricflow/sql/sql_exprs.py
+++ b/metricflow/sql/sql_exprs.py
@@ -6,9 +6,8 @@ import itertools
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import Enum
-from typing import Dict, Generic, Iterable, List, Mapping, Optional, Sequence, Tuple
+from typing import Dict, Generic, List, Mapping, Optional, Sequence, Tuple
 
-import more_itertools
 from dbt_semantic_interfaces.enum_extension import assert_values_exhausted
 from dbt_semantic_interfaces.protocols.measure import MeasureAggregationParameters
 from dbt_semantic_interfaces.type_enums.aggregation_type import AggregationType
@@ -109,20 +108,6 @@ class SqlExpressionTreeLineage(Mergeable):
     column_reference_exprs: Tuple[SqlColumnReferenceExpression, ...] = ()
     column_alias_reference_exprs: Tuple[SqlColumnAliasReferenceExpression, ...] = ()
     other_exprs: Tuple[SqlExpressionNode, ...] = ()
-
-    @classmethod
-    @override
-    def merge_iterable(cls, items: Iterable[SqlExpressionTreeLineage]) -> SqlExpressionTreeLineage:
-        """Combine multiple lineages into one lineage, without de-duping."""
-        return SqlExpressionTreeLineage(
-            string_exprs=tuple(more_itertools.flatten(tuple(x.string_exprs for x in items))),
-            function_exprs=tuple(more_itertools.flatten(tuple(x.function_exprs for x in items))),
-            column_reference_exprs=tuple(more_itertools.flatten(tuple(x.column_reference_exprs for x in items))),
-            column_alias_reference_exprs=tuple(
-                more_itertools.flatten(tuple(x.column_alias_reference_exprs for x in items))
-            ),
-            other_exprs=tuple(more_itertools.flatten(tuple(x.other_exprs for x in items))),
-        )
 
     @property
     def contains_string_exprs(self) -> bool:  # noqa: D102


### PR DESCRIPTION
This PR implements `Mergeable` for `SqlExpressionTreeLineage` to reuse code available in `Mergeable`.