### PR TITLE
Renames related to `SqlPlan` - Part 2

### DIFF
--- a/metricflow-semantics/metricflow_semantics/dag/id_prefix.py
+++ b/metricflow-semantics/metricflow_semantics/dag/id_prefix.py
@@ -99,7 +99,7 @@ class StaticIdPrefix(IdPrefix, Enum, metaclass=EnumMetaClassHelper):
     DATAFLOW_PLAN_PREFIX = "dfp"
     DATAFLOW_PLAN_SUBGRAPH_PREFIX = "dfpsub"
     OPTIMIZED_DATAFLOW_PLAN_PREFIX = "dfpo"
-    SQL_QUERY_PLAN_PREFIX = "sqp"
+    SQL_PLAN_PREFIX = "sqp"
     EXEC_PLAN_PREFIX = "ep"
 
     MF_DAG = "mfd"

--- a/metricflow/engine/metricflow_engine.py
+++ b/metricflow/engine/metricflow_engine.py
@@ -55,7 +55,7 @@ from metricflow.execution.execution_plan import ExecutionPlan, SqlStatement
 from metricflow.execution.executor import SequentialPlanExecutor
 from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlPlanConverter
 from metricflow.protocols.sql_client import SqlClient
-from metricflow.sql.optimizer.optimization_levels import SqlQueryOptimizationLevel
+from metricflow.sql.optimizer.optimization_levels import SqlOptimizationLevel
 from metricflow.telemetry.models import TelemetryLevel
 from metricflow.telemetry.reporter import TelemetryReporter, log_call
 
@@ -112,7 +112,7 @@ class MetricFlowQueryRequest:
     order_by_names: Optional[Sequence[str]]
     order_by: Optional[Sequence[OrderByQueryParameter]]
     min_max_only: bool
-    sql_optimization_level: SqlQueryOptimizationLevel
+    sql_optimization_level: SqlOptimizationLevel
     dataflow_plan_optimizations: FrozenSet[DataflowPlanOptimization]
     query_type: MetricFlowQueryType
 
@@ -129,7 +129,7 @@ class MetricFlowQueryRequest:
         where_constraints: Optional[Sequence[str]] = None,
         order_by_names: Optional[Sequence[str]] = None,
         order_by: Optional[Sequence[OrderByQueryParameter]] = None,
-        sql_optimization_level: SqlQueryOptimizationLevel = SqlQueryOptimizationLevel.default_level(),
+        sql_optimization_level: SqlOptimizationLevel = SqlOptimizationLevel.default_level(),
         dataflow_plan_optimizations: FrozenSet[
             DataflowPlanOptimization
         ] = DataflowPlanOptimization.enabled_optimizations(),

--- a/metricflow/engine/metricflow_engine.py
+++ b/metricflow/engine/metricflow_engine.py
@@ -399,7 +399,7 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
             source_node_builder=source_node_builder,
             dataflow_plan_builder_cache=self._dataflow_plan_builder_cache,
         )
-        self._to_sql_query_plan_converter = DataflowToSqlPlanConverter(
+        self._to_sql_plan_converter = DataflowToSqlPlanConverter(
             column_association_resolver=self._column_association_resolver,
             semantic_manifest_lookup=self._semantic_manifest_lookup,
         )
@@ -531,7 +531,7 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
 
         logger.info(LazyFormat("Building execution plan"))
         _to_execution_plan_converter = DataflowToExecutionPlanConverter(
-            sql_plan_converter=self._to_sql_query_plan_converter,
+            sql_plan_converter=self._to_sql_plan_converter,
             sql_plan_renderer=self._sql_client.sql_query_plan_renderer,
             sql_client=self._sql_client,
             sql_optimization_level=mf_query_request.sql_optimization_level,

--- a/metricflow/execution/dataflow_to_execution.py
+++ b/metricflow/execution/dataflow_to_execution.py
@@ -72,7 +72,7 @@ class DataflowToExecutionPlanConverter(DataflowPlanNodeVisitor[ConvertToExecutio
 
     def _convert_to_sql_plan(self, node: DataflowPlanNode) -> ConvertToSqlPlanResult:
         logger.debug(LazyFormat(lambda: f"Generating SQL query plan from {node.node_id}"))
-        result = self._sql_plan_converter.convert_to_sql_query_plan(
+        result = self._sql_plan_converter.convert_to_sql_plan(
             sql_engine_type=self._sql_client.sql_engine_type,
             optimization_level=self._optimization_level,
             dataflow_plan_node=node,

--- a/metricflow/execution/dataflow_to_execution.py
+++ b/metricflow/execution/dataflow_to_execution.py
@@ -41,7 +41,7 @@ from metricflow.execution.execution_plan import (
 from metricflow.plan_conversion.convert_to_sql_plan import ConvertToSqlPlanResult
 from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlPlanConverter
 from metricflow.protocols.sql_client import SqlClient
-from metricflow.sql.optimizer.optimization_levels import SqlQueryOptimizationLevel
+from metricflow.sql.optimizer.optimization_levels import SqlOptimizationLevel
 from metricflow.sql.render.sql_plan_renderer import SqlPlanRenderResult, SqlQueryPlanRenderer
 
 logger = logging.getLogger(__name__)
@@ -55,7 +55,7 @@ class DataflowToExecutionPlanConverter(DataflowPlanNodeVisitor[ConvertToExecutio
         sql_plan_converter: DataflowToSqlPlanConverter,
         sql_plan_renderer: SqlQueryPlanRenderer,
         sql_client: SqlClient,
-        sql_optimization_level: SqlQueryOptimizationLevel,
+        sql_optimization_level: SqlOptimizationLevel,
     ) -> None:
         """Constructor.
 

--- a/metricflow/plan_conversion/dataflow_to_sql.py
+++ b/metricflow/plan_conversion/dataflow_to_sql.py
@@ -179,7 +179,7 @@ class DataflowToSqlPlanConverter:
     def column_association_resolver(self) -> ColumnAssociationResolver:  # noqa: D102
         return self._column_association_resolver
 
-    def convert_to_sql_query_plan(
+    def convert_to_sql_plan(
         self,
         sql_engine_type: SqlEngine,
         dataflow_plan_node: DataflowPlanNode,

--- a/metricflow/plan_conversion/dataflow_to_sql.py
+++ b/metricflow/plan_conversion/dataflow_to_sql.py
@@ -131,7 +131,7 @@ from metricflow.plan_conversion.sql_join_builder import (
 from metricflow.protocols.sql_client import SqlEngine
 from metricflow.sql.optimizer.optimization_levels import (
     SqlGenerationOptionSet,
-    SqlQueryOptimizationLevel,
+    SqlOptimizationLevel,
 )
 from metricflow.sql.optimizer.sql_query_plan_optimizer import SqlPlanOptimizer
 from metricflow.sql.sql_plan import (
@@ -183,19 +183,19 @@ class DataflowToSqlPlanConverter:
         self,
         sql_engine_type: SqlEngine,
         dataflow_plan_node: DataflowPlanNode,
-        optimization_level: SqlQueryOptimizationLevel = SqlQueryOptimizationLevel.default_level(),
+        optimization_level: SqlOptimizationLevel = SqlOptimizationLevel.default_level(),
         sql_query_plan_id: Optional[DagId] = None,
     ) -> ConvertToSqlPlanResult:
         """Create an SQL query plan that represents the computation up to the given dataflow plan node."""
         # In case there are bugs that raise exceptions at higher optimization levels, retry generation at a lower
         # optimization level. Generally skip O0 (unless requested) as that level does not include the column pruner.
         # Without that, the generated SQL can be enormous.
-        optimization_levels_to_attempt: Sequence[SqlQueryOptimizationLevel] = sorted(
+        optimization_levels_to_attempt: Sequence[SqlOptimizationLevel] = sorted(
             # Union handles case if O0 was specifically requested.
             set(
                 possible_level
-                for possible_level in SqlQueryOptimizationLevel
-                if SqlQueryOptimizationLevel.O1 <= possible_level <= optimization_level
+                for possible_level in SqlOptimizationLevel
+                if SqlOptimizationLevel.O1 <= possible_level <= optimization_level
             ).union({optimization_level}),
             reverse=True,
         )

--- a/metricflow/sql/optimizer/optimization_levels.py
+++ b/metricflow/sql/optimizer/optimization_levels.py
@@ -15,7 +15,7 @@ from metricflow.sql.optimizer.table_alias_simplifier import SqlTableAliasSimplif
 
 
 @functools.total_ordering
-class SqlQueryOptimizationLevel(Enum):
+class SqlOptimizationLevel(Enum):
     """Defines the level of query optimization and the associated optimizers to apply."""
 
     O0 = "O0"
@@ -26,11 +26,11 @@ class SqlQueryOptimizationLevel(Enum):
     O5 = "O5"
 
     @staticmethod
-    def default_level() -> SqlQueryOptimizationLevel:  # noqa: D102
-        return SqlQueryOptimizationLevel.O5
+    def default_level() -> SqlOptimizationLevel:  # noqa: D102
+        return SqlOptimizationLevel.O5
 
-    def __lt__(self, other: SqlQueryOptimizationLevel) -> bool:  # noqa: D105
-        if not isinstance(other, SqlQueryOptimizationLevel):
+    def __lt__(self, other: SqlOptimizationLevel) -> bool:  # noqa: D105
+        if not isinstance(other, SqlOptimizationLevel):
             return NotImplemented
 
         return self.name < other.name
@@ -47,25 +47,25 @@ class SqlGenerationOptionSet:
 
     @staticmethod
     def options_for_level(  # noqa: D102
-        level: SqlQueryOptimizationLevel, use_column_alias_in_group_by: bool
+        level: SqlOptimizationLevel, use_column_alias_in_group_by: bool
     ) -> SqlGenerationOptionSet:
         optimizers: Tuple[SqlPlanOptimizer, ...] = ()
         allow_cte = False
-        if level is SqlQueryOptimizationLevel.O0:
+        if level is SqlOptimizationLevel.O0:
             pass
-        elif level is SqlQueryOptimizationLevel.O1:
+        elif level is SqlOptimizationLevel.O1:
             optimizers = (SqlTableAliasSimplifier(),)
-        elif level is SqlQueryOptimizationLevel.O2:
+        elif level is SqlOptimizationLevel.O2:
             optimizers = (SqlColumnPrunerOptimizer(), SqlTableAliasSimplifier())
-        elif level is SqlQueryOptimizationLevel.O3:
+        elif level is SqlOptimizationLevel.O3:
             optimizers = (SqlColumnPrunerOptimizer(), SqlSubQueryReducer(), SqlTableAliasSimplifier())
-        elif level is SqlQueryOptimizationLevel.O4:
+        elif level is SqlOptimizationLevel.O4:
             optimizers = (
                 SqlColumnPrunerOptimizer(),
                 SqlRewritingSubQueryReducer(use_column_alias_in_group_bys=use_column_alias_in_group_by),
                 SqlTableAliasSimplifier(),
             )
-        elif level is SqlQueryOptimizationLevel.O5:
+        elif level is SqlOptimizationLevel.O5:
             optimizers = (
                 SqlColumnPrunerOptimizer(),
                 SqlRewritingSubQueryReducer(use_column_alias_in_group_bys=use_column_alias_in_group_by),

--- a/metricflow/sql/sql_plan.py
+++ b/metricflow/sql/sql_plan.py
@@ -403,7 +403,7 @@ class SqlPlan(MetricFlowDag[SqlPlanNode]):
         """
         self._render_node = render_node
         super().__init__(
-            dag_id=plan_id or DagId.from_id_prefix(StaticIdPrefix.SQL_QUERY_PLAN_PREFIX),
+            dag_id=plan_id or DagId.from_id_prefix(StaticIdPrefix.SQL_PLAN_PREFIX),
             sink_nodes=[self._render_node],
         )
 

--- a/metricflow/validation/data_warehouse_model_validator.py
+++ b/metricflow/validation/data_warehouse_model_validator.py
@@ -121,7 +121,7 @@ class DataWarehouseTaskBuilder:
         sql_client: SqlClient, plan_converter: DataflowToSqlPlanConverter, plan_id: str, nodes: FilterElementsNode
     ) -> Tuple[str, SqlBindParameterSet]:
         """Generates a sql query plan and returns the rendered sql and bind_parameter_set."""
-        conversion_result = plan_converter.convert_to_sql_query_plan(
+        conversion_result = plan_converter.convert_to_sql_plan(
             sql_engine_type=sql_client.sql_engine_type,
             dataflow_plan_node=nodes,
         )

--- a/tests_metricflow/engine/test_explain.py
+++ b/tests_metricflow/engine/test_explain.py
@@ -10,7 +10,7 @@ from metricflow_semantics.mf_logging.pretty_print import mf_pformat_dict
 from metricflow_semantics.test_helpers.config_helpers import MetricFlowTestConfiguration
 
 from metricflow.engine.metricflow_engine import MetricFlowEngine, MetricFlowExplainResult, MetricFlowQueryRequest
-from metricflow.sql.optimizer.optimization_levels import SqlQueryOptimizationLevel
+from metricflow.sql.optimizer.optimization_levels import SqlOptimizationLevel
 from tests_metricflow.fixtures.manifest_fixtures import MetricFlowEngineTestFixture, SemanticManifestSetup
 from tests_metricflow.snapshot_utils import assert_str_snapshot_equal
 
@@ -52,9 +52,9 @@ def test_optimization_level(
     mf_engine = mf_engine_test_fixture_mapping[SemanticManifestSetup.SIMPLE_MANIFEST].metricflow_engine
 
     results = {}
-    for optimization_level in SqlQueryOptimizationLevel:
+    for optimization_level in SqlOptimizationLevel:
         # Skip lower optimization levels as they are generally not used.
-        if optimization_level <= SqlQueryOptimizationLevel.O3:
+        if optimization_level <= SqlOptimizationLevel.O3:
             continue
 
         explain_result: MetricFlowExplainResult = mf_engine.explain(
@@ -73,5 +73,5 @@ def test_optimization_level(
         snapshot_str=mf_pformat_dict(
             description=None, obj_dict=results, preserve_raw_strings=True, pad_items_with_newlines=True
         ),
-        expectation_description=f"The result for {SqlQueryOptimizationLevel.O5} should be SQL uses a CTE.",
+        expectation_description=f"The result for {SqlOptimizationLevel.O5} should be SQL uses a CTE.",
     )

--- a/tests_metricflow/examples/test_node_sql.py
+++ b/tests_metricflow/examples/test_node_sql.py
@@ -51,7 +51,7 @@ def test_view_sql_generated_at_a_node(
     # Show SQL and spec set at a source node.
     bookings_source_data_set = to_data_set_converter.create_sql_source_data_set(bookings_semantic_model)
     read_source_node = ReadSqlSourceNode.create(bookings_source_data_set)
-    conversion_result = to_sql_plan_converter.convert_to_sql_query_plan(
+    conversion_result = to_sql_plan_converter.convert_to_sql_plan(
         sql_engine_type=sql_client.sql_engine_type,
         dataflow_plan_node=read_source_node,
     )
@@ -79,7 +79,7 @@ def test_view_sql_generated_at_a_node(
             ),
         ),
     )
-    conversion_result = to_sql_plan_converter.convert_to_sql_query_plan(
+    conversion_result = to_sql_plan_converter.convert_to_sql_plan(
         sql_engine_type=sql_client.sql_engine_type,
         dataflow_plan_node=filter_elements_node,
     )

--- a/tests_metricflow/plan_conversion/dataflow_to_sql/test_cte_sql.py
+++ b/tests_metricflow/plan_conversion/dataflow_to_sql/test_cte_sql.py
@@ -22,7 +22,7 @@ from metricflow.dataflow.dataflow_plan import (
 from metricflow.dataflow.dataflow_plan_analyzer import DataflowPlanAnalyzer
 from metricflow.dataflow.nodes.filter_elements import FilterElementsNode
 from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlPlanConverter
-from metricflow.sql.optimizer.optimization_levels import SqlGenerationOptionSet, SqlQueryOptimizationLevel
+from metricflow.sql.optimizer.optimization_levels import SqlGenerationOptionSet, SqlOptimizationLevel
 from metricflow.sql.render.sql_plan_renderer import DefaultSqlQueryPlanRenderer
 from tests_metricflow.fixtures.manifest_fixtures import MetricFlowEngineTestFixture, SemanticManifestSetup
 
@@ -39,7 +39,7 @@ def convert_and_check(
     """Convert the dataflow plan to SQL and compare with snapshots."""
     # Generate without CTEs
     optimizers = SqlGenerationOptionSet.options_for_level(
-        SqlQueryOptimizationLevel.O5, use_column_alias_in_group_by=False
+        SqlOptimizationLevel.O5, use_column_alias_in_group_by=False
     ).optimizers
     conversion_result = dataflow_to_sql_converter.convert_using_specifics(
         dataflow_plan_node=node,

--- a/tests_metricflow/plan_conversion/test_dataflow_to_execution.py
+++ b/tests_metricflow/plan_conversion/test_dataflow_to_execution.py
@@ -15,7 +15,7 @@ from metricflow.dataflow.builder.dataflow_plan_builder import DataflowPlanBuilde
 from metricflow.execution.dataflow_to_execution import DataflowToExecutionPlanConverter
 from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlPlanConverter
 from metricflow.protocols.sql_client import SqlClient
-from metricflow.sql.optimizer.optimization_levels import SqlQueryOptimizationLevel
+from metricflow.sql.optimizer.optimization_levels import SqlOptimizationLevel
 from metricflow.sql.render.sql_plan_renderer import DefaultSqlQueryPlanRenderer
 from tests_metricflow.snapshot_utils import assert_execution_plan_text_equal
 
@@ -31,7 +31,7 @@ def make_execution_plan_converter(  # noqa: D103
         ),
         sql_plan_renderer=DefaultSqlQueryPlanRenderer(),
         sql_client=sql_client,
-        sql_optimization_level=SqlQueryOptimizationLevel.default_level(),
+        sql_optimization_level=SqlOptimizationLevel.default_level(),
     )
 
 

--- a/tests_metricflow/plan_conversion/test_dataflow_to_sql_plan.py
+++ b/tests_metricflow/plan_conversion/test_dataflow_to_sql_plan.py
@@ -49,7 +49,7 @@ from metricflow.dataflow.nodes.where_filter import WhereConstraintNode
 from metricflow.dataflow.nodes.write_to_data_table import WriteToResultDataTableNode
 from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlPlanConverter
 from metricflow.protocols.sql_client import SqlClient
-from metricflow.sql.optimizer.optimization_levels import SqlQueryOptimizationLevel
+from metricflow.sql.optimizer.optimization_levels import SqlOptimizationLevel
 from tests_metricflow.dataflow_plan_to_svg import display_graph_if_requested
 from tests_metricflow.fixtures.manifest_fixtures import MetricFlowEngineTestFixture, SemanticManifestSetup
 from tests_metricflow.sql.compare_sql_plan import assert_rendered_sql_from_plan_equal, assert_sql_plan_text_equal
@@ -68,7 +68,7 @@ def convert_and_check(
         sql_engine_type=sql_client.sql_engine_type,
         sql_query_plan_id=DagId.from_str("plan0"),
         dataflow_plan_node=node,
-        optimization_level=SqlQueryOptimizationLevel.O0,
+        optimization_level=SqlOptimizationLevel.O0,
     )
     sql_query_plan = conversion_result.sql_plan
     display_graph_if_requested(

--- a/tests_metricflow/plan_conversion/test_dataflow_to_sql_plan.py
+++ b/tests_metricflow/plan_conversion/test_dataflow_to_sql_plan.py
@@ -64,7 +64,7 @@ def convert_and_check(
 ) -> None:
     """Convert the dataflow plan to SQL and compare with snapshots."""
     # Generate plans w/o optimizers
-    conversion_result = dataflow_to_sql_converter.convert_to_sql_query_plan(
+    conversion_result = dataflow_to_sql_converter.convert_to_sql_plan(
         sql_engine_type=sql_client.sql_engine_type,
         sql_query_plan_id=DagId.from_str("plan0"),
         dataflow_plan_node=node,
@@ -91,7 +91,7 @@ def convert_and_check(
     )
 
     # Generate plans with optimizers
-    conversion_result = dataflow_to_sql_converter.convert_to_sql_query_plan(
+    conversion_result = dataflow_to_sql_converter.convert_to_sql_plan(
         sql_engine_type=sql_client.sql_engine_type,
         sql_query_plan_id=DagId.from_str("plan0_optimized"),
         dataflow_plan_node=node,

--- a/tests_metricflow/query_rendering/compare_rendered_query.py
+++ b/tests_metricflow/query_rendering/compare_rendered_query.py
@@ -31,7 +31,7 @@ def render_and_check(
         base_plan = dataflow_plan_builder.build_plan_for_distinct_values(query_spec=query_spec)
     else:
         base_plan = dataflow_plan_builder.build_plan(query_spec)
-    conversion_result = dataflow_to_sql_converter.convert_to_sql_query_plan(
+    conversion_result = dataflow_to_sql_converter.convert_to_sql_plan(
         sql_engine_type=sql_client.sql_engine_type,
         dataflow_plan_node=base_plan.sink_node,
         optimization_level=SqlOptimizationLevel.O0,
@@ -60,7 +60,7 @@ def render_and_check(
         optimized_plan = dataflow_plan_builder.build_plan(
             query_spec, optimizations=DataflowPlanOptimization.enabled_optimizations()
         )
-    conversion_result = dataflow_to_sql_converter.convert_to_sql_query_plan(
+    conversion_result = dataflow_to_sql_converter.convert_to_sql_plan(
         sql_engine_type=sql_client.sql_engine_type,
         dataflow_plan_node=optimized_plan.sink_node,
         sql_query_plan_id=DagId.from_str("plan0_optimized"),

--- a/tests_metricflow/query_rendering/compare_rendered_query.py
+++ b/tests_metricflow/query_rendering/compare_rendered_query.py
@@ -11,7 +11,7 @@ from metricflow.dataflow.builder.dataflow_plan_builder import DataflowPlanBuilde
 from metricflow.dataflow.optimizer.dataflow_optimizer_factory import DataflowPlanOptimization
 from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlPlanConverter
 from metricflow.protocols.sql_client import SqlClient
-from metricflow.sql.optimizer.optimization_levels import SqlQueryOptimizationLevel
+from metricflow.sql.optimizer.optimization_levels import SqlOptimizationLevel
 from tests_metricflow.dataflow_plan_to_svg import display_graph_if_requested
 from tests_metricflow.sql.compare_sql_plan import assert_rendered_sql_from_plan_equal
 
@@ -34,7 +34,7 @@ def render_and_check(
     conversion_result = dataflow_to_sql_converter.convert_to_sql_query_plan(
         sql_engine_type=sql_client.sql_engine_type,
         dataflow_plan_node=base_plan.sink_node,
-        optimization_level=SqlQueryOptimizationLevel.O0,
+        optimization_level=SqlOptimizationLevel.O0,
         sql_query_plan_id=DagId.from_str("plan0"),
     )
     sql_query_plan = conversion_result.sql_plan

--- a/tests_metricflow/snapshots/test_explain.py/str/test_optimization_level__result.txt
+++ b/tests_metricflow/snapshots/test_explain.py/str/test_optimization_level__result.txt
@@ -3,7 +3,7 @@ test_filename: test_explain.py
 docstring:
   Tests that the results of explain reflect the SQL optimization level in the request.
 expectation_description:
-  The result for SqlQueryOptimizationLevel.O5 should be SQL uses a CTE.
+  The result for SqlOptimizationLevel.O5 should be SQL uses a CTE.
 ---
 O4:
   SELECT


### PR DESCRIPTION
This PR renames a few symbols related to the recent rename from `SqlQueryPlan` to `SqlPlan`.