### PR TITLE
Dedupe filter specs in join to time spine queries

### DIFF
--- a/metricflow/dataflow/builder/dataflow_plan_builder.py
+++ b/metricflow/dataflow/builder/dataflow_plan_builder.py
@@ -1648,7 +1648,9 @@ class DataflowPlanBuilder:
             join_on_time_dimension_spec = self._determine_time_spine_join_spec(
                 measure_properties=measure_properties, required_time_spine_specs=base_queried_agg_time_dimension_specs
             )
-            required_time_spine_specs = (join_on_time_dimension_spec,) + base_queried_agg_time_dimension_specs
+            required_time_spine_specs = base_queried_agg_time_dimension_specs
+            if join_on_time_dimension_spec not in required_time_spine_specs:
+                required_time_spine_specs = (join_on_time_dimension_spec,) + required_time_spine_specs
             time_spine_node = self._build_time_spine_node(required_time_spine_specs)
             unaggregated_measure_node = JoinToTimeSpineNode.create(
                 metric_source_node=unaggregated_measure_node,

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/BigQuery/test_offset_metric_with_custom_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/BigQuery/test_offset_metric_with_custom_granularity__plan0.sql
@@ -125,7 +125,7 @@ FROM (
           , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           , subq_5.martian_day AS booking__ds__martian_day
         FROM (
-          -- Pass Only Elements: ['booking__ds__day', 'booking__ds__day']
+          -- Pass Only Elements: ['booking__ds__day',]
           SELECT
             subq_3.booking__ds__day
           FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/BigQuery/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/BigQuery/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
@@ -227,7 +227,7 @@ FROM (
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             , subq_5.martian_day AS metric_time__martian_day
           FROM (
-            -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+            -- Pass Only Elements: ['metric_time__day',]
             SELECT
               subq_3.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Databricks/test_offset_metric_with_custom_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Databricks/test_offset_metric_with_custom_granularity__plan0.sql
@@ -125,7 +125,7 @@ FROM (
           , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           , subq_5.martian_day AS booking__ds__martian_day
         FROM (
-          -- Pass Only Elements: ['booking__ds__day', 'booking__ds__day']
+          -- Pass Only Elements: ['booking__ds__day',]
           SELECT
             subq_3.booking__ds__day
           FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Databricks/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Databricks/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
@@ -227,7 +227,7 @@ FROM (
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             , subq_5.martian_day AS metric_time__martian_day
           FROM (
-            -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+            -- Pass Only Elements: ['metric_time__day',]
             SELECT
               subq_3.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/DuckDB/test_offset_metric_with_custom_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/DuckDB/test_offset_metric_with_custom_granularity__plan0.sql
@@ -125,7 +125,7 @@ FROM (
           , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           , subq_5.martian_day AS booking__ds__martian_day
         FROM (
-          -- Pass Only Elements: ['booking__ds__day', 'booking__ds__day']
+          -- Pass Only Elements: ['booking__ds__day',]
           SELECT
             subq_3.booking__ds__day
           FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/DuckDB/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/DuckDB/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
@@ -227,7 +227,7 @@ FROM (
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             , subq_5.martian_day AS metric_time__martian_day
           FROM (
-            -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+            -- Pass Only Elements: ['metric_time__day',]
             SELECT
               subq_3.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Postgres/test_offset_metric_with_custom_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Postgres/test_offset_metric_with_custom_granularity__plan0.sql
@@ -125,7 +125,7 @@ FROM (
           , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           , subq_5.martian_day AS booking__ds__martian_day
         FROM (
-          -- Pass Only Elements: ['booking__ds__day', 'booking__ds__day']
+          -- Pass Only Elements: ['booking__ds__day',]
           SELECT
             subq_3.booking__ds__day
           FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Postgres/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Postgres/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
@@ -227,7 +227,7 @@ FROM (
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             , subq_5.martian_day AS metric_time__martian_day
           FROM (
-            -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+            -- Pass Only Elements: ['metric_time__day',]
             SELECT
               subq_3.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Redshift/test_offset_metric_with_custom_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Redshift/test_offset_metric_with_custom_granularity__plan0.sql
@@ -125,7 +125,7 @@ FROM (
           , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           , subq_5.martian_day AS booking__ds__martian_day
         FROM (
-          -- Pass Only Elements: ['booking__ds__day', 'booking__ds__day']
+          -- Pass Only Elements: ['booking__ds__day',]
           SELECT
             subq_3.booking__ds__day
           FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Redshift/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Redshift/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
@@ -227,7 +227,7 @@ FROM (
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             , subq_5.martian_day AS metric_time__martian_day
           FROM (
-            -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+            -- Pass Only Elements: ['metric_time__day',]
             SELECT
               subq_3.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Snowflake/test_offset_metric_with_custom_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Snowflake/test_offset_metric_with_custom_granularity__plan0.sql
@@ -125,7 +125,7 @@ FROM (
           , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           , subq_5.martian_day AS booking__ds__martian_day
         FROM (
-          -- Pass Only Elements: ['booking__ds__day', 'booking__ds__day']
+          -- Pass Only Elements: ['booking__ds__day',]
           SELECT
             subq_3.booking__ds__day
           FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Snowflake/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Snowflake/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
@@ -227,7 +227,7 @@ FROM (
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             , subq_5.martian_day AS metric_time__martian_day
           FROM (
-            -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+            -- Pass Only Elements: ['metric_time__day',]
             SELECT
               subq_3.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Trino/test_offset_metric_with_custom_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Trino/test_offset_metric_with_custom_granularity__plan0.sql
@@ -125,7 +125,7 @@ FROM (
           , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           , subq_5.martian_day AS booking__ds__martian_day
         FROM (
-          -- Pass Only Elements: ['booking__ds__day', 'booking__ds__day']
+          -- Pass Only Elements: ['booking__ds__day',]
           SELECT
             subq_3.booking__ds__day
           FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Trino/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Trino/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
@@ -227,7 +227,7 @@ FROM (
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             , subq_5.martian_day AS metric_time__martian_day
           FROM (
-            -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+            -- Pass Only Elements: ['metric_time__day',]
             SELECT
               subq_3.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_metric_offset_to_grain__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_metric_offset_to_grain__dfp_0.xml
@@ -96,13 +96,8 @@ docstring:
                                     </ReadSqlSourceNode>
                                 </MetricTimeDimensionTransformNode>
                                 <FilterElementsNode>
-                                    <!-- description = "Pass Only Elements: ['metric_time__day', 'metric_time__day']" -->
+                                    <!-- description = "Pass Only Elements: ['metric_time__day',]" -->
                                     <!-- node_id = NodeId(id_str='pfe_1') -->
-                                    <!-- include_spec =                                                                  -->
-                                    <!--   TimeDimensionSpec(                                                            -->
-                                    <!--     element_name='metric_time',                                                 -->
-                                    <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
-                                    <!--   )                                                                             -->
                                     <!-- include_spec =                                                                  -->
                                     <!--   TimeDimensionSpec(                                                            -->
                                     <!--     element_name='metric_time',                                                 -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_metric_offset_window__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_metric_offset_window__dfp_0.xml
@@ -62,13 +62,8 @@ docstring:
                                 </ReadSqlSourceNode>
                             </MetricTimeDimensionTransformNode>
                             <FilterElementsNode>
-                                <!-- description = "Pass Only Elements: ['metric_time__day', 'metric_time__day']" -->
+                                <!-- description = "Pass Only Elements: ['metric_time__day',]" -->
                                 <!-- node_id = NodeId(id_str='pfe_0') -->
-                                <!-- include_spec =                                                                  -->
-                                <!--   TimeDimensionSpec(                                                            -->
-                                <!--     element_name='metric_time',                                                 -->
-                                <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
-                                <!--   )                                                                             -->
                                 <!-- include_spec =                                                                  -->
                                 <!--   TimeDimensionSpec(                                                            -->
                                 <!--     element_name='metric_time',                                                 -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_offset_cumulative_metric__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_offset_cumulative_metric__dfp_0.xml
@@ -73,13 +73,8 @@ test_filename: test_dataflow_plan_builder.py
                                 </MetricTimeDimensionTransformNode>
                             </JoinOverTimeRangeNode>
                             <FilterElementsNode>
-                                <!-- description = "Pass Only Elements: ['metric_time__day', 'metric_time__day']" -->
+                                <!-- description = "Pass Only Elements: ['metric_time__day',]" -->
                                 <!-- node_id = NodeId(id_str='pfe_0') -->
-                                <!-- include_spec =                                                                  -->
-                                <!--   TimeDimensionSpec(                                                            -->
-                                <!--     element_name='metric_time',                                                 -->
-                                <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
-                                <!--   )                                                                             -->
                                 <!-- include_spec =                                                                  -->
                                 <!--   TimeDimensionSpec(                                                            -->
                                 <!--     element_name='metric_time',                                                 -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_join_to_time_spine_derived_metric__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_join_to_time_spine_derived_metric__dfp_0.xml
@@ -169,17 +169,8 @@ test_filename: test_dataflow_plan_builder.py
                                         </ReadSqlSourceNode>
                                     </MetricTimeDimensionTransformNode>
                                     <FilterElementsNode>
-                                        <!-- description =                                                    -->
-                                        <!--   "Pass Only Elements: ['metric_time__day', 'metric_time__day']" -->
+                                        <!-- description = "Pass Only Elements: ['metric_time__day',]" -->
                                         <!-- node_id = NodeId(id_str='pfe_2') -->
-                                        <!-- include_spec =                                -->
-                                        <!--   TimeDimensionSpec(                          -->
-                                        <!--     element_name='metric_time',               -->
-                                        <!--     time_granularity=ExpandedTimeGranularity( -->
-                                        <!--       name='day',                             -->
-                                        <!--       base_granularity=DAY,                   -->
-                                        <!--     ),                                        -->
-                                        <!--   )                                           -->
                                         <!-- include_spec =                                -->
                                         <!--   TimeDimensionSpec(                          -->
                                         <!--     element_name='metric_time',               -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_nested_derived_metric_with_outer_offset__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_nested_derived_metric_with_outer_offset__dfp_0.xml
@@ -85,17 +85,8 @@ test_filename: test_dataflow_plan_builder.py
                                         </ReadSqlSourceNode>
                                     </MetricTimeDimensionTransformNode>
                                     <FilterElementsNode>
-                                        <!-- description =                                                    -->
-                                        <!--   "Pass Only Elements: ['metric_time__day', 'metric_time__day']" -->
+                                        <!-- description = "Pass Only Elements: ['metric_time__day',]" -->
                                         <!-- node_id = NodeId(id_str='pfe_0') -->
-                                        <!-- include_spec =                                -->
-                                        <!--   TimeDimensionSpec(                          -->
-                                        <!--     element_name='metric_time',               -->
-                                        <!--     time_granularity=ExpandedTimeGranularity( -->
-                                        <!--       name='day',                             -->
-                                        <!--       base_granularity=DAY,                   -->
-                                        <!--     ),                                        -->
-                                        <!--   )                                           -->
                                         <!-- include_spec =                                -->
                                         <!--   TimeDimensionSpec(                          -->
                                         <!--     element_name='metric_time',               -->

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
@@ -224,7 +224,7 @@ FROM (
             , subq_4.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_4.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+            -- Pass Only Elements: ['metric_time__day',]
             SELECT
               subq_6.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
@@ -46,7 +46,7 @@ FROM (
           , subq_1.booking_monthly__listing AS booking_monthly__listing
           , subq_1.bookings_monthly AS bookings_monthly
         FROM (
-          -- Pass Only Elements: ['metric_time__month', 'metric_time__month']
+          -- Pass Only Elements: ['metric_time__month',]
           SELECT
             subq_3.metric_time__month
           FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_derived_metric_with_month_dimension_and_offset_window__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_derived_metric_with_month_dimension_and_offset_window__plan0_optimized.sql
@@ -17,7 +17,7 @@ FROM (
   FROM (
     -- Read From Time Spine 'mf_time_spine'
     -- Change Column Aliases
-    -- Pass Only Elements: ['metric_time__month', 'metric_time__month']
+    -- Pass Only Elements: ['metric_time__month',]
     SELECT
       DATETIME_TRUNC(ds, month) AS metric_time__month
     FROM ***************************.mf_time_spine time_spine_src_16006

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_derived_metric_with_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_derived_metric_with_offset_to_grain__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+            -- Pass Only Elements: ['metric_time__day',]
             SELECT
               subq_8.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_derived_metric_with_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_derived_metric_with_offset_window__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+            -- Pass Only Elements: ['metric_time__day',]
             SELECT
               subq_8.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
@@ -129,7 +129,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+            -- Pass Only Elements: ['metric_time__day',]
             SELECT
               subq_3.metric_time__day
             FROM (
@@ -486,7 +486,7 @@ FROM (
             , subq_10.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_10.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+            -- Pass Only Elements: ['metric_time__day',]
             SELECT
               subq_12.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
@@ -548,7 +548,7 @@ FROM (
               , subq_7.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
               , subq_7.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             FROM (
-              -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+              -- Pass Only Elements: ['metric_time__day',]
               SELECT
                 subq_9.metric_time__day
               FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_derived_offset_cumulative_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_derived_offset_cumulative_metric__plan0.sql
@@ -123,7 +123,7 @@ FROM (
           , subq_4.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
           , subq_4.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
         FROM (
-          -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+          -- Pass Only Elements: ['metric_time__day',]
           SELECT
             subq_6.metric_time__day
           FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_derived_offset_metric_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_derived_offset_metric_with_agg_time_dim__plan0.sql
@@ -129,7 +129,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['booking__ds__day', 'booking__ds__day']
+            -- Pass Only Elements: ['booking__ds__day',]
             SELECT
               subq_3.booking__ds__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_derived_offset_metric_with_one_input_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_derived_offset_metric_with_one_input_metric__plan0.sql
@@ -123,7 +123,7 @@ FROM (
           , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
           , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
         FROM (
-          -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+          -- Pass Only Elements: ['metric_time__day',]
           SELECT
             subq_3.metric_time__day
           FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0.sql
@@ -187,7 +187,7 @@ FROM (
                   , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                   , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
                 FROM (
-                  -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+                  -- Pass Only Elements: ['metric_time__day',]
                   SELECT
                     subq_3.metric_time__day
                   FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_nested_offsets__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_nested_offsets__plan0.sql
@@ -171,7 +171,7 @@ FROM (
               , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
               , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             FROM (
-              -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+              -- Pass Only Elements: ['metric_time__day',]
               SELECT
                 subq_3.metric_time__day
               FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_nested_offsets_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_nested_offsets_with_time_constraint__plan0.sql
@@ -176,7 +176,7 @@ FROM (
                 , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                 , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
               FROM (
-                -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+                -- Pass Only Elements: ['metric_time__day',]
                 SELECT
                   subq_3.metric_time__day
                 FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_nested_offsets_with_where_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_nested_offsets_with_where_constraint__plan0.sql
@@ -176,7 +176,7 @@ FROM (
                 , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                 , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
               FROM (
-                -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+                -- Pass Only Elements: ['metric_time__day',]
                 SELECT
                   subq_3.metric_time__day
                 FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_offset_to_grain_metric_multiple_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_offset_to_grain_metric_multiple_granularities__plan0.sql
@@ -133,7 +133,7 @@ FROM (
           , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
           , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
         FROM (
-          -- Pass Only Elements: ['metric_time__day', 'metric_time__day', 'metric_time__month', 'metric_time__year']
+          -- Pass Only Elements: ['metric_time__day', 'metric_time__month', 'metric_time__year']
           SELECT
             subq_3.metric_time__day
             , subq_3.metric_time__month

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_offset_to_grain_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_offset_to_grain_with_agg_time_dim__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['booking__ds__day', 'booking__ds__day']
+            -- Pass Only Elements: ['booking__ds__day',]
             SELECT
               subq_8.booking__ds__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_offset_window_metric_multiple_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_offset_window_metric_multiple_granularities__plan0.sql
@@ -141,7 +141,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day', 'metric_time__day', 'metric_time__month', 'metric_time__year']
+            -- Pass Only Elements: ['metric_time__day', 'metric_time__month', 'metric_time__year']
             SELECT
               subq_3.metric_time__day
               , subq_3.metric_time__month

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_offset_window_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_offset_window_with_agg_time_dim__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['booking__ds__day', 'booking__ds__day']
+            -- Pass Only Elements: ['booking__ds__day',]
             SELECT
               subq_8.booking__ds__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_time_offset_metric_with_time_constraint__plan0.sql
@@ -224,7 +224,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+            -- Pass Only Elements: ['metric_time__day',]
             SELECT
               subq_3.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
@@ -224,7 +224,7 @@ FROM (
             , subq_4.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_4.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+            -- Pass Only Elements: ['metric_time__day',]
             SELECT
               subq_6.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
@@ -46,7 +46,7 @@ FROM (
           , subq_1.booking_monthly__listing AS booking_monthly__listing
           , subq_1.bookings_monthly AS bookings_monthly
         FROM (
-          -- Pass Only Elements: ['metric_time__month', 'metric_time__month']
+          -- Pass Only Elements: ['metric_time__month',]
           SELECT
             subq_3.metric_time__month
           FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_derived_metric_with_month_dimension_and_offset_window__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_derived_metric_with_month_dimension_and_offset_window__plan0_optimized.sql
@@ -17,7 +17,7 @@ FROM (
   FROM (
     -- Read From Time Spine 'mf_time_spine'
     -- Change Column Aliases
-    -- Pass Only Elements: ['metric_time__month', 'metric_time__month']
+    -- Pass Only Elements: ['metric_time__month',]
     SELECT
       DATE_TRUNC('month', ds) AS metric_time__month
     FROM ***************************.mf_time_spine time_spine_src_16006

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_derived_metric_with_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_derived_metric_with_offset_to_grain__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+            -- Pass Only Elements: ['metric_time__day',]
             SELECT
               subq_8.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_derived_metric_with_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_derived_metric_with_offset_window__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+            -- Pass Only Elements: ['metric_time__day',]
             SELECT
               subq_8.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
@@ -129,7 +129,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+            -- Pass Only Elements: ['metric_time__day',]
             SELECT
               subq_3.metric_time__day
             FROM (
@@ -486,7 +486,7 @@ FROM (
             , subq_10.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_10.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+            -- Pass Only Elements: ['metric_time__day',]
             SELECT
               subq_12.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
@@ -548,7 +548,7 @@ FROM (
               , subq_7.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
               , subq_7.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             FROM (
-              -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+              -- Pass Only Elements: ['metric_time__day',]
               SELECT
                 subq_9.metric_time__day
               FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_derived_offset_cumulative_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_derived_offset_cumulative_metric__plan0.sql
@@ -123,7 +123,7 @@ FROM (
           , subq_4.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
           , subq_4.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
         FROM (
-          -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+          -- Pass Only Elements: ['metric_time__day',]
           SELECT
             subq_6.metric_time__day
           FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_derived_offset_metric_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_derived_offset_metric_with_agg_time_dim__plan0.sql
@@ -129,7 +129,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['booking__ds__day', 'booking__ds__day']
+            -- Pass Only Elements: ['booking__ds__day',]
             SELECT
               subq_3.booking__ds__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_derived_offset_metric_with_one_input_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_derived_offset_metric_with_one_input_metric__plan0.sql
@@ -123,7 +123,7 @@ FROM (
           , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
           , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
         FROM (
-          -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+          -- Pass Only Elements: ['metric_time__day',]
           SELECT
             subq_3.metric_time__day
           FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0.sql
@@ -187,7 +187,7 @@ FROM (
                   , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                   , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
                 FROM (
-                  -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+                  -- Pass Only Elements: ['metric_time__day',]
                   SELECT
                     subq_3.metric_time__day
                   FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_nested_offsets__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_nested_offsets__plan0.sql
@@ -171,7 +171,7 @@ FROM (
               , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
               , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             FROM (
-              -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+              -- Pass Only Elements: ['metric_time__day',]
               SELECT
                 subq_3.metric_time__day
               FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_nested_offsets_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_nested_offsets_with_time_constraint__plan0.sql
@@ -176,7 +176,7 @@ FROM (
                 , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                 , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
               FROM (
-                -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+                -- Pass Only Elements: ['metric_time__day',]
                 SELECT
                   subq_3.metric_time__day
                 FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_nested_offsets_with_where_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_nested_offsets_with_where_constraint__plan0.sql
@@ -176,7 +176,7 @@ FROM (
                 , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                 , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
               FROM (
-                -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+                -- Pass Only Elements: ['metric_time__day',]
                 SELECT
                   subq_3.metric_time__day
                 FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_offset_to_grain_metric_multiple_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_offset_to_grain_metric_multiple_granularities__plan0.sql
@@ -133,7 +133,7 @@ FROM (
           , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
           , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
         FROM (
-          -- Pass Only Elements: ['metric_time__day', 'metric_time__day', 'metric_time__month', 'metric_time__year']
+          -- Pass Only Elements: ['metric_time__day', 'metric_time__month', 'metric_time__year']
           SELECT
             subq_3.metric_time__day
             , subq_3.metric_time__month

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_offset_to_grain_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_offset_to_grain_with_agg_time_dim__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['booking__ds__day', 'booking__ds__day']
+            -- Pass Only Elements: ['booking__ds__day',]
             SELECT
               subq_8.booking__ds__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_offset_window_metric_multiple_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_offset_window_metric_multiple_granularities__plan0.sql
@@ -141,7 +141,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day', 'metric_time__day', 'metric_time__month', 'metric_time__year']
+            -- Pass Only Elements: ['metric_time__day', 'metric_time__month', 'metric_time__year']
             SELECT
               subq_3.metric_time__day
               , subq_3.metric_time__month

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_offset_window_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_offset_window_with_agg_time_dim__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['booking__ds__day', 'booking__ds__day']
+            -- Pass Only Elements: ['booking__ds__day',]
             SELECT
               subq_8.booking__ds__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_time_offset_metric_with_time_constraint__plan0.sql
@@ -224,7 +224,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+            -- Pass Only Elements: ['metric_time__day',]
             SELECT
               subq_3.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
@@ -224,7 +224,7 @@ FROM (
             , subq_4.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_4.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+            -- Pass Only Elements: ['metric_time__day',]
             SELECT
               subq_6.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
@@ -46,7 +46,7 @@ FROM (
           , subq_1.booking_monthly__listing AS booking_monthly__listing
           , subq_1.bookings_monthly AS bookings_monthly
         FROM (
-          -- Pass Only Elements: ['metric_time__month', 'metric_time__month']
+          -- Pass Only Elements: ['metric_time__month',]
           SELECT
             subq_3.metric_time__month
           FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_derived_metric_with_month_dimension_and_offset_window__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_derived_metric_with_month_dimension_and_offset_window__plan0_optimized.sql
@@ -17,7 +17,7 @@ FROM (
   FROM (
     -- Read From Time Spine 'mf_time_spine'
     -- Change Column Aliases
-    -- Pass Only Elements: ['metric_time__month', 'metric_time__month']
+    -- Pass Only Elements: ['metric_time__month',]
     SELECT
       DATE_TRUNC('month', ds) AS metric_time__month
     FROM ***************************.mf_time_spine time_spine_src_16006

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_derived_metric_with_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_derived_metric_with_offset_to_grain__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+            -- Pass Only Elements: ['metric_time__day',]
             SELECT
               subq_8.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_derived_metric_with_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_derived_metric_with_offset_window__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+            -- Pass Only Elements: ['metric_time__day',]
             SELECT
               subq_8.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
@@ -129,7 +129,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+            -- Pass Only Elements: ['metric_time__day',]
             SELECT
               subq_3.metric_time__day
             FROM (
@@ -486,7 +486,7 @@ FROM (
             , subq_10.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_10.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+            -- Pass Only Elements: ['metric_time__day',]
             SELECT
               subq_12.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
@@ -548,7 +548,7 @@ FROM (
               , subq_7.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
               , subq_7.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             FROM (
-              -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+              -- Pass Only Elements: ['metric_time__day',]
               SELECT
                 subq_9.metric_time__day
               FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_derived_offset_cumulative_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_derived_offset_cumulative_metric__plan0.sql
@@ -123,7 +123,7 @@ FROM (
           , subq_4.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
           , subq_4.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
         FROM (
-          -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+          -- Pass Only Elements: ['metric_time__day',]
           SELECT
             subq_6.metric_time__day
           FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_derived_offset_metric_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_derived_offset_metric_with_agg_time_dim__plan0.sql
@@ -129,7 +129,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['booking__ds__day', 'booking__ds__day']
+            -- Pass Only Elements: ['booking__ds__day',]
             SELECT
               subq_3.booking__ds__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_derived_offset_metric_with_one_input_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_derived_offset_metric_with_one_input_metric__plan0.sql
@@ -123,7 +123,7 @@ FROM (
           , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
           , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
         FROM (
-          -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+          -- Pass Only Elements: ['metric_time__day',]
           SELECT
             subq_3.metric_time__day
           FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0.sql
@@ -187,7 +187,7 @@ FROM (
                   , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                   , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
                 FROM (
-                  -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+                  -- Pass Only Elements: ['metric_time__day',]
                   SELECT
                     subq_3.metric_time__day
                   FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_nested_offsets__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_nested_offsets__plan0.sql
@@ -171,7 +171,7 @@ FROM (
               , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
               , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             FROM (
-              -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+              -- Pass Only Elements: ['metric_time__day',]
               SELECT
                 subq_3.metric_time__day
               FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_nested_offsets_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_nested_offsets_with_time_constraint__plan0.sql
@@ -176,7 +176,7 @@ FROM (
                 , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                 , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
               FROM (
-                -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+                -- Pass Only Elements: ['metric_time__day',]
                 SELECT
                   subq_3.metric_time__day
                 FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_nested_offsets_with_where_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_nested_offsets_with_where_constraint__plan0.sql
@@ -176,7 +176,7 @@ FROM (
                 , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                 , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
               FROM (
-                -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+                -- Pass Only Elements: ['metric_time__day',]
                 SELECT
                   subq_3.metric_time__day
                 FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_offset_to_grain_metric_multiple_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_offset_to_grain_metric_multiple_granularities__plan0.sql
@@ -133,7 +133,7 @@ FROM (
           , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
           , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
         FROM (
-          -- Pass Only Elements: ['metric_time__day', 'metric_time__day', 'metric_time__month', 'metric_time__year']
+          -- Pass Only Elements: ['metric_time__day', 'metric_time__month', 'metric_time__year']
           SELECT
             subq_3.metric_time__day
             , subq_3.metric_time__month

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_offset_to_grain_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_offset_to_grain_with_agg_time_dim__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['booking__ds__day', 'booking__ds__day']
+            -- Pass Only Elements: ['booking__ds__day',]
             SELECT
               subq_8.booking__ds__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_offset_window_metric_multiple_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_offset_window_metric_multiple_granularities__plan0.sql
@@ -141,7 +141,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day', 'metric_time__day', 'metric_time__month', 'metric_time__year']
+            -- Pass Only Elements: ['metric_time__day', 'metric_time__month', 'metric_time__year']
             SELECT
               subq_3.metric_time__day
               , subq_3.metric_time__month

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_offset_window_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_offset_window_with_agg_time_dim__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['booking__ds__day', 'booking__ds__day']
+            -- Pass Only Elements: ['booking__ds__day',]
             SELECT
               subq_8.booking__ds__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_time_offset_metric_with_time_constraint__plan0.sql
@@ -224,7 +224,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+            -- Pass Only Elements: ['metric_time__day',]
             SELECT
               subq_3.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
@@ -224,7 +224,7 @@ FROM (
             , subq_4.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_4.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+            -- Pass Only Elements: ['metric_time__day',]
             SELECT
               subq_6.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
@@ -46,7 +46,7 @@ FROM (
           , subq_1.booking_monthly__listing AS booking_monthly__listing
           , subq_1.bookings_monthly AS bookings_monthly
         FROM (
-          -- Pass Only Elements: ['metric_time__month', 'metric_time__month']
+          -- Pass Only Elements: ['metric_time__month',]
           SELECT
             subq_3.metric_time__month
           FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_derived_metric_with_month_dimension_and_offset_window__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_derived_metric_with_month_dimension_and_offset_window__plan0_optimized.sql
@@ -17,7 +17,7 @@ FROM (
   FROM (
     -- Read From Time Spine 'mf_time_spine'
     -- Change Column Aliases
-    -- Pass Only Elements: ['metric_time__month', 'metric_time__month']
+    -- Pass Only Elements: ['metric_time__month',]
     SELECT
       DATE_TRUNC('month', ds) AS metric_time__month
     FROM ***************************.mf_time_spine time_spine_src_16006

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_derived_metric_with_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_derived_metric_with_offset_to_grain__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+            -- Pass Only Elements: ['metric_time__day',]
             SELECT
               subq_8.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_derived_metric_with_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_derived_metric_with_offset_window__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+            -- Pass Only Elements: ['metric_time__day',]
             SELECT
               subq_8.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
@@ -129,7 +129,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+            -- Pass Only Elements: ['metric_time__day',]
             SELECT
               subq_3.metric_time__day
             FROM (
@@ -486,7 +486,7 @@ FROM (
             , subq_10.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_10.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+            -- Pass Only Elements: ['metric_time__day',]
             SELECT
               subq_12.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
@@ -548,7 +548,7 @@ FROM (
               , subq_7.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
               , subq_7.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             FROM (
-              -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+              -- Pass Only Elements: ['metric_time__day',]
               SELECT
                 subq_9.metric_time__day
               FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_derived_offset_cumulative_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_derived_offset_cumulative_metric__plan0.sql
@@ -123,7 +123,7 @@ FROM (
           , subq_4.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
           , subq_4.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
         FROM (
-          -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+          -- Pass Only Elements: ['metric_time__day',]
           SELECT
             subq_6.metric_time__day
           FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_derived_offset_metric_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_derived_offset_metric_with_agg_time_dim__plan0.sql
@@ -129,7 +129,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['booking__ds__day', 'booking__ds__day']
+            -- Pass Only Elements: ['booking__ds__day',]
             SELECT
               subq_3.booking__ds__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_derived_offset_metric_with_one_input_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_derived_offset_metric_with_one_input_metric__plan0.sql
@@ -123,7 +123,7 @@ FROM (
           , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
           , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
         FROM (
-          -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+          -- Pass Only Elements: ['metric_time__day',]
           SELECT
             subq_3.metric_time__day
           FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0.sql
@@ -187,7 +187,7 @@ FROM (
                   , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                   , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
                 FROM (
-                  -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+                  -- Pass Only Elements: ['metric_time__day',]
                   SELECT
                     subq_3.metric_time__day
                   FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_nested_offsets__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_nested_offsets__plan0.sql
@@ -171,7 +171,7 @@ FROM (
               , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
               , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             FROM (
-              -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+              -- Pass Only Elements: ['metric_time__day',]
               SELECT
                 subq_3.metric_time__day
               FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_nested_offsets_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_nested_offsets_with_time_constraint__plan0.sql
@@ -176,7 +176,7 @@ FROM (
                 , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                 , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
               FROM (
-                -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+                -- Pass Only Elements: ['metric_time__day',]
                 SELECT
                   subq_3.metric_time__day
                 FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_nested_offsets_with_where_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_nested_offsets_with_where_constraint__plan0.sql
@@ -176,7 +176,7 @@ FROM (
                 , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                 , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
               FROM (
-                -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+                -- Pass Only Elements: ['metric_time__day',]
                 SELECT
                   subq_3.metric_time__day
                 FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_offset_to_grain_metric_multiple_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_offset_to_grain_metric_multiple_granularities__plan0.sql
@@ -133,7 +133,7 @@ FROM (
           , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
           , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
         FROM (
-          -- Pass Only Elements: ['metric_time__day', 'metric_time__day', 'metric_time__month', 'metric_time__year']
+          -- Pass Only Elements: ['metric_time__day', 'metric_time__month', 'metric_time__year']
           SELECT
             subq_3.metric_time__day
             , subq_3.metric_time__month

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_offset_to_grain_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_offset_to_grain_with_agg_time_dim__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['booking__ds__day', 'booking__ds__day']
+            -- Pass Only Elements: ['booking__ds__day',]
             SELECT
               subq_8.booking__ds__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_offset_window_metric_multiple_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_offset_window_metric_multiple_granularities__plan0.sql
@@ -141,7 +141,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day', 'metric_time__day', 'metric_time__month', 'metric_time__year']
+            -- Pass Only Elements: ['metric_time__day', 'metric_time__month', 'metric_time__year']
             SELECT
               subq_3.metric_time__day
               , subq_3.metric_time__month

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_offset_window_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_offset_window_with_agg_time_dim__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['booking__ds__day', 'booking__ds__day']
+            -- Pass Only Elements: ['booking__ds__day',]
             SELECT
               subq_8.booking__ds__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_time_offset_metric_with_time_constraint__plan0.sql
@@ -224,7 +224,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+            -- Pass Only Elements: ['metric_time__day',]
             SELECT
               subq_3.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
@@ -224,7 +224,7 @@ FROM (
             , subq_4.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_4.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+            -- Pass Only Elements: ['metric_time__day',]
             SELECT
               subq_6.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
@@ -46,7 +46,7 @@ FROM (
           , subq_1.booking_monthly__listing AS booking_monthly__listing
           , subq_1.bookings_monthly AS bookings_monthly
         FROM (
-          -- Pass Only Elements: ['metric_time__month', 'metric_time__month']
+          -- Pass Only Elements: ['metric_time__month',]
           SELECT
             subq_3.metric_time__month
           FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_derived_metric_with_month_dimension_and_offset_window__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_derived_metric_with_month_dimension_and_offset_window__plan0_optimized.sql
@@ -17,7 +17,7 @@ FROM (
   FROM (
     -- Read From Time Spine 'mf_time_spine'
     -- Change Column Aliases
-    -- Pass Only Elements: ['metric_time__month', 'metric_time__month']
+    -- Pass Only Elements: ['metric_time__month',]
     SELECT
       DATE_TRUNC('month', ds) AS metric_time__month
     FROM ***************************.mf_time_spine time_spine_src_16006

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_derived_metric_with_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_derived_metric_with_offset_to_grain__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+            -- Pass Only Elements: ['metric_time__day',]
             SELECT
               subq_8.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_derived_metric_with_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_derived_metric_with_offset_window__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+            -- Pass Only Elements: ['metric_time__day',]
             SELECT
               subq_8.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
@@ -129,7 +129,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+            -- Pass Only Elements: ['metric_time__day',]
             SELECT
               subq_3.metric_time__day
             FROM (
@@ -486,7 +486,7 @@ FROM (
             , subq_10.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_10.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+            -- Pass Only Elements: ['metric_time__day',]
             SELECT
               subq_12.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
@@ -548,7 +548,7 @@ FROM (
               , subq_7.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
               , subq_7.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             FROM (
-              -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+              -- Pass Only Elements: ['metric_time__day',]
               SELECT
                 subq_9.metric_time__day
               FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_derived_offset_cumulative_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_derived_offset_cumulative_metric__plan0.sql
@@ -123,7 +123,7 @@ FROM (
           , subq_4.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
           , subq_4.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
         FROM (
-          -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+          -- Pass Only Elements: ['metric_time__day',]
           SELECT
             subq_6.metric_time__day
           FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_derived_offset_metric_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_derived_offset_metric_with_agg_time_dim__plan0.sql
@@ -129,7 +129,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['booking__ds__day', 'booking__ds__day']
+            -- Pass Only Elements: ['booking__ds__day',]
             SELECT
               subq_3.booking__ds__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_derived_offset_metric_with_one_input_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_derived_offset_metric_with_one_input_metric__plan0.sql
@@ -123,7 +123,7 @@ FROM (
           , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
           , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
         FROM (
-          -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+          -- Pass Only Elements: ['metric_time__day',]
           SELECT
             subq_3.metric_time__day
           FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0.sql
@@ -187,7 +187,7 @@ FROM (
                   , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                   , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
                 FROM (
-                  -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+                  -- Pass Only Elements: ['metric_time__day',]
                   SELECT
                     subq_3.metric_time__day
                   FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_nested_offsets__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_nested_offsets__plan0.sql
@@ -171,7 +171,7 @@ FROM (
               , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
               , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             FROM (
-              -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+              -- Pass Only Elements: ['metric_time__day',]
               SELECT
                 subq_3.metric_time__day
               FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_nested_offsets_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_nested_offsets_with_time_constraint__plan0.sql
@@ -176,7 +176,7 @@ FROM (
                 , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                 , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
               FROM (
-                -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+                -- Pass Only Elements: ['metric_time__day',]
                 SELECT
                   subq_3.metric_time__day
                 FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_nested_offsets_with_where_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_nested_offsets_with_where_constraint__plan0.sql
@@ -176,7 +176,7 @@ FROM (
                 , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                 , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
               FROM (
-                -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+                -- Pass Only Elements: ['metric_time__day',]
                 SELECT
                   subq_3.metric_time__day
                 FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_offset_to_grain_metric_multiple_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_offset_to_grain_metric_multiple_granularities__plan0.sql
@@ -133,7 +133,7 @@ FROM (
           , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
           , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
         FROM (
-          -- Pass Only Elements: ['metric_time__day', 'metric_time__day', 'metric_time__month', 'metric_time__year']
+          -- Pass Only Elements: ['metric_time__day', 'metric_time__month', 'metric_time__year']
           SELECT
             subq_3.metric_time__day
             , subq_3.metric_time__month

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_offset_to_grain_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_offset_to_grain_with_agg_time_dim__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['booking__ds__day', 'booking__ds__day']
+            -- Pass Only Elements: ['booking__ds__day',]
             SELECT
               subq_8.booking__ds__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_offset_window_metric_multiple_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_offset_window_metric_multiple_granularities__plan0.sql
@@ -141,7 +141,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day', 'metric_time__day', 'metric_time__month', 'metric_time__year']
+            -- Pass Only Elements: ['metric_time__day', 'metric_time__month', 'metric_time__year']
             SELECT
               subq_3.metric_time__day
               , subq_3.metric_time__month

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_offset_window_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_offset_window_with_agg_time_dim__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['booking__ds__day', 'booking__ds__day']
+            -- Pass Only Elements: ['booking__ds__day',]
             SELECT
               subq_8.booking__ds__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_time_offset_metric_with_time_constraint__plan0.sql
@@ -224,7 +224,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+            -- Pass Only Elements: ['metric_time__day',]
             SELECT
               subq_3.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
@@ -224,7 +224,7 @@ FROM (
             , subq_4.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_4.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+            -- Pass Only Elements: ['metric_time__day',]
             SELECT
               subq_6.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
@@ -46,7 +46,7 @@ FROM (
           , subq_1.booking_monthly__listing AS booking_monthly__listing
           , subq_1.bookings_monthly AS bookings_monthly
         FROM (
-          -- Pass Only Elements: ['metric_time__month', 'metric_time__month']
+          -- Pass Only Elements: ['metric_time__month',]
           SELECT
             subq_3.metric_time__month
           FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_derived_metric_with_month_dimension_and_offset_window__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_derived_metric_with_month_dimension_and_offset_window__plan0_optimized.sql
@@ -17,7 +17,7 @@ FROM (
   FROM (
     -- Read From Time Spine 'mf_time_spine'
     -- Change Column Aliases
-    -- Pass Only Elements: ['metric_time__month', 'metric_time__month']
+    -- Pass Only Elements: ['metric_time__month',]
     SELECT
       DATE_TRUNC('month', ds) AS metric_time__month
     FROM ***************************.mf_time_spine time_spine_src_16006

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_derived_metric_with_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_derived_metric_with_offset_to_grain__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+            -- Pass Only Elements: ['metric_time__day',]
             SELECT
               subq_8.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_derived_metric_with_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_derived_metric_with_offset_window__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+            -- Pass Only Elements: ['metric_time__day',]
             SELECT
               subq_8.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
@@ -129,7 +129,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+            -- Pass Only Elements: ['metric_time__day',]
             SELECT
               subq_3.metric_time__day
             FROM (
@@ -486,7 +486,7 @@ FROM (
             , subq_10.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_10.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+            -- Pass Only Elements: ['metric_time__day',]
             SELECT
               subq_12.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
@@ -548,7 +548,7 @@ FROM (
               , subq_7.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
               , subq_7.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             FROM (
-              -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+              -- Pass Only Elements: ['metric_time__day',]
               SELECT
                 subq_9.metric_time__day
               FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_derived_offset_cumulative_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_derived_offset_cumulative_metric__plan0.sql
@@ -123,7 +123,7 @@ FROM (
           , subq_4.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
           , subq_4.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
         FROM (
-          -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+          -- Pass Only Elements: ['metric_time__day',]
           SELECT
             subq_6.metric_time__day
           FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_derived_offset_metric_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_derived_offset_metric_with_agg_time_dim__plan0.sql
@@ -129,7 +129,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['booking__ds__day', 'booking__ds__day']
+            -- Pass Only Elements: ['booking__ds__day',]
             SELECT
               subq_3.booking__ds__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_derived_offset_metric_with_one_input_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_derived_offset_metric_with_one_input_metric__plan0.sql
@@ -123,7 +123,7 @@ FROM (
           , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
           , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
         FROM (
-          -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+          -- Pass Only Elements: ['metric_time__day',]
           SELECT
             subq_3.metric_time__day
           FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0.sql
@@ -187,7 +187,7 @@ FROM (
                   , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                   , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
                 FROM (
-                  -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+                  -- Pass Only Elements: ['metric_time__day',]
                   SELECT
                     subq_3.metric_time__day
                   FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_nested_offsets__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_nested_offsets__plan0.sql
@@ -171,7 +171,7 @@ FROM (
               , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
               , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             FROM (
-              -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+              -- Pass Only Elements: ['metric_time__day',]
               SELECT
                 subq_3.metric_time__day
               FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_nested_offsets_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_nested_offsets_with_time_constraint__plan0.sql
@@ -176,7 +176,7 @@ FROM (
                 , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                 , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
               FROM (
-                -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+                -- Pass Only Elements: ['metric_time__day',]
                 SELECT
                   subq_3.metric_time__day
                 FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_nested_offsets_with_where_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_nested_offsets_with_where_constraint__plan0.sql
@@ -176,7 +176,7 @@ FROM (
                 , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                 , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
               FROM (
-                -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+                -- Pass Only Elements: ['metric_time__day',]
                 SELECT
                   subq_3.metric_time__day
                 FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_offset_to_grain_metric_multiple_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_offset_to_grain_metric_multiple_granularities__plan0.sql
@@ -133,7 +133,7 @@ FROM (
           , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
           , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
         FROM (
-          -- Pass Only Elements: ['metric_time__day', 'metric_time__day', 'metric_time__month', 'metric_time__year']
+          -- Pass Only Elements: ['metric_time__day', 'metric_time__month', 'metric_time__year']
           SELECT
             subq_3.metric_time__day
             , subq_3.metric_time__month

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_offset_to_grain_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_offset_to_grain_with_agg_time_dim__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['booking__ds__day', 'booking__ds__day']
+            -- Pass Only Elements: ['booking__ds__day',]
             SELECT
               subq_8.booking__ds__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_offset_window_metric_multiple_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_offset_window_metric_multiple_granularities__plan0.sql
@@ -141,7 +141,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day', 'metric_time__day', 'metric_time__month', 'metric_time__year']
+            -- Pass Only Elements: ['metric_time__day', 'metric_time__month', 'metric_time__year']
             SELECT
               subq_3.metric_time__day
               , subq_3.metric_time__month

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_offset_window_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_offset_window_with_agg_time_dim__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['booking__ds__day', 'booking__ds__day']
+            -- Pass Only Elements: ['booking__ds__day',]
             SELECT
               subq_8.booking__ds__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_time_offset_metric_with_time_constraint__plan0.sql
@@ -224,7 +224,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+            -- Pass Only Elements: ['metric_time__day',]
             SELECT
               subq_3.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
@@ -224,7 +224,7 @@ FROM (
             , subq_4.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_4.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+            -- Pass Only Elements: ['metric_time__day',]
             SELECT
               subq_6.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
@@ -46,7 +46,7 @@ FROM (
           , subq_1.booking_monthly__listing AS booking_monthly__listing
           , subq_1.bookings_monthly AS bookings_monthly
         FROM (
-          -- Pass Only Elements: ['metric_time__month', 'metric_time__month']
+          -- Pass Only Elements: ['metric_time__month',]
           SELECT
             subq_3.metric_time__month
           FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_derived_metric_with_month_dimension_and_offset_window__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_derived_metric_with_month_dimension_and_offset_window__plan0_optimized.sql
@@ -17,7 +17,7 @@ FROM (
   FROM (
     -- Read From Time Spine 'mf_time_spine'
     -- Change Column Aliases
-    -- Pass Only Elements: ['metric_time__month', 'metric_time__month']
+    -- Pass Only Elements: ['metric_time__month',]
     SELECT
       DATE_TRUNC('month', ds) AS metric_time__month
     FROM ***************************.mf_time_spine time_spine_src_16006

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_derived_metric_with_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_derived_metric_with_offset_to_grain__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+            -- Pass Only Elements: ['metric_time__day',]
             SELECT
               subq_8.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_derived_metric_with_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_derived_metric_with_offset_window__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+            -- Pass Only Elements: ['metric_time__day',]
             SELECT
               subq_8.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
@@ -129,7 +129,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+            -- Pass Only Elements: ['metric_time__day',]
             SELECT
               subq_3.metric_time__day
             FROM (
@@ -486,7 +486,7 @@ FROM (
             , subq_10.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_10.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+            -- Pass Only Elements: ['metric_time__day',]
             SELECT
               subq_12.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
@@ -548,7 +548,7 @@ FROM (
               , subq_7.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
               , subq_7.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             FROM (
-              -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+              -- Pass Only Elements: ['metric_time__day',]
               SELECT
                 subq_9.metric_time__day
               FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_derived_offset_cumulative_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_derived_offset_cumulative_metric__plan0.sql
@@ -123,7 +123,7 @@ FROM (
           , subq_4.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
           , subq_4.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
         FROM (
-          -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+          -- Pass Only Elements: ['metric_time__day',]
           SELECT
             subq_6.metric_time__day
           FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_derived_offset_metric_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_derived_offset_metric_with_agg_time_dim__plan0.sql
@@ -129,7 +129,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['booking__ds__day', 'booking__ds__day']
+            -- Pass Only Elements: ['booking__ds__day',]
             SELECT
               subq_3.booking__ds__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_derived_offset_metric_with_one_input_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_derived_offset_metric_with_one_input_metric__plan0.sql
@@ -123,7 +123,7 @@ FROM (
           , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
           , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
         FROM (
-          -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+          -- Pass Only Elements: ['metric_time__day',]
           SELECT
             subq_3.metric_time__day
           FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0.sql
@@ -187,7 +187,7 @@ FROM (
                   , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                   , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
                 FROM (
-                  -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+                  -- Pass Only Elements: ['metric_time__day',]
                   SELECT
                     subq_3.metric_time__day
                   FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_nested_offsets__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_nested_offsets__plan0.sql
@@ -171,7 +171,7 @@ FROM (
               , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
               , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             FROM (
-              -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+              -- Pass Only Elements: ['metric_time__day',]
               SELECT
                 subq_3.metric_time__day
               FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_nested_offsets_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_nested_offsets_with_time_constraint__plan0.sql
@@ -176,7 +176,7 @@ FROM (
                 , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                 , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
               FROM (
-                -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+                -- Pass Only Elements: ['metric_time__day',]
                 SELECT
                   subq_3.metric_time__day
                 FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_nested_offsets_with_where_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_nested_offsets_with_where_constraint__plan0.sql
@@ -176,7 +176,7 @@ FROM (
                 , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                 , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
               FROM (
-                -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+                -- Pass Only Elements: ['metric_time__day',]
                 SELECT
                   subq_3.metric_time__day
                 FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_offset_to_grain_metric_multiple_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_offset_to_grain_metric_multiple_granularities__plan0.sql
@@ -133,7 +133,7 @@ FROM (
           , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
           , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
         FROM (
-          -- Pass Only Elements: ['metric_time__day', 'metric_time__day', 'metric_time__month', 'metric_time__year']
+          -- Pass Only Elements: ['metric_time__day', 'metric_time__month', 'metric_time__year']
           SELECT
             subq_3.metric_time__day
             , subq_3.metric_time__month

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_offset_to_grain_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_offset_to_grain_with_agg_time_dim__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['booking__ds__day', 'booking__ds__day']
+            -- Pass Only Elements: ['booking__ds__day',]
             SELECT
               subq_8.booking__ds__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_offset_window_metric_multiple_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_offset_window_metric_multiple_granularities__plan0.sql
@@ -141,7 +141,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day', 'metric_time__day', 'metric_time__month', 'metric_time__year']
+            -- Pass Only Elements: ['metric_time__day', 'metric_time__month', 'metric_time__year']
             SELECT
               subq_3.metric_time__day
               , subq_3.metric_time__month

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_offset_window_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_offset_window_with_agg_time_dim__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['booking__ds__day', 'booking__ds__day']
+            -- Pass Only Elements: ['booking__ds__day',]
             SELECT
               subq_8.booking__ds__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_time_offset_metric_with_time_constraint__plan0.sql
@@ -224,7 +224,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+            -- Pass Only Elements: ['metric_time__day',]
             SELECT
               subq_3.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/BigQuery/test_derived_fill_nulls_for_one_input_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/BigQuery/test_derived_fill_nulls_for_one_input_metric__plan0.sql
@@ -390,7 +390,7 @@ FROM (
             , subq_10.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_10.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+            -- Pass Only Elements: ['metric_time__day',]
             SELECT
               subq_12.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Databricks/test_derived_fill_nulls_for_one_input_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Databricks/test_derived_fill_nulls_for_one_input_metric__plan0.sql
@@ -390,7 +390,7 @@ FROM (
             , subq_10.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_10.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+            -- Pass Only Elements: ['metric_time__day',]
             SELECT
               subq_12.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/DuckDB/test_derived_fill_nulls_for_one_input_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/DuckDB/test_derived_fill_nulls_for_one_input_metric__plan0.sql
@@ -390,7 +390,7 @@ FROM (
             , subq_10.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_10.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+            -- Pass Only Elements: ['metric_time__day',]
             SELECT
               subq_12.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Postgres/test_derived_fill_nulls_for_one_input_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Postgres/test_derived_fill_nulls_for_one_input_metric__plan0.sql
@@ -390,7 +390,7 @@ FROM (
             , subq_10.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_10.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+            -- Pass Only Elements: ['metric_time__day',]
             SELECT
               subq_12.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Redshift/test_derived_fill_nulls_for_one_input_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Redshift/test_derived_fill_nulls_for_one_input_metric__plan0.sql
@@ -390,7 +390,7 @@ FROM (
             , subq_10.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_10.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+            -- Pass Only Elements: ['metric_time__day',]
             SELECT
               subq_12.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Snowflake/test_derived_fill_nulls_for_one_input_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Snowflake/test_derived_fill_nulls_for_one_input_metric__plan0.sql
@@ -390,7 +390,7 @@ FROM (
             , subq_10.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_10.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+            -- Pass Only Elements: ['metric_time__day',]
             SELECT
               subq_12.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Trino/test_derived_fill_nulls_for_one_input_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Trino/test_derived_fill_nulls_for_one_input_metric__plan0.sql
@@ -390,7 +390,7 @@ FROM (
             , subq_10.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_10.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+            -- Pass Only Elements: ['metric_time__day',]
             SELECT
               subq_12.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/BigQuery/test_subdaily_offset_to_grain_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/BigQuery/test_subdaily_offset_to_grain_metric__plan0.sql
@@ -215,7 +215,7 @@ FROM (
           , subq_1.user__home_state AS user__home_state
           , subq_1.archived_users AS archived_users
         FROM (
-          -- Pass Only Elements: ['metric_time__hour', 'metric_time__hour']
+          -- Pass Only Elements: ['metric_time__hour',]
           SELECT
             subq_3.metric_time__hour
           FROM (

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/BigQuery/test_subdaily_offset_window_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/BigQuery/test_subdaily_offset_window_metric__plan0.sql
@@ -215,7 +215,7 @@ FROM (
           , subq_1.user__home_state AS user__home_state
           , subq_1.archived_users AS archived_users
         FROM (
-          -- Pass Only Elements: ['metric_time__hour', 'metric_time__hour']
+          -- Pass Only Elements: ['metric_time__hour',]
           SELECT
             subq_3.metric_time__hour
           FROM (

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Databricks/test_subdaily_offset_to_grain_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Databricks/test_subdaily_offset_to_grain_metric__plan0.sql
@@ -215,7 +215,7 @@ FROM (
           , subq_1.user__home_state AS user__home_state
           , subq_1.archived_users AS archived_users
         FROM (
-          -- Pass Only Elements: ['metric_time__hour', 'metric_time__hour']
+          -- Pass Only Elements: ['metric_time__hour',]
           SELECT
             subq_3.metric_time__hour
           FROM (

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Databricks/test_subdaily_offset_window_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Databricks/test_subdaily_offset_window_metric__plan0.sql
@@ -215,7 +215,7 @@ FROM (
           , subq_1.user__home_state AS user__home_state
           , subq_1.archived_users AS archived_users
         FROM (
-          -- Pass Only Elements: ['metric_time__hour', 'metric_time__hour']
+          -- Pass Only Elements: ['metric_time__hour',]
           SELECT
             subq_3.metric_time__hour
           FROM (

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/DuckDB/test_subdaily_offset_to_grain_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/DuckDB/test_subdaily_offset_to_grain_metric__plan0.sql
@@ -215,7 +215,7 @@ FROM (
           , subq_1.user__home_state AS user__home_state
           , subq_1.archived_users AS archived_users
         FROM (
-          -- Pass Only Elements: ['metric_time__hour', 'metric_time__hour']
+          -- Pass Only Elements: ['metric_time__hour',]
           SELECT
             subq_3.metric_time__hour
           FROM (

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/DuckDB/test_subdaily_offset_window_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/DuckDB/test_subdaily_offset_window_metric__plan0.sql
@@ -215,7 +215,7 @@ FROM (
           , subq_1.user__home_state AS user__home_state
           , subq_1.archived_users AS archived_users
         FROM (
-          -- Pass Only Elements: ['metric_time__hour', 'metric_time__hour']
+          -- Pass Only Elements: ['metric_time__hour',]
           SELECT
             subq_3.metric_time__hour
           FROM (

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Postgres/test_subdaily_offset_to_grain_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Postgres/test_subdaily_offset_to_grain_metric__plan0.sql
@@ -215,7 +215,7 @@ FROM (
           , subq_1.user__home_state AS user__home_state
           , subq_1.archived_users AS archived_users
         FROM (
-          -- Pass Only Elements: ['metric_time__hour', 'metric_time__hour']
+          -- Pass Only Elements: ['metric_time__hour',]
           SELECT
             subq_3.metric_time__hour
           FROM (

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Postgres/test_subdaily_offset_window_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Postgres/test_subdaily_offset_window_metric__plan0.sql
@@ -215,7 +215,7 @@ FROM (
           , subq_1.user__home_state AS user__home_state
           , subq_1.archived_users AS archived_users
         FROM (
-          -- Pass Only Elements: ['metric_time__hour', 'metric_time__hour']
+          -- Pass Only Elements: ['metric_time__hour',]
           SELECT
             subq_3.metric_time__hour
           FROM (

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Redshift/test_subdaily_offset_to_grain_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Redshift/test_subdaily_offset_to_grain_metric__plan0.sql
@@ -215,7 +215,7 @@ FROM (
           , subq_1.user__home_state AS user__home_state
           , subq_1.archived_users AS archived_users
         FROM (
-          -- Pass Only Elements: ['metric_time__hour', 'metric_time__hour']
+          -- Pass Only Elements: ['metric_time__hour',]
           SELECT
             subq_3.metric_time__hour
           FROM (

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Redshift/test_subdaily_offset_window_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Redshift/test_subdaily_offset_window_metric__plan0.sql
@@ -215,7 +215,7 @@ FROM (
           , subq_1.user__home_state AS user__home_state
           , subq_1.archived_users AS archived_users
         FROM (
-          -- Pass Only Elements: ['metric_time__hour', 'metric_time__hour']
+          -- Pass Only Elements: ['metric_time__hour',]
           SELECT
             subq_3.metric_time__hour
           FROM (

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Snowflake/test_subdaily_offset_to_grain_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Snowflake/test_subdaily_offset_to_grain_metric__plan0.sql
@@ -215,7 +215,7 @@ FROM (
           , subq_1.user__home_state AS user__home_state
           , subq_1.archived_users AS archived_users
         FROM (
-          -- Pass Only Elements: ['metric_time__hour', 'metric_time__hour']
+          -- Pass Only Elements: ['metric_time__hour',]
           SELECT
             subq_3.metric_time__hour
           FROM (

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Snowflake/test_subdaily_offset_window_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Snowflake/test_subdaily_offset_window_metric__plan0.sql
@@ -215,7 +215,7 @@ FROM (
           , subq_1.user__home_state AS user__home_state
           , subq_1.archived_users AS archived_users
         FROM (
-          -- Pass Only Elements: ['metric_time__hour', 'metric_time__hour']
+          -- Pass Only Elements: ['metric_time__hour',]
           SELECT
             subq_3.metric_time__hour
           FROM (

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Trino/test_subdaily_offset_to_grain_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Trino/test_subdaily_offset_to_grain_metric__plan0.sql
@@ -215,7 +215,7 @@ FROM (
           , subq_1.user__home_state AS user__home_state
           , subq_1.archived_users AS archived_users
         FROM (
-          -- Pass Only Elements: ['metric_time__hour', 'metric_time__hour']
+          -- Pass Only Elements: ['metric_time__hour',]
           SELECT
             subq_3.metric_time__hour
           FROM (

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Trino/test_subdaily_offset_window_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Trino/test_subdaily_offset_window_metric__plan0.sql
@@ -215,7 +215,7 @@ FROM (
           , subq_1.user__home_state AS user__home_state
           , subq_1.archived_users AS archived_users
         FROM (
-          -- Pass Only Elements: ['metric_time__hour', 'metric_time__hour']
+          -- Pass Only Elements: ['metric_time__hour',]
           SELECT
             subq_3.metric_time__hour
           FROM (

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/BigQuery/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/BigQuery/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
@@ -999,7 +999,7 @@ FROM (
                   , subq_15.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                   , subq_15.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
                 FROM (
-                  -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+                  -- Pass Only Elements: ['metric_time__day',]
                   SELECT
                     subq_17.metric_time__day
                   FROM (

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/BigQuery/test_offset_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/BigQuery/test_offset_metric_with_query_time_filters__plan0.sql
@@ -908,7 +908,7 @@ FROM (
                 , subq_11.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                 , subq_11.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
               FROM (
-                -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+                -- Pass Only Elements: ['metric_time__day',]
                 SELECT
                   subq_13.metric_time__day
                 FROM (

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Databricks/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Databricks/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
@@ -999,7 +999,7 @@ FROM (
                   , subq_15.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                   , subq_15.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
                 FROM (
-                  -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+                  -- Pass Only Elements: ['metric_time__day',]
                   SELECT
                     subq_17.metric_time__day
                   FROM (

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Databricks/test_offset_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Databricks/test_offset_metric_with_query_time_filters__plan0.sql
@@ -908,7 +908,7 @@ FROM (
                 , subq_11.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                 , subq_11.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
               FROM (
-                -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+                -- Pass Only Elements: ['metric_time__day',]
                 SELECT
                   subq_13.metric_time__day
                 FROM (

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/DuckDB/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/DuckDB/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
@@ -999,7 +999,7 @@ FROM (
                   , subq_15.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                   , subq_15.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
                 FROM (
-                  -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+                  -- Pass Only Elements: ['metric_time__day',]
                   SELECT
                     subq_17.metric_time__day
                   FROM (

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/DuckDB/test_offset_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/DuckDB/test_offset_metric_with_query_time_filters__plan0.sql
@@ -908,7 +908,7 @@ FROM (
                 , subq_11.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                 , subq_11.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
               FROM (
-                -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+                -- Pass Only Elements: ['metric_time__day',]
                 SELECT
                   subq_13.metric_time__day
                 FROM (

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Postgres/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Postgres/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
@@ -999,7 +999,7 @@ FROM (
                   , subq_15.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                   , subq_15.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
                 FROM (
-                  -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+                  -- Pass Only Elements: ['metric_time__day',]
                   SELECT
                     subq_17.metric_time__day
                   FROM (

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Postgres/test_offset_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Postgres/test_offset_metric_with_query_time_filters__plan0.sql
@@ -908,7 +908,7 @@ FROM (
                 , subq_11.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                 , subq_11.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
               FROM (
-                -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+                -- Pass Only Elements: ['metric_time__day',]
                 SELECT
                   subq_13.metric_time__day
                 FROM (

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Redshift/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Redshift/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
@@ -999,7 +999,7 @@ FROM (
                   , subq_15.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                   , subq_15.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
                 FROM (
-                  -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+                  -- Pass Only Elements: ['metric_time__day',]
                   SELECT
                     subq_17.metric_time__day
                   FROM (

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Redshift/test_offset_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Redshift/test_offset_metric_with_query_time_filters__plan0.sql
@@ -908,7 +908,7 @@ FROM (
                 , subq_11.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                 , subq_11.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
               FROM (
-                -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+                -- Pass Only Elements: ['metric_time__day',]
                 SELECT
                   subq_13.metric_time__day
                 FROM (

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Snowflake/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Snowflake/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
@@ -999,7 +999,7 @@ FROM (
                   , subq_15.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                   , subq_15.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
                 FROM (
-                  -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+                  -- Pass Only Elements: ['metric_time__day',]
                   SELECT
                     subq_17.metric_time__day
                   FROM (

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Snowflake/test_offset_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Snowflake/test_offset_metric_with_query_time_filters__plan0.sql
@@ -908,7 +908,7 @@ FROM (
                 , subq_11.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                 , subq_11.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
               FROM (
-                -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+                -- Pass Only Elements: ['metric_time__day',]
                 SELECT
                   subq_13.metric_time__day
                 FROM (

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Trino/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Trino/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
@@ -999,7 +999,7 @@ FROM (
                   , subq_15.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                   , subq_15.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
                 FROM (
-                  -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+                  -- Pass Only Elements: ['metric_time__day',]
                   SELECT
                     subq_17.metric_time__day
                   FROM (

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Trino/test_offset_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Trino/test_offset_metric_with_query_time_filters__plan0.sql
@@ -908,7 +908,7 @@ FROM (
                 , subq_11.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                 , subq_11.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
               FROM (
-                -- Pass Only Elements: ['metric_time__day', 'metric_time__day']
+                -- Pass Only Elements: ['metric_time__day',]
                 SELECT
                   subq_13.metric_time__day
                 FROM (


### PR DESCRIPTION
There was a duplicate spec being passed into one of the `FilterElementsNodes`, which caused duplicates to show up in the printed dataflow plan. This fixes that.