### PR TITLE
Renames related to `SqlPlan` - Part 1

### DIFF
--- a/metricflow/dataset/sql_dataset.py
+++ b/metricflow/dataset/sql_dataset.py
@@ -16,7 +16,7 @@ from typing_extensions import override
 
 from metricflow.dataset.dataset_classes import DataSet
 from metricflow.sql.sql_plan import (
-    SqlQueryPlanNode,
+    SqlPlanNode,
     SqlSelectStatementNode,
 )
 
@@ -28,7 +28,7 @@ class SqlDataSet(DataSet):
         self,
         instance_set: InstanceSet,
         sql_select_node: Optional[SqlSelectStatementNode] = None,
-        sql_node: Optional[SqlQueryPlanNode] = None,
+        sql_node: Optional[SqlPlanNode] = None,
     ) -> None:
         """Constructor.
 
@@ -42,7 +42,7 @@ class SqlDataSet(DataSet):
         super().__init__(instance_set=instance_set)
 
     @property
-    def sql_node(self) -> SqlQueryPlanNode:  # noqa: D102
+    def sql_node(self) -> SqlPlanNode:  # noqa: D102
         node_to_return = self._sql_select_node or self._sql_node
         if node_to_return is None:
             raise RuntimeError(

--- a/metricflow/engine/metricflow_engine.py
+++ b/metricflow/engine/metricflow_engine.py
@@ -53,7 +53,7 @@ from metricflow.execution.dataflow_to_execution import (
 )
 from metricflow.execution.execution_plan import ExecutionPlan, SqlStatement
 from metricflow.execution.executor import SequentialPlanExecutor
-from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlQueryPlanConverter
+from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlPlanConverter
 from metricflow.protocols.sql_client import SqlClient
 from metricflow.sql.optimizer.optimization_levels import SqlQueryOptimizationLevel
 from metricflow.telemetry.models import TelemetryLevel
@@ -399,7 +399,7 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
             source_node_builder=source_node_builder,
             dataflow_plan_builder_cache=self._dataflow_plan_builder_cache,
         )
-        self._to_sql_query_plan_converter = DataflowToSqlQueryPlanConverter(
+        self._to_sql_query_plan_converter = DataflowToSqlPlanConverter(
             column_association_resolver=self._column_association_resolver,
             semantic_manifest_lookup=self._semantic_manifest_lookup,
         )

--- a/metricflow/execution/dataflow_to_execution.py
+++ b/metricflow/execution/dataflow_to_execution.py
@@ -39,7 +39,7 @@ from metricflow.execution.execution_plan import (
     SqlStatement,
 )
 from metricflow.plan_conversion.convert_to_sql_plan import ConvertToSqlPlanResult
-from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlQueryPlanConverter
+from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlPlanConverter
 from metricflow.protocols.sql_client import SqlClient
 from metricflow.sql.optimizer.optimization_levels import SqlQueryOptimizationLevel
 from metricflow.sql.render.sql_plan_renderer import SqlPlanRenderResult, SqlQueryPlanRenderer
@@ -52,7 +52,7 @@ class DataflowToExecutionPlanConverter(DataflowPlanNodeVisitor[ConvertToExecutio
 
     def __init__(
         self,
-        sql_plan_converter: DataflowToSqlQueryPlanConverter,
+        sql_plan_converter: DataflowToSqlPlanConverter,
         sql_plan_renderer: SqlQueryPlanRenderer,
         sql_client: SqlClient,
         sql_optimization_level: SqlQueryOptimizationLevel,

--- a/metricflow/plan_conversion/dataflow_to_sql.py
+++ b/metricflow/plan_conversion/dataflow_to_sql.py
@@ -140,7 +140,7 @@ from metricflow.sql.sql_plan import (
     SqlJoinDescription,
     SqlOrderByDescription,
     SqlPlan,
-    SqlQueryPlanNode,
+    SqlPlanNode,
     SqlSelectColumn,
     SqlSelectStatementNode,
     SqlTableNode,
@@ -313,7 +313,7 @@ class DataflowToSqlQueryPlanConverter:
                 ),
             )
 
-        sql_node: SqlQueryPlanNode = data_set.sql_node
+        sql_node: SqlPlanNode = data_set.sql_node
 
         for optimizer in optimizers:
             logger.debug(LazyFormat(lambda: f"Applying optimizer: {optimizer.__class__.__name__}"))

--- a/metricflow/plan_conversion/dataflow_to_sql.py
+++ b/metricflow/plan_conversion/dataflow_to_sql.py
@@ -126,7 +126,7 @@ from metricflow.plan_conversion.spec_transforms import (
 from metricflow.plan_conversion.sql_join_builder import (
     AnnotatedSqlDataSet,
     ColumnEqualityDescription,
-    SqlQueryPlanJoinBuilder,
+    SqlPlanJoinBuilder,
 )
 from metricflow.protocols.sql_client import SqlEngine
 from metricflow.sql.optimizer.optimization_levels import (
@@ -539,7 +539,7 @@ class DataflowNodeToSqlSubqueryVisitor(DataflowPlanNodeVisitor[SqlDataSet]):
         join_spec = self._choose_instance_for_time_spine_join(agg_time_dimension_instances).spec
         annotated_parent = parent_data_set.annotate(alias=parent_data_set_alias, metric_time_spec=join_spec)
         annotated_time_spine = time_spine_data_set.annotate(alias=time_spine_data_set_alias, metric_time_spec=join_spec)
-        join_desc = SqlQueryPlanJoinBuilder.make_cumulative_metric_time_range_join_description(
+        join_desc = SqlPlanJoinBuilder.make_cumulative_metric_time_range_join_description(
             node=node, metric_data_set=annotated_parent, time_spine_data_set=annotated_time_spine
         )
 
@@ -598,7 +598,7 @@ class DataflowNodeToSqlSubqueryVisitor(DataflowPlanNodeVisitor[SqlDataSet]):
             right_data_set_alias = self._next_unique_table_alias()
 
             # Build join description.
-            sql_join_desc = SqlQueryPlanJoinBuilder.make_base_output_join_description(
+            sql_join_desc = SqlPlanJoinBuilder.make_base_output_join_description(
                 left_data_set=AnnotatedSqlDataSet(data_set=from_data_set, alias=from_data_set_alias),
                 right_data_set=AnnotatedSqlDataSet(data_set=right_data_set, alias=right_data_set_alias),
                 join_description=join_description,
@@ -1110,7 +1110,7 @@ class DataflowNodeToSqlSubqueryVisitor(DataflowPlanNodeVisitor[SqlDataSet]):
         aliases_seen = [from_data_set.alias]
         for join_data_set in join_data_sets:
             joins_descriptions.append(
-                SqlQueryPlanJoinBuilder.make_join_description_for_combining_datasets(
+                SqlPlanJoinBuilder.make_join_description_for_combining_datasets(
                     from_data_set=from_data_set,
                     join_data_set=join_data_set,
                     join_type=join_type,
@@ -1397,7 +1397,7 @@ class DataflowNodeToSqlSubqueryVisitor(DataflowPlanNodeVisitor[SqlDataSet]):
         )
 
         join_data_set_alias = self._next_unique_table_alias()
-        sql_join_desc = SqlQueryPlanJoinBuilder.make_column_equality_sql_join_description(
+        sql_join_desc = SqlPlanJoinBuilder.make_column_equality_sql_join_description(
             right_source_node=row_filter_sql_select_node,
             left_source_alias=from_data_set_alias,
             right_source_alias=join_data_set_alias,
@@ -1444,7 +1444,7 @@ class DataflowNodeToSqlSubqueryVisitor(DataflowPlanNodeVisitor[SqlDataSet]):
 
         # Build join expression.
         join_column_name = self._column_association_resolver.resolve_spec(node.join_on_time_dimension_spec).column_name
-        join_description = SqlQueryPlanJoinBuilder.make_join_to_time_spine_join_description(
+        join_description = SqlPlanJoinBuilder.make_join_to_time_spine_join_description(
             node=node,
             time_spine_alias=time_spine_alias,
             agg_time_dimension_column_name=join_column_name,
@@ -1756,7 +1756,7 @@ class DataflowNodeToSqlSubqueryVisitor(DataflowPlanNodeVisitor[SqlDataSet]):
             constant_property_column_names.append((base_property_col_name, conversion_property_col_name))
 
         # Builds the join conditions that is required for a successful conversion
-        sql_join_description = SqlQueryPlanJoinBuilder.make_join_conversion_join_description(
+        sql_join_description = SqlPlanJoinBuilder.make_join_conversion_join_description(
             node=node,
             base_data_set=AnnotatedSqlDataSet(
                 data_set=base_data_set,

--- a/metricflow/plan_conversion/dataflow_to_sql.py
+++ b/metricflow/plan_conversion/dataflow_to_sql.py
@@ -149,7 +149,7 @@ from metricflow.sql.sql_plan import (
 logger = logging.getLogger(__name__)
 
 
-class DataflowToSqlQueryPlanConverter:
+class DataflowToSqlPlanConverter:
     """Generates an SQL query plan from a node in the metric dataflow plan."""
 
     def __init__(

--- a/metricflow/plan_conversion/dataflow_to_sql.py
+++ b/metricflow/plan_conversion/dataflow_to_sql.py
@@ -133,7 +133,7 @@ from metricflow.sql.optimizer.optimization_levels import (
     SqlGenerationOptionSet,
     SqlQueryOptimizationLevel,
 )
-from metricflow.sql.optimizer.sql_query_plan_optimizer import SqlQueryPlanOptimizer
+from metricflow.sql.optimizer.sql_query_plan_optimizer import SqlPlanOptimizer
 from metricflow.sql.sql_plan import (
     SqlCreateTableAsNode,
     SqlCteNode,
@@ -272,7 +272,7 @@ class DataflowToSqlPlanConverter:
         dataflow_plan_node: DataflowPlanNode,
         sql_query_plan_id: Optional[DagId],
         nodes_to_convert_to_cte: FrozenSet[DataflowPlanNode],
-        optimizers: Sequence[SqlQueryPlanOptimizer],
+        optimizers: Sequence[SqlPlanOptimizer],
     ) -> ConvertToSqlPlanResult:
         """Helper method to convert using specific options. Main use case are tests."""
         logger.debug(

--- a/metricflow/plan_conversion/sql_join_builder.py
+++ b/metricflow/plan_conversion/sql_join_builder.py
@@ -46,7 +46,7 @@ class ColumnEqualityDescription:
     treat_nulls_as_equal: bool = False
 
 
-class SqlQueryPlanJoinBuilder:
+class SqlPlanJoinBuilder:
     """Helper class for constructing various join components in a SqlQueryPlan."""
 
     @staticmethod
@@ -194,11 +194,11 @@ class SqlQueryPlanJoinBuilder:
                 )
             )
 
-        validity_conditions = SqlQueryPlanJoinBuilder._make_validity_window_on_conditions(
+        validity_conditions = SqlPlanJoinBuilder._make_validity_window_on_conditions(
             left_data_set=left_data_set, right_data_set=right_data_set, join_description=join_description
         )
 
-        return SqlQueryPlanJoinBuilder.make_column_equality_sql_join_description(
+        return SqlPlanJoinBuilder.make_column_equality_sql_join_description(
             right_source_node=right_data_set.data_set.checked_sql_select_node,
             left_source_alias=left_data_set.alias,
             right_source_alias=right_data_set.alias,
@@ -253,7 +253,7 @@ class SqlQueryPlanJoinBuilder:
         window_end_dimension_name = right_data_set.data_set.column_association_for_time_dimension(
             join_description.validity_window.window_end_dimension
         ).column_name
-        window_join_condition = SqlQueryPlanJoinBuilder._make_time_window_join_condition(
+        window_join_condition = SqlPlanJoinBuilder._make_time_window_join_condition(
             left_source_alias=left_data_set.alias,
             left_source_time_dimension_name=left_data_set_time_dimension_name,
             right_source_alias=right_data_set.alias,
@@ -331,7 +331,7 @@ class SqlQueryPlanJoinBuilder:
                 len(column_names) > 0
             ), "Attempting to do a FULL OUTER JOIN to combine metrics, but no columns were provided for join keys!"
             equality_exprs = [
-                SqlQueryPlanJoinBuilder._make_equality_expression_for_full_outer_join(
+                SqlPlanJoinBuilder._make_equality_expression_for_full_outer_join(
                     table_aliases_for_coalesce, join_data_set.alias, colname
                 )
                 for colname in column_names
@@ -352,7 +352,7 @@ class SqlQueryPlanJoinBuilder:
                 ColumnEqualityDescription(left_column_alias=name, right_column_alias=name, treat_nulls_as_equal=True)
                 for name in column_names
             ]
-            return SqlQueryPlanJoinBuilder.make_column_equality_sql_join_description(
+            return SqlPlanJoinBuilder.make_column_equality_sql_join_description(
                 right_source_node=join_data_set.data_set.checked_sql_select_node,
                 left_source_alias=from_data_set.alias,
                 right_source_alias=join_data_set.alias,
@@ -484,12 +484,12 @@ class SqlQueryPlanJoinBuilder:
         under the condition of being within the time range and other conditions (such as constant properties).
         This builds the join description to satisfy all those conditions.
         """
-        window_condition = SqlQueryPlanJoinBuilder._make_time_range_window_join_condition(
+        window_condition = SqlPlanJoinBuilder._make_time_range_window_join_condition(
             base_data_set=base_data_set,
             time_comparison_dataset=conversion_data_set,
             window=node.window,
         )
-        return SqlQueryPlanJoinBuilder.make_column_equality_sql_join_description(
+        return SqlPlanJoinBuilder.make_column_equality_sql_join_description(
             right_source_node=conversion_data_set.data_set.checked_sql_select_node,
             left_source_alias=base_data_set.alias,
             right_source_alias=conversion_data_set.alias,
@@ -509,7 +509,7 @@ class SqlQueryPlanJoinBuilder:
         Cumulative metrics must be joined against a time spine in a backward-looking fashion, with
         a range determined by a time window (delta against metric_time) and optional cumulative grain.
         """
-        cumulative_join_condition = SqlQueryPlanJoinBuilder._make_time_range_window_join_condition(
+        cumulative_join_condition = SqlPlanJoinBuilder._make_time_range_window_join_condition(
             base_data_set=metric_data_set,
             time_comparison_dataset=time_spine_data_set,
             window=node.window,

--- a/metricflow/sql/optimizer/column_pruner.py
+++ b/metricflow/sql/optimizer/column_pruner.py
@@ -11,7 +11,7 @@ from metricflow.sql.optimizer.tag_column_aliases import NodeToColumnAliasMapping
 from metricflow.sql.sql_plan import (
     SqlCreateTableAsNode,
     SqlCteNode,
-    SqlQueryPlanNode,
+    SqlPlanNode,
     SqlQueryPlanNodeVisitor,
     SqlSelectQueryFromClauseNode,
     SqlSelectStatementNode,
@@ -21,7 +21,7 @@ from metricflow.sql.sql_plan import (
 logger = logging.getLogger(__name__)
 
 
-class SqlColumnPrunerVisitor(SqlQueryPlanNodeVisitor[SqlQueryPlanNode]):
+class SqlColumnPrunerVisitor(SqlQueryPlanNodeVisitor[SqlPlanNode]):
     """Removes unnecessary columns from SELECT statements in the SQL query plan.
 
     This requires a set of tagged column aliases that should be kept for each SQL node.
@@ -38,7 +38,7 @@ class SqlColumnPrunerVisitor(SqlQueryPlanNodeVisitor[SqlQueryPlanNode]):
         """
         self._required_alias_mapping = required_alias_mapping
 
-    def visit_select_statement_node(self, node: SqlSelectStatementNode) -> SqlQueryPlanNode:  # noqa: D102
+    def visit_select_statement_node(self, node: SqlSelectStatementNode) -> SqlPlanNode:  # noqa: D102
         # Remove columns that are not needed from this SELECT statement because the parent SELECT statement doesn't
         # need them. However, keep columns that are in group bys because that changes the meaning of the query.
         # Similarly, if this node is a distinct select node, keep all columns as it may return a different result set.
@@ -81,29 +81,29 @@ class SqlColumnPrunerVisitor(SqlQueryPlanNodeVisitor[SqlQueryPlanNode]):
             distinct=node.distinct,
         )
 
-    def visit_table_node(self, node: SqlTableNode) -> SqlQueryPlanNode:
+    def visit_table_node(self, node: SqlTableNode) -> SqlPlanNode:
         """There are no SELECT columns in this node, so pruning cannot apply."""
         return node
 
-    def visit_query_from_clause_node(self, node: SqlSelectQueryFromClauseNode) -> SqlQueryPlanNode:
+    def visit_query_from_clause_node(self, node: SqlSelectQueryFromClauseNode) -> SqlPlanNode:
         """Pruning cannot be done here since this is an arbitrary user-provided SQL query."""
         return node
 
-    def visit_create_table_as_node(self, node: SqlCreateTableAsNode) -> SqlQueryPlanNode:  # noqa: D102
+    def visit_create_table_as_node(self, node: SqlCreateTableAsNode) -> SqlPlanNode:  # noqa: D102
         return SqlCreateTableAsNode.create(
             sql_table=node.sql_table,
             parent_node=node.parent_node.accept(self),
         )
 
     @override
-    def visit_cte_node(self, node: SqlCteNode) -> SqlQueryPlanNode:
+    def visit_cte_node(self, node: SqlCteNode) -> SqlPlanNode:
         return node.with_new_select(node.select_statement.accept(self))
 
 
 class SqlColumnPrunerOptimizer(SqlQueryPlanOptimizer):
     """Removes unnecessary columns in the SELECT statements."""
 
-    def optimize(self, node: SqlQueryPlanNode) -> SqlQueryPlanNode:  # noqa: D102
+    def optimize(self, node: SqlPlanNode) -> SqlPlanNode:  # noqa: D102
         # ALl columns in the nearest SELECT node need to be kept as otherwise, the meaning of the query changes.
         required_select_columns = node.nearest_select_columns({})
 

--- a/metricflow/sql/optimizer/column_pruner.py
+++ b/metricflow/sql/optimizer/column_pruner.py
@@ -6,7 +6,7 @@ from metricflow_semantics.mf_logging.lazy_formattable import LazyFormat
 from typing_extensions import override
 
 from metricflow.sql.optimizer.required_column_aliases import SqlMapRequiredColumnAliasesVisitor
-from metricflow.sql.optimizer.sql_query_plan_optimizer import SqlQueryPlanOptimizer
+from metricflow.sql.optimizer.sql_query_plan_optimizer import SqlPlanOptimizer
 from metricflow.sql.optimizer.tag_column_aliases import NodeToColumnAliasMapping
 from metricflow.sql.sql_plan import (
     SqlCreateTableAsNode,
@@ -100,7 +100,7 @@ class SqlColumnPrunerVisitor(SqlPlanNodeVisitor[SqlPlanNode]):
         return node.with_new_select(node.select_statement.accept(self))
 
 
-class SqlColumnPrunerOptimizer(SqlQueryPlanOptimizer):
+class SqlColumnPrunerOptimizer(SqlPlanOptimizer):
     """Removes unnecessary columns in the SELECT statements."""
 
     def optimize(self, node: SqlPlanNode) -> SqlPlanNode:  # noqa: D102

--- a/metricflow/sql/optimizer/column_pruner.py
+++ b/metricflow/sql/optimizer/column_pruner.py
@@ -12,7 +12,7 @@ from metricflow.sql.sql_plan import (
     SqlCreateTableAsNode,
     SqlCteNode,
     SqlPlanNode,
-    SqlQueryPlanNodeVisitor,
+    SqlPlanNodeVisitor,
     SqlSelectQueryFromClauseNode,
     SqlSelectStatementNode,
     SqlTableNode,
@@ -21,7 +21,7 @@ from metricflow.sql.sql_plan import (
 logger = logging.getLogger(__name__)
 
 
-class SqlColumnPrunerVisitor(SqlQueryPlanNodeVisitor[SqlPlanNode]):
+class SqlColumnPrunerVisitor(SqlPlanNodeVisitor[SqlPlanNode]):
     """Removes unnecessary columns from SELECT statements in the SQL query plan.
 
     This requires a set of tagged column aliases that should be kept for each SQL node.

--- a/metricflow/sql/optimizer/optimization_levels.py
+++ b/metricflow/sql/optimizer/optimization_levels.py
@@ -9,7 +9,7 @@ from dbt_semantic_interfaces.enum_extension import assert_values_exhausted
 
 from metricflow.sql.optimizer.column_pruner import SqlColumnPrunerOptimizer
 from metricflow.sql.optimizer.rewriting_sub_query_reducer import SqlRewritingSubQueryReducer
-from metricflow.sql.optimizer.sql_query_plan_optimizer import SqlQueryPlanOptimizer
+from metricflow.sql.optimizer.sql_query_plan_optimizer import SqlPlanOptimizer
 from metricflow.sql.optimizer.sub_query_reducer import SqlSubQueryReducer
 from metricflow.sql.optimizer.table_alias_simplifier import SqlTableAliasSimplifier
 
@@ -40,7 +40,7 @@ class SqlQueryOptimizationLevel(Enum):
 class SqlGenerationOptionSet:
     """Defines the different SQL generation optimizers / options that should be used at each level."""
 
-    optimizers: Tuple[SqlQueryPlanOptimizer, ...]
+    optimizers: Tuple[SqlPlanOptimizer, ...]
 
     # Specifies whether CTEs can be used to simplify generated SQL.
     allow_cte: bool
@@ -49,7 +49,7 @@ class SqlGenerationOptionSet:
     def options_for_level(  # noqa: D102
         level: SqlQueryOptimizationLevel, use_column_alias_in_group_by: bool
     ) -> SqlGenerationOptionSet:
-        optimizers: Tuple[SqlQueryPlanOptimizer, ...] = ()
+        optimizers: Tuple[SqlPlanOptimizer, ...] = ()
         allow_cte = False
         if level is SqlQueryOptimizationLevel.O0:
             pass

--- a/metricflow/sql/optimizer/required_column_aliases.py
+++ b/metricflow/sql/optimizer/required_column_aliases.py
@@ -13,7 +13,7 @@ from metricflow.sql.sql_plan import (
     SqlCreateTableAsNode,
     SqlCteNode,
     SqlPlanNode,
-    SqlQueryPlanNodeVisitor,
+    SqlPlanNodeVisitor,
     SqlSelectColumn,
     SqlSelectQueryFromClauseNode,
     SqlSelectStatementNode,
@@ -23,7 +23,7 @@ from metricflow.sql.sql_plan import (
 logger = logging.getLogger(__name__)
 
 
-class SqlMapRequiredColumnAliasesVisitor(SqlQueryPlanNodeVisitor[None]):
+class SqlMapRequiredColumnAliasesVisitor(SqlPlanNodeVisitor[None]):
     """To aid column pruning, traverse the SQL-query representation DAG and map the SELECT columns needed at each node.
 
     For example, the query:

--- a/metricflow/sql/optimizer/required_column_aliases.py
+++ b/metricflow/sql/optimizer/required_column_aliases.py
@@ -12,7 +12,7 @@ from metricflow.sql.optimizer.tag_column_aliases import NodeToColumnAliasMapping
 from metricflow.sql.sql_plan import (
     SqlCreateTableAsNode,
     SqlCteNode,
-    SqlQueryPlanNode,
+    SqlPlanNode,
     SqlQueryPlanNodeVisitor,
     SqlSelectColumn,
     SqlSelectQueryFromClauseNode,
@@ -55,7 +55,7 @@ class SqlMapRequiredColumnAliasesVisitor(SqlQueryPlanNodeVisitor[None]):
         ) source_0
     """
 
-    def __init__(self, start_node: SqlQueryPlanNode, required_column_aliases_in_start_node: FrozenSet[str]) -> None:
+    def __init__(self, start_node: SqlPlanNode, required_column_aliases_in_start_node: FrozenSet[str]) -> None:
         """Initializer.
 
         Args:
@@ -114,7 +114,7 @@ class SqlMapRequiredColumnAliasesVisitor(SqlQueryPlanNodeVisitor[None]):
         # Visit parent nodes.
         select_statement.accept(self)
 
-    def _visit_parents(self, node: SqlQueryPlanNode) -> None:
+    def _visit_parents(self, node: SqlPlanNode) -> None:
         """Default recursive handler to visit the parents of the given node."""
         for parent_node in node.parent_nodes:
             parent_node.accept(self)

--- a/metricflow/sql/optimizer/rewriting_sub_query_reducer.py
+++ b/metricflow/sql/optimizer/rewriting_sub_query_reducer.py
@@ -17,7 +17,7 @@ from metricflow_semantics.sql.sql_exprs import (
 )
 from typing_extensions import override
 
-from metricflow.sql.optimizer.sql_query_plan_optimizer import SqlQueryPlanOptimizer
+from metricflow.sql.optimizer.sql_query_plan_optimizer import SqlPlanOptimizer
 from metricflow.sql.sql_plan import (
     SqlCreateTableAsNode,
     SqlCteNode,
@@ -832,7 +832,7 @@ class SqlGroupByRewritingVisitor(SqlPlanNodeVisitor[SqlPlanNode]):
         )
 
 
-class SqlRewritingSubQueryReducer(SqlQueryPlanOptimizer):
+class SqlRewritingSubQueryReducer(SqlPlanOptimizer):
     """Simplify queries by eliminating sub-queries when possible by rewriting expressions.
 
      Expressions in the SELECT, GROUP BY, and WHERE are can be rewritten.

--- a/metricflow/sql/optimizer/rewriting_sub_query_reducer.py
+++ b/metricflow/sql/optimizer/rewriting_sub_query_reducer.py
@@ -24,7 +24,7 @@ from metricflow.sql.sql_plan import (
     SqlJoinDescription,
     SqlOrderByDescription,
     SqlPlanNode,
-    SqlQueryPlanNodeVisitor,
+    SqlPlanNodeVisitor,
     SqlSelectColumn,
     SqlSelectQueryFromClauseNode,
     SqlSelectStatementNode,
@@ -85,7 +85,7 @@ class RewritableSqlClauses:
         )
 
 
-class SqlRewritingSubQueryReducerVisitor(SqlQueryPlanNodeVisitor[SqlPlanNode]):
+class SqlRewritingSubQueryReducerVisitor(SqlPlanNodeVisitor[SqlPlanNode]):
     """Visits the SQL query plan to simplify sub-queries. On each visit, return a simplified node.
 
     Unlike SqlSubQueryReducerVisitor, this will re-write expressions to realize more reductions.
@@ -757,7 +757,7 @@ class SqlRewritingSubQueryReducerVisitor(SqlQueryPlanNodeVisitor[SqlPlanNode]):
         )
 
 
-class SqlGroupByRewritingVisitor(SqlQueryPlanNodeVisitor[SqlPlanNode]):
+class SqlGroupByRewritingVisitor(SqlPlanNodeVisitor[SqlPlanNode]):
     """Re-writes the GROUP BY to use a SqlColumnAliasReferenceExpression."""
 
     @staticmethod

--- a/metricflow/sql/optimizer/sql_query_plan_optimizer.py
+++ b/metricflow/sql/optimizer/sql_query_plan_optimizer.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 
-from metricflow.sql.sql_plan import SqlQueryPlanNode
+from metricflow.sql.sql_plan import SqlPlanNode
 
 
 class SqlQueryPlanOptimizer(ABC):
@@ -12,5 +12,5 @@ class SqlQueryPlanOptimizer(ABC):
     """
 
     @abstractmethod
-    def optimize(self, node: SqlQueryPlanNode) -> SqlQueryPlanNode:  # noqa :D
+    def optimize(self, node: SqlPlanNode) -> SqlPlanNode:  # noqa :D
         pass

--- a/metricflow/sql/optimizer/sql_query_plan_optimizer.py
+++ b/metricflow/sql/optimizer/sql_query_plan_optimizer.py
@@ -5,7 +5,7 @@ from abc import ABC, abstractmethod
 from metricflow.sql.sql_plan import SqlPlanNode
 
 
-class SqlQueryPlanOptimizer(ABC):
+class SqlPlanOptimizer(ABC):
     """Optimize the SQL query plan in some way.
 
     e.g. a column pruner that removes unnecessary select columns in sub-queries.

--- a/metricflow/sql/optimizer/sub_query_reducer.py
+++ b/metricflow/sql/optimizer/sub_query_reducer.py
@@ -12,7 +12,7 @@ from metricflow.sql.sql_plan import (
     SqlCteNode,
     SqlJoinDescription,
     SqlOrderByDescription,
-    SqlQueryPlanNode,
+    SqlPlanNode,
     SqlQueryPlanNodeVisitor,
     SqlSelectQueryFromClauseNode,
     SqlSelectStatementNode,
@@ -22,7 +22,7 @@ from metricflow.sql.sql_plan import (
 logger = logging.getLogger(__name__)
 
 
-class SqlSubQueryReducerVisitor(SqlQueryPlanNodeVisitor[SqlQueryPlanNode]):
+class SqlSubQueryReducerVisitor(SqlQueryPlanNodeVisitor[SqlPlanNode]):
     """Visits the SQL query plan to simplify sub-queries. On each visit, return a simplfied node."""
 
     def _reduce_parents(
@@ -125,10 +125,10 @@ class SqlSubQueryReducerVisitor(SqlQueryPlanNodeVisitor[SqlQueryPlanNode]):
         return None
 
     @override
-    def visit_cte_node(self, node: SqlCteNode) -> SqlQueryPlanNode:
+    def visit_cte_node(self, node: SqlCteNode) -> SqlPlanNode:
         raise NotImplementedError
 
-    def visit_select_statement_node(self, node: SqlSelectStatementNode) -> SqlQueryPlanNode:  # noqa: D102
+    def visit_select_statement_node(self, node: SqlSelectStatementNode) -> SqlPlanNode:  # noqa: D102
         node_with_reduced_parents = self._reduce_parents(node)
 
         if not self._reduce_is_possible(node_with_reduced_parents):
@@ -195,13 +195,13 @@ class SqlSubQueryReducerVisitor(SqlQueryPlanNodeVisitor[SqlQueryPlanNode]):
             distinct=parent_select_node.distinct,
         )
 
-    def visit_table_node(self, node: SqlTableNode) -> SqlQueryPlanNode:  # noqa: D102
+    def visit_table_node(self, node: SqlTableNode) -> SqlPlanNode:  # noqa: D102
         return node
 
-    def visit_query_from_clause_node(self, node: SqlSelectQueryFromClauseNode) -> SqlQueryPlanNode:  # noqa: D102
+    def visit_query_from_clause_node(self, node: SqlSelectQueryFromClauseNode) -> SqlPlanNode:  # noqa: D102
         return node
 
-    def visit_create_table_as_node(self, node: SqlCreateTableAsNode) -> SqlQueryPlanNode:  # noqa: D102
+    def visit_create_table_as_node(self, node: SqlCreateTableAsNode) -> SqlPlanNode:  # noqa: D102
         return SqlCreateTableAsNode.create(
             sql_table=node.sql_table,
             parent_node=node.parent_node.accept(self),
@@ -223,5 +223,5 @@ class SqlSubQueryReducer(SqlQueryPlanOptimizer):
     SELECT a.foo FROM bar a
     """
 
-    def optimize(self, node: SqlQueryPlanNode) -> SqlQueryPlanNode:  # noqa: D102
+    def optimize(self, node: SqlPlanNode) -> SqlPlanNode:  # noqa: D102
         return node.accept(SqlSubQueryReducerVisitor())

--- a/metricflow/sql/optimizer/sub_query_reducer.py
+++ b/metricflow/sql/optimizer/sub_query_reducer.py
@@ -13,7 +13,7 @@ from metricflow.sql.sql_plan import (
     SqlJoinDescription,
     SqlOrderByDescription,
     SqlPlanNode,
-    SqlQueryPlanNodeVisitor,
+    SqlPlanNodeVisitor,
     SqlSelectQueryFromClauseNode,
     SqlSelectStatementNode,
     SqlTableNode,
@@ -22,7 +22,7 @@ from metricflow.sql.sql_plan import (
 logger = logging.getLogger(__name__)
 
 
-class SqlSubQueryReducerVisitor(SqlQueryPlanNodeVisitor[SqlPlanNode]):
+class SqlSubQueryReducerVisitor(SqlPlanNodeVisitor[SqlPlanNode]):
     """Visits the SQL query plan to simplify sub-queries. On each visit, return a simplfied node."""
 
     def _reduce_parents(

--- a/metricflow/sql/optimizer/sub_query_reducer.py
+++ b/metricflow/sql/optimizer/sub_query_reducer.py
@@ -6,7 +6,7 @@ from typing import List, Optional
 from metricflow_semantics.sql.sql_exprs import SqlColumnReference, SqlColumnReferenceExpression
 from typing_extensions import override
 
-from metricflow.sql.optimizer.sql_query_plan_optimizer import SqlQueryPlanOptimizer
+from metricflow.sql.optimizer.sql_query_plan_optimizer import SqlPlanOptimizer
 from metricflow.sql.sql_plan import (
     SqlCreateTableAsNode,
     SqlCteNode,
@@ -208,7 +208,7 @@ class SqlSubQueryReducerVisitor(SqlPlanNodeVisitor[SqlPlanNode]):
         )
 
 
-class SqlSubQueryReducer(SqlQueryPlanOptimizer):
+class SqlSubQueryReducer(SqlPlanOptimizer):
     """Simplify queries by eliminating sub-queries when possible.
 
     e.g. from

--- a/metricflow/sql/optimizer/table_alias_simplifier.py
+++ b/metricflow/sql/optimizer/table_alias_simplifier.py
@@ -11,7 +11,7 @@ from metricflow.sql.sql_plan import (
     SqlJoinDescription,
     SqlOrderByDescription,
     SqlPlanNode,
-    SqlQueryPlanNodeVisitor,
+    SqlPlanNodeVisitor,
     SqlSelectColumn,
     SqlSelectQueryFromClauseNode,
     SqlSelectStatementNode,
@@ -21,7 +21,7 @@ from metricflow.sql.sql_plan import (
 logger = logging.getLogger(__name__)
 
 
-class SqlTableAliasSimplifierVisitor(SqlQueryPlanNodeVisitor[SqlPlanNode]):
+class SqlTableAliasSimplifierVisitor(SqlPlanNodeVisitor[SqlPlanNode]):
     """Visits the SQL query plan to see if table aliases can be omitted when rendering column references."""
 
     @override

--- a/metricflow/sql/optimizer/table_alias_simplifier.py
+++ b/metricflow/sql/optimizer/table_alias_simplifier.py
@@ -4,7 +4,7 @@ import logging
 
 from typing_extensions import override
 
-from metricflow.sql.optimizer.sql_query_plan_optimizer import SqlQueryPlanOptimizer
+from metricflow.sql.optimizer.sql_query_plan_optimizer import SqlPlanOptimizer
 from metricflow.sql.sql_plan import (
     SqlCreateTableAsNode,
     SqlCteNode,
@@ -95,7 +95,7 @@ class SqlTableAliasSimplifierVisitor(SqlPlanNodeVisitor[SqlPlanNode]):
         )
 
 
-class SqlTableAliasSimplifier(SqlQueryPlanOptimizer):
+class SqlTableAliasSimplifier(SqlPlanOptimizer):
     """Simplify queries by eliminating table aliases when possible.
 
     e.g. from

--- a/metricflow/sql/optimizer/tag_column_aliases.py
+++ b/metricflow/sql/optimizer/tag_column_aliases.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from typing import Dict, FrozenSet, Iterable, Set
 
 from metricflow.sql.sql_plan import (
-    SqlQueryPlanNode,
+    SqlPlanNode,
 )
 
 logger = logging.getLogger(__name__)
@@ -20,14 +20,14 @@ class NodeToColumnAliasMapping:
     """
 
     def __init__(self) -> None:  # noqa: D107
-        self._node_to_tagged_aliases: Dict[SqlQueryPlanNode, Set[str]] = defaultdict(set)
+        self._node_to_tagged_aliases: Dict[SqlPlanNode, Set[str]] = defaultdict(set)
 
-    def get_aliases(self, node: SqlQueryPlanNode) -> FrozenSet[str]:
+    def get_aliases(self, node: SqlPlanNode) -> FrozenSet[str]:
         """Return the column aliases added for the given SQL node."""
         return frozenset(self._node_to_tagged_aliases[node])
 
-    def add_alias(self, node: SqlQueryPlanNode, column_alias: str) -> None:  # noqa: D102
+    def add_alias(self, node: SqlPlanNode, column_alias: str) -> None:  # noqa: D102
         return self._node_to_tagged_aliases[node].add(column_alias)
 
-    def add_aliases(self, node: SqlQueryPlanNode, column_aliases: Iterable[str]) -> None:  # noqa: D102
+    def add_aliases(self, node: SqlPlanNode, column_aliases: Iterable[str]) -> None:  # noqa: D102
         self._node_to_tagged_aliases[node].update(column_aliases)

--- a/metricflow/sql/render/sql_plan_renderer.py
+++ b/metricflow/sql/render/sql_plan_renderer.py
@@ -24,7 +24,7 @@ from metricflow.sql.sql_plan import (
     SqlJoinDescription,
     SqlOrderByDescription,
     SqlPlan,
-    SqlQueryPlanNode,
+    SqlPlanNode,
     SqlQueryPlanNodeVisitor,
     SqlSelectColumn,
     SqlSelectQueryFromClauseNode,
@@ -46,7 +46,7 @@ class SqlPlanRenderResult:  # noqa: D101
 class SqlQueryPlanRenderer(SqlQueryPlanNodeVisitor[SqlPlanRenderResult], ABC):
     """Renders SQL plans to a string."""
 
-    def _render_node(self, node: SqlQueryPlanNode) -> SqlPlanRenderResult:
+    def _render_node(self, node: SqlPlanNode) -> SqlPlanRenderResult:
         return node.accept(self)
 
     def render_sql_query_plan(self, sql_query_plan: SqlPlan) -> SqlPlanRenderResult:  # noqa: D102
@@ -175,7 +175,7 @@ class DefaultSqlQueryPlanRenderer(SqlQueryPlanRenderer):
 
         return SqlPlanRenderResult("\n".join(select_section_lines), params)
 
-    def _render_from_section(self, from_source: SqlQueryPlanNode, from_source_alias: str) -> SqlPlanRenderResult:
+    def _render_from_section(self, from_source: SqlPlanNode, from_source_alias: str) -> SqlPlanRenderResult:
         """Convert the node into a "FROM" section.
 
         e.g.

--- a/metricflow/sql/render/sql_plan_renderer.py
+++ b/metricflow/sql/render/sql_plan_renderer.py
@@ -25,7 +25,7 @@ from metricflow.sql.sql_plan import (
     SqlOrderByDescription,
     SqlPlan,
     SqlPlanNode,
-    SqlQueryPlanNodeVisitor,
+    SqlPlanNodeVisitor,
     SqlSelectColumn,
     SqlSelectQueryFromClauseNode,
     SqlSelectStatementNode,
@@ -43,7 +43,7 @@ class SqlPlanRenderResult:  # noqa: D101
     bind_parameter_set: SqlBindParameterSet
 
 
-class SqlQueryPlanRenderer(SqlQueryPlanNodeVisitor[SqlPlanRenderResult], ABC):
+class SqlQueryPlanRenderer(SqlPlanNodeVisitor[SqlPlanRenderResult], ABC):
     """Renders SQL plans to a string."""
 
     def _render_node(self, node: SqlPlanNode) -> SqlPlanRenderResult:

--- a/metricflow/sql/sql_plan.py
+++ b/metricflow/sql/sql_plan.py
@@ -34,7 +34,7 @@ class SqlPlanNode(DagNode["SqlPlanNode"], ABC):
     """
 
     @abstractmethod
-    def accept(self, visitor: SqlQueryPlanNodeVisitor[VisitorOutputT]) -> VisitorOutputT:
+    def accept(self, visitor: SqlPlanNodeVisitor[VisitorOutputT]) -> VisitorOutputT:
         """Called when a visitor needs to visit this node."""
         raise NotImplementedError
 
@@ -67,8 +67,8 @@ class SqlPlanNode(DagNode["SqlPlanNode"], ABC):
         raise NotImplementedError
 
 
-class SqlQueryPlanNodeVisitor(Generic[VisitorOutputT], ABC):
-    """An object that can be used to visit the nodes of an SQL query.
+class SqlPlanNodeVisitor(Generic[VisitorOutputT], ABC):
+    """An object that can be used to visit the nodes of an SQL plan.
 
     See similar visitor DataflowPlanVisitor.
     """
@@ -204,7 +204,7 @@ class SqlSelectStatementNode(SqlPlanNode):
             + (DisplayedProperty("distinct", self.distinct),)
         )
 
-    def accept(self, visitor: SqlQueryPlanNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D102
+    def accept(self, visitor: SqlPlanNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D102
         return visitor.visit_select_statement_node(self)
 
     @property
@@ -268,7 +268,7 @@ class SqlTableNode(SqlPlanNode):
     def displayed_properties(self) -> Sequence[DisplayedProperty]:  # noqa: D102
         return tuple(super().displayed_properties) + (DisplayedProperty("table_id", self.sql_table.sql),)
 
-    def accept(self, visitor: SqlQueryPlanNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D102
+    def accept(self, visitor: SqlPlanNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D102
         return visitor.visit_table_node(self)
 
     @property
@@ -316,7 +316,7 @@ class SqlSelectQueryFromClauseNode(SqlPlanNode):
     def description(self) -> str:  # noqa: D102
         return "Read From a Select Query"
 
-    def accept(self, visitor: SqlQueryPlanNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D102
+    def accept(self, visitor: SqlPlanNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D102
         return visitor.visit_query_from_clause_node(self)
 
     @property
@@ -357,7 +357,7 @@ class SqlCreateTableAsNode(SqlPlanNode):
         )
 
     @override
-    def accept(self, visitor: SqlQueryPlanNodeVisitor[VisitorOutputT]) -> VisitorOutputT:
+    def accept(self, visitor: SqlPlanNodeVisitor[VisitorOutputT]) -> VisitorOutputT:
         return visitor.visit_create_table_as_node(self)
 
     @property
@@ -439,7 +439,7 @@ class SqlCteNode(SqlPlanNode):
         )
 
     @override
-    def accept(self, visitor: SqlQueryPlanNodeVisitor[VisitorOutputT]) -> VisitorOutputT:
+    def accept(self, visitor: SqlPlanNodeVisitor[VisitorOutputT]) -> VisitorOutputT:
         return visitor.visit_cte_node(self)
 
     @property

--- a/metricflow/validation/data_warehouse_model_validator.py
+++ b/metricflow/validation/data_warehouse_model_validator.py
@@ -43,7 +43,7 @@ from metricflow.dataflow.nodes.filter_elements import FilterElementsNode
 from metricflow.dataset.convert_semantic_model import SemanticModelToDataSetConverter
 from metricflow.dataset.dataset_classes import DataSet
 from metricflow.engine.metricflow_engine import MetricFlowEngine, MetricFlowExplainResult, MetricFlowQueryRequest
-from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlQueryPlanConverter
+from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlPlanConverter
 from metricflow.protocols.sql_client import SqlClient
 
 
@@ -58,7 +58,7 @@ class QueryRenderingTools:
     semantic_manifest_lookup: SemanticManifestLookup
     source_node_builder: SourceNodeBuilder
     converter: SemanticModelToDataSetConverter
-    plan_converter: DataflowToSqlQueryPlanConverter
+    plan_converter: DataflowToSqlPlanConverter
 
     def __init__(self, manifest: SemanticManifest) -> None:  # noqa: D107
         self.semantic_manifest_lookup = SemanticManifestLookup(semantic_manifest=manifest)
@@ -67,7 +67,7 @@ class QueryRenderingTools:
             semantic_manifest_lookup=self.semantic_manifest_lookup,
         )
         self.converter = SemanticModelToDataSetConverter(column_association_resolver=DunderColumnAssociationResolver())
-        self.plan_converter = DataflowToSqlQueryPlanConverter(
+        self.plan_converter = DataflowToSqlPlanConverter(
             column_association_resolver=DunderColumnAssociationResolver(),
             semantic_manifest_lookup=self.semantic_manifest_lookup,
         )
@@ -118,7 +118,7 @@ class DataWarehouseTaskBuilder:
 
     @staticmethod
     def renderize(
-        sql_client: SqlClient, plan_converter: DataflowToSqlQueryPlanConverter, plan_id: str, nodes: FilterElementsNode
+        sql_client: SqlClient, plan_converter: DataflowToSqlPlanConverter, plan_id: str, nodes: FilterElementsNode
     ) -> Tuple[str, SqlBindParameterSet]:
         """Generates a sql query plan and returns the rendered sql and bind_parameter_set."""
         conversion_result = plan_converter.convert_to_sql_query_plan(

--- a/tests_metricflow/examples/test_node_sql.py
+++ b/tests_metricflow/examples/test_node_sql.py
@@ -18,7 +18,7 @@ from metricflow.dataflow.nodes.filter_elements import FilterElementsNode
 from metricflow.dataflow.nodes.metric_time_transform import MetricTimeDimensionTransformNode
 from metricflow.dataflow.nodes.read_sql_source import ReadSqlSourceNode
 from metricflow.dataset.convert_semantic_model import SemanticModelToDataSetConverter
-from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlQueryPlanConverter
+from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlPlanConverter
 from metricflow.protocols.sql_client import SqlClient
 from metricflow.sql.render.sql_plan_renderer import SqlQueryPlanRenderer
 
@@ -38,7 +38,7 @@ def test_view_sql_generated_at_a_node(
     column_association_resolver = DunderColumnAssociationResolver()
     to_data_set_converter = SemanticModelToDataSetConverter(column_association_resolver)
 
-    to_sql_plan_converter = DataflowToSqlQueryPlanConverter(
+    to_sql_plan_converter = DataflowToSqlPlanConverter(
         column_association_resolver=DunderColumnAssociationResolver(),
         semantic_manifest_lookup=simple_semantic_manifest_lookup,
     )

--- a/tests_metricflow/fixtures/manifest_fixtures.py
+++ b/tests_metricflow/fixtures/manifest_fixtures.py
@@ -52,7 +52,7 @@ from metricflow.dataflow.nodes.read_sql_source import ReadSqlSourceNode
 from metricflow.dataset.convert_semantic_model import SemanticModelToDataSetConverter
 from metricflow.dataset.semantic_model_adapter import SemanticModelDataSet
 from metricflow.engine.metricflow_engine import MetricFlowEngine
-from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlQueryPlanConverter
+from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlPlanConverter
 from metricflow.protocols.sql_client import SqlClient
 
 logger = logging.getLogger(__name__)
@@ -155,7 +155,7 @@ class MetricFlowEngineTestFixture:
     data_set_mapping: OrderedDict[str, SemanticModelDataSet]
     read_node_mapping: OrderedDict[str, ReadSqlSourceNode]
     source_node_set: SourceNodeSet
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter
     query_parser: MetricFlowQueryParser
     metricflow_engine: MetricFlowEngine
     source_node_builder: SourceNodeBuilder
@@ -186,7 +186,7 @@ class MetricFlowEngineTestFixture:
             read_node_mapping=read_node_mapping,
             source_node_set=source_node_set,
             _node_output_resolver=node_output_resolver,
-            dataflow_to_sql_converter=DataflowToSqlQueryPlanConverter(
+            dataflow_to_sql_converter=DataflowToSqlPlanConverter(
                 column_association_resolver=column_association_resolver,
                 semantic_manifest_lookup=semantic_manifest_lookup,
             ),

--- a/tests_metricflow/fixtures/sql_fixtures.py
+++ b/tests_metricflow/fixtures/sql_fixtures.py
@@ -4,7 +4,7 @@ from typing import Mapping
 
 import pytest
 
-from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlQueryPlanConverter
+from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlPlanConverter
 from metricflow.sql.render.sql_plan_renderer import DefaultSqlQueryPlanRenderer, SqlQueryPlanRenderer
 from tests_metricflow.fixtures.manifest_fixtures import MetricFlowEngineTestFixture, SemanticManifestSetup
 
@@ -17,21 +17,21 @@ def default_sql_plan_renderer() -> SqlQueryPlanRenderer:  # noqa: D103
 @pytest.fixture(scope="session")
 def dataflow_to_sql_converter(  # noqa: D103
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture]
-) -> DataflowToSqlQueryPlanConverter:
+) -> DataflowToSqlPlanConverter:
     return mf_engine_test_fixture_mapping[SemanticManifestSetup.SIMPLE_MANIFEST].dataflow_to_sql_converter
 
 
 @pytest.fixture(scope="session")
 def extended_date_dataflow_to_sql_converter(  # noqa: D103
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture]
-) -> DataflowToSqlQueryPlanConverter:
+) -> DataflowToSqlPlanConverter:
     return mf_engine_test_fixture_mapping[SemanticManifestSetup.EXTENDED_DATE_MANIFEST].dataflow_to_sql_converter
 
 
 @pytest.fixture(scope="session")
 def multihop_dataflow_to_sql_converter(  # noqa: D103
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture]
-) -> DataflowToSqlQueryPlanConverter:
+) -> DataflowToSqlPlanConverter:
     return mf_engine_test_fixture_mapping[
         SemanticManifestSetup.PARTITIONED_MULTI_HOP_JOIN_MANIFEST
     ].dataflow_to_sql_converter
@@ -40,5 +40,5 @@ def multihop_dataflow_to_sql_converter(  # noqa: D103
 @pytest.fixture(scope="session")
 def scd_dataflow_to_sql_converter(  # noqa: D103
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture]
-) -> DataflowToSqlQueryPlanConverter:
+) -> DataflowToSqlPlanConverter:
     return mf_engine_test_fixture_mapping[SemanticManifestSetup.SCD_MANIFEST].dataflow_to_sql_converter

--- a/tests_metricflow/plan_conversion/dataflow_to_sql/test_conversion_metrics_to_sql.py
+++ b/tests_metricflow/plan_conversion/dataflow_to_sql/test_conversion_metrics_to_sql.py
@@ -12,7 +12,7 @@ from metricflow_semantics.test_helpers.config_helpers import MetricFlowTestConfi
 from metricflow_semantics.time.granularity import ExpandedTimeGranularity
 
 from metricflow.dataflow.builder.dataflow_plan_builder import DataflowPlanBuilder
-from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlQueryPlanConverter
+from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlPlanConverter
 from metricflow.protocols.sql_client import SqlClient
 from tests_metricflow.plan_conversion.test_dataflow_to_sql_plan import convert_and_check
 
@@ -22,7 +22,7 @@ def test_conversion_rate(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     """Test conversion metric data flow plan rendering."""
@@ -53,7 +53,7 @@ def test_conversion_rate_with_window(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     """Test conversion metric with a window data flow plan rendering."""
@@ -90,7 +90,7 @@ def test_conversion_rate_with_no_group_by(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     """Test conversion metric with no group by data flow plan rendering."""
@@ -116,7 +116,7 @@ def test_conversion_count_with_no_group_by(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     """Test conversion metric with no group by data flow plan rendering."""
@@ -142,7 +142,7 @@ def test_conversion_rate_with_constant_properties(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     """Test conversion metric with constant properties by data flow plan rendering."""
@@ -178,7 +178,7 @@ def test_conversion_metric_join_to_timespine_and_fill_nulls_with_0(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     """Test conversion metric that joins to time spine and fills nulls with 0."""

--- a/tests_metricflow/plan_conversion/dataflow_to_sql/test_cte_sql.py
+++ b/tests_metricflow/plan_conversion/dataflow_to_sql/test_cte_sql.py
@@ -21,7 +21,7 @@ from metricflow.dataflow.dataflow_plan import (
 )
 from metricflow.dataflow.dataflow_plan_analyzer import DataflowPlanAnalyzer
 from metricflow.dataflow.nodes.filter_elements import FilterElementsNode
-from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlQueryPlanConverter
+from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlPlanConverter
 from metricflow.sql.optimizer.optimization_levels import SqlGenerationOptionSet, SqlQueryOptimizationLevel
 from metricflow.sql.render.sql_plan_renderer import DefaultSqlQueryPlanRenderer
 from tests_metricflow.fixtures.manifest_fixtures import MetricFlowEngineTestFixture, SemanticManifestSetup
@@ -32,7 +32,7 @@ logger = logging.getLogger(__name__)
 def convert_and_check(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     node: DataflowPlanNode,
     nodes_to_convert_to_cte: FrozenSet[DataflowPlanNode],
 ) -> None:
@@ -81,7 +81,7 @@ def convert_and_check(
 def test_cte_for_simple_dataflow_plan(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
 ) -> None:
     """Test a simple case for generating a CTE for a specific dataflow plan node."""
@@ -114,7 +114,7 @@ def test_cte_for_shared_metrics(
     column_association_resolver: ColumnAssociationResolver,
     dataflow_plan_builder: DataflowPlanBuilder,
     query_parser: MetricFlowQueryParser,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
 ) -> None:
     """Check common branches in a query that uses derived metrics defined from metrics that are also in the query."""
     parse_result = query_parser.parse_and_validate_query(

--- a/tests_metricflow/plan_conversion/dataflow_to_sql/test_distinct_values_to_sql.py
+++ b/tests_metricflow/plan_conversion/dataflow_to_sql/test_distinct_values_to_sql.py
@@ -11,7 +11,7 @@ from metricflow_semantics.specs.query_spec import MetricFlowQuerySpec
 from metricflow_semantics.test_helpers.config_helpers import MetricFlowTestConfiguration
 
 from metricflow.dataflow.builder.dataflow_plan_builder import DataflowPlanBuilder
-from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlQueryPlanConverter
+from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlPlanConverter
 from metricflow.protocols.sql_client import SqlClient
 from tests_metricflow.plan_conversion.test_dataflow_to_sql_plan import convert_and_check
 
@@ -21,7 +21,7 @@ def test_dimensions_requiring_join(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     """Tests querying 2 dimensions that require a join."""
@@ -49,7 +49,7 @@ def test_dimension_values_with_a_join_and_a_filter(
     column_association_resolver: ColumnAssociationResolver,
     query_parser: MetricFlowQueryParser,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     """Tests querying 2 dimensions that require a join and a filter."""

--- a/tests_metricflow/plan_conversion/dataflow_to_sql/test_metric_time_dimension_to_sql.py
+++ b/tests_metricflow/plan_conversion/dataflow_to_sql/test_metric_time_dimension_to_sql.py
@@ -12,7 +12,7 @@ from metricflow_semantics.test_helpers.metric_time_dimension import MTD_SPEC_DAY
 
 from metricflow.dataflow.builder.dataflow_plan_builder import DataflowPlanBuilder
 from metricflow.dataflow.nodes.metric_time_transform import MetricTimeDimensionTransformNode
-from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlQueryPlanConverter
+from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlPlanConverter
 from metricflow.protocols.sql_client import SqlClient
 from tests_metricflow.fixtures.manifest_fixtures import MetricFlowEngineTestFixture, SemanticManifestSetup
 from tests_metricflow.plan_conversion.test_dataflow_to_sql_plan import convert_and_check
@@ -22,7 +22,7 @@ from tests_metricflow.plan_conversion.test_dataflow_to_sql_plan import convert_a
 def test_metric_time_dimension_transform_node_using_primary_time(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
     sql_client: SqlClient,
 ) -> None:
@@ -46,7 +46,7 @@ def test_metric_time_dimension_transform_node_using_primary_time(
 def test_metric_time_dimension_transform_node_using_non_primary_time(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
     sql_client: SqlClient,
 ) -> None:
@@ -71,7 +71,7 @@ def test_metric_time_dimension_transform_node_using_non_primary_time(
 def test_simple_query_with_metric_time_dimension(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
     sql_client: SqlClient,
     dataflow_plan_builder: DataflowPlanBuilder,

--- a/tests_metricflow/plan_conversion/test_dataflow_to_execution.py
+++ b/tests_metricflow/plan_conversion/test_dataflow_to_execution.py
@@ -13,7 +13,7 @@ from metricflow_semantics.test_helpers.config_helpers import MetricFlowTestConfi
 
 from metricflow.dataflow.builder.dataflow_plan_builder import DataflowPlanBuilder
 from metricflow.execution.dataflow_to_execution import DataflowToExecutionPlanConverter
-from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlQueryPlanConverter
+from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlPlanConverter
 from metricflow.protocols.sql_client import SqlClient
 from metricflow.sql.optimizer.optimization_levels import SqlQueryOptimizationLevel
 from metricflow.sql.render.sql_plan_renderer import DefaultSqlQueryPlanRenderer
@@ -25,7 +25,7 @@ def make_execution_plan_converter(  # noqa: D103
     sql_client: SqlClient,
 ) -> DataflowToExecutionPlanConverter:
     return DataflowToExecutionPlanConverter(
-        sql_plan_converter=DataflowToSqlQueryPlanConverter(
+        sql_plan_converter=DataflowToSqlPlanConverter(
             column_association_resolver=DunderColumnAssociationResolver(),
             semantic_manifest_lookup=semantic_manifest_lookup,
         ),

--- a/tests_metricflow/plan_conversion/test_dataflow_to_sql_plan.py
+++ b/tests_metricflow/plan_conversion/test_dataflow_to_sql_plan.py
@@ -47,7 +47,7 @@ from metricflow.dataflow.nodes.order_by_limit import OrderByLimitNode
 from metricflow.dataflow.nodes.semi_additive_join import SemiAdditiveJoinNode
 from metricflow.dataflow.nodes.where_filter import WhereConstraintNode
 from metricflow.dataflow.nodes.write_to_data_table import WriteToResultDataTableNode
-from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlQueryPlanConverter
+from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlPlanConverter
 from metricflow.protocols.sql_client import SqlClient
 from metricflow.sql.optimizer.optimization_levels import SqlQueryOptimizationLevel
 from tests_metricflow.dataflow_plan_to_svg import display_graph_if_requested
@@ -58,7 +58,7 @@ from tests_metricflow.sql.compare_sql_plan import assert_rendered_sql_from_plan_
 def convert_and_check(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
     node: DataflowPlanNode,
 ) -> None:
@@ -115,7 +115,7 @@ def convert_and_check(
 def test_source_node(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
     sql_client: SqlClient,
 ) -> None:
@@ -137,7 +137,7 @@ def test_source_node(
 def test_filter_node(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
     sql_client: SqlClient,
 ) -> None:
@@ -166,7 +166,7 @@ def test_filter_with_where_constraint_node(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     column_association_resolver: ColumnAssociationResolver,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
     sql_client: SqlClient,
 ) -> None:
@@ -233,7 +233,7 @@ def test_filter_with_where_constraint_node(
 def test_measure_aggregation_node(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
     sql_client: SqlClient,
 ) -> None:
@@ -281,7 +281,7 @@ def test_measure_aggregation_node(
 def test_single_join_node(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
     sql_client: SqlClient,
 ) -> None:
@@ -342,7 +342,7 @@ def test_single_join_node(
 def test_multi_join_node(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
     sql_client: SqlClient,
 ) -> None:
@@ -407,7 +407,7 @@ def test_multi_join_node(
 def test_compute_metrics_node(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
     sql_client: SqlClient,
 ) -> None:
@@ -480,7 +480,7 @@ def test_compute_metrics_node(
 def test_compute_metrics_node_simple_expr(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
     sql_client: SqlClient,
 ) -> None:
@@ -565,7 +565,7 @@ def test_compute_metrics_node_simple_expr(
 def test_compute_metrics_node_ratio_from_single_semantic_model(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
     sql_client: SqlClient,
 ) -> None:
@@ -641,7 +641,7 @@ def test_order_by_node(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     """Tests converting a dataflow plan to a SQL query plan where there is a leaf compute metrics node."""
@@ -711,7 +711,7 @@ def test_semi_additive_join_node(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     """Tests converting a dataflow plan to a SQL query plan using a SemiAdditiveJoinNode."""
@@ -742,7 +742,7 @@ def test_semi_additive_join_node_with_queried_group_by(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     """Tests converting a dataflow plan to a SQL query plan using a SemiAdditiveJoinNode."""
@@ -778,7 +778,7 @@ def test_semi_additive_join_node_with_grouping(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     """Tests converting a dataflow plan to a SQL query plan using a SemiAdditiveJoinNode with a window_grouping."""
@@ -813,7 +813,7 @@ def test_constrain_time_range_node(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     """Tests converting the ConstrainTimeRangeNode to SQL."""
@@ -864,7 +864,7 @@ def test_compute_metrics_node_ratio_from_multiple_semantic_models(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     """Tests the combine metrics node for ratio type metrics."""
@@ -899,7 +899,7 @@ def test_compute_metrics_node_ratio_from_multiple_semantic_models(
 def test_combine_output_node(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
     sql_client: SqlClient,
 ) -> None:
@@ -960,7 +960,7 @@ def test_dimensions_requiring_join(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     """Tests querying 2 dimensions that require a join."""
@@ -987,7 +987,7 @@ def test_dimension_with_joined_where_constraint(
     mf_test_configuration: MetricFlowTestConfiguration,
     query_parser: MetricFlowQueryParser,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
     column_association_resolver: ColumnAssociationResolver,
 ) -> None:

--- a/tests_metricflow/query_rendering/compare_rendered_query.py
+++ b/tests_metricflow/query_rendering/compare_rendered_query.py
@@ -9,7 +9,7 @@ from metricflow_semantics.test_helpers.config_helpers import MetricFlowTestConfi
 
 from metricflow.dataflow.builder.dataflow_plan_builder import DataflowPlanBuilder
 from metricflow.dataflow.optimizer.dataflow_optimizer_factory import DataflowPlanOptimization
-from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlQueryPlanConverter
+from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlPlanConverter
 from metricflow.protocols.sql_client import SqlClient
 from metricflow.sql.optimizer.optimization_levels import SqlQueryOptimizationLevel
 from tests_metricflow.dataflow_plan_to_svg import display_graph_if_requested
@@ -20,7 +20,7 @@ def render_and_check(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
     query_spec: MetricFlowQuerySpec,
 ) -> None:

--- a/tests_metricflow/query_rendering/test_conversion_metric_rendering.py
+++ b/tests_metricflow/query_rendering/test_conversion_metric_rendering.py
@@ -9,7 +9,7 @@ from metricflow_semantics.query.query_parser import MetricFlowQueryParser
 from metricflow_semantics.test_helpers.config_helpers import MetricFlowTestConfiguration
 
 from metricflow.dataflow.builder.dataflow_plan_builder import DataflowPlanBuilder
-from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlQueryPlanConverter
+from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlPlanConverter
 from metricflow.protocols.sql_client import SqlClient
 from tests_metricflow.query_rendering.compare_rendered_query import render_and_check
 
@@ -19,7 +19,7 @@ def test_conversion_metric(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
     query_parser: MetricFlowQueryParser,
     create_source_tables: bool,
@@ -48,7 +48,7 @@ def test_conversion_metric_with_window(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
     query_parser: MetricFlowQueryParser,
     create_source_tables: bool,
@@ -77,7 +77,7 @@ def test_conversion_metric_with_categorical_filter(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
     query_parser: MetricFlowQueryParser,
     create_source_tables: bool,
@@ -106,7 +106,7 @@ def test_conversion_metric_with_time_constraint(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
     query_parser: MetricFlowQueryParser,
     create_source_tables: bool,
@@ -137,7 +137,7 @@ def test_conversion_metric_with_window_and_time_constraint(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
     query_parser: MetricFlowQueryParser,
     create_source_tables: bool,
@@ -171,7 +171,7 @@ def test_conversion_metric_with_filter(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
     query_parser: MetricFlowQueryParser,
     create_source_tables: bool,
@@ -199,7 +199,7 @@ def test_conversion_metric_with_filter_not_in_group_by(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
     query_parser: MetricFlowQueryParser,
     create_source_tables: bool,
@@ -227,7 +227,7 @@ def test_conversion_metric_with_different_time_dimension_grains(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
     query_parser: MetricFlowQueryParser,
     create_source_tables: bool,

--- a/tests_metricflow/query_rendering/test_cumulative_metric_rendering.py
+++ b/tests_metricflow/query_rendering/test_cumulative_metric_rendering.py
@@ -28,7 +28,7 @@ from metricflow_semantics.test_helpers.metric_time_dimension import (
 from metricflow_semantics.time.granularity import ExpandedTimeGranularity
 
 from metricflow.dataflow.builder.dataflow_plan_builder import DataflowPlanBuilder
-from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlQueryPlanConverter
+from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlPlanConverter
 from metricflow.protocols.sql_client import SqlClient
 from tests_metricflow.fixtures.manifest_fixtures import MetricFlowEngineTestFixture, SemanticManifestSetup
 from tests_metricflow.query_rendering.compare_rendered_query import render_and_check
@@ -39,7 +39,7 @@ def test_cumulative_metric(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
     sql_client: SqlClient,
 ) -> None:
@@ -70,7 +70,7 @@ def test_cumulative_metric_with_time_constraint(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
     sql_client: SqlClient,
 ) -> None:
@@ -112,7 +112,7 @@ def test_cumulative_metric_with_non_adjustable_time_filter(
     column_association_resolver: ColumnAssociationResolver,
     query_parser: MetricFlowQueryParser,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
     sql_client: SqlClient,
 ) -> None:
@@ -150,7 +150,7 @@ def test_cumulative_metric_no_ds(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
     sql_client: SqlClient,
 ) -> None:
@@ -175,7 +175,7 @@ def test_cumulative_metric_no_window(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
     sql_client: SqlClient,
 ) -> None:
@@ -206,7 +206,7 @@ def test_cumulative_metric_no_window_with_time_constraint(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
     sql_client: SqlClient,
 ) -> None:
@@ -234,7 +234,7 @@ def test_cumulative_metric_grain_to_date(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
     sql_client: SqlClient,
 ) -> None:
@@ -266,7 +266,7 @@ def test_cumulative_metric_month(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     extended_date_dataflow_plan_builder: DataflowPlanBuilder,
-    extended_date_dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    extended_date_dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
     sql_client: SqlClient,
 ) -> None:
@@ -294,7 +294,7 @@ def test_cumulative_metric_with_agg_time_dimension(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
     sql_client: SqlClient,
 ) -> None:
@@ -321,7 +321,7 @@ def test_cumulative_metric_with_multiple_agg_time_dimensions(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
     sql_client: SqlClient,
 ) -> None:
@@ -357,7 +357,7 @@ def test_cumulative_metric_with_multiple_metric_time_dimensions(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
     sql_client: SqlClient,
 ) -> None:
@@ -382,7 +382,7 @@ def test_cumulative_metric_with_agg_time_and_metric_time(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
     sql_client: SqlClient,
 ) -> None:
@@ -414,7 +414,7 @@ def test_cumulative_metric_with_non_default_grain(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
     sql_client: SqlClient,
 ) -> None:
@@ -439,7 +439,7 @@ def test_window_metric_with_non_default_grain(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
     sql_client: SqlClient,
 ) -> None:
@@ -464,7 +464,7 @@ def test_grain_to_date_metric_with_non_default_grain(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
     sql_client: SqlClient,
 ) -> None:
@@ -489,7 +489,7 @@ def test_window_metric_with_non_default_grains(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
     sql_client: SqlClient,
 ) -> None:
@@ -524,7 +524,7 @@ def test_grain_to_date_metric_with_non_default_grains(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
     sql_client: SqlClient,
 ) -> None:
@@ -563,7 +563,7 @@ def test_all_time_metric_with_non_default_grains(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
     sql_client: SqlClient,
 ) -> None:
@@ -591,7 +591,7 @@ def test_derived_cumulative_metric_with_non_default_grains(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
     sql_client: SqlClient,
 ) -> None:

--- a/tests_metricflow/query_rendering/test_custom_granularity.py
+++ b/tests_metricflow/query_rendering/test_custom_granularity.py
@@ -20,7 +20,7 @@ from metricflow_semantics.test_helpers.metric_time_dimension import MTD_SPEC_DAY
 from metricflow_semantics.time.granularity import ExpandedTimeGranularity
 
 from metricflow.dataflow.builder.dataflow_plan_builder import DataflowPlanBuilder
-from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlQueryPlanConverter
+from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlPlanConverter
 from metricflow.protocols.sql_client import SqlClient
 from tests_metricflow.query_rendering.compare_rendered_query import render_and_check
 
@@ -47,7 +47,7 @@ def test_simple_metric_with_custom_granularity(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     query_spec = MetricFlowQuerySpec(
@@ -70,7 +70,7 @@ def test_cumulative_metric_with_custom_granularity(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     query_spec = MetricFlowQuerySpec(
@@ -93,7 +93,7 @@ def test_derived_metric_with_custom_granularity(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     query_spec = MetricFlowQuerySpec(
@@ -117,7 +117,7 @@ def test_multiple_metrics_with_custom_granularity(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     query_spec = MetricFlowQuerySpec(
@@ -141,7 +141,7 @@ def test_metric_custom_granularity_joined_to_non_default_grain(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     query_spec = MetricFlowQuerySpec(
@@ -171,7 +171,7 @@ def test_no_metric_custom_granularity_non_metric_time(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     query_spec = MetricFlowQuerySpec(
@@ -193,7 +193,7 @@ def test_no_metric_custom_granularity_joined_to_non_default_grain(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     query_spec = MetricFlowQuerySpec(
@@ -225,7 +225,7 @@ def test_no_metric_custom_granularity_metric_time(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     query_spec = MetricFlowQuerySpec(
@@ -247,7 +247,7 @@ def test_simple_metric_with_custom_granularity_and_join(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     query_spec = MetricFlowQuerySpec(
@@ -277,7 +277,7 @@ def test_simple_metric_with_custom_granularity_filter(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
     query_parser: MetricFlowQueryParser,
 ) -> None:
@@ -305,7 +305,7 @@ def test_simple_metric_with_custom_granularity_in_filter_and_group_by(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
     query_parser: MetricFlowQueryParser,
 ) -> None:
@@ -333,7 +333,7 @@ def test_no_metrics_with_custom_granularity_filter(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
     query_parser: MetricFlowQueryParser,
 ) -> None:
@@ -360,7 +360,7 @@ def test_no_metrics_with_custom_granularity_in_filter_and_group_by(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
     query_parser: MetricFlowQueryParser,
 ) -> None:
@@ -387,7 +387,7 @@ def test_simple_metric_with_multi_hop_custom_granularity(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
     query_parser: MetricFlowQueryParser,
 ) -> None:
@@ -412,7 +412,7 @@ def test_offset_metric_with_custom_granularity(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     query_spec = MetricFlowQuerySpec(
@@ -435,7 +435,7 @@ def test_offset_metric_with_custom_granularity_filter_not_in_group_by(  # noqa: 
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
     query_parser: MetricFlowQueryParser,
 ) -> None:
@@ -462,7 +462,7 @@ def test_conversion_metric_with_custom_granularity(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
     query_parser: MetricFlowQueryParser,
 ) -> None:
@@ -486,7 +486,7 @@ def test_conversion_metric_with_custom_granularity_filter(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
     query_parser: MetricFlowQueryParser,
 ) -> None:
@@ -513,7 +513,7 @@ def test_conversion_metric_with_custom_granularity_filter_not_in_group_by(  # no
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
     query_parser: MetricFlowQueryParser,
 ) -> None:
@@ -539,7 +539,7 @@ def test_join_to_time_spine_metric_grouped_by_custom_grain(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
     query_parser: MetricFlowQueryParser,
 ) -> None:
@@ -563,7 +563,7 @@ def test_join_to_timespine_metric_with_custom_granularity_filter(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
     query_parser: MetricFlowQueryParser,
 ) -> None:
@@ -590,7 +590,7 @@ def test_join_to_timespine_metric_with_custom_granularity_filter_not_in_group_by
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
     query_parser: MetricFlowQueryParser,
 ) -> None:

--- a/tests_metricflow/query_rendering/test_derived_metric_rendering.py
+++ b/tests_metricflow/query_rendering/test_derived_metric_rendering.py
@@ -24,7 +24,7 @@ from metricflow_semantics.test_helpers.metric_time_dimension import (
 )
 
 from metricflow.dataflow.builder.dataflow_plan_builder import DataflowPlanBuilder
-from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlQueryPlanConverter
+from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlPlanConverter
 from metricflow.protocols.sql_client import SqlClient
 from tests_metricflow.query_rendering.compare_rendered_query import render_and_check
 
@@ -34,7 +34,7 @@ def test_derived_metric(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     query_spec = MetricFlowQuerySpec(
@@ -57,7 +57,7 @@ def test_nested_derived_metric(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     query_spec = MetricFlowQuerySpec(
@@ -80,7 +80,7 @@ def test_derived_metric_with_offset_window(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     query_spec = MetricFlowQuerySpec(
@@ -105,7 +105,7 @@ def test_derived_metric_with_offset_window_and_time_filter(  # noqa: D103
     column_association_resolver: ColumnAssociationResolver,
     query_parser: MetricFlowQueryParser,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     query_spec = query_parser.parse_and_validate_query(
@@ -136,7 +136,7 @@ def test_derived_metric_with_offset_to_grain(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     query_spec = MetricFlowQuerySpec(
@@ -159,7 +159,7 @@ def test_derived_metric_with_offset_window_and_offset_to_grain(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     query_spec = MetricFlowQuerySpec(
@@ -182,7 +182,7 @@ def test_derived_offset_metric_with_one_input_metric(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     query_spec = MetricFlowQuerySpec(
@@ -205,7 +205,7 @@ def test_derived_metric_with_offset_window_and_granularity(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     query_spec = MetricFlowQuerySpec(
@@ -228,7 +228,7 @@ def test_derived_metric_with_month_dimension_and_offset_window(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     extended_date_dataflow_plan_builder: DataflowPlanBuilder,
-    extended_date_dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    extended_date_dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     query_spec = MetricFlowQuerySpec(
@@ -251,7 +251,7 @@ def test_derived_metric_with_offset_to_grain_and_granularity(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     query_spec = MetricFlowQuerySpec(
@@ -274,7 +274,7 @@ def test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity( 
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     query_spec = MetricFlowQuerySpec(
@@ -297,7 +297,7 @@ def test_derived_offset_cumulative_metric(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     query_spec = MetricFlowQuerySpec(
@@ -320,7 +320,7 @@ def test_nested_offsets(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
     create_source_tables: bool,
 ) -> None:
@@ -344,7 +344,7 @@ def test_nested_derived_metric_with_offset_multiple_input_metrics(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
     create_source_tables: bool,
 ) -> None:
@@ -369,7 +369,7 @@ def test_nested_offsets_with_where_constraint(  # noqa: D103
     mf_test_configuration: MetricFlowTestConfiguration,
     query_parser: MetricFlowQueryParser,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
     column_association_resolver: ColumnAssociationResolver,
     create_source_tables: bool,
@@ -402,7 +402,7 @@ def test_nested_offsets_with_time_constraint(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
     create_source_tables: bool,
 ) -> None:
@@ -429,7 +429,7 @@ def test_time_offset_metric_with_time_constraint(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
     create_source_tables: bool,
 ) -> None:
@@ -457,7 +457,7 @@ def test_nested_filters(
     mf_test_configuration: MetricFlowTestConfiguration,
     query_parser: MetricFlowQueryParser,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
     create_source_tables: bool,
 ) -> None:
@@ -479,7 +479,7 @@ def test_cumulative_time_offset_metric_with_time_constraint(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
     create_source_tables: bool,
 ) -> None:
@@ -507,7 +507,7 @@ def test_nested_derived_metric_offset_with_joined_where_constraint_not_selected(
     mf_test_configuration: MetricFlowTestConfiguration,
     query_parser: MetricFlowQueryParser,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
     create_source_tables: bool,
     column_association_resolver: ColumnAssociationResolver,
@@ -537,7 +537,7 @@ def test_offset_window_with_agg_time_dim(  # noqa: D103
     mf_test_configuration: MetricFlowTestConfiguration,
     query_parser: MetricFlowQueryParser,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
     create_source_tables: bool,
     column_association_resolver: ColumnAssociationResolver,
@@ -563,7 +563,7 @@ def test_offset_to_grain_with_agg_time_dim(  # noqa: D103
     mf_test_configuration: MetricFlowTestConfiguration,
     query_parser: MetricFlowQueryParser,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
     create_source_tables: bool,
     column_association_resolver: ColumnAssociationResolver,
@@ -589,7 +589,7 @@ def test_derived_offset_metric_with_agg_time_dim(  # noqa: D103
     mf_test_configuration: MetricFlowTestConfiguration,
     query_parser: MetricFlowQueryParser,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
     create_source_tables: bool,
     column_association_resolver: ColumnAssociationResolver,
@@ -614,7 +614,7 @@ def test_multi_metric_fill_null(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
     create_source_tables: bool,
 ) -> None:
@@ -641,7 +641,7 @@ def test_nested_fill_nulls_without_time_spine(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
     create_source_tables: bool,
 ) -> None:
@@ -665,7 +665,7 @@ def test_nested_fill_nulls_without_time_spine_multi_metric(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
     create_source_tables: bool,
 ) -> None:
@@ -692,7 +692,7 @@ def test_offset_window_metric_multiple_granularities(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
     query_parser: MetricFlowQueryParser,
     create_source_tables: bool,
@@ -718,7 +718,7 @@ def test_offset_to_grain_metric_multiple_granularities(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
     query_parser: MetricFlowQueryParser,
     create_source_tables: bool,
@@ -744,7 +744,7 @@ def test_offset_window_metric_filter_and_query_have_different_granularities(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
     query_parser: MetricFlowQueryParser,
     create_source_tables: bool,
@@ -773,7 +773,7 @@ def test_offset_to_grain_metric_filter_and_query_have_different_granularities(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
     query_parser: MetricFlowQueryParser,
     create_source_tables: bool,
@@ -804,7 +804,7 @@ def test_derived_metric_that_defines_the_same_alias_in_different_components(
     dataflow_plan_builder: DataflowPlanBuilder,
     query_parser: MetricFlowQueryParser,
     sql_client: SqlClient,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
 ) -> None:
     """Tests querying a derived metric which give the same alias to its components."""
     query_spec = query_parser.parse_and_validate_query(

--- a/tests_metricflow/query_rendering/test_fill_nulls_with_rendering.py
+++ b/tests_metricflow/query_rendering/test_fill_nulls_with_rendering.py
@@ -19,7 +19,7 @@ from metricflow_semantics.test_helpers.config_helpers import MetricFlowTestConfi
 from metricflow_semantics.test_helpers.metric_time_dimension import MTD_SPEC_DAY, MTD_SPEC_MONTH
 
 from metricflow.dataflow.builder.dataflow_plan_builder import DataflowPlanBuilder
-from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlQueryPlanConverter
+from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlPlanConverter
 from metricflow.protocols.sql_client import SqlClient
 from tests_metricflow.query_rendering.compare_rendered_query import render_and_check
 
@@ -29,7 +29,7 @@ def test_simple_fill_nulls_with_0_metric_time(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     query_spec = MetricFlowQuerySpec(
@@ -52,7 +52,7 @@ def test_simple_fill_nulls_with_0_month(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     query_spec = MetricFlowQuerySpec(
@@ -75,7 +75,7 @@ def test_simple_fill_nulls_with_0_with_non_metric_time(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     query_spec = MetricFlowQuerySpec(
@@ -98,7 +98,7 @@ def test_simple_fill_nulls_with_0_with_categorical_dimension(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     query_spec = MetricFlowQuerySpec(
@@ -121,7 +121,7 @@ def test_simple_fill_nulls_without_time_spine(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     query_spec = MetricFlowQuerySpec(
@@ -144,7 +144,7 @@ def test_cumulative_fill_nulls(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     query_spec = MetricFlowQuerySpec(
@@ -167,7 +167,7 @@ def test_derived_fill_nulls_for_one_input_metric(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     query_spec = MetricFlowQuerySpec(
@@ -190,7 +190,7 @@ def test_join_to_time_spine_with_filters(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
     query_parser: MetricFlowQueryParser,
 ) -> None:
@@ -221,7 +221,7 @@ def test_join_to_time_spine_with_filter_not_in_group_by(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
     query_parser: MetricFlowQueryParser,
 ) -> None:
@@ -248,7 +248,7 @@ def test_join_to_time_spine_with_filter_smaller_than_group_by(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
     query_parser: MetricFlowQueryParser,
 ) -> None:
@@ -278,7 +278,7 @@ def test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time(  # noqa:
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
     query_parser: MetricFlowQueryParser,
 ) -> None:
@@ -305,7 +305,7 @@ def test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time_and_metri
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
     query_parser: MetricFlowQueryParser,
 ) -> None:

--- a/tests_metricflow/query_rendering/test_granularity_date_part_rendering.py
+++ b/tests_metricflow/query_rendering/test_granularity_date_part_rendering.py
@@ -22,7 +22,7 @@ from metricflow_semantics.time.granularity import ExpandedTimeGranularity
 
 from metricflow.dataflow.builder.dataflow_plan_builder import DataflowPlanBuilder
 from metricflow.dataset.dataset_classes import DataSet
-from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlQueryPlanConverter
+from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlPlanConverter
 from metricflow.protocols.sql_client import SqlClient
 from tests_metricflow.query_rendering.compare_rendered_query import render_and_check
 
@@ -32,7 +32,7 @@ def test_simple_query_with_date_part(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     query_spec = MetricFlowQuerySpec(
@@ -60,7 +60,7 @@ def test_simple_query_with_multiple_date_parts(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     query_spec = MetricFlowQuerySpec(
@@ -108,7 +108,7 @@ def test_offset_window_with_date_part(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     query_spec = MetricFlowQuerySpec(
@@ -136,7 +136,7 @@ def test_sub_daily_metric_time(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     query_spec = MetricFlowQuerySpec(
@@ -162,7 +162,7 @@ def test_sub_daily_dimension(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     query_spec = MetricFlowQuerySpec(
@@ -190,7 +190,7 @@ def test_simple_metric_with_sub_daily_dimension(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     query_spec = MetricFlowQuerySpec(
@@ -219,7 +219,7 @@ def test_simple_metric_with_joined_sub_daily_dimension(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     query_spec = MetricFlowQuerySpec(
@@ -251,7 +251,7 @@ def test_subdaily_cumulative_window_metric(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     query_spec = MetricFlowQuerySpec(
@@ -278,7 +278,7 @@ def test_subdaily_cumulative_grain_to_date_metric(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     query_spec = MetricFlowQuerySpec(
@@ -305,7 +305,7 @@ def test_subdaily_offset_window_metric(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     query_spec = MetricFlowQuerySpec(
@@ -332,7 +332,7 @@ def test_subdaily_offset_to_grain_metric(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     query_spec = MetricFlowQuerySpec(
@@ -359,7 +359,7 @@ def test_subdaily_join_to_time_spine_metric(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     query_spec = MetricFlowQuerySpec(
@@ -386,7 +386,7 @@ def test_subdaily_time_constraint_without_metrics(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     query_spec = MetricFlowQuerySpec(
@@ -415,7 +415,7 @@ def test_subdaily_time_constraint_with_metric(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     query_spec = MetricFlowQuerySpec(
@@ -445,7 +445,7 @@ def test_subdaily_granularity_overrides_metric_default_granularity(  # noqa: D10
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     query_spec = MetricFlowQuerySpec(

--- a/tests_metricflow/query_rendering/test_metric_filter_rendering.py
+++ b/tests_metricflow/query_rendering/test_metric_filter_rendering.py
@@ -7,7 +7,7 @@ from metricflow_semantics.query.query_parser import MetricFlowQueryParser
 from metricflow_semantics.test_helpers.config_helpers import MetricFlowTestConfiguration
 
 from metricflow.dataflow.builder.dataflow_plan_builder import DataflowPlanBuilder
-from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlQueryPlanConverter
+from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlPlanConverter
 from metricflow.protocols.sql_client import SqlClient
 from tests_metricflow.query_rendering.compare_rendered_query import render_and_check
 
@@ -18,7 +18,7 @@ def test_query_with_simple_metric_in_where_filter(
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     sql_client: SqlClient,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     query_parser: MetricFlowQueryParser,
 ) -> None:
     """Tests a query with a simple metric in the query-level where filter."""
@@ -47,7 +47,7 @@ def test_metric_with_metric_in_where_filter(
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     sql_client: SqlClient,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     query_parser: MetricFlowQueryParser,
 ) -> None:
     """Tests a query with a metric in the metric-level where filter."""
@@ -72,7 +72,7 @@ def test_query_with_derived_metric_in_where_filter(
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     sql_client: SqlClient,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     query_parser: MetricFlowQueryParser,
 ) -> None:
     """Tests a query with a derived metric in the query-level where filter."""
@@ -101,7 +101,7 @@ def test_query_with_ratio_metric_in_where_filter(
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     sql_client: SqlClient,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     query_parser: MetricFlowQueryParser,
 ) -> None:
     """Tests a query with a ratio metric in the query-level where filter."""
@@ -130,7 +130,7 @@ def test_query_with_cumulative_metric_in_where_filter(
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     sql_client: SqlClient,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     query_parser: MetricFlowQueryParser,
 ) -> None:
     """Tests a query with a cumulative metric in the query-level where filter.
@@ -162,7 +162,7 @@ def test_query_with_multiple_metrics_in_filter(
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     sql_client: SqlClient,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     query_parser: MetricFlowQueryParser,
 ) -> None:
     """Tests a query with 2 simple metrics in the query-level where filter."""
@@ -191,7 +191,7 @@ def test_filter_by_metric_in_same_semantic_model_as_queried_metric(
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     sql_client: SqlClient,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     query_parser: MetricFlowQueryParser,
 ) -> None:
     """Tests a query with a simple metric in the query-level where filter."""
@@ -220,7 +220,7 @@ def test_distinct_values_query_with_metric_filter(
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     sql_client: SqlClient,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     query_parser: MetricFlowQueryParser,
 ) -> None:
     """Tests a distinct values query with a metric in the query-level where filter."""
@@ -249,7 +249,7 @@ def test_metric_filtered_by_itself(
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     sql_client: SqlClient,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     query_parser: MetricFlowQueryParser,
 ) -> None:
     """Tests a query for a metric that filters by the same metric."""
@@ -278,7 +278,7 @@ def test_group_by_has_local_entity_prefix(  # noqa: D103
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     sql_client: SqlClient,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     query_parser: MetricFlowQueryParser,
 ) -> None:
     query_spec = query_parser.parse_and_validate_query(
@@ -306,7 +306,7 @@ def test_filter_with_conversion_metric(  # noqa: D103
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     sql_client: SqlClient,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     query_parser: MetricFlowQueryParser,
 ) -> None:
     query_spec = query_parser.parse_and_validate_query(
@@ -334,7 +334,7 @@ def test_inner_query_single_hop(
     mf_test_configuration: MetricFlowTestConfiguration,
     multihop_dataflow_plan_builder: DataflowPlanBuilder,
     sql_client: SqlClient,
-    multihop_dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    multihop_dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     multihop_query_parser: MetricFlowQueryParser,
 ) -> None:
     """Tests rendering for a metric filter using a one-hop join in the inner query."""
@@ -363,7 +363,7 @@ def test_inner_query_multi_hop(
     mf_test_configuration: MetricFlowTestConfiguration,
     multihop_dataflow_plan_builder: DataflowPlanBuilder,
     sql_client: SqlClient,
-    multihop_dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    multihop_dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     multihop_query_parser: MetricFlowQueryParser,
 ) -> None:
     """Tests rendering for a metric filter using a two-hop join in the inner query."""

--- a/tests_metricflow/query_rendering/test_metric_time_without_metrics.py
+++ b/tests_metricflow/query_rendering/test_metric_time_without_metrics.py
@@ -15,7 +15,7 @@ from metricflow_semantics.test_helpers.metric_time_dimension import MTD_SPEC_DAY
 from metricflow_semantics.time.granularity import ExpandedTimeGranularity
 
 from metricflow.dataflow.builder.dataflow_plan_builder import DataflowPlanBuilder
-from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlQueryPlanConverter
+from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlPlanConverter
 from metricflow.protocols.sql_client import SqlClient
 from tests_metricflow.plan_conversion.test_dataflow_to_sql_plan import convert_and_check
 
@@ -25,7 +25,7 @@ def test_metric_time_only(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     """Tests querying only metric time."""
@@ -49,7 +49,7 @@ def test_metric_time_quarter_alone(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     dataflow_plan = dataflow_plan_builder.build_plan_for_distinct_values(
@@ -78,7 +78,7 @@ def test_metric_time_with_other_dimensions(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     dataflow_plan = dataflow_plan_builder.build_plan_for_distinct_values(
@@ -105,7 +105,7 @@ def test_dimensions_with_time_constraint(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     dataflow_plan = dataflow_plan_builder.build_plan_for_distinct_values(

--- a/tests_metricflow/query_rendering/test_predicate_pushdown_rendering.py
+++ b/tests_metricflow/query_rendering/test_predicate_pushdown_rendering.py
@@ -8,7 +8,7 @@ from metricflow_semantics.specs.query_param_implementations import SavedQueryPar
 from metricflow_semantics.test_helpers.config_helpers import MetricFlowTestConfiguration
 
 from metricflow.dataflow.builder.dataflow_plan_builder import DataflowPlanBuilder
-from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlQueryPlanConverter
+from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlPlanConverter
 from metricflow.protocols.sql_client import SqlClient
 from tests_metricflow.query_rendering.compare_rendered_query import render_and_check
 
@@ -19,7 +19,7 @@ def test_single_categorical_dimension_pushdown(
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     query_parser: MetricFlowQueryParser,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     """Tests rendering a query where we expect predicate pushdown for a single categorical dimension."""
@@ -49,7 +49,7 @@ def test_multiple_categorical_dimension_pushdown(
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     query_parser: MetricFlowQueryParser,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     """Tests rendering a query where we expect predicate pushdown for more than one categorical dimension."""
@@ -79,7 +79,7 @@ def test_different_filters_on_same_measure_source_categorical_dimension(
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     query_parser: MetricFlowQueryParser,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     """Tests rendering a query where multiple filters against the same measure dimension need to be an effective OR.
@@ -113,7 +113,7 @@ def test_skipped_pushdown(
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     query_parser: MetricFlowQueryParser,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     """Tests rendering a query where we expect to skip predicate pushdown because it is unsafe.
@@ -149,7 +149,7 @@ def test_metric_time_filter_with_two_targets(
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     query_parser: MetricFlowQueryParser,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     """Tests pushdown optimization for a simple metric time predicate through a single join.
@@ -180,7 +180,7 @@ def test_conversion_metric_query_filters(
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     query_parser: MetricFlowQueryParser,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     """Tests pushdown optimizer behavior for a simple predicate on a conversion metric."""
@@ -206,7 +206,7 @@ def test_cumulative_metric_with_query_time_filters(
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     query_parser: MetricFlowQueryParser,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     """Tests pushdown optimizer behavior for a query against a cumulative metric.
@@ -235,7 +235,7 @@ def test_offset_metric_with_query_time_filters(
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     query_parser: MetricFlowQueryParser,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     """Tests pushdown optimizer behavior for a query against a derived offset metric.
@@ -264,7 +264,7 @@ def test_fill_nulls_time_spine_metric_predicate_pushdown(
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     query_parser: MetricFlowQueryParser,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     """Tests pushdown optimizer behavior for a metric with a time spine and fill_nulls_with enabled.
@@ -293,7 +293,7 @@ def test_simple_join_to_time_spine_pushdown_filter_application(
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     query_parser: MetricFlowQueryParser,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     """Tests rendering a query where we join to a time spine and query the filter input.
@@ -326,7 +326,7 @@ def test_saved_query_with_metric_joins_and_filter(
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     query_parser: MetricFlowQueryParser,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     """Tests rendering a query where we join to a time spine and query the filter input.

--- a/tests_metricflow/query_rendering/test_query_rendering.py
+++ b/tests_metricflow/query_rendering/test_query_rendering.py
@@ -31,7 +31,7 @@ from metricflow_semantics.test_helpers.metric_time_dimension import MTD_SPEC_DAY
 from metricflow_semantics.time.granularity import ExpandedTimeGranularity
 
 from metricflow.dataflow.builder.dataflow_plan_builder import DataflowPlanBuilder
-from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlQueryPlanConverter
+from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlPlanConverter
 from metricflow.protocols.sql_client import SqlClient
 from tests_metricflow.query_rendering.compare_rendered_query import render_and_check
 
@@ -41,7 +41,7 @@ def test_multihop_node(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     multihop_dataflow_plan_builder: DataflowPlanBuilder,
-    multihop_dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    multihop_dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     """Tests converting a dataflow plan to a SQL query plan where there is a join between 1 measure and 2 dimensions."""
@@ -74,7 +74,7 @@ def test_filter_with_where_constraint_on_join_dim(
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     query_parser: MetricFlowQueryParser,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     """Tests converting a dataflow plan to a SQL query plan where there is a join between 1 measure and 2 dimensions."""
@@ -103,7 +103,7 @@ def test_partitioned_join(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     """Tests converting a dataflow plan where there's a join on a partitioned dimension."""
@@ -132,7 +132,7 @@ def test_limit_rows(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     """Tests a plan with a limit to the number of rows returned."""
@@ -163,7 +163,7 @@ def test_distinct_values(
     mf_test_configuration: MetricFlowTestConfiguration,
     query_parser: MetricFlowQueryParser,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     column_association_resolver: ColumnAssociationResolver,
     sql_client: SqlClient,
 ) -> None:
@@ -194,7 +194,7 @@ def test_local_dimension_using_local_entity(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     query_spec = MetricFlowQuerySpec(
@@ -223,7 +223,7 @@ def test_measure_constraint(  # noqa: D103
     mf_test_configuration: MetricFlowTestConfiguration,
     query_parser: MetricFlowQueryParser,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     query_spec = query_parser.parse_and_validate_query(
@@ -247,7 +247,7 @@ def test_measure_constraint_with_reused_measure(  # noqa: D103
     mf_test_configuration: MetricFlowTestConfiguration,
     query_parser: MetricFlowQueryParser,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     query_spec = query_parser.parse_and_validate_query(
@@ -271,7 +271,7 @@ def test_measure_constraint_with_single_expr_and_alias(  # noqa: D103
     mf_test_configuration: MetricFlowTestConfiguration,
     query_parser: MetricFlowQueryParser,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     query_spec = query_parser.parse_and_validate_query(
@@ -296,7 +296,7 @@ def test_join_to_scd_dimension(
     scd_column_association_resolver: ColumnAssociationResolver,
     scd_query_parser: MetricFlowQueryParser,
     scd_dataflow_plan_builder: DataflowPlanBuilder,
-    scd_dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    scd_dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     """Tests conversion of a plan using a dimension with a validity window inside a measure constraint."""
@@ -325,7 +325,7 @@ def test_multi_hop_through_scd_dimension(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     scd_dataflow_plan_builder: DataflowPlanBuilder,
-    scd_dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    scd_dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     """Tests conversion of a plan using a dimension that is reached through an SCD table."""
@@ -354,7 +354,7 @@ def test_multi_hop_to_scd_dimension(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     scd_dataflow_plan_builder: DataflowPlanBuilder,
-    scd_dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    scd_dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     """Tests conversion of a plan using an SCD dimension that is reached through another table."""
@@ -384,7 +384,7 @@ def test_multiple_metrics_no_dimensions(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     query_spec = MetricFlowQuerySpec(
@@ -409,7 +409,7 @@ def test_metric_with_measures_from_multiple_sources_no_dimensions(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     query_spec = MetricFlowQuerySpec(
@@ -431,7 +431,7 @@ def test_common_semantic_model(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     query_spec = MetricFlowQuerySpec(
@@ -454,7 +454,7 @@ def test_min_max_only_categorical(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     """Tests a min max only query with a categorical dimension."""
@@ -483,7 +483,7 @@ def test_min_max_only_time(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     """Tests a min max only query with a time dimension."""
@@ -513,7 +513,7 @@ def test_min_max_only_time_quarter(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     """Tests a min max only query with a time dimension and non-default granularity."""
@@ -544,7 +544,7 @@ def test_min_max_metric_time(
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     sql_client: SqlClient,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
 ) -> None:
     """Tests a plan to get the min & max distinct values of metric_time."""
     query_spec = MetricFlowQuerySpec(
@@ -568,7 +568,7 @@ def test_min_max_metric_time_week(
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     sql_client: SqlClient,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
 ) -> None:
     """Tests a plan to get the min & max distinct values of metric_time with non-default granularity."""
     query_spec = MetricFlowQuerySpec(
@@ -592,7 +592,7 @@ def test_non_additive_dimension_with_non_default_grain(
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     sql_client: SqlClient,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
 ) -> None:
     """Tests querying a metric with a non-additive agg_time_dimension that has non-default granularity."""
     query_spec = MetricFlowQuerySpec(
@@ -617,7 +617,7 @@ def test_metric_alias(
     dataflow_plan_builder: DataflowPlanBuilder,
     sql_client: SqlClient,
     query_parser: MetricFlowQueryParser,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
 ) -> None:
     """Tests a plan with an aliased metric."""
     metric = MetricParameter(name="bookings", alias="bookings_alias")
@@ -647,7 +647,7 @@ def test_derived_metric_alias(
     dataflow_plan_builder: DataflowPlanBuilder,
     sql_client: SqlClient,
     query_parser: MetricFlowQueryParser,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
 ) -> None:
     """Tests a plan with an aliased metric."""
     metric = MetricParameter(name="booking_fees", alias="bookings_alias")

--- a/tests_metricflow/query_rendering/test_time_spine_join_rendering.py
+++ b/tests_metricflow/query_rendering/test_time_spine_join_rendering.py
@@ -20,7 +20,7 @@ from metricflow_semantics.test_helpers.config_helpers import MetricFlowTestConfi
 from metricflow_semantics.test_helpers.metric_time_dimension import MTD_SPEC_DAY
 
 from metricflow.dataflow.builder.dataflow_plan_builder import DataflowPlanBuilder
-from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlQueryPlanConverter
+from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlPlanConverter
 from metricflow.protocols.sql_client import SqlClient
 from tests_metricflow.query_rendering.compare_rendered_query import render_and_check
 
@@ -30,7 +30,7 @@ def test_simple_join_to_time_spine(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     query_spec = MetricFlowQuerySpec(
@@ -53,7 +53,7 @@ def test_simple_join_to_time_spine_with_filter(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
     query_parser: MetricFlowQueryParser,
 ) -> None:
@@ -79,7 +79,7 @@ def test_simple_join_to_time_spine_with_queried_filter(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
     query_parser: MetricFlowQueryParser,
 ) -> None:
@@ -106,7 +106,7 @@ def test_join_to_time_spine_with_time_constraint(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
     query_parser: MetricFlowQueryParser,
 ) -> None:
@@ -132,7 +132,7 @@ def test_join_to_time_spine_with_queried_time_constraint(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
     query_parser: MetricFlowQueryParser,
 ) -> None:
@@ -159,7 +159,7 @@ def test_join_to_time_spine_with_input_measure_constraint(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
     query_parser: MetricFlowQueryParser,
 ) -> None:

--- a/tests_metricflow/sql/compare_sql_plan.py
+++ b/tests_metricflow/sql/compare_sql_plan.py
@@ -11,7 +11,7 @@ from metricflow_semantics.test_helpers.snapshot_helpers import (
 
 from metricflow.protocols.sql_client import SqlClient
 from metricflow.sql.render.sql_plan_renderer import DefaultSqlQueryPlanRenderer
-from metricflow.sql.sql_plan import SqlPlan, SqlQueryPlanNode
+from metricflow.sql.sql_plan import SqlPlan, SqlPlanNode
 from tests_metricflow.fixtures.setup_fixtures import check_sql_engine_snapshot_marker
 from tests_metricflow.snapshot_utils import (
     _EXCLUDE_TABLE_ALIAS_REGEX,
@@ -23,7 +23,7 @@ def assert_default_rendered_sql_equal(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     plan_id: str,
-    sql_plan_node: SqlQueryPlanNode,
+    sql_plan_node: SqlPlanNode,
 ) -> None:
     """Helper function to render a select statement and compare with the one saved as a file."""
     sql_query_plan = SqlPlan(render_node=sql_plan_node, plan_id=DagId.from_str(plan_id))
@@ -45,7 +45,7 @@ def assert_rendered_sql_equal(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     plan_id: str,
-    sql_plan_node: SqlQueryPlanNode,
+    sql_plan_node: SqlPlanNode,
     sql_client: SqlClient,
 ) -> None:
     """Helper function to render a select statement and compare with the one saved as a file."""

--- a/tests_metricflow/sql/optimizer/check_optimizer.py
+++ b/tests_metricflow/sql/optimizer/check_optimizer.py
@@ -8,7 +8,7 @@ from metricflow_semantics.mf_logging.lazy_formattable import LazyFormat
 from metricflow_semantics.test_helpers.config_helpers import MetricFlowTestConfiguration
 from metricflow_semantics.test_helpers.snapshot_helpers import assert_str_snapshot_equal
 
-from metricflow.sql.optimizer.sql_query_plan_optimizer import SqlQueryPlanOptimizer
+from metricflow.sql.optimizer.sql_query_plan_optimizer import SqlPlanOptimizer
 from metricflow.sql.render.sql_plan_renderer import SqlQueryPlanRenderer
 from metricflow.sql.sql_plan import SqlPlan, SqlSelectStatementNode
 
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 def assert_optimizer_result_snapshot_equal(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
-    optimizer: SqlQueryPlanOptimizer,
+    optimizer: SqlPlanOptimizer,
     sql_plan_renderer: SqlQueryPlanRenderer,
     select_statement: SqlSelectStatementNode,
 ) -> None:

--- a/tests_metricflow/sql/optimizer/test_column_pruner.py
+++ b/tests_metricflow/sql/optimizer/test_column_pruner.py
@@ -21,7 +21,7 @@ from metricflow.sql.optimizer.column_pruner import SqlColumnPrunerOptimizer
 from metricflow.sql.render.sql_plan_renderer import DefaultSqlQueryPlanRenderer, SqlQueryPlanRenderer
 from metricflow.sql.sql_plan import (
     SqlJoinDescription,
-    SqlQueryPlanNode,
+    SqlPlanNode,
     SqlSelectColumn,
     SqlSelectStatementNode,
     SqlTableNode,
@@ -714,7 +714,7 @@ def test_prune_grandparents(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     column_pruner: SqlColumnPrunerOptimizer,
-    grandparent_pruning_select_statement: SqlQueryPlanNode,
+    grandparent_pruning_select_statement: SqlPlanNode,
 ) -> None:
     """Tests a case where a string expr in a node prevents the parent from being pruned, but prunes grandparents."""
     assert_default_rendered_sql_equal(


### PR DESCRIPTION
This PR renames a few symbols related to the recent rename from `SqlQueryPlan` to `SqlPlan`.