### PR TITLE
Renames related to `SqlPlan` - Part 3

### DIFF
--- a/dbt-metricflow/dbt_metricflow/cli/dbt_connectors/adapter_backed_client.py
+++ b/dbt-metricflow/dbt_metricflow/cli/dbt_connectors/adapter_backed_client.py
@@ -14,14 +14,14 @@ from metricflow_semantics.sql.sql_bind_parameters import SqlBindParameterSet
 
 from metricflow.data_table.mf_table import MetricFlowDataTable
 from metricflow.protocols.sql_client import SqlEngine
-from metricflow.sql.render.big_query import BigQuerySqlQueryPlanRenderer
-from metricflow.sql.render.databricks import DatabricksSqlQueryPlanRenderer
-from metricflow.sql.render.duckdb_renderer import DuckDbSqlQueryPlanRenderer
-from metricflow.sql.render.postgres import PostgresSQLSqlQueryPlanRenderer
-from metricflow.sql.render.redshift import RedshiftSqlQueryPlanRenderer
-from metricflow.sql.render.snowflake import SnowflakeSqlQueryPlanRenderer
+from metricflow.sql.render.big_query import BigQuerySqlPlanRenderer
+from metricflow.sql.render.databricks import DatabricksSqlPlanRenderer
+from metricflow.sql.render.duckdb_renderer import DuckDbSqlPlanRenderer
+from metricflow.sql.render.postgres import PostgresSQLSqlPlanRenderer
+from metricflow.sql.render.redshift import RedshiftSqlPlanRenderer
+from metricflow.sql.render.snowflake import SnowflakeSqlPlanRenderer
 from metricflow.sql.render.sql_plan_renderer import SqlPlanRenderer
-from metricflow.sql.render.trino import TrinoSqlQueryPlanRenderer
+from metricflow.sql.render.trino import TrinoSqlPlanRenderer
 from metricflow.sql_request.sql_request_attributes import SqlRequestId
 
 logger = logging.getLogger(__name__)
@@ -67,19 +67,19 @@ class SupportedAdapterTypes(enum.Enum):
     def sql_query_plan_renderer(self) -> SqlPlanRenderer:
         """Return the SqlQueryPlanRenderer corresponding to the supported adapter type."""
         if self is SupportedAdapterTypes.BIGQUERY:
-            return BigQuerySqlQueryPlanRenderer()
+            return BigQuerySqlPlanRenderer()
         elif self is SupportedAdapterTypes.DATABRICKS:
-            return DatabricksSqlQueryPlanRenderer()
+            return DatabricksSqlPlanRenderer()
         elif self is SupportedAdapterTypes.POSTGRES:
-            return PostgresSQLSqlQueryPlanRenderer()
+            return PostgresSQLSqlPlanRenderer()
         elif self is SupportedAdapterTypes.REDSHIFT:
-            return RedshiftSqlQueryPlanRenderer()
+            return RedshiftSqlPlanRenderer()
         elif self is SupportedAdapterTypes.SNOWFLAKE:
-            return SnowflakeSqlQueryPlanRenderer()
+            return SnowflakeSqlPlanRenderer()
         elif self is SupportedAdapterTypes.DUCKDB:
-            return DuckDbSqlQueryPlanRenderer()
+            return DuckDbSqlPlanRenderer()
         elif self is SupportedAdapterTypes.TRINO:
-            return TrinoSqlQueryPlanRenderer()
+            return TrinoSqlPlanRenderer()
         else:
             assert_values_exhausted(self)
 

--- a/dbt-metricflow/dbt_metricflow/cli/dbt_connectors/adapter_backed_client.py
+++ b/dbt-metricflow/dbt_metricflow/cli/dbt_connectors/adapter_backed_client.py
@@ -20,7 +20,7 @@ from metricflow.sql.render.duckdb_renderer import DuckDbSqlQueryPlanRenderer
 from metricflow.sql.render.postgres import PostgresSQLSqlQueryPlanRenderer
 from metricflow.sql.render.redshift import RedshiftSqlQueryPlanRenderer
 from metricflow.sql.render.snowflake import SnowflakeSqlQueryPlanRenderer
-from metricflow.sql.render.sql_plan_renderer import SqlQueryPlanRenderer
+from metricflow.sql.render.sql_plan_renderer import SqlPlanRenderer
 from metricflow.sql.render.trino import TrinoSqlQueryPlanRenderer
 from metricflow.sql_request.sql_request_attributes import SqlRequestId
 
@@ -64,7 +64,7 @@ class SupportedAdapterTypes(enum.Enum):
             assert_values_exhausted(self)
 
     @property
-    def sql_query_plan_renderer(self) -> SqlQueryPlanRenderer:
+    def sql_query_plan_renderer(self) -> SqlPlanRenderer:
         """Return the SqlQueryPlanRenderer corresponding to the supported adapter type."""
         if self is SupportedAdapterTypes.BIGQUERY:
             return BigQuerySqlQueryPlanRenderer()
@@ -120,7 +120,7 @@ class AdapterBackedSqlClient:
         return self._sql_engine_type
 
     @property
-    def sql_query_plan_renderer(self) -> SqlQueryPlanRenderer:
+    def sql_query_plan_renderer(self) -> SqlPlanRenderer:
         """Dialect-specific SQL query plan renderer used for converting MetricFlow's query plan to executable SQL."""
         return self._sql_query_plan_renderer
 

--- a/dbt-metricflow/dbt_metricflow/cli/dbt_connectors/adapter_backed_client.py
+++ b/dbt-metricflow/dbt_metricflow/cli/dbt_connectors/adapter_backed_client.py
@@ -64,8 +64,8 @@ class SupportedAdapterTypes(enum.Enum):
             assert_values_exhausted(self)
 
     @property
-    def sql_query_plan_renderer(self) -> SqlPlanRenderer:
-        """Return the SqlQueryPlanRenderer corresponding to the supported adapter type."""
+    def sql_plan_renderer(self) -> SqlPlanRenderer:
+        """Return the SqlPlanRenderer corresponding to the supported adapter type."""
         if self is SupportedAdapterTypes.BIGQUERY:
             return BigQuerySqlPlanRenderer()
         elif self is SupportedAdapterTypes.DATABRICKS:
@@ -109,7 +109,7 @@ class AdapterBackedSqlClient:
             ) from e
 
         self._sql_engine_type = adapter_type.sql_engine_type
-        self._sql_query_plan_renderer = adapter_type.sql_query_plan_renderer
+        self._sql_plan_renderer = adapter_type.sql_plan_renderer
         logger.debug(
             LazyFormat(lambda: f"Initialized AdapterBackedSqlClient with dbt adapter type `{adapter_type.value}`")
         )
@@ -120,9 +120,9 @@ class AdapterBackedSqlClient:
         return self._sql_engine_type
 
     @property
-    def sql_query_plan_renderer(self) -> SqlPlanRenderer:
+    def sql_plan_renderer(self) -> SqlPlanRenderer:
         """Dialect-specific SQL query plan renderer used for converting MetricFlow's query plan to executable SQL."""
-        return self._sql_query_plan_renderer
+        return self._sql_plan_renderer
 
     def query(
         self,

--- a/metricflow/engine/metricflow_engine.py
+++ b/metricflow/engine/metricflow_engine.py
@@ -532,7 +532,7 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
         logger.info(LazyFormat("Building execution plan"))
         _to_execution_plan_converter = DataflowToExecutionPlanConverter(
             sql_plan_converter=self._to_sql_plan_converter,
-            sql_plan_renderer=self._sql_client.sql_query_plan_renderer,
+            sql_plan_renderer=self._sql_client.sql_plan_renderer,
             sql_client=self._sql_client,
             sql_optimization_level=mf_query_request.sql_optimization_level,
         )

--- a/metricflow/execution/dataflow_to_execution.py
+++ b/metricflow/execution/dataflow_to_execution.py
@@ -81,7 +81,7 @@ class DataflowToExecutionPlanConverter(DataflowPlanNodeVisitor[ConvertToExecutio
         return result
 
     def _render_sql(self, convert_to_sql_plan_result: ConvertToSqlPlanResult) -> SqlPlanRenderResult:
-        return self._sql_plan_renderer.render_sql_query_plan(convert_to_sql_plan_result.sql_plan)
+        return self._sql_plan_renderer.render_sql_plan(convert_to_sql_plan_result.sql_plan)
 
     @override
     def visit_write_to_result_data_table_node(self, node: WriteToResultDataTableNode) -> ConvertToExecutionPlanResult:

--- a/metricflow/execution/dataflow_to_execution.py
+++ b/metricflow/execution/dataflow_to_execution.py
@@ -42,7 +42,7 @@ from metricflow.plan_conversion.convert_to_sql_plan import ConvertToSqlPlanResul
 from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlPlanConverter
 from metricflow.protocols.sql_client import SqlClient
 from metricflow.sql.optimizer.optimization_levels import SqlOptimizationLevel
-from metricflow.sql.render.sql_plan_renderer import SqlPlanRenderResult, SqlPlanRenderer
+from metricflow.sql.render.sql_plan_renderer import SqlPlanRenderer, SqlPlanRenderResult
 
 logger = logging.getLogger(__name__)
 

--- a/metricflow/execution/dataflow_to_execution.py
+++ b/metricflow/execution/dataflow_to_execution.py
@@ -42,7 +42,7 @@ from metricflow.plan_conversion.convert_to_sql_plan import ConvertToSqlPlanResul
 from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlPlanConverter
 from metricflow.protocols.sql_client import SqlClient
 from metricflow.sql.optimizer.optimization_levels import SqlOptimizationLevel
-from metricflow.sql.render.sql_plan_renderer import SqlPlanRenderResult, SqlQueryPlanRenderer
+from metricflow.sql.render.sql_plan_renderer import SqlPlanRenderResult, SqlPlanRenderer
 
 logger = logging.getLogger(__name__)
 
@@ -53,7 +53,7 @@ class DataflowToExecutionPlanConverter(DataflowPlanNodeVisitor[ConvertToExecutio
     def __init__(
         self,
         sql_plan_converter: DataflowToSqlPlanConverter,
-        sql_plan_renderer: SqlQueryPlanRenderer,
+        sql_plan_renderer: SqlPlanRenderer,
         sql_client: SqlClient,
         sql_optimization_level: SqlOptimizationLevel,
     ) -> None:

--- a/metricflow/protocols/sql_client.py
+++ b/metricflow/protocols/sql_client.py
@@ -9,7 +9,7 @@ from dbt_semantic_interfaces.type_enums.time_granularity import TimeGranularity
 from metricflow_semantics.sql.sql_bind_parameters import SqlBindParameterSet
 
 from metricflow.data_table.mf_table import MetricFlowDataTable
-from metricflow.sql.render.sql_plan_renderer import SqlQueryPlanRenderer
+from metricflow.sql.render.sql_plan_renderer import SqlPlanRenderer
 
 
 class SqlEngine(Enum):
@@ -67,7 +67,7 @@ class SqlClient(Protocol):
 
     @property
     @abstractmethod
-    def sql_plan_renderer(self) -> SqlQueryPlanRenderer:
+    def sql_plan_renderer(self) -> SqlPlanRenderer:
         """Dialect-specific SQL plan renderer used for converting MetricFlow's query plan to executable SQL.
 
         This is bundled with the SqlClient partly as a convenenience for accessing a single instance of the renderer,

--- a/metricflow/protocols/sql_client.py
+++ b/metricflow/protocols/sql_client.py
@@ -67,8 +67,8 @@ class SqlClient(Protocol):
 
     @property
     @abstractmethod
-    def sql_query_plan_renderer(self) -> SqlQueryPlanRenderer:
-        """Dialect-specific SQL query plan renderer used for converting MetricFlow's query plan to executable SQL.
+    def sql_plan_renderer(self) -> SqlQueryPlanRenderer:
+        """Dialect-specific SQL plan renderer used for converting MetricFlow's query plan to executable SQL.
 
         This is bundled with the SqlClient partly as a convenenience for accessing a single instance of the renderer,
         and partly due to the close relationship between dialect and engine capabilities.

--- a/metricflow/sql/render/big_query.py
+++ b/metricflow/sql/render/big_query.py
@@ -196,7 +196,7 @@ class BigQuerySqlExpressionRenderer(DefaultSqlExpressionRenderer):
         )
 
 
-class BigQuerySqlQueryPlanRenderer(DefaultSqlPlanRenderer):
+class BigQuerySqlPlanRenderer(DefaultSqlPlanRenderer):
     """Plan renderer for the BigQuery engine."""
 
     EXPR_RENDERER = BigQuerySqlExpressionRenderer()

--- a/metricflow/sql/render/big_query.py
+++ b/metricflow/sql/render/big_query.py
@@ -26,7 +26,7 @@ from metricflow.sql.render.expr_renderer import (
     SqlExpressionRenderer,
     SqlExpressionRenderResult,
 )
-from metricflow.sql.render.sql_plan_renderer import DefaultSqlQueryPlanRenderer
+from metricflow.sql.render.sql_plan_renderer import DefaultSqlPlanRenderer
 from metricflow.sql.sql_plan import SqlSelectColumn
 
 
@@ -196,7 +196,7 @@ class BigQuerySqlExpressionRenderer(DefaultSqlExpressionRenderer):
         )
 
 
-class BigQuerySqlQueryPlanRenderer(DefaultSqlQueryPlanRenderer):
+class BigQuerySqlQueryPlanRenderer(DefaultSqlPlanRenderer):
     """Plan renderer for the BigQuery engine."""
 
     EXPR_RENDERER = BigQuerySqlExpressionRenderer()

--- a/metricflow/sql/render/databricks.py
+++ b/metricflow/sql/render/databricks.py
@@ -68,7 +68,7 @@ class DatabricksSqlExpressionRenderer(DefaultSqlExpressionRenderer):
         )
 
 
-class DatabricksSqlQueryPlanRenderer(DefaultSqlPlanRenderer):
+class DatabricksSqlPlanRenderer(DefaultSqlPlanRenderer):
     """Plan renderer for the Snowflake engine."""
 
     EXPR_RENDERER = DatabricksSqlExpressionRenderer()

--- a/metricflow/sql/render/databricks.py
+++ b/metricflow/sql/render/databricks.py
@@ -14,7 +14,7 @@ from metricflow.sql.render.expr_renderer import (
     SqlExpressionRenderer,
     SqlExpressionRenderResult,
 )
-from metricflow.sql.render.sql_plan_renderer import DefaultSqlQueryPlanRenderer
+from metricflow.sql.render.sql_plan_renderer import DefaultSqlPlanRenderer
 
 
 class DatabricksSqlExpressionRenderer(DefaultSqlExpressionRenderer):
@@ -68,7 +68,7 @@ class DatabricksSqlExpressionRenderer(DefaultSqlExpressionRenderer):
         )
 
 
-class DatabricksSqlQueryPlanRenderer(DefaultSqlQueryPlanRenderer):
+class DatabricksSqlQueryPlanRenderer(DefaultSqlPlanRenderer):
     """Plan renderer for the Snowflake engine."""
 
     EXPR_RENDERER = DatabricksSqlExpressionRenderer()

--- a/metricflow/sql/render/duckdb_renderer.py
+++ b/metricflow/sql/render/duckdb_renderer.py
@@ -117,7 +117,7 @@ class DuckDbSqlExpressionRenderer(DefaultSqlExpressionRenderer):
         )
 
 
-class DuckDbSqlQueryPlanRenderer(DefaultSqlPlanRenderer):
+class DuckDbSqlPlanRenderer(DefaultSqlPlanRenderer):
     """Plan renderer for the DuckDB engine."""
 
     EXPR_RENDERER = DuckDbSqlExpressionRenderer()

--- a/metricflow/sql/render/duckdb_renderer.py
+++ b/metricflow/sql/render/duckdb_renderer.py
@@ -23,7 +23,7 @@ from metricflow.sql.render.expr_renderer import (
     SqlExpressionRenderer,
     SqlExpressionRenderResult,
 )
-from metricflow.sql.render.sql_plan_renderer import DefaultSqlQueryPlanRenderer
+from metricflow.sql.render.sql_plan_renderer import DefaultSqlPlanRenderer
 
 
 class DuckDbSqlExpressionRenderer(DefaultSqlExpressionRenderer):
@@ -117,7 +117,7 @@ class DuckDbSqlExpressionRenderer(DefaultSqlExpressionRenderer):
         )
 
 
-class DuckDbSqlQueryPlanRenderer(DefaultSqlQueryPlanRenderer):
+class DuckDbSqlQueryPlanRenderer(DefaultSqlPlanRenderer):
     """Plan renderer for the DuckDB engine."""
 
     EXPR_RENDERER = DuckDbSqlExpressionRenderer()

--- a/metricflow/sql/render/postgres.py
+++ b/metricflow/sql/render/postgres.py
@@ -24,7 +24,7 @@ from metricflow.sql.render.expr_renderer import (
     SqlExpressionRenderer,
     SqlExpressionRenderResult,
 )
-from metricflow.sql.render.sql_plan_renderer import DefaultSqlQueryPlanRenderer
+from metricflow.sql.render.sql_plan_renderer import DefaultSqlPlanRenderer
 
 
 class PostgresSqlExpressionRenderer(DefaultSqlExpressionRenderer):
@@ -119,7 +119,7 @@ class PostgresSqlExpressionRenderer(DefaultSqlExpressionRenderer):
         )
 
 
-class PostgresSQLSqlQueryPlanRenderer(DefaultSqlQueryPlanRenderer):
+class PostgresSQLSqlQueryPlanRenderer(DefaultSqlPlanRenderer):
     """Plan renderer for the PostgreSQL engine."""
 
     EXPR_RENDERER = PostgresSqlExpressionRenderer()

--- a/metricflow/sql/render/postgres.py
+++ b/metricflow/sql/render/postgres.py
@@ -119,7 +119,7 @@ class PostgresSqlExpressionRenderer(DefaultSqlExpressionRenderer):
         )
 
 
-class PostgresSQLSqlQueryPlanRenderer(DefaultSqlPlanRenderer):
+class PostgresSQLSqlPlanRenderer(DefaultSqlPlanRenderer):
     """Plan renderer for the PostgreSQL engine."""
 
     EXPR_RENDERER = PostgresSqlExpressionRenderer()

--- a/metricflow/sql/render/redshift.py
+++ b/metricflow/sql/render/redshift.py
@@ -108,7 +108,7 @@ class RedshiftSqlExpressionRenderer(DefaultSqlExpressionRenderer):
         )
 
 
-class RedshiftSqlQueryPlanRenderer(DefaultSqlPlanRenderer):
+class RedshiftSqlPlanRenderer(DefaultSqlPlanRenderer):
     """Plan renderer for the Redshift engine."""
 
     EXPR_RENDERER = RedshiftSqlExpressionRenderer()

--- a/metricflow/sql/render/redshift.py
+++ b/metricflow/sql/render/redshift.py
@@ -20,7 +20,7 @@ from metricflow.sql.render.expr_renderer import (
     SqlExpressionRenderer,
     SqlExpressionRenderResult,
 )
-from metricflow.sql.render.sql_plan_renderer import DefaultSqlQueryPlanRenderer
+from metricflow.sql.render.sql_plan_renderer import DefaultSqlPlanRenderer
 
 
 class RedshiftSqlExpressionRenderer(DefaultSqlExpressionRenderer):
@@ -108,7 +108,7 @@ class RedshiftSqlExpressionRenderer(DefaultSqlExpressionRenderer):
         )
 
 
-class RedshiftSqlQueryPlanRenderer(DefaultSqlQueryPlanRenderer):
+class RedshiftSqlQueryPlanRenderer(DefaultSqlPlanRenderer):
     """Plan renderer for the Redshift engine."""
 
     EXPR_RENDERER = RedshiftSqlExpressionRenderer()

--- a/metricflow/sql/render/snowflake.py
+++ b/metricflow/sql/render/snowflake.py
@@ -80,7 +80,7 @@ class SnowflakeSqlExpressionRenderer(DefaultSqlExpressionRenderer):
         )
 
 
-class SnowflakeSqlQueryPlanRenderer(DefaultSqlPlanRenderer):
+class SnowflakeSqlPlanRenderer(DefaultSqlPlanRenderer):
     """Plan renderer for the Snowflake engine."""
 
     EXPR_RENDERER = SnowflakeSqlExpressionRenderer()

--- a/metricflow/sql/render/snowflake.py
+++ b/metricflow/sql/render/snowflake.py
@@ -19,7 +19,7 @@ from metricflow.sql.render.expr_renderer import (
     SqlExpressionRenderer,
     SqlExpressionRenderResult,
 )
-from metricflow.sql.render.sql_plan_renderer import DefaultSqlQueryPlanRenderer
+from metricflow.sql.render.sql_plan_renderer import DefaultSqlPlanRenderer
 
 
 class SnowflakeSqlExpressionRenderer(DefaultSqlExpressionRenderer):
@@ -80,7 +80,7 @@ class SnowflakeSqlExpressionRenderer(DefaultSqlExpressionRenderer):
         )
 
 
-class SnowflakeSqlQueryPlanRenderer(DefaultSqlQueryPlanRenderer):
+class SnowflakeSqlQueryPlanRenderer(DefaultSqlPlanRenderer):
     """Plan renderer for the Snowflake engine."""
 
     EXPR_RENDERER = SnowflakeSqlExpressionRenderer()

--- a/metricflow/sql/render/sql_plan_renderer.py
+++ b/metricflow/sql/render/sql_plan_renderer.py
@@ -43,7 +43,7 @@ class SqlPlanRenderResult:  # noqa: D101
     bind_parameter_set: SqlBindParameterSet
 
 
-class SqlQueryPlanRenderer(SqlPlanNodeVisitor[SqlPlanRenderResult], ABC):
+class SqlPlanRenderer(SqlPlanNodeVisitor[SqlPlanRenderResult], ABC):
     """Renders SQL plans to a string."""
 
     def _render_node(self, node: SqlPlanNode) -> SqlPlanRenderResult:
@@ -69,7 +69,7 @@ class StringJoinDescription:
     on_condition_str: str
 
 
-class DefaultSqlQueryPlanRenderer(SqlQueryPlanRenderer):
+class DefaultSqlPlanRenderer(SqlPlanRenderer):
     """Renders an SQL plan following ANSI SQL."""
 
     # The renderer that is used to render the SQL expressions.

--- a/metricflow/sql/render/sql_plan_renderer.py
+++ b/metricflow/sql/render/sql_plan_renderer.py
@@ -49,7 +49,7 @@ class SqlPlanRenderer(SqlPlanNodeVisitor[SqlPlanRenderResult], ABC):
     def _render_node(self, node: SqlPlanNode) -> SqlPlanRenderResult:
         return node.accept(self)
 
-    def render_sql_query_plan(self, sql_query_plan: SqlPlan) -> SqlPlanRenderResult:  # noqa: D102
+    def render_sql_plan(self, sql_query_plan: SqlPlan) -> SqlPlanRenderResult:  # noqa: D102
         return self._render_node(sql_query_plan.render_node)
 
     @property

--- a/metricflow/sql/render/trino.py
+++ b/metricflow/sql/render/trino.py
@@ -26,7 +26,7 @@ from metricflow.sql.render.expr_renderer import (
     SqlExpressionRenderer,
     SqlExpressionRenderResult,
 )
-from metricflow.sql.render.sql_plan_renderer import DefaultSqlQueryPlanRenderer
+from metricflow.sql.render.sql_plan_renderer import DefaultSqlPlanRenderer
 
 
 class TrinoSqlExpressionRenderer(DefaultSqlExpressionRenderer):
@@ -146,7 +146,7 @@ class TrinoSqlExpressionRenderer(DefaultSqlExpressionRenderer):
         return date_part.value
 
 
-class TrinoSqlQueryPlanRenderer(DefaultSqlQueryPlanRenderer):
+class TrinoSqlQueryPlanRenderer(DefaultSqlPlanRenderer):
     """Plan renderer for the Trino engine."""
 
     EXPR_RENDERER = TrinoSqlExpressionRenderer()

--- a/metricflow/sql/render/trino.py
+++ b/metricflow/sql/render/trino.py
@@ -146,7 +146,7 @@ class TrinoSqlExpressionRenderer(DefaultSqlExpressionRenderer):
         return date_part.value
 
 
-class TrinoSqlQueryPlanRenderer(DefaultSqlPlanRenderer):
+class TrinoSqlPlanRenderer(DefaultSqlPlanRenderer):
     """Plan renderer for the Trino engine."""
 
     EXPR_RENDERER = TrinoSqlExpressionRenderer()

--- a/metricflow/validation/data_warehouse_model_validator.py
+++ b/metricflow/validation/data_warehouse_model_validator.py
@@ -127,7 +127,7 @@ class DataWarehouseTaskBuilder:
         )
         sql_plan = conversion_result.sql_plan
 
-        rendered_plan = sql_client.sql_plan_renderer.render_sql_query_plan(sql_plan)
+        rendered_plan = sql_client.sql_plan_renderer.render_sql_plan(sql_plan)
         return (rendered_plan.sql, rendered_plan.bind_parameter_set)
 
     @classmethod

--- a/metricflow/validation/data_warehouse_model_validator.py
+++ b/metricflow/validation/data_warehouse_model_validator.py
@@ -127,7 +127,7 @@ class DataWarehouseTaskBuilder:
         )
         sql_plan = conversion_result.sql_plan
 
-        rendered_plan = sql_client.sql_query_plan_renderer.render_sql_query_plan(sql_plan)
+        rendered_plan = sql_client.sql_plan_renderer.render_sql_query_plan(sql_plan)
         return (rendered_plan.sql, rendered_plan.bind_parameter_set)
 
     @classmethod

--- a/tests_metricflow/examples/test_node_sql.py
+++ b/tests_metricflow/examples/test_node_sql.py
@@ -42,7 +42,7 @@ def test_view_sql_generated_at_a_node(
         column_association_resolver=DunderColumnAssociationResolver(),
         semantic_manifest_lookup=simple_semantic_manifest_lookup,
     )
-    sql_renderer: SqlQueryPlanRenderer = sql_client.sql_query_plan_renderer
+    sql_renderer: SqlQueryPlanRenderer = sql_client.sql_plan_renderer
     node_output_resolver = DataflowPlanNodeOutputDataSetResolver(
         column_association_resolver=column_association_resolver,
         semantic_manifest_lookup=simple_semantic_manifest_lookup,

--- a/tests_metricflow/examples/test_node_sql.py
+++ b/tests_metricflow/examples/test_node_sql.py
@@ -56,7 +56,7 @@ def test_view_sql_generated_at_a_node(
         dataflow_plan_node=read_source_node,
     )
     sql_plan_at_read_node = conversion_result.sql_plan
-    sql_at_read_node = sql_renderer.render_sql_query_plan(sql_plan_at_read_node).sql
+    sql_at_read_node = sql_renderer.render_sql_plan(sql_plan_at_read_node).sql
     spec_set_at_read_node = node_output_resolver.get_output_data_set(read_source_node).instance_set.spec_set
     logger.debug(LazyFormat(lambda: f"SQL generated at {read_source_node} is:\n\n{sql_at_read_node}"))
     logger.debug(LazyFormat(lambda: f"Spec set at {read_source_node} is:\n\n{mf_pformat(spec_set_at_read_node)}"))
@@ -84,7 +84,7 @@ def test_view_sql_generated_at_a_node(
         dataflow_plan_node=filter_elements_node,
     )
     sql_plan_at_filter_elements_node = conversion_result.sql_plan
-    sql_at_filter_elements_node = sql_renderer.render_sql_query_plan(sql_plan_at_filter_elements_node).sql
+    sql_at_filter_elements_node = sql_renderer.render_sql_plan(sql_plan_at_filter_elements_node).sql
     spec_set_at_filter_elements_node = node_output_resolver.get_output_data_set(
         filter_elements_node
     ).instance_set.spec_set

--- a/tests_metricflow/examples/test_node_sql.py
+++ b/tests_metricflow/examples/test_node_sql.py
@@ -20,7 +20,7 @@ from metricflow.dataflow.nodes.read_sql_source import ReadSqlSourceNode
 from metricflow.dataset.convert_semantic_model import SemanticModelToDataSetConverter
 from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlPlanConverter
 from metricflow.protocols.sql_client import SqlClient
-from metricflow.sql.render.sql_plan_renderer import SqlQueryPlanRenderer
+from metricflow.sql.render.sql_plan_renderer import SqlPlanRenderer
 
 logger = logging.getLogger(__name__)
 
@@ -42,7 +42,7 @@ def test_view_sql_generated_at_a_node(
         column_association_resolver=DunderColumnAssociationResolver(),
         semantic_manifest_lookup=simple_semantic_manifest_lookup,
     )
-    sql_renderer: SqlQueryPlanRenderer = sql_client.sql_plan_renderer
+    sql_renderer: SqlPlanRenderer = sql_client.sql_plan_renderer
     node_output_resolver = DataflowPlanNodeOutputDataSetResolver(
         column_association_resolver=column_association_resolver,
         semantic_manifest_lookup=simple_semantic_manifest_lookup,

--- a/tests_metricflow/fixtures/sql_clients/adapter_backed_ddl_client.py
+++ b/tests_metricflow/fixtures/sql_clients/adapter_backed_ddl_client.py
@@ -112,9 +112,9 @@ class AdapterBackedDDLSqlClient(AdapterBackedSqlClient):
         elif column_type is int:
             return "bigint"
         elif column_type is float:
-            return self._sql_query_plan_renderer.expr_renderer.double_data_type
+            return self._sql_plan_renderer.expr_renderer.double_data_type
         elif column_type is datetime.datetime:
-            return self._sql_query_plan_renderer.expr_renderer.timestamp_data_type
+            return self._sql_plan_renderer.expr_renderer.timestamp_data_type
         else:
             raise ValueError(f"Encountered unexpected {column_type=}!")
 

--- a/tests_metricflow/fixtures/sql_fixtures.py
+++ b/tests_metricflow/fixtures/sql_fixtures.py
@@ -5,13 +5,13 @@ from typing import Mapping
 import pytest
 
 from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlPlanConverter
-from metricflow.sql.render.sql_plan_renderer import DefaultSqlQueryPlanRenderer, SqlQueryPlanRenderer
+from metricflow.sql.render.sql_plan_renderer import DefaultSqlPlanRenderer, SqlPlanRenderer
 from tests_metricflow.fixtures.manifest_fixtures import MetricFlowEngineTestFixture, SemanticManifestSetup
 
 
 @pytest.fixture
-def default_sql_plan_renderer() -> SqlQueryPlanRenderer:  # noqa: D103
-    return DefaultSqlQueryPlanRenderer()
+def default_sql_plan_renderer() -> SqlPlanRenderer:  # noqa: D103
+    return DefaultSqlPlanRenderer()
 
 
 @pytest.fixture(scope="session")

--- a/tests_metricflow/integration/query_output/test_cumulative_metrics.py
+++ b/tests_metricflow/integration/query_output/test_cumulative_metrics.py
@@ -134,8 +134,8 @@ def test_cumulative_metric_with_non_adjustable_filter(
 ) -> None:
     """Tests a cumulative metric with a filter that cannot be adjusted to ensure all data is included."""
     # Handle ds expression based on engine to support Trino.
-    first_ds_expr = f"CAST('2020-03-15' AS {sql_client.sql_query_plan_renderer.expr_renderer.timestamp_data_type})"
-    second_ds_expr = f"CAST('2020-04-30' AS {sql_client.sql_query_plan_renderer.expr_renderer.timestamp_data_type})"
+    first_ds_expr = f"CAST('2020-03-15' AS {sql_client.sql_plan_renderer.expr_renderer.timestamp_data_type})"
+    second_ds_expr = f"CAST('2020-04-30' AS {sql_client.sql_plan_renderer.expr_renderer.timestamp_data_type})"
     where_constraint = f"{{{{ TimeDimension('metric_time', 'day') }}}} = {first_ds_expr} or"
     where_constraint += f" {{{{ TimeDimension('metric_time', 'day') }}}} = {second_ds_expr}"
 

--- a/tests_metricflow/integration/test_configured_cases.py
+++ b/tests_metricflow/integration/test_configured_cases.py
@@ -77,7 +77,7 @@ class CheckQueryHelpers:
 
     def cast_expr_to_ts(self, expr: str) -> str:
         """Returns the expression as a new expression cast to the timestamp type, if applicable for the DB."""
-        return f"CAST({expr} AS {self._sql_client.sql_query_plan_renderer.expr_renderer.timestamp_data_type})"
+        return f"CAST({expr} AS {self._sql_client.sql_plan_renderer.expr_renderer.timestamp_data_type})"
 
     def cast_to_ts(self, string_literal: str) -> str:
         """Similar to cast_expr_to_ts, but assumes the input string is to be converted into a string literal."""
@@ -96,7 +96,7 @@ class CheckQueryHelpers:
             count=count,
             granularity=granularity,
         )
-        return self._sql_client.sql_query_plan_renderer.expr_renderer.render_sql_expr(expr).sql
+        return self._sql_client.sql_plan_renderer.expr_renderer.render_sql_expr(expr).sql
 
     def render_date_trunc(self, expr: str, granularity: TimeGranularity) -> str:
         """Return the DATE_TRUNC() call that can be used for converting the given expr to the granularity."""
@@ -109,7 +109,7 @@ class CheckQueryHelpers:
                 )
             ),
         )
-        return self._sql_client.sql_query_plan_renderer.expr_renderer.render_sql_expr(renderable_expr).sql
+        return self._sql_client.sql_plan_renderer.expr_renderer.render_sql_expr(renderable_expr).sql
 
     def render_extract(self, expr: str, date_part: DatePart) -> str:
         """Return the EXTRACT call that can be used for converting the given expr to the date_part."""
@@ -122,7 +122,7 @@ class CheckQueryHelpers:
                 )
             ),
         )
-        return self._sql_client.sql_query_plan_renderer.expr_renderer.render_sql_expr(renderable_expr).sql
+        return self._sql_client.sql_plan_renderer.expr_renderer.render_sql_expr(renderable_expr).sql
 
     def render_percentile_expr(
         self, expr: str, percentile: float, use_discrete_percentile: bool, use_approximate_percentile: bool
@@ -143,12 +143,12 @@ class CheckQueryHelpers:
             ),
             percentile_args=percentile_args,
         )
-        return self._sql_client.sql_query_plan_renderer.expr_renderer.render_sql_expr(renderable_expr).sql
+        return self._sql_client.sql_plan_renderer.expr_renderer.render_sql_expr(renderable_expr).sql
 
     @property
     def double_data_type_name(self) -> str:
         """Return the name of the double data type for the relevant SQL engine."""
-        return self._sql_client.sql_query_plan_renderer.expr_renderer.double_data_type
+        return self._sql_client.sql_plan_renderer.expr_renderer.double_data_type
 
     def render_dimension_template(self, dimension_name: str, entity_path: Sequence[str] = ()) -> str:
         """Renders a template that can be used to retrieve a dimension.
@@ -186,7 +186,7 @@ class CheckQueryHelpers:
     def generate_random_uuid(self) -> str:
         """Returns the generate random UUID SQL function."""
         expr = SqlGenerateUuidExpression.create()
-        return self._sql_client.sql_query_plan_renderer.expr_renderer.render_sql_expr(expr).sql
+        return self._sql_client.sql_plan_renderer.expr_renderer.render_sql_expr(expr).sql
 
 
 def filter_not_supported_features(
@@ -196,22 +196,22 @@ def filter_not_supported_features(
     not_supported_features: List[RequiredDwEngineFeature] = []
     for required_feature in required_features:
         if required_feature is RequiredDwEngineFeature.CONTINUOUS_PERCENTILE_AGGREGATION:
-            if not sql_client.sql_query_plan_renderer.expr_renderer.can_render_percentile_function(
+            if not sql_client.sql_plan_renderer.expr_renderer.can_render_percentile_function(
                 SqlPercentileFunctionType.CONTINUOUS
             ):
                 not_supported_features.append(required_feature)
         elif required_feature is RequiredDwEngineFeature.DISCRETE_PERCENTILE_AGGREGATION:
-            if not sql_client.sql_query_plan_renderer.expr_renderer.can_render_percentile_function(
+            if not sql_client.sql_plan_renderer.expr_renderer.can_render_percentile_function(
                 SqlPercentileFunctionType.DISCRETE
             ):
                 not_supported_features.append(required_feature)
         elif required_feature is RequiredDwEngineFeature.APPROXIMATE_CONTINUOUS_PERCENTILE_AGGREGATION:
-            if not sql_client.sql_query_plan_renderer.expr_renderer.can_render_percentile_function(
+            if not sql_client.sql_plan_renderer.expr_renderer.can_render_percentile_function(
                 SqlPercentileFunctionType.APPROXIMATE_CONTINUOUS
             ):
                 not_supported_features.append(required_feature)
         elif required_feature is RequiredDwEngineFeature.APPROXIMATE_DISCRETE_PERCENTILE_AGGREGATION:
-            if not sql_client.sql_query_plan_renderer.expr_renderer.can_render_percentile_function(
+            if not sql_client.sql_plan_renderer.expr_renderer.can_render_percentile_function(
                 SqlPercentileFunctionType.APPROXIMATE_DISCRETE
             ):
                 not_supported_features.append(required_feature)

--- a/tests_metricflow/plan_conversion/dataflow_to_sql/test_cte_sql.py
+++ b/tests_metricflow/plan_conversion/dataflow_to_sql/test_cte_sql.py
@@ -61,10 +61,10 @@ def convert_and_check(
 
     lines = [
         "sql_without_cte:",
-        indent(renderer.render_sql_query_plan(sql_plan_without_cte).sql),
+        indent(renderer.render_sql_plan(sql_plan_without_cte).sql),
         "\n",
         "sql_with_cte:",
-        indent(renderer.render_sql_query_plan(sql_plan_with_cte).sql),
+        indent(renderer.render_sql_plan(sql_plan_with_cte).sql),
     ]
 
     assert_str_snapshot_equal(

--- a/tests_metricflow/plan_conversion/dataflow_to_sql/test_cte_sql.py
+++ b/tests_metricflow/plan_conversion/dataflow_to_sql/test_cte_sql.py
@@ -23,7 +23,7 @@ from metricflow.dataflow.dataflow_plan_analyzer import DataflowPlanAnalyzer
 from metricflow.dataflow.nodes.filter_elements import FilterElementsNode
 from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlPlanConverter
 from metricflow.sql.optimizer.optimization_levels import SqlGenerationOptionSet, SqlOptimizationLevel
-from metricflow.sql.render.sql_plan_renderer import DefaultSqlQueryPlanRenderer
+from metricflow.sql.render.sql_plan_renderer import DefaultSqlPlanRenderer
 from tests_metricflow.fixtures.manifest_fixtures import MetricFlowEngineTestFixture, SemanticManifestSetup
 
 logger = logging.getLogger(__name__)
@@ -57,7 +57,7 @@ def convert_and_check(
         nodes_to_convert_to_cte=nodes_to_convert_to_cte,
     )
     sql_plan_with_cte = conversion_result.sql_plan
-    renderer = DefaultSqlQueryPlanRenderer()
+    renderer = DefaultSqlPlanRenderer()
 
     lines = [
         "sql_without_cte:",

--- a/tests_metricflow/plan_conversion/test_dataflow_to_execution.py
+++ b/tests_metricflow/plan_conversion/test_dataflow_to_execution.py
@@ -16,7 +16,7 @@ from metricflow.execution.dataflow_to_execution import DataflowToExecutionPlanCo
 from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlPlanConverter
 from metricflow.protocols.sql_client import SqlClient
 from metricflow.sql.optimizer.optimization_levels import SqlOptimizationLevel
-from metricflow.sql.render.sql_plan_renderer import DefaultSqlQueryPlanRenderer
+from metricflow.sql.render.sql_plan_renderer import DefaultSqlPlanRenderer
 from tests_metricflow.snapshot_utils import assert_execution_plan_text_equal
 
 
@@ -29,7 +29,7 @@ def make_execution_plan_converter(  # noqa: D103
             column_association_resolver=DunderColumnAssociationResolver(),
             semantic_manifest_lookup=semantic_manifest_lookup,
         ),
-        sql_plan_renderer=DefaultSqlQueryPlanRenderer(),
+        sql_plan_renderer=DefaultSqlPlanRenderer(),
         sql_client=sql_client,
         sql_optimization_level=SqlOptimizationLevel.default_level(),
     )

--- a/tests_metricflow/sql/compare_sql_plan.py
+++ b/tests_metricflow/sql/compare_sql_plan.py
@@ -10,7 +10,7 @@ from metricflow_semantics.test_helpers.snapshot_helpers import (
 )
 
 from metricflow.protocols.sql_client import SqlClient
-from metricflow.sql.render.sql_plan_renderer import DefaultSqlQueryPlanRenderer
+from metricflow.sql.render.sql_plan_renderer import DefaultSqlPlanRenderer
 from metricflow.sql.sql_plan import SqlPlan, SqlPlanNode
 from tests_metricflow.fixtures.setup_fixtures import check_sql_engine_snapshot_marker
 from tests_metricflow.snapshot_utils import (
@@ -27,7 +27,7 @@ def assert_default_rendered_sql_equal(
 ) -> None:
     """Helper function to render a select statement and compare with the one saved as a file."""
     sql_query_plan = SqlPlan(render_node=sql_plan_node, plan_id=DagId.from_str(plan_id))
-    rendered_sql = DefaultSqlQueryPlanRenderer().render_sql_query_plan(sql_query_plan).sql
+    rendered_sql = DefaultSqlPlanRenderer().render_sql_query_plan(sql_query_plan).sql
 
     assert_plan_snapshot_text_equal(
         request=request,

--- a/tests_metricflow/sql/compare_sql_plan.py
+++ b/tests_metricflow/sql/compare_sql_plan.py
@@ -68,7 +68,7 @@ def assert_rendered_sql_from_plan_equal(
     """Similar to assert_rendered_sql_equal, but takes in a SQL query plan."""
     check_sql_engine_snapshot_marker(request)
 
-    rendered_sql = sql_client.sql_query_plan_renderer.render_sql_query_plan(sql_query_plan).sql
+    rendered_sql = sql_client.sql_plan_renderer.render_sql_query_plan(sql_query_plan).sql
 
     sql_engine = sql_client.sql_engine_type
     assert_snapshot_text_equal(

--- a/tests_metricflow/sql/compare_sql_plan.py
+++ b/tests_metricflow/sql/compare_sql_plan.py
@@ -27,7 +27,7 @@ def assert_default_rendered_sql_equal(
 ) -> None:
     """Helper function to render a select statement and compare with the one saved as a file."""
     sql_query_plan = SqlPlan(render_node=sql_plan_node, plan_id=DagId.from_str(plan_id))
-    rendered_sql = DefaultSqlPlanRenderer().render_sql_query_plan(sql_query_plan).sql
+    rendered_sql = DefaultSqlPlanRenderer().render_sql_plan(sql_query_plan).sql
 
     assert_plan_snapshot_text_equal(
         request=request,
@@ -68,7 +68,7 @@ def assert_rendered_sql_from_plan_equal(
     """Similar to assert_rendered_sql_equal, but takes in a SQL query plan."""
     check_sql_engine_snapshot_marker(request)
 
-    rendered_sql = sql_client.sql_plan_renderer.render_sql_query_plan(sql_query_plan).sql
+    rendered_sql = sql_client.sql_plan_renderer.render_sql_plan(sql_query_plan).sql
 
     sql_engine = sql_client.sql_engine_type
     assert_snapshot_text_equal(

--- a/tests_metricflow/sql/optimizer/check_optimizer.py
+++ b/tests_metricflow/sql/optimizer/check_optimizer.py
@@ -9,7 +9,7 @@ from metricflow_semantics.test_helpers.config_helpers import MetricFlowTestConfi
 from metricflow_semantics.test_helpers.snapshot_helpers import assert_str_snapshot_equal
 
 from metricflow.sql.optimizer.sql_query_plan_optimizer import SqlPlanOptimizer
-from metricflow.sql.render.sql_plan_renderer import SqlQueryPlanRenderer
+from metricflow.sql.render.sql_plan_renderer import SqlPlanRenderer
 from metricflow.sql.sql_plan import SqlPlan, SqlSelectStatementNode
 
 logger = logging.getLogger(__name__)
@@ -19,7 +19,7 @@ def assert_optimizer_result_snapshot_equal(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     optimizer: SqlPlanOptimizer,
-    sql_plan_renderer: SqlQueryPlanRenderer,
+    sql_plan_renderer: SqlPlanRenderer,
     select_statement: SqlSelectStatementNode,
 ) -> None:
     """Helper to assert that the SQL snapshot of the optimizer result is the same as the stored one."""

--- a/tests_metricflow/sql/optimizer/check_optimizer.py
+++ b/tests_metricflow/sql/optimizer/check_optimizer.py
@@ -23,7 +23,7 @@ def assert_optimizer_result_snapshot_equal(
     select_statement: SqlSelectStatementNode,
 ) -> None:
     """Helper to assert that the SQL snapshot of the optimizer result is the same as the stored one."""
-    sql_before_optimizing = sql_plan_renderer.render_sql_query_plan(SqlPlan(select_statement)).sql
+    sql_before_optimizing = sql_plan_renderer.render_sql_plan(SqlPlan(select_statement)).sql
     logger.debug(
         LazyFormat(
             "Optimizing SELECT statement",
@@ -33,7 +33,7 @@ def assert_optimizer_result_snapshot_equal(
     )
 
     column_pruned_select_node = optimizer.optimize(select_statement)
-    sql_after_optimizing = sql_plan_renderer.render_sql_query_plan(SqlPlan(column_pruned_select_node)).sql
+    sql_after_optimizing = sql_plan_renderer.render_sql_plan(SqlPlan(column_pruned_select_node)).sql
     logger.debug(
         LazyFormat(
             "Optimized SQL",

--- a/tests_metricflow/sql/optimizer/test_column_pruner.py
+++ b/tests_metricflow/sql/optimizer/test_column_pruner.py
@@ -18,7 +18,7 @@ from metricflow_semantics.sql.sql_table import SqlTable
 from metricflow_semantics.test_helpers.config_helpers import MetricFlowTestConfiguration
 
 from metricflow.sql.optimizer.column_pruner import SqlColumnPrunerOptimizer
-from metricflow.sql.render.sql_plan_renderer import DefaultSqlQueryPlanRenderer, SqlQueryPlanRenderer
+from metricflow.sql.render.sql_plan_renderer import DefaultSqlPlanRenderer, SqlPlanRenderer
 from metricflow.sql.sql_plan import (
     SqlJoinDescription,
     SqlPlanNode,
@@ -37,8 +37,8 @@ def column_pruner() -> SqlColumnPrunerOptimizer:  # noqa: D103
 
 
 @pytest.fixture
-def sql_plan_renderer() -> SqlQueryPlanRenderer:  # noqa: D103
-    return DefaultSqlQueryPlanRenderer()
+def sql_plan_renderer() -> SqlPlanRenderer:  # noqa: D103
+    return DefaultSqlPlanRenderer()
 
 
 @pytest.fixture

--- a/tests_metricflow/sql/optimizer/test_cte_column_pruner.py
+++ b/tests_metricflow/sql/optimizer/test_cte_column_pruner.py
@@ -15,7 +15,7 @@ from metricflow_semantics.sql.sql_table import SqlTable
 from metricflow_semantics.test_helpers.config_helpers import MetricFlowTestConfiguration
 
 from metricflow.sql.optimizer.column_pruner import SqlColumnPrunerOptimizer
-from metricflow.sql.render.sql_plan_renderer import DefaultSqlQueryPlanRenderer, SqlQueryPlanRenderer
+from metricflow.sql.render.sql_plan_renderer import DefaultSqlPlanRenderer, SqlPlanRenderer
 from metricflow.sql.sql_plan import (
     SqlCteNode,
     SqlJoinDescription,
@@ -34,15 +34,15 @@ def column_pruner() -> SqlColumnPrunerOptimizer:  # noqa: D103
 
 
 @pytest.fixture
-def sql_plan_renderer() -> SqlQueryPlanRenderer:  # noqa: D103
-    return DefaultSqlQueryPlanRenderer()
+def sql_plan_renderer() -> SqlPlanRenderer:  # noqa: D103
+    return DefaultSqlPlanRenderer()
 
 
 def test_no_pruning(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     column_pruner: SqlColumnPrunerOptimizer,
-    sql_plan_renderer: DefaultSqlQueryPlanRenderer,
+    sql_plan_renderer: DefaultSqlPlanRenderer,
 ) -> None:
     """Tests a case where no pruning should occur for a CTE."""
     select_statement = SqlSelectStatementNode.create(
@@ -91,7 +91,7 @@ def test_simple_pruning(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     column_pruner: SqlColumnPrunerOptimizer,
-    sql_plan_renderer: DefaultSqlQueryPlanRenderer,
+    sql_plan_renderer: DefaultSqlPlanRenderer,
 ) -> None:
     """Tests the simplest case of pruning a CTE where a query depends on a CTE, and that CTE is pruned."""
     select_statement = SqlSelectStatementNode.create(
@@ -146,7 +146,7 @@ def test_nested_pruning(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     column_pruner: SqlColumnPrunerOptimizer,
-    sql_plan_renderer: DefaultSqlQueryPlanRenderer,
+    sql_plan_renderer: DefaultSqlPlanRenderer,
 ) -> None:
     """Tests the case of pruning a CTE where a query depends on a CTE, and that CTE depends on another CTE."""
     select_statement = SqlSelectStatementNode.create(
@@ -228,7 +228,7 @@ def test_multi_child_pruning(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     column_pruner: SqlColumnPrunerOptimizer,
-    sql_plan_renderer: DefaultSqlQueryPlanRenderer,
+    sql_plan_renderer: DefaultSqlPlanRenderer,
 ) -> None:
     """Tests the case of pruning a CTE where difference sources depend on the same CTE."""
     select_statement = SqlSelectStatementNode.create(

--- a/tests_metricflow/sql/optimizer/test_cte_rewriting_sub_query_reducer.py
+++ b/tests_metricflow/sql/optimizer/test_cte_rewriting_sub_query_reducer.py
@@ -15,7 +15,7 @@ from metricflow_semantics.sql.sql_table import SqlTable
 from metricflow_semantics.test_helpers.config_helpers import MetricFlowTestConfiguration
 
 from metricflow.sql.optimizer.rewriting_sub_query_reducer import SqlRewritingSubQueryReducer
-from metricflow.sql.render.sql_plan_renderer import DefaultSqlQueryPlanRenderer, SqlQueryPlanRenderer
+from metricflow.sql.render.sql_plan_renderer import DefaultSqlPlanRenderer, SqlPlanRenderer
 from metricflow.sql.sql_plan import (
     SqlCteNode,
     SqlJoinDescription,
@@ -34,8 +34,8 @@ def sub_query_reducer() -> SqlRewritingSubQueryReducer:  # noqa: D103
 
 
 @pytest.fixture
-def sql_plan_renderer() -> SqlQueryPlanRenderer:  # noqa: D103
-    return DefaultSqlQueryPlanRenderer()
+def sql_plan_renderer() -> SqlPlanRenderer:  # noqa: D103
+    return DefaultSqlPlanRenderer()
 
 
 @pytest.fixture(scope="module")
@@ -230,7 +230,7 @@ def test_reduce_cte(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     sub_query_reducer: SqlRewritingSubQueryReducer,
-    sql_plan_renderer: DefaultSqlQueryPlanRenderer,
+    sql_plan_renderer: DefaultSqlPlanRenderer,
     base_select_statement_to_reduce: SqlSelectStatementNode,
 ) -> None:
     """Tests that the SELECT statements in CTEs are reduced."""
@@ -246,7 +246,7 @@ def test_reduce_cte(
 def test_reduce_cte_with_use_column_alias_in_group_bys(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
-    sql_plan_renderer: DefaultSqlQueryPlanRenderer,
+    sql_plan_renderer: DefaultSqlPlanRenderer,
     base_select_statement_to_reduce: SqlSelectStatementNode,
 ) -> None:
     """This tests reducing with the `use_column_alias_in_group_bys` flag set."""

--- a/tests_metricflow/sql/optimizer/test_cte_table_alias_simplifier.py
+++ b/tests_metricflow/sql/optimizer/test_cte_table_alias_simplifier.py
@@ -13,7 +13,7 @@ from metricflow_semantics.sql.sql_table import SqlTable
 from metricflow_semantics.test_helpers.config_helpers import MetricFlowTestConfiguration
 
 from metricflow.sql.optimizer.table_alias_simplifier import SqlTableAliasSimplifier
-from metricflow.sql.render.sql_plan_renderer import DefaultSqlQueryPlanRenderer
+from metricflow.sql.render.sql_plan_renderer import DefaultSqlPlanRenderer
 from metricflow.sql.sql_plan import (
     SqlCteNode,
     SqlJoinDescription,
@@ -25,14 +25,14 @@ from tests_metricflow.sql.optimizer.check_optimizer import assert_optimizer_resu
 
 
 @pytest.fixture
-def sql_plan_renderer() -> DefaultSqlQueryPlanRenderer:  # noqa: D103
-    return DefaultSqlQueryPlanRenderer()
+def sql_plan_renderer() -> DefaultSqlPlanRenderer:  # noqa: D103
+    return DefaultSqlPlanRenderer()
 
 
 def test_table_alias_simplification(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
-    sql_plan_renderer: DefaultSqlQueryPlanRenderer,
+    sql_plan_renderer: DefaultSqlPlanRenderer,
 ) -> None:
     """Tests that table aliases in the SELECT statement of a CTE are removed when not needed."""
     select_statement = SqlSelectStatementNode.create(
@@ -172,7 +172,7 @@ def test_table_alias_simplification(
 def test_table_alias_no_simplification(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
-    sql_plan_renderer: DefaultSqlQueryPlanRenderer,
+    sql_plan_renderer: DefaultSqlPlanRenderer,
 ) -> None:
     """Tests that table aliases in the SELECT statement of a CTE are not removed when required."""
     select_statement = SqlSelectStatementNode.create(

--- a/tests_metricflow/sql/optimizer/test_table_alias_simplifier.py
+++ b/tests_metricflow/sql/optimizer/test_table_alias_simplifier.py
@@ -13,7 +13,7 @@ from metricflow_semantics.sql.sql_table import SqlTable
 from metricflow_semantics.test_helpers.config_helpers import MetricFlowTestConfiguration
 
 from metricflow.sql.optimizer.table_alias_simplifier import SqlTableAliasSimplifier
-from metricflow.sql.render.sql_plan_renderer import DefaultSqlQueryPlanRenderer, SqlQueryPlanRenderer
+from metricflow.sql.render.sql_plan_renderer import DefaultSqlPlanRenderer, SqlPlanRenderer
 from metricflow.sql.sql_plan import (
     SqlJoinDescription,
     SqlSelectColumn,
@@ -24,8 +24,8 @@ from tests_metricflow.sql.compare_sql_plan import assert_default_rendered_sql_eq
 
 
 @pytest.fixture
-def sql_plan_renderer() -> SqlQueryPlanRenderer:  # noqa: D103
-    return DefaultSqlQueryPlanRenderer()
+def sql_plan_renderer() -> SqlPlanRenderer:  # noqa: D103
+    return DefaultSqlPlanRenderer()
 
 
 @pytest.fixture

--- a/tests_metricflow/sql/test_engine_specific_rendering.py
+++ b/tests_metricflow/sql/test_engine_specific_rendering.py
@@ -111,7 +111,7 @@ def test_continuous_percentile_expr(
     sql_client: SqlClient,
 ) -> None:
     """Tests rendering of the continuous percentile expression in a query."""
-    if not sql_client.sql_query_plan_renderer.expr_renderer.can_render_percentile_function(
+    if not sql_client.sql_plan_renderer.expr_renderer.can_render_percentile_function(
         SqlPercentileFunctionType.CONTINUOUS
     ):
         pytest.skip("Warehouse does not support continuous percentile expressions")
@@ -160,7 +160,7 @@ def test_discrete_percentile_expr(
     sql_client: SqlClient,
 ) -> None:
     """Tests rendering of the discrete percentile expression in a query."""
-    if not sql_client.sql_query_plan_renderer.expr_renderer.can_render_percentile_function(
+    if not sql_client.sql_plan_renderer.expr_renderer.can_render_percentile_function(
         SqlPercentileFunctionType.DISCRETE
     ):
         pytest.skip("Warehouse does not support discrete percentile expressions")
@@ -209,7 +209,7 @@ def test_approximate_continuous_percentile_expr(
     sql_client: SqlClient,
 ) -> None:
     """Tests rendering of the approximate continuous percentile expression in a query."""
-    if not sql_client.sql_query_plan_renderer.expr_renderer.can_render_percentile_function(
+    if not sql_client.sql_plan_renderer.expr_renderer.can_render_percentile_function(
         SqlPercentileFunctionType.APPROXIMATE_CONTINUOUS
     ):
         pytest.skip("Warehouse does not support approximate_continuous percentile expressions")
@@ -258,7 +258,7 @@ def test_approximate_discrete_percentile_expr(
     sql_client: SqlClient,
 ) -> None:
     """Tests rendering of the approximate discrete percentile expression in a query."""
-    if not sql_client.sql_query_plan_renderer.expr_renderer.can_render_percentile_function(
+    if not sql_client.sql_plan_renderer.expr_renderer.can_render_percentile_function(
         SqlPercentileFunctionType.APPROXIMATE_DISCRETE
     ):
         pytest.skip("Warehouse does not support percentile expressions")

--- a/tests_metricflow/sql_clients/test_date_time_operations.py
+++ b/tests_metricflow/sql_clients/test_date_time_operations.py
@@ -58,7 +58,7 @@ def test_date_trunc_to_year(sql_client: SqlClient) -> None:
     # The ISO year start for 2015 is 2014-12-29, but we should always get 2015-01-01
     ISO_DATE_STRING = "2015-06-15"
     expected = datetime.datetime(year=2015, month=1, day=1)
-    date_trunc_stmt = sql_client.sql_query_plan_renderer.expr_renderer.render_sql_expr(
+    date_trunc_stmt = sql_client.sql_plan_renderer.expr_renderer.render_sql_expr(
         _build_date_trunc_expression(date_string=ISO_DATE_STRING, time_granularity=TimeGranularity.YEAR)
     ).sql
 
@@ -83,7 +83,7 @@ def test_date_trunc_to_quarter(sql_client: SqlClient, input: str, expected: date
     This should generally pin to the first day of the "natural" yearly quarters, for example,
     2015-01-01, 2015-04-01, 2015-07-01, and 2015-10-01.
     """
-    date_trunc_stmt = sql_client.sql_query_plan_renderer.expr_renderer.render_sql_expr(
+    date_trunc_stmt = sql_client.sql_plan_renderer.expr_renderer.render_sql_expr(
         _build_date_trunc_expression(date_string=input, time_granularity=TimeGranularity.QUARTER)
     ).sql
 
@@ -107,7 +107,7 @@ def test_date_trunc_to_week(sql_client: SqlClient, input: str, expected: datetim
     This is needed because some engines default to Monday and some default to Sunday for their week start.
     On a human level, both are reasonable, so we coerce to the ISO standard of Monday.
     """
-    date_trunc_stmt = sql_client.sql_query_plan_renderer.expr_renderer.render_sql_expr(
+    date_trunc_stmt = sql_client.sql_plan_renderer.expr_renderer.render_sql_expr(
         _build_date_trunc_expression(date_string=input, time_granularity=TimeGranularity.WEEK)
     ).sql
 
@@ -132,7 +132,7 @@ def test_date_part_year(sql_client: SqlClient) -> None:
     ISO_DATE_STRING = "2014-12-30"
     # We, however, expect the calendar year
     expected = 2014
-    extract_stmt = sql_client.sql_query_plan_renderer.expr_renderer.render_sql_expr(
+    extract_stmt = sql_client.sql_plan_renderer.expr_renderer.render_sql_expr(
         _build_extract_expression(date_string=ISO_DATE_STRING, date_part=DatePart.YEAR)
     ).sql
 
@@ -157,7 +157,7 @@ def test_date_part_quarter(sql_client: SqlClient, input: str, expected: int) -> 
     We expect the quarter boundaries to line up and results to be in [1, 4] corresponding to the natural
     4 calendar quarters.
     """
-    extract_stmt = sql_client.sql_query_plan_renderer.expr_renderer.render_sql_expr(
+    extract_stmt = sql_client.sql_plan_renderer.expr_renderer.render_sql_expr(
         _build_extract_expression(date_string=input, date_part=DatePart.QUARTER)
     ).sql
 
@@ -176,7 +176,7 @@ def test_date_part_day_of_year(sql_client: SqlClient) -> None:
     ISO_DATE_STRING = "2014-12-30"
     # We, however, expect the calendar year, so it should return 364
     expected = 364
-    extract_stmt = sql_client.sql_query_plan_renderer.expr_renderer.render_sql_expr(
+    extract_stmt = sql_client.sql_plan_renderer.expr_renderer.render_sql_expr(
         _build_extract_expression(date_string=ISO_DATE_STRING, date_part=DatePart.DOY)
     ).sql
 
@@ -200,7 +200,7 @@ def test_date_part_day_of_year(sql_client: SqlClient) -> None:
 )
 def test_date_part_day_of_week(sql_client: SqlClient, input: str, expected: int) -> None:
     """Tests date_part or extract behavior for day of week."""
-    extract_stmt = sql_client.sql_query_plan_renderer.expr_renderer.render_sql_expr(
+    extract_stmt = sql_client.sql_plan_renderer.expr_renderer.render_sql_expr(
         _build_extract_expression(date_string=input, date_part=DatePart.DOW)
     ).sql
 


### PR DESCRIPTION
This PR renames a few symbols related to the recent rename from `SqlQueryPlan` to `SqlPlan`.