### PR TITLE
Build DataflowPlan for custom offset window

### DIFF
--- a/.changes/unreleased/Features-20241218-133743.yaml
+++ b/.changes/unreleased/Features-20241218-133743.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Support for custom offset windows.
+time: 2024-12-18T13:37:43.23915-08:00
+custom:
+  Author: courtneyholcomb
+  Issue: "1584"

--- a/metricflow-semantics/metricflow_semantics/specs/measure_spec.py
+++ b/metricflow-semantics/metricflow_semantics/specs/measure_spec.py
@@ -91,3 +91,10 @@ class JoinToTimeSpineDescription:
     join_type: SqlJoinType
     offset_window: Optional[MetricTimeWindow]
     offset_to_grain: Optional[TimeGranularity]
+
+    @property
+    def standard_offset_window(self) -> Optional[MetricTimeWindow]:
+        """Return the standard offset window if it is a standard granularity."""
+        if self.offset_window and self.offset_window.is_standard_granularity:
+            return self.offset_window
+        return None

--- a/metricflow-semantics/metricflow_semantics/specs/metric_spec.py
+++ b/metricflow-semantics/metricflow_semantics/specs/metric_spec.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from typing import Optional
 
 from dbt_semantic_interfaces.implementations.metric import PydanticMetricTimeWindow
+from dbt_semantic_interfaces.protocols.metric import MetricTimeWindow
 from dbt_semantic_interfaces.references import MetricReference
 from dbt_semantic_interfaces.type_enums import TimeGranularity
 
@@ -67,3 +68,10 @@ class MetricSpec(InstanceSpec):  # noqa: D101
             offset_window=self.offset_window,
             offset_to_grain=self.offset_to_grain,
         )
+
+    @property
+    def standard_offset_window(self) -> Optional[MetricTimeWindow]:
+        """Return the offset window if it exists and uses a standard granularity."""
+        if self.offset_window and self.offset_window.is_standard_granularity:
+            return self.offset_window
+        return None

--- a/metricflow-semantics/tests_metricflow_semantics/model/semantics/test_metric_lookup.py
+++ b/metricflow-semantics/tests_metricflow_semantics/model/semantics/test_metric_lookup.py
@@ -27,12 +27,7 @@ def test_min_queryable_time_granularity_for_different_agg_time_grains(  # noqa: 
 def test_custom_offset_window_for_metric(
     simple_semantic_manifest_lookup: SemanticManifestLookup,
 ) -> None:
-    """Test offset window with custom grain supplied.
-
-    TODO: As of now, the functionality of an offset window with a custom grain is not supported in MF.
-          This test is added to show that at least the parsing is successful using a custom grain offset window.
-          Once support for that is added in MF + relevant tests, this test can be removed.
-    """
+    """Test offset window with custom grain supplied."""
     metric = simple_semantic_manifest_lookup.metric_lookup.get_metric(MetricReference("bookings_offset_martian_day"))
 
     assert len(metric.input_metrics) == 1

--- a/metricflow/dataflow/builder/dataflow_plan_builder.py
+++ b/metricflow/dataflow/builder/dataflow_plan_builder.py
@@ -92,6 +92,7 @@ from metricflow.dataflow.nodes.join_to_custom_granularity import JoinToCustomGra
 from metricflow.dataflow.nodes.join_to_time_spine import JoinToTimeSpineNode
 from metricflow.dataflow.nodes.metric_time_transform import MetricTimeDimensionTransformNode
 from metricflow.dataflow.nodes.min_max import MinMaxNode
+from metricflow.dataflow.nodes.offset_by_custom_granularity import OffsetByCustomGranularityNode
 from metricflow.dataflow.nodes.order_by_limit import OrderByLimitNode
 from metricflow.dataflow.nodes.read_sql_source import ReadSqlSourceNode
 from metricflow.dataflow.nodes.semi_additive_join import SemiAdditiveJoinNode
@@ -661,13 +662,18 @@ class DataflowPlanBuilder:
         )
         if metric_spec.has_time_offset and queried_agg_time_dimension_specs:
             # TODO: move this to a helper method
-            time_spine_node = self._build_time_spine_node(queried_agg_time_dimension_specs)
+            time_spine_node = self._build_time_spine_node(
+                queried_time_spine_specs=queried_agg_time_dimension_specs,
+                offset_window=metric_spec.offset_window,
+            )
             output_node = JoinToTimeSpineNode.create(
                 metric_source_node=output_node,
                 time_spine_node=time_spine_node,
                 requested_agg_time_dimension_specs=queried_agg_time_dimension_specs,
                 join_on_time_dimension_spec=self._sort_by_base_granularity(queried_agg_time_dimension_specs)[0],
-                offset_window=metric_spec.offset_window,
+                offset_window=(
+                    metric_spec.offset_window if not self._offset_window_is_custom(metric_spec.offset_window) else None
+                ),
                 offset_to_grain=metric_spec.offset_to_grain,
                 join_type=SqlJoinType.INNER,
             )
@@ -1668,13 +1674,20 @@ class DataflowPlanBuilder:
             required_time_spine_specs = base_queried_agg_time_dimension_specs
             if join_on_time_dimension_spec not in required_time_spine_specs:
                 required_time_spine_specs = (join_on_time_dimension_spec,) + required_time_spine_specs
-            time_spine_node = self._build_time_spine_node(required_time_spine_specs)
+            time_spine_node = self._build_time_spine_node(
+                queried_time_spine_specs=required_time_spine_specs,
+                offset_window=before_aggregation_time_spine_join_description.offset_window,
+            )
             unaggregated_measure_node = JoinToTimeSpineNode.create(
                 metric_source_node=unaggregated_measure_node,
                 time_spine_node=time_spine_node,
                 requested_agg_time_dimension_specs=base_queried_agg_time_dimension_specs,
                 join_on_time_dimension_spec=join_on_time_dimension_spec,
-                offset_window=before_aggregation_time_spine_join_description.offset_window,
+                offset_window=(
+                    before_aggregation_time_spine_join_description.offset_window
+                    if not self._offset_window_is_custom(before_aggregation_time_spine_join_description.offset_window)
+                    else None
+                ),
                 offset_to_grain=before_aggregation_time_spine_join_description.offset_to_grain,
                 join_type=before_aggregation_time_spine_join_description.join_type,
             )
@@ -1881,6 +1894,7 @@ class DataflowPlanBuilder:
         queried_time_spine_specs: Sequence[TimeDimensionSpec],
         where_filter_specs: Sequence[WhereFilterSpec] = (),
         time_range_constraint: Optional[TimeRangeConstraint] = None,
+        offset_window: Optional[MetricTimeWindow] = None,
     ) -> DataflowPlanNode:
         """Return the time spine node needed to satisfy the specs."""
         required_time_spine_spec_set = self.__get_required_linkable_specs(
@@ -1889,37 +1903,62 @@ class DataflowPlanBuilder:
         )
         required_time_spine_specs = required_time_spine_spec_set.time_dimension_specs
 
-        # TODO: support multiple time spines here. Build node on the one with the smallest base grain.
-        # Then, pass custom_granularity_specs into _build_pre_aggregation_plan if they aren't satisfied by smallest time spine.
-        time_spine_source = self._choose_time_spine_source(required_time_spine_specs)
-        read_node = self._choose_time_spine_read_node(time_spine_source)
-        time_spine_data_set = self._node_data_set_resolver.get_output_data_set(read_node)
-
-        # Change the column aliases to match the specs that were requested in the query.
-        time_spine_node = AliasSpecsNode.create(
-            parent_node=read_node,
-            change_specs=tuple(
-                SpecToAlias(
-                    input_spec=time_spine_data_set.instance_from_time_dimension_grain_and_date_part(
-                        time_granularity_name=required_spec.time_granularity_name, date_part=required_spec.date_part
-                    ).spec,
-                    output_spec=required_spec,
-                )
-                for required_spec in required_time_spine_specs
-            ),
-        )
-
-        # If the base grain of the time spine isn't selected, it will have duplicate rows that need deduping.
-        should_dedupe = ExpandedTimeGranularity.from_time_granularity(time_spine_source.base_granularity) not in {
-            spec.time_granularity for spec in queried_time_spine_specs
-        }
+        should_dedupe = False
+        filter_to_specs = tuple(queried_time_spine_specs)
+        if offset_window and self._offset_window_is_custom(offset_window):
+            time_spine_node = self._build_custom_offset_time_spine_node(
+                offset_window=offset_window, required_time_spine_specs=required_time_spine_specs
+            )
+            filter_to_specs = self._node_data_set_resolver.get_output_data_set(
+                time_spine_node
+            ).instance_set.spec_set.time_dimension_specs
+        else:
+            # For simpler time spine queries, choose the appropriate time spine node and apply requested aliases.
+            time_spine_source = self._choose_time_spine_source(required_time_spine_specs)
+            # TODO: support multiple time spines here. Build node on the one with the smallest base grain.
+            # Then, pass custom_granularity_specs into _build_pre_aggregation_plan if they aren't satisfied by smallest time spine.
+            read_node = self._choose_time_spine_read_node(time_spine_source)
+            time_spine_data_set = self._node_data_set_resolver.get_output_data_set(read_node)
+            # Change the column aliases to match the specs that were requested in the query.
+            time_spine_node = AliasSpecsNode.create(
+                parent_node=read_node,
+                change_specs=tuple(
+                    SpecToAlias(
+                        input_spec=time_spine_data_set.instance_from_time_dimension_grain_and_date_part(
+                            time_granularity_name=required_spec.time_granularity_name, date_part=required_spec.date_part
+                        ).spec,
+                        output_spec=required_spec,
+                    )
+                    for required_spec in required_time_spine_specs
+                ),
+            )
+            # If the base grain of the time spine isn't selected, it will have duplicate rows that need deduping.
+            should_dedupe = ExpandedTimeGranularity.from_time_granularity(time_spine_source.base_granularity) not in {
+                spec.time_granularity for spec in queried_time_spine_specs
+            }
 
         return self._build_pre_aggregation_plan(
             source_node=time_spine_node,
-            filter_to_specs=InstanceSpecSet(time_dimension_specs=tuple(queried_time_spine_specs)),
+            filter_to_specs=InstanceSpecSet(time_dimension_specs=filter_to_specs),
             time_range_constraint=time_range_constraint,
             where_filter_specs=where_filter_specs,
             distinct=should_dedupe,
+        )
+
+    def _build_custom_offset_time_spine_node(
+        self, offset_window: MetricTimeWindow, required_time_spine_specs: Tuple[TimeDimensionSpec, ...]
+    ) -> DataflowPlanNode:
+        # Build time spine node that offsets agg time dimensions by a custom grain.
+        custom_grain = self._semantic_model_lookup._custom_granularities[offset_window.granularity]
+        time_spine_source = self._choose_time_spine_source((DataSet.metric_time_dimension_spec(custom_grain),))
+        time_spine_read_node = self._choose_time_spine_read_node(time_spine_source)
+        if {spec.time_granularity for spec in required_time_spine_specs} == {custom_grain}:
+            # TODO: If querying with only the same grain as is used in the offset_window, can use a simpler plan.
+            pass
+        return OffsetByCustomGranularityNode.create(
+            time_spine_node=time_spine_read_node,
+            offset_window=offset_window,
+            required_time_spine_specs=required_time_spine_specs,
         )
 
     def _sort_by_base_granularity(self, time_dimension_specs: Sequence[TimeDimensionSpec]) -> List[TimeDimensionSpec]:
@@ -1950,3 +1989,9 @@ class DataflowPlanBuilder:
             sample_agg_time_dimension_spec = required_time_spine_specs[0]
             join_on_time_dimension_spec = sample_agg_time_dimension_spec.with_grain(time_granularity=join_spec_grain)
         return join_on_time_dimension_spec
+
+    def _offset_window_is_custom(self, offset_window: Optional[MetricTimeWindow]) -> bool:
+        return (
+            offset_window is not None
+            and offset_window.granularity in self._semantic_model_lookup.custom_granularity_names
+        )

--- a/metricflow/dataflow/builder/dataflow_plan_builder.py
+++ b/metricflow/dataflow/builder/dataflow_plan_builder.py
@@ -1900,7 +1900,7 @@ class DataflowPlanBuilder:
         should_dedupe = False
         filter_to_specs = tuple(queried_time_spine_specs)
         if offset_window and not offset_window.is_standard_granularity:
-            time_spine_node = self._build_custom_offset_time_spine_node(
+            time_spine_node = self.build_custom_offset_time_spine_node(
                 offset_window=offset_window, required_time_spine_specs=required_time_spine_specs
             )
             filter_to_specs = self._node_data_set_resolver.get_output_data_set(
@@ -1939,9 +1939,10 @@ class DataflowPlanBuilder:
             distinct=should_dedupe,
         )
 
-    def _build_custom_offset_time_spine_node(
+    def build_custom_offset_time_spine_node(
         self, offset_window: MetricTimeWindow, required_time_spine_specs: Tuple[TimeDimensionSpec, ...]
     ) -> DataflowPlanNode:
+        """Builds an OffsetByCustomGranularityNode used for custom offset windows."""
         # Build time spine node that offsets agg time dimensions by a custom grain.
         custom_grain = self._semantic_model_lookup._custom_granularities[offset_window.granularity]
         time_spine_source = self._choose_time_spine_source((DataSet.metric_time_dimension_spec(custom_grain),))

--- a/metricflow/plan_conversion/dataflow_to_sql.py
+++ b/metricflow/plan_conversion/dataflow_to_sql.py
@@ -1455,47 +1455,73 @@ class DataflowNodeToSqlSubqueryVisitor(DataflowPlanNodeVisitor[SqlDataSet]):
         time_spine_alias = self._next_unique_table_alias()
 
         required_agg_time_dimension_specs = tuple(node.requested_agg_time_dimension_specs)
-        if node.join_on_time_dimension_spec not in node.requested_agg_time_dimension_specs:
+        join_spec_was_requested = node.join_on_time_dimension_spec in node.requested_agg_time_dimension_specs
+        if not join_spec_was_requested:
             required_agg_time_dimension_specs += (node.join_on_time_dimension_spec,)
 
         # Build join expression.
-        join_column_name = self._column_association_resolver.resolve_spec(node.join_on_time_dimension_spec).column_name
+        parent_join_column_name = self._column_association_resolver.resolve_spec(
+            node.join_on_time_dimension_spec
+        ).column_name
+        time_spine_jon_column_name = time_spine_data_set.instance_from_time_dimension_grain_and_date_part(
+            time_granularity_name=node.join_on_time_dimension_spec.time_granularity_name, date_part=None
+        ).associated_column.column_name
         join_description = SqlPlanJoinBuilder.make_join_to_time_spine_join_description(
             node=node,
             time_spine_alias=time_spine_alias,
-            agg_time_dimension_column_name=join_column_name,
+            time_spine_column_name=time_spine_jon_column_name,
+            parent_column_name=parent_join_column_name,
             parent_sql_select_node=parent_data_set.checked_sql_select_node,
             parent_alias=parent_alias,
         )
 
-        # Build combined instance set.
+        # Build new instances and columns.
         time_spine_required_spec_set = InstanceSpecSet(time_dimension_specs=required_agg_time_dimension_specs)
-        parent_instance_set = parent_data_set.instance_set.transform(
+        output_parent_instance_set = parent_data_set.instance_set.transform(
             FilterElements(exclude_specs=time_spine_required_spec_set)
         )
-        time_spine_instance_set = time_spine_data_set.instance_set.transform(
-            FilterElements(include_specs=time_spine_required_spec_set)
-        )
-        output_instance_set = InstanceSet.merge([parent_instance_set, time_spine_instance_set])
+        output_time_spine_instances: Tuple[TimeDimensionInstance, ...] = ()
+        output_time_spine_columns: Tuple[SqlSelectColumn, ...] = ()
+        for old_instance in time_spine_data_set.instance_set.time_dimension_instances:
+            new_spec = old_instance.spec.with_window_functions(())
+            if new_spec not in required_agg_time_dimension_specs:
+                continue
+            if old_instance.spec.window_functions:
+                new_instance = old_instance.with_new_spec(
+                    new_spec=new_spec, column_association_resolver=self._column_association_resolver
+                )
+                column = SqlSelectColumn(
+                    expr=SqlColumnReferenceExpression.from_column_reference(
+                        table_alias=time_spine_alias, column_name=old_instance.associated_column.column_name
+                    ),
+                    column_alias=new_instance.associated_column.column_name,
+                )
+            else:
+                new_instance = old_instance
+                column = SqlSelectColumn.from_column_reference(
+                    table_alias=time_spine_alias, column_name=old_instance.associated_column.column_name
+                )
+            output_time_spine_instances += (new_instance,)
+            output_time_spine_columns += (column,)
 
-        # Build new simple select columns.
-        select_columns = create_simple_select_columns_for_instance_sets(
+        output_instance_set = InstanceSet.merge(
+            [output_parent_instance_set, InstanceSet(time_dimension_instances=output_time_spine_instances)]
+        )
+        select_columns = output_time_spine_columns + create_simple_select_columns_for_instance_sets(
             self._column_association_resolver,
-            OrderedDict({parent_alias: parent_instance_set, time_spine_alias: time_spine_instance_set}),
+            OrderedDict({parent_alias: output_parent_instance_set}),
         )
 
         # If offset_to_grain is used, will need to filter down to rows that match selected granularities.
         # Does not apply if one of the granularities selected matches the time spine column granularity.
         where_filter: Optional[SqlExpressionNode] = None
-        need_where_filter = (
-            node.offset_to_grain and node.join_on_time_dimension_spec not in node.requested_agg_time_dimension_specs
-        )
+        need_where_filter = node.offset_to_grain and not join_spec_was_requested
 
         # Filter down to one row per granularity period requested in the group by. Any other granularities
         # included here will be filtered out before aggregation and so should not be included in where filter.
         if need_where_filter:
             join_column_expr = SqlColumnReferenceExpression.from_column_reference(
-                table_alias=time_spine_alias, column_name=join_column_name
+                table_alias=time_spine_alias, column_name=parent_join_column_name
             )
             for requested_spec in node.requested_agg_time_dimension_specs:
                 column_name = self._column_association_resolver.resolve_spec(requested_spec).column_name
@@ -1902,7 +1928,7 @@ class DataflowNodeToSqlSubqueryVisitor(DataflowPlanNodeVisitor[SqlDataSet]):
 
     def visit_window_reaggregation_node(self, node: WindowReaggregationNode) -> SqlDataSet:  # noqa: D102
         from_data_set = node.parent_node.accept(self)
-        parent_instance_set = from_data_set.instance_set  # remove order by col
+        parent_instance_set = from_data_set.instance_set
         parent_data_set_alias = self._next_unique_table_alias()
 
         metric_instance = None

--- a/metricflow/plan_conversion/sql_join_builder.py
+++ b/metricflow/plan_conversion/sql_join_builder.py
@@ -536,11 +536,11 @@ class SqlPlanJoinBuilder:
         left_expr: SqlExpressionNode = SqlColumnReferenceExpression.create(
             col_ref=SqlColumnReference(table_alias=time_spine_alias, column_name=time_spine_column_name)
         )
-        if node.offset_window:
+        if node.standard_offset_window:
             left_expr = SqlSubtractTimeIntervalExpression.create(
                 arg=left_expr,
-                count=node.offset_window.count,
-                granularity=error_if_not_standard_grain(input_granularity=node.offset_window.granularity),
+                count=node.standard_offset_window.count,
+                granularity=error_if_not_standard_grain(input_granularity=node.standard_offset_window.granularity),
             )
         elif node.offset_to_grain:
             left_expr = SqlDateTruncExpression.create(time_granularity=node.offset_to_grain, arg=left_expr)

--- a/metricflow/plan_conversion/sql_join_builder.py
+++ b/metricflow/plan_conversion/sql_join_builder.py
@@ -527,13 +527,14 @@ class SqlPlanJoinBuilder:
     def make_join_to_time_spine_join_description(
         node: JoinToTimeSpineNode,
         time_spine_alias: str,
-        agg_time_dimension_column_name: str,
+        time_spine_column_name: str,
+        parent_column_name: str,
         parent_sql_select_node: SqlSelectStatementNode,
         parent_alias: str,
     ) -> SqlJoinDescription:
         """Build join expression used to join a metric to a time spine dataset."""
         left_expr: SqlExpressionNode = SqlColumnReferenceExpression.create(
-            col_ref=SqlColumnReference(table_alias=time_spine_alias, column_name=agg_time_dimension_column_name)
+            col_ref=SqlColumnReference(table_alias=time_spine_alias, column_name=time_spine_column_name)
         )
         if node.offset_window:
             left_expr = SqlSubtractTimeIntervalExpression.create(
@@ -551,7 +552,7 @@ class SqlPlanJoinBuilder:
                 left_expr=left_expr,
                 comparison=SqlComparison.EQUALS,
                 right_expr=SqlColumnReferenceExpression.create(
-                    col_ref=SqlColumnReference(table_alias=parent_alias, column_name=agg_time_dimension_column_name)
+                    col_ref=SqlColumnReference(table_alias=parent_alias, column_name=parent_column_name)
                 ),
             ),
             join_type=node.join_type,

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/test_conversion_metric_join_to_timespine_and_fill_nulls_with_0__plan0.xml
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/test_conversion_metric_join_to_timespine_and_fill_nulls_with_0__plan0.xml
@@ -53,8 +53,8 @@ docstring:
                 <!-- description = 'Join to Time Spine Dataset' -->
                 <!-- node_id = NodeId(id_str='ss_8') -->
                 <!-- col0 =                                                                                               -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_61), column_alias='metric_time__day') -->
-                <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_60), column_alias='visits') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_60), column_alias='metric_time__day') -->
+                <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_61), column_alias='visits') -->
                 <!-- from_source = SqlSelectStatementNode(node_id=ss_7) -->
                 <!-- join_0 =                                                 -->
                 <!--   SqlJoinDescription(                                    -->
@@ -610,8 +610,8 @@ docstring:
                 <!-- description = 'Join to Time Spine Dataset' -->
                 <!-- node_id = NodeId(id_str='ss_22') -->
                 <!-- col0 =                                                                                                -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_256), column_alias='metric_time__day') -->
-                <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_255), column_alias='buys') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_255), column_alias='metric_time__day') -->
+                <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_256), column_alias='buys') -->
                 <!-- from_source = SqlSelectStatementNode(node_id=ss_21) -->
                 <!-- join_0 =                                                 -->
                 <!--   SqlJoinDescription(                                    -->

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/BigQuery/test_offset_metric_with_custom_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/BigQuery/test_offset_metric_with_custom_granularity__plan0.sql
@@ -25,7 +25,8 @@ FROM (
         -- Join to Time Spine Dataset
         -- Join to Custom Granularity Dataset
         SELECT
-          subq_1.ds__day AS ds__day
+          subq_4.booking__ds__day AS booking__ds__day
+          , subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
@@ -101,7 +102,6 @@ FROM (
           , subq_1.metric_time__extract_day AS metric_time__extract_day
           , subq_1.metric_time__extract_dow AS metric_time__extract_dow
           , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-          , subq_4.booking__ds__day AS booking__ds__day
           , subq_1.listing AS listing
           , subq_1.guest AS guest
           , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/BigQuery/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/BigQuery/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
@@ -127,7 +127,8 @@ FROM (
           -- Join to Time Spine Dataset
           -- Join to Custom Granularity Dataset
           SELECT
-            subq_1.ds__day AS ds__day
+            subq_4.metric_time__day AS metric_time__day
+            , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -203,7 +204,6 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_4.metric_time__day AS metric_time__day
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Databricks/test_offset_metric_with_custom_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Databricks/test_offset_metric_with_custom_granularity__plan0.sql
@@ -25,7 +25,8 @@ FROM (
         -- Join to Time Spine Dataset
         -- Join to Custom Granularity Dataset
         SELECT
-          subq_1.ds__day AS ds__day
+          subq_4.booking__ds__day AS booking__ds__day
+          , subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
@@ -101,7 +102,6 @@ FROM (
           , subq_1.metric_time__extract_day AS metric_time__extract_day
           , subq_1.metric_time__extract_dow AS metric_time__extract_dow
           , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-          , subq_4.booking__ds__day AS booking__ds__day
           , subq_1.listing AS listing
           , subq_1.guest AS guest
           , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Databricks/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Databricks/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
@@ -127,7 +127,8 @@ FROM (
           -- Join to Time Spine Dataset
           -- Join to Custom Granularity Dataset
           SELECT
-            subq_1.ds__day AS ds__day
+            subq_4.metric_time__day AS metric_time__day
+            , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -203,7 +204,6 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_4.metric_time__day AS metric_time__day
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/DuckDB/test_offset_metric_with_custom_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/DuckDB/test_offset_metric_with_custom_granularity__plan0.sql
@@ -25,7 +25,8 @@ FROM (
         -- Join to Time Spine Dataset
         -- Join to Custom Granularity Dataset
         SELECT
-          subq_1.ds__day AS ds__day
+          subq_4.booking__ds__day AS booking__ds__day
+          , subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
@@ -101,7 +102,6 @@ FROM (
           , subq_1.metric_time__extract_day AS metric_time__extract_day
           , subq_1.metric_time__extract_dow AS metric_time__extract_dow
           , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-          , subq_4.booking__ds__day AS booking__ds__day
           , subq_1.listing AS listing
           , subq_1.guest AS guest
           , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/DuckDB/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/DuckDB/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
@@ -127,7 +127,8 @@ FROM (
           -- Join to Time Spine Dataset
           -- Join to Custom Granularity Dataset
           SELECT
-            subq_1.ds__day AS ds__day
+            subq_4.metric_time__day AS metric_time__day
+            , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -203,7 +204,6 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_4.metric_time__day AS metric_time__day
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Postgres/test_offset_metric_with_custom_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Postgres/test_offset_metric_with_custom_granularity__plan0.sql
@@ -25,7 +25,8 @@ FROM (
         -- Join to Time Spine Dataset
         -- Join to Custom Granularity Dataset
         SELECT
-          subq_1.ds__day AS ds__day
+          subq_4.booking__ds__day AS booking__ds__day
+          , subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
@@ -101,7 +102,6 @@ FROM (
           , subq_1.metric_time__extract_day AS metric_time__extract_day
           , subq_1.metric_time__extract_dow AS metric_time__extract_dow
           , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-          , subq_4.booking__ds__day AS booking__ds__day
           , subq_1.listing AS listing
           , subq_1.guest AS guest
           , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Postgres/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Postgres/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
@@ -127,7 +127,8 @@ FROM (
           -- Join to Time Spine Dataset
           -- Join to Custom Granularity Dataset
           SELECT
-            subq_1.ds__day AS ds__day
+            subq_4.metric_time__day AS metric_time__day
+            , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -203,7 +204,6 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_4.metric_time__day AS metric_time__day
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Redshift/test_offset_metric_with_custom_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Redshift/test_offset_metric_with_custom_granularity__plan0.sql
@@ -25,7 +25,8 @@ FROM (
         -- Join to Time Spine Dataset
         -- Join to Custom Granularity Dataset
         SELECT
-          subq_1.ds__day AS ds__day
+          subq_4.booking__ds__day AS booking__ds__day
+          , subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
@@ -101,7 +102,6 @@ FROM (
           , subq_1.metric_time__extract_day AS metric_time__extract_day
           , subq_1.metric_time__extract_dow AS metric_time__extract_dow
           , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-          , subq_4.booking__ds__day AS booking__ds__day
           , subq_1.listing AS listing
           , subq_1.guest AS guest
           , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Redshift/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Redshift/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
@@ -127,7 +127,8 @@ FROM (
           -- Join to Time Spine Dataset
           -- Join to Custom Granularity Dataset
           SELECT
-            subq_1.ds__day AS ds__day
+            subq_4.metric_time__day AS metric_time__day
+            , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -203,7 +204,6 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_4.metric_time__day AS metric_time__day
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Snowflake/test_offset_metric_with_custom_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Snowflake/test_offset_metric_with_custom_granularity__plan0.sql
@@ -25,7 +25,8 @@ FROM (
         -- Join to Time Spine Dataset
         -- Join to Custom Granularity Dataset
         SELECT
-          subq_1.ds__day AS ds__day
+          subq_4.booking__ds__day AS booking__ds__day
+          , subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
@@ -101,7 +102,6 @@ FROM (
           , subq_1.metric_time__extract_day AS metric_time__extract_day
           , subq_1.metric_time__extract_dow AS metric_time__extract_dow
           , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-          , subq_4.booking__ds__day AS booking__ds__day
           , subq_1.listing AS listing
           , subq_1.guest AS guest
           , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Snowflake/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Snowflake/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
@@ -127,7 +127,8 @@ FROM (
           -- Join to Time Spine Dataset
           -- Join to Custom Granularity Dataset
           SELECT
-            subq_1.ds__day AS ds__day
+            subq_4.metric_time__day AS metric_time__day
+            , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -203,7 +204,6 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_4.metric_time__day AS metric_time__day
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Trino/test_offset_metric_with_custom_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Trino/test_offset_metric_with_custom_granularity__plan0.sql
@@ -25,7 +25,8 @@ FROM (
         -- Join to Time Spine Dataset
         -- Join to Custom Granularity Dataset
         SELECT
-          subq_1.ds__day AS ds__day
+          subq_4.booking__ds__day AS booking__ds__day
+          , subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
@@ -101,7 +102,6 @@ FROM (
           , subq_1.metric_time__extract_day AS metric_time__extract_day
           , subq_1.metric_time__extract_dow AS metric_time__extract_dow
           , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-          , subq_4.booking__ds__day AS booking__ds__day
           , subq_1.listing AS listing
           , subq_1.guest AS guest
           , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Trino/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Trino/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
@@ -127,7 +127,8 @@ FROM (
           -- Join to Time Spine Dataset
           -- Join to Custom Granularity Dataset
           SELECT
-            subq_1.ds__day AS ds__day
+            subq_4.metric_time__day AS metric_time__day
+            , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -203,7 +204,6 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_4.metric_time__day AS metric_time__day
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_metric_offset_window__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_metric_offset_window__dfp_0.xml
@@ -50,7 +50,7 @@ docstring:
                             <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
                             <!--   )                                                                             -->
                             <!-- join_type = INNER -->
-                            <!-- offset_window = PydanticMetricTimeWindow(count=5, granularity='day') -->
+                            <!-- standard_offset_window = PydanticMetricTimeWindow(count=5, granularity='day') -->
                             <MetricTimeDimensionTransformNode>
                                 <!-- description = "Metric Time Dimension 'ds'" -->
                                 <!-- node_id = NodeId(id_str='sma_28009') -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_metric_offset_with_granularity__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_metric_offset_with_granularity__dfp_0.xml
@@ -48,7 +48,7 @@ test_filename: test_dataflow_plan_builder.py
                             <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
                             <!--   )                                                                             -->
                             <!-- join_type = INNER -->
-                            <!-- offset_window = PydanticMetricTimeWindow(count=5, granularity='day') -->
+                            <!-- standard_offset_window = PydanticMetricTimeWindow(count=5, granularity='day') -->
                             <MetricTimeDimensionTransformNode>
                                 <!-- description = "Metric Time Dimension 'ds'" -->
                                 <!-- node_id = NodeId(id_str='sma_28009') -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_offset_cumulative_metric__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_offset_cumulative_metric__dfp_0.xml
@@ -49,7 +49,7 @@ test_filename: test_dataflow_plan_builder.py
                             <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
                             <!--   )                                                                             -->
                             <!-- join_type = INNER -->
-                            <!-- offset_window = PydanticMetricTimeWindow(count=2, granularity='day') -->
+                            <!-- standard_offset_window = PydanticMetricTimeWindow(count=2, granularity='day') -->
                             <JoinOverTimeRangeNode>
                                 <!-- description = 'Join Self Over Time Range' -->
                                 <!-- node_id = NodeId(id_str='jotr_0') -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_join_to_time_spine_derived_metric__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_join_to_time_spine_derived_metric__dfp_0.xml
@@ -157,7 +157,7 @@ test_filename: test_dataflow_plan_builder.py
                                     <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
                                     <!--   )                                                                             -->
                                     <!-- join_type = INNER -->
-                                    <!-- offset_window = PydanticMetricTimeWindow(count=14, granularity='day') -->
+                                    <!-- standard_offset_window = PydanticMetricTimeWindow(count=14, granularity='day') -->
                                     <MetricTimeDimensionTransformNode>
                                         <!-- description = "Metric Time Dimension 'ds'" -->
                                         <!-- node_id = NodeId(id_str='sma_28009') -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_nested_derived_metric_with_outer_offset__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_nested_derived_metric_with_outer_offset__dfp_0.xml
@@ -25,7 +25,7 @@ test_filename: test_dataflow_plan_builder.py
                 <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
                 <!--   )                                                                             -->
                 <!-- join_type = INNER -->
-                <!-- offset_window = PydanticMetricTimeWindow(count=2, granularity='day') -->
+                <!-- standard_offset_window = PydanticMetricTimeWindow(count=2, granularity='day') -->
                 <ComputeMetricsNode>
                     <!-- description = 'Compute Metrics via Expressions' -->
                     <!-- node_id = NodeId(id_str='cm_1') -->
@@ -73,7 +73,7 @@ test_filename: test_dataflow_plan_builder.py
                                     <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
                                     <!--   )                                                                             -->
                                     <!-- join_type = INNER -->
-                                    <!-- offset_window = PydanticMetricTimeWindow(count=5, granularity='day') -->
+                                    <!-- standard_offset_window = PydanticMetricTimeWindow(count=5, granularity='day') -->
                                     <MetricTimeDimensionTransformNode>
                                         <!-- description = "Metric Time Dimension 'ds'" -->
                                         <!-- node_id = NodeId(id_str='sma_28009') -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_offset_window_metric_filter_and_query_have_different_granularities__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_offset_window_metric_filter_and_query_have_different_granularities__dfp_0.xml
@@ -181,7 +181,7 @@ docstring:
                                     <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
                                     <!--   )                                                                             -->
                                     <!-- join_type = INNER -->
-                                    <!-- offset_window = PydanticMetricTimeWindow(count=1, granularity='week') -->
+                                    <!-- standard_offset_window = PydanticMetricTimeWindow(count=1, granularity='week') -->
                                     <MetricTimeDimensionTransformNode>
                                         <!-- description = "Metric Time Dimension 'ds'" -->
                                         <!-- node_id = NodeId(id_str='sma_28009') -->

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/DuckDB/test_offset_by_custom_granularity_node__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/DuckDB/test_offset_by_custom_granularity_node__plan0.sql
@@ -1,0 +1,88 @@
+test_name: test_offset_by_custom_granularity_node
+test_filename: test_dataflow_to_sql_plan.py
+sql_engine: DuckDB
+---
+-- Apply Requested Granularities
+SELECT
+  subq_3.ds__day
+  , DATE_TRUNC('month', subq_3.ds__day__lead) AS metric_time__month
+FROM (
+  -- Offset Base Granularity By Custom Granularity Period(s)
+  WITH cte_0 AS (
+    -- Get Custom Granularity Bounds
+    SELECT
+      time_spine_src_28006.ds AS ds__day
+      , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week
+      , DATE_TRUNC('month', time_spine_src_28006.ds) AS ds__month
+      , DATE_TRUNC('quarter', time_spine_src_28006.ds) AS ds__quarter
+      , DATE_TRUNC('year', time_spine_src_28006.ds) AS ds__year
+      , EXTRACT(year FROM time_spine_src_28006.ds) AS ds__extract_year
+      , EXTRACT(quarter FROM time_spine_src_28006.ds) AS ds__extract_quarter
+      , EXTRACT(month FROM time_spine_src_28006.ds) AS ds__extract_month
+      , EXTRACT(day FROM time_spine_src_28006.ds) AS ds__extract_day
+      , EXTRACT(isodow FROM time_spine_src_28006.ds) AS ds__extract_dow
+      , EXTRACT(doy FROM time_spine_src_28006.ds) AS ds__extract_doy
+      , time_spine_src_28006.martian_day AS ds__martian_day
+      , FIRST_VALUE(subq_0.ds__day) OVER (
+        PARTITION BY subq_0.ds__martian_day
+        ORDER BY subq_0.ds__day
+        ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+      ) AS ds__martian_day__first_value
+      , LAST_VALUE(subq_0.ds__day) OVER (
+        PARTITION BY subq_0.ds__martian_day
+        ORDER BY subq_0.ds__day
+        ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+      ) AS ds__martian_day__last_value
+      , ROW_NUMBER() OVER (
+        PARTITION BY subq_0.ds__martian_day
+        ORDER BY subq_0.ds__day
+      ) AS ds__day__row_number
+    FROM (
+      -- Read From Time Spine 'mf_time_spine'
+      SELECT
+        time_spine_src_28006.ds AS ds__day
+        , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week
+        , DATE_TRUNC('month', time_spine_src_28006.ds) AS ds__month
+        , DATE_TRUNC('quarter', time_spine_src_28006.ds) AS ds__quarter
+        , DATE_TRUNC('year', time_spine_src_28006.ds) AS ds__year
+        , EXTRACT(year FROM time_spine_src_28006.ds) AS ds__extract_year
+        , EXTRACT(quarter FROM time_spine_src_28006.ds) AS ds__extract_quarter
+        , EXTRACT(month FROM time_spine_src_28006.ds) AS ds__extract_month
+        , EXTRACT(day FROM time_spine_src_28006.ds) AS ds__extract_day
+        , EXTRACT(isodow FROM time_spine_src_28006.ds) AS ds__extract_dow
+        , EXTRACT(doy FROM time_spine_src_28006.ds) AS ds__extract_doy
+        , time_spine_src_28006.martian_day AS ds__martian_day
+      FROM ***************************.mf_time_spine time_spine_src_28006
+    ) subq_0
+  )
+
+  SELECT
+    cte_0.ds__day AS ds__day
+    , CASE
+      WHEN subq_2.ds__martian_day__first_value__lead + INTERVAL (cte_0.ds__day__row_number - 1) day <= subq_2.ds__martian_day__last_value__lead
+        THEN subq_2.ds__martian_day__first_value__lead + INTERVAL (cte_0.ds__day__row_number - 1) day
+      ELSE NULL
+    END AS ds__day__lead
+  FROM cte_0 cte_0
+  INNER JOIN (
+    -- Offset Custom Granularity Bounds
+    SELECT
+      subq_1.ds__martian_day
+      , LEAD(subq_1.ds__martian_day__first_value, 3) OVER (ORDER BY subq_1.ds__martian_day) AS ds__martian_day__first_value__lead
+      , LEAD(subq_1.ds__martian_day__last_value, 3) OVER (ORDER BY subq_1.ds__martian_day) AS ds__martian_day__last_value__lead
+    FROM (
+      -- Get Unique Rows for Custom Granularity Bounds
+      SELECT
+        cte_0.ds__martian_day
+        , cte_0.ds__martian_day__first_value
+        , cte_0.ds__martian_day__last_value
+      FROM cte_0 cte_0
+      GROUP BY
+        cte_0.ds__martian_day
+        , cte_0.ds__martian_day__first_value
+        , cte_0.ds__martian_day__last_value
+    ) subq_1
+  ) subq_2
+  ON
+    cte_0.ds__martian_day = subq_2.ds__martian_day
+) subq_3

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/DuckDB/test_offset_by_custom_granularity_node__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/DuckDB/test_offset_by_custom_granularity_node__plan0_optimized.sql
@@ -1,0 +1,56 @@
+test_name: test_offset_by_custom_granularity_node
+test_filename: test_dataflow_to_sql_plan.py
+sql_engine: DuckDB
+---
+-- Apply Requested Granularities
+SELECT
+  ds__day
+  , DATE_TRUNC('month', ds__day__lead) AS metric_time__month
+FROM (
+  -- Offset Base Granularity By Custom Granularity Period(s)
+  WITH cte_2 AS (
+    -- Read From Time Spine 'mf_time_spine'
+    -- Get Custom Granularity Bounds
+    SELECT
+      ds AS ds__day
+      , martian_day AS ds__martian_day
+      , FIRST_VALUE(ds) OVER (
+        PARTITION BY martian_day
+        ORDER BY ds
+        ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+      ) AS ds__martian_day__first_value
+      , LAST_VALUE(ds) OVER (
+        PARTITION BY martian_day
+        ORDER BY ds
+        ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+      ) AS ds__martian_day__last_value
+      , ROW_NUMBER() OVER (
+        PARTITION BY martian_day
+        ORDER BY ds
+      ) AS ds__day__row_number
+    FROM ***************************.mf_time_spine time_spine_src_28006
+  )
+
+  SELECT
+    cte_2.ds__day AS ds__day
+    , CASE
+      WHEN LEAD(subq_5.ds__martian_day__first_value, 3) OVER (ORDER BY subq_5.ds__martian_day) + INTERVAL (cte_2.ds__day__row_number - 1) day <= LEAD(subq_5.ds__martian_day__last_value, 3) OVER (ORDER BY subq_5.ds__martian_day)
+        THEN LEAD(subq_5.ds__martian_day__first_value, 3) OVER (ORDER BY subq_5.ds__martian_day) + INTERVAL (cte_2.ds__day__row_number - 1) day
+      ELSE NULL
+    END AS ds__day__lead
+  FROM cte_2 cte_2
+  INNER JOIN (
+    -- Get Unique Rows for Custom Granularity Bounds
+    SELECT
+      ds__martian_day
+      , ds__martian_day__first_value
+      , ds__martian_day__last_value
+    FROM cte_2 cte_2
+    GROUP BY
+      ds__martian_day
+      , ds__martian_day__first_value
+      , ds__martian_day__last_value
+  ) subq_5
+  ON
+    cte_2.ds__martian_day = subq_5.ds__martian_day
+) subq_7

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/test_offset_by_custom_granularity_node__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/test_offset_by_custom_granularity_node__plan0.xml
@@ -1,0 +1,209 @@
+test_name: test_offset_by_custom_granularity_node
+test_filename: test_dataflow_to_sql_plan.py
+---
+<SqlPlan>
+    <SqlSelectStatementNode>
+        <!-- description = 'Apply Requested Granularities' -->
+        <!-- node_id = NodeId(id_str='ss_5') -->
+        <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_15), column_alias='ds__day') -->
+        <!-- col1 = SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_0), column_alias='metric_time__month') -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_4) -->
+        <!-- where = None -->
+        <!-- distinct = False -->
+        <SqlSelectStatementNode>
+            <!-- description = 'Offset Base Granularity By Custom Granularity Period(s)' -->
+            <!-- node_id = NodeId(id_str='ss_4') -->
+            <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_11), column_alias='ds__day') -->
+            <!-- col1 = SqlSelectColumn(expr=SqlCaseExpression(node_id=case_0), column_alias='ds__day__lead') -->
+            <!-- from_source = SqlTableNode(node_id=tfc_1) -->
+            <!-- join_0 =                                                 -->
+            <!--   SqlJoinDescription(                                    -->
+            <!--     right_source=SqlSelectStatementNode(node_id=ss_3),   -->
+            <!--     right_source_alias='subq_2',                         -->
+            <!--     join_type=INNER,                                     -->
+            <!--     on_condition=SqlComparisonExpression(node_id=cmp_1), -->
+            <!--   )                                                      -->
+            <!-- where = None -->
+            <!-- distinct = False -->
+            <SqlTableNode>
+                <!-- description = 'Read from cte_0' -->
+                <!-- node_id = NodeId(id_str='tfc_1') -->
+                <!-- table_id = 'cte_0' -->
+            </SqlTableNode>
+            <SqlSelectStatementNode>
+                <!-- description = 'Offset Custom Granularity Bounds' -->
+                <!-- node_id = NodeId(id_str='ss_3') -->
+                <!-- col0 =                                                                                             -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_5), column_alias='ds__martian_day') -->
+                <!-- col1 =                                                                   -->
+                <!--   SqlSelectColumn(                                                       -->
+                <!--     expr=SqlWindowFunctionExpression(node_id=wfnc_3, sql_function=LEAD), -->
+                <!--     column_alias='ds__martian_day__first_value__lead',                   -->
+                <!--   )                                                                      -->
+                <!-- col2 =                                                                   -->
+                <!--   SqlSelectColumn(                                                       -->
+                <!--     expr=SqlWindowFunctionExpression(node_id=wfnc_4, sql_function=LEAD), -->
+                <!--     column_alias='ds__martian_day__last_value__lead',                    -->
+                <!--   )                                                                      -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_2) -->
+                <!-- where = None -->
+                <!-- distinct = False -->
+                <SqlSelectStatementNode>
+                    <!-- description = 'Get Unique Rows for Custom Granularity Bounds' -->
+                    <!-- node_id = NodeId(id_str='ss_2') -->
+                    <!-- col0 =                                               -->
+                    <!--   SqlSelectColumn(                                   -->
+                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_2), -->
+                    <!--     column_alias='ds__martian_day',                  -->
+                    <!--   )                                                  -->
+                    <!-- col1 =                                               -->
+                    <!--   SqlSelectColumn(                                   -->
+                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_3), -->
+                    <!--     column_alias='ds__martian_day__first_value',     -->
+                    <!--   )                                                  -->
+                    <!-- col2 =                                               -->
+                    <!--   SqlSelectColumn(                                   -->
+                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_4), -->
+                    <!--     column_alias='ds__martian_day__last_value',      -->
+                    <!--   )                                                  -->
+                    <!-- from_source = SqlTableNode(node_id=tfc_0) -->
+                    <!-- group_by0 =                                          -->
+                    <!--   SqlSelectColumn(                                   -->
+                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_2), -->
+                    <!--     column_alias='ds__martian_day',                  -->
+                    <!--   )                                                  -->
+                    <!-- group_by1 =                                          -->
+                    <!--   SqlSelectColumn(                                   -->
+                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_3), -->
+                    <!--     column_alias='ds__martian_day__first_value',     -->
+                    <!--   )                                                  -->
+                    <!-- group_by2 =                                          -->
+                    <!--   SqlSelectColumn(                                   -->
+                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_4), -->
+                    <!--     column_alias='ds__martian_day__last_value',      -->
+                    <!--   )                                                  -->
+                    <!-- where = None -->
+                    <!-- distinct = False -->
+                    <SqlTableNode>
+                        <!-- description = 'Read from cte_0' -->
+                        <!-- node_id = NodeId(id_str='tfc_0') -->
+                        <!-- table_id = 'cte_0' -->
+                    </SqlTableNode>
+                </SqlSelectStatementNode>
+            </SqlSelectStatementNode>
+            <SqlCteNode>
+                <!-- description = 'CTE' -->
+                <!-- node_id = NodeId(id_str='cte_1') -->
+                <SqlSelectStatementNode>
+                    <!-- description = 'Get Custom Granularity Bounds' -->
+                    <!-- node_id = NodeId(id_str='ss_1') -->
+                    <!-- col0 =                                                                                         -->
+                    <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28130), column_alias='ds__day') -->
+                    <!-- col1 = SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_28287), column_alias='ds__week') -->
+                    <!-- col2 = SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_28288), column_alias='ds__month') -->
+                    <!-- col3 =                                                                                       -->
+                    <!--   SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_28289), column_alias='ds__quarter') -->
+                    <!-- col4 = SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_28290), column_alias='ds__year') -->
+                    <!-- col5 =                                                                                          -->
+                    <!--   SqlSelectColumn(expr=SqlExtractExpression(node_id=ex_28300), column_alias='ds__extract_year') -->
+                    <!-- col6 =                                           -->
+                    <!--   SqlSelectColumn(                               -->
+                    <!--     expr=SqlExtractExpression(node_id=ex_28301), -->
+                    <!--     column_alias='ds__extract_quarter',          -->
+                    <!--   )                                              -->
+                    <!-- col7 =                                                                                           -->
+                    <!--   SqlSelectColumn(expr=SqlExtractExpression(node_id=ex_28302), column_alias='ds__extract_month') -->
+                    <!-- col8 =                                                                                         -->
+                    <!--   SqlSelectColumn(expr=SqlExtractExpression(node_id=ex_28303), column_alias='ds__extract_day') -->
+                    <!-- col9 =                                                                                         -->
+                    <!--   SqlSelectColumn(expr=SqlExtractExpression(node_id=ex_28304), column_alias='ds__extract_dow') -->
+                    <!-- col10 =                                                                                        -->
+                    <!--   SqlSelectColumn(expr=SqlExtractExpression(node_id=ex_28305), column_alias='ds__extract_doy') -->
+                    <!-- col11 =                                                  -->
+                    <!--   SqlSelectColumn(                                       -->
+                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_28131), -->
+                    <!--     column_alias='ds__martian_day',                      -->
+                    <!--   )                                                      -->
+                    <!-- col12 =                                                                         -->
+                    <!--   SqlSelectColumn(                                                              -->
+                    <!--     expr=SqlWindowFunctionExpression(node_id=wfnc_0, sql_function=FIRST_VALUE), -->
+                    <!--     column_alias='ds__martian_day__first_value',                                -->
+                    <!--   )                                                                             -->
+                    <!-- col13 =                                                                        -->
+                    <!--   SqlSelectColumn(                                                             -->
+                    <!--     expr=SqlWindowFunctionExpression(node_id=wfnc_1, sql_function=LAST_VALUE), -->
+                    <!--     column_alias='ds__martian_day__last_value',                                -->
+                    <!--   )                                                                            -->
+                    <!-- col14 =                                                                        -->
+                    <!--   SqlSelectColumn(                                                             -->
+                    <!--     expr=SqlWindowFunctionExpression(node_id=wfnc_2, sql_function=ROW_NUMBER), -->
+                    <!--     column_alias='ds__day__row_number',                                        -->
+                    <!--   )                                                                            -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
+                    <!-- where = None -->
+                    <!-- distinct = False -->
+                    <SqlSelectStatementNode>
+                        <!-- description = "Read From Time Spine 'mf_time_spine'" -->
+                        <!-- node_id = NodeId(id_str='ss_0') -->
+                        <!-- col0 =                                                   -->
+                        <!--   SqlSelectColumn(                                       -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_28130), -->
+                        <!--     column_alias='ds__day',                              -->
+                        <!--   )                                                      -->
+                        <!-- col1 =                                                                                    -->
+                        <!--   SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_28287), column_alias='ds__week') -->
+                        <!-- col2 =                                                                                     -->
+                        <!--   SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_28288), column_alias='ds__month') -->
+                        <!-- col3 =                                                                                       -->
+                        <!--   SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_28289), column_alias='ds__quarter') -->
+                        <!-- col4 =                                                                                    -->
+                        <!--   SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_28290), column_alias='ds__year') -->
+                        <!-- col5 =                                           -->
+                        <!--   SqlSelectColumn(                               -->
+                        <!--     expr=SqlExtractExpression(node_id=ex_28300), -->
+                        <!--     column_alias='ds__extract_year',             -->
+                        <!--   )                                              -->
+                        <!-- col6 =                                           -->
+                        <!--   SqlSelectColumn(                               -->
+                        <!--     expr=SqlExtractExpression(node_id=ex_28301), -->
+                        <!--     column_alias='ds__extract_quarter',          -->
+                        <!--   )                                              -->
+                        <!-- col7 =                                           -->
+                        <!--   SqlSelectColumn(                               -->
+                        <!--     expr=SqlExtractExpression(node_id=ex_28302), -->
+                        <!--     column_alias='ds__extract_month',            -->
+                        <!--   )                                              -->
+                        <!-- col8 =                                           -->
+                        <!--   SqlSelectColumn(                               -->
+                        <!--     expr=SqlExtractExpression(node_id=ex_28303), -->
+                        <!--     column_alias='ds__extract_day',              -->
+                        <!--   )                                              -->
+                        <!-- col9 =                                           -->
+                        <!--   SqlSelectColumn(                               -->
+                        <!--     expr=SqlExtractExpression(node_id=ex_28304), -->
+                        <!--     column_alias='ds__extract_dow',              -->
+                        <!--   )                                              -->
+                        <!-- col10 =                                          -->
+                        <!--   SqlSelectColumn(                               -->
+                        <!--     expr=SqlExtractExpression(node_id=ex_28305), -->
+                        <!--     column_alias='ds__extract_doy',              -->
+                        <!--   )                                              -->
+                        <!-- col11 =                                                  -->
+                        <!--   SqlSelectColumn(                                       -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_28131), -->
+                        <!--     column_alias='ds__martian_day',                      -->
+                        <!--   )                                                      -->
+                        <!-- from_source = SqlTableNode(node_id=tfc_28018) -->
+                        <!-- where = None -->
+                        <!-- distinct = False -->
+                        <SqlTableNode>
+                            <!-- description = 'Read from ***************************.mf_time_spine' -->
+                            <!-- node_id = NodeId(id_str='tfc_28018') -->
+                            <!-- table_id = '***************************.mf_time_spine' -->
+                        </SqlTableNode>
+                    </SqlSelectStatementNode>
+                </SqlSelectStatementNode>
+            </SqlCteNode>
+        </SqlSelectStatementNode>
+    </SqlSelectStatementNode>
+</SqlPlan>

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
@@ -125,7 +125,8 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_4.ds__day AS ds__day
+            subq_7.metric_time__day AS metric_time__day
+            , subq_4.ds__day AS ds__day
             , subq_4.ds__week AS ds__week
             , subq_4.ds__month AS ds__month
             , subq_4.ds__quarter AS ds__quarter
@@ -201,7 +202,6 @@ FROM (
             , subq_4.metric_time__extract_day AS metric_time__extract_day
             , subq_4.metric_time__extract_dow AS metric_time__extract_dow
             , subq_4.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_7.metric_time__day AS metric_time__day
             , subq_4.listing AS listing
             , subq_4.guest AS guest
             , subq_4.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
@@ -24,7 +24,8 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_1.ds__month AS ds__month
+          subq_4.metric_time__month AS metric_time__month
+          , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
           , subq_1.ds__year AS ds__year
           , subq_1.ds__extract_year AS ds__extract_year
@@ -41,7 +42,6 @@ FROM (
           , subq_1.metric_time__extract_year AS metric_time__extract_year
           , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
           , subq_1.metric_time__extract_month AS metric_time__extract_month
-          , subq_4.metric_time__month AS metric_time__month
           , subq_1.listing AS listing
           , subq_1.booking_monthly__listing AS booking_monthly__listing
           , subq_1.bookings_monthly AS bookings_monthly

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_derived_metric_with_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_derived_metric_with_offset_to_grain__plan0.sql
@@ -245,7 +245,8 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_6.ds__day AS ds__day
+            subq_9.metric_time__day AS metric_time__day
+            , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -321,7 +322,6 @@ FROM (
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_9.metric_time__day AS metric_time__day
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_derived_metric_with_offset_to_grain_and_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_derived_metric_with_offset_to_grain_and_granularity__plan0.sql
@@ -245,7 +245,9 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_6.ds__day AS ds__day
+            subq_9.metric_time__day AS metric_time__day
+            , subq_9.metric_time__week AS metric_time__week
+            , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -320,8 +322,6 @@ FROM (
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_9.metric_time__day AS metric_time__day
-            , subq_9.metric_time__week AS metric_time__week
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_derived_metric_with_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_derived_metric_with_offset_window__plan0.sql
@@ -245,7 +245,8 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_6.ds__day AS ds__day
+            subq_9.metric_time__day AS metric_time__day
+            , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -321,7 +322,6 @@ FROM (
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_9.metric_time__day AS metric_time__day
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_derived_metric_with_offset_window_and_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_derived_metric_with_offset_window_and_granularity__plan0.sql
@@ -245,7 +245,9 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_6.ds__day AS ds__day
+            subq_9.metric_time__day AS metric_time__day
+            , subq_9.metric_time__quarter AS metric_time__quarter
+            , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -320,8 +322,6 @@ FROM (
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_9.metric_time__day AS metric_time__day
-            , subq_9.metric_time__quarter AS metric_time__quarter
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
@@ -30,7 +30,8 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_1.ds__day AS ds__day
+            subq_4.metric_time__day AS metric_time__day
+            , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -106,7 +107,6 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_4.metric_time__day AS metric_time__day
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host
@@ -387,7 +387,8 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_10.ds__day AS ds__day
+            subq_13.metric_time__day AS metric_time__day
+            , subq_10.ds__day AS ds__day
             , subq_10.ds__week AS ds__week
             , subq_10.ds__month AS ds__month
             , subq_10.ds__quarter AS ds__quarter
@@ -463,7 +464,6 @@ FROM (
             , subq_10.metric_time__extract_day AS metric_time__extract_day
             , subq_10.metric_time__extract_dow AS metric_time__extract_dow
             , subq_10.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_13.metric_time__day AS metric_time__day
             , subq_10.listing AS listing
             , subq_10.guest AS guest
             , subq_10.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0.sql
@@ -30,7 +30,9 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_1.ds__day AS ds__day
+            subq_4.metric_time__day AS metric_time__day
+            , subq_4.metric_time__year AS metric_time__year
+            , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -105,8 +107,6 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_4.metric_time__day AS metric_time__day
-            , subq_4.metric_time__year AS metric_time__year
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host
@@ -389,7 +389,9 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_10.ds__day AS ds__day
+            subq_13.metric_time__day AS metric_time__day
+            , subq_13.metric_time__year AS metric_time__year
+            , subq_10.ds__day AS ds__day
             , subq_10.ds__week AS ds__week
             , subq_10.ds__month AS ds__month
             , subq_10.ds__quarter AS ds__quarter
@@ -464,8 +466,6 @@ FROM (
             , subq_10.metric_time__extract_day AS metric_time__extract_day
             , subq_10.metric_time__extract_dow AS metric_time__extract_dow
             , subq_10.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_13.metric_time__day AS metric_time__day
-            , subq_13.metric_time__year AS metric_time__year
             , subq_10.listing AS listing
             , subq_10.guest AS guest
             , subq_10.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
@@ -449,7 +449,8 @@ FROM (
           FROM (
             -- Join to Time Spine Dataset
             SELECT
-              subq_7.ds__day AS ds__day
+              subq_10.metric_time__day AS metric_time__day
+              , subq_7.ds__day AS ds__day
               , subq_7.ds__week AS ds__week
               , subq_7.ds__month AS ds__month
               , subq_7.ds__quarter AS ds__quarter
@@ -525,7 +526,6 @@ FROM (
               , subq_7.metric_time__extract_day AS metric_time__extract_day
               , subq_7.metric_time__extract_dow AS metric_time__extract_dow
               , subq_7.metric_time__extract_doy AS metric_time__extract_doy
-              , subq_10.metric_time__day AS metric_time__day
               , subq_7.listing AS listing
               , subq_7.guest AS guest
               , subq_7.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_derived_offset_cumulative_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_derived_offset_cumulative_metric__plan0.sql
@@ -24,7 +24,8 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_4.ds__day AS ds__day
+          subq_7.metric_time__day AS metric_time__day
+          , subq_4.ds__day AS ds__day
           , subq_4.ds__week AS ds__week
           , subq_4.ds__month AS ds__month
           , subq_4.ds__quarter AS ds__quarter
@@ -100,7 +101,6 @@ FROM (
           , subq_4.metric_time__extract_day AS metric_time__extract_day
           , subq_4.metric_time__extract_dow AS metric_time__extract_dow
           , subq_4.metric_time__extract_doy AS metric_time__extract_doy
-          , subq_7.metric_time__day AS metric_time__day
           , subq_4.listing AS listing
           , subq_4.guest AS guest
           , subq_4.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_derived_offset_metric_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_derived_offset_metric_with_agg_time_dim__plan0.sql
@@ -30,7 +30,8 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_1.ds__day AS ds__day
+            subq_4.booking__ds__day AS booking__ds__day
+            , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -106,7 +107,6 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_4.booking__ds__day AS booking__ds__day
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_derived_offset_metric_with_one_input_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_derived_offset_metric_with_one_input_metric__plan0.sql
@@ -24,7 +24,8 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_1.ds__day AS ds__day
+          subq_4.metric_time__day AS metric_time__day
+          , subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
@@ -100,7 +101,6 @@ FROM (
           , subq_1.metric_time__extract_day AS metric_time__extract_day
           , subq_1.metric_time__extract_dow AS metric_time__extract_dow
           , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-          , subq_4.metric_time__day AS metric_time__day
           , subq_1.listing AS listing
           , subq_1.guest AS guest
           , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0.sql
@@ -88,7 +88,8 @@ FROM (
               FROM (
                 -- Join to Time Spine Dataset
                 SELECT
-                  subq_1.ds__day AS ds__day
+                  subq_4.metric_time__day AS metric_time__day
+                  , subq_1.ds__day AS ds__day
                   , subq_1.ds__week AS ds__week
                   , subq_1.ds__month AS ds__month
                   , subq_1.ds__quarter AS ds__quarter
@@ -164,7 +165,6 @@ FROM (
                   , subq_1.metric_time__extract_day AS metric_time__extract_day
                   , subq_1.metric_time__extract_dow AS metric_time__extract_dow
                   , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-                  , subq_4.metric_time__day AS metric_time__day
                   , subq_1.listing AS listing
                   , subq_1.guest AS guest
                   , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_nested_offsets__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_nested_offsets__plan0.sql
@@ -72,7 +72,8 @@ FROM (
           FROM (
             -- Join to Time Spine Dataset
             SELECT
-              subq_1.ds__day AS ds__day
+              subq_4.metric_time__day AS metric_time__day
+              , subq_1.ds__day AS ds__day
               , subq_1.ds__week AS ds__week
               , subq_1.ds__month AS ds__month
               , subq_1.ds__quarter AS ds__quarter
@@ -148,7 +149,6 @@ FROM (
               , subq_1.metric_time__extract_day AS metric_time__extract_day
               , subq_1.metric_time__extract_dow AS metric_time__extract_dow
               , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-              , subq_4.metric_time__day AS metric_time__day
               , subq_1.listing AS listing
               , subq_1.guest AS guest
               , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_nested_offsets_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_nested_offsets_with_time_constraint__plan0.sql
@@ -77,7 +77,8 @@ FROM (
             FROM (
               -- Join to Time Spine Dataset
               SELECT
-                subq_1.ds__day AS ds__day
+                subq_4.metric_time__day AS metric_time__day
+                , subq_1.ds__day AS ds__day
                 , subq_1.ds__week AS ds__week
                 , subq_1.ds__month AS ds__month
                 , subq_1.ds__quarter AS ds__quarter
@@ -153,7 +154,6 @@ FROM (
                 , subq_1.metric_time__extract_day AS metric_time__extract_day
                 , subq_1.metric_time__extract_dow AS metric_time__extract_dow
                 , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-                , subq_4.metric_time__day AS metric_time__day
                 , subq_1.listing AS listing
                 , subq_1.guest AS guest
                 , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_nested_offsets_with_where_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_nested_offsets_with_where_constraint__plan0.sql
@@ -77,7 +77,8 @@ FROM (
             FROM (
               -- Join to Time Spine Dataset
               SELECT
-                subq_1.ds__day AS ds__day
+                subq_4.metric_time__day AS metric_time__day
+                , subq_1.ds__day AS ds__day
                 , subq_1.ds__week AS ds__week
                 , subq_1.ds__month AS ds__month
                 , subq_1.ds__quarter AS ds__quarter
@@ -153,7 +154,6 @@ FROM (
                 , subq_1.metric_time__extract_day AS metric_time__extract_day
                 , subq_1.metric_time__extract_dow AS metric_time__extract_dow
                 , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-                , subq_4.metric_time__day AS metric_time__day
                 , subq_1.listing AS listing
                 , subq_1.guest AS guest
                 , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0.sql
@@ -127,7 +127,9 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_1.ds__day AS ds__day
+            subq_4.metric_time__day AS metric_time__day
+            , subq_4.metric_time__month AS metric_time__month
+            , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -202,8 +204,6 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_4.metric_time__day AS metric_time__day
-            , subq_4.metric_time__month AS metric_time__month
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_offset_to_grain_metric_multiple_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_offset_to_grain_metric_multiple_granularities__plan0.sql
@@ -34,7 +34,10 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_1.ds__day AS ds__day
+          subq_4.metric_time__day AS metric_time__day
+          , subq_4.metric_time__month AS metric_time__month
+          , subq_4.metric_time__year AS metric_time__year
+          , subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
@@ -108,9 +111,6 @@ FROM (
           , subq_1.metric_time__extract_day AS metric_time__extract_day
           , subq_1.metric_time__extract_dow AS metric_time__extract_dow
           , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-          , subq_4.metric_time__day AS metric_time__day
-          , subq_4.metric_time__month AS metric_time__month
-          , subq_4.metric_time__year AS metric_time__year
           , subq_1.listing AS listing
           , subq_1.guest AS guest
           , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_offset_to_grain_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_offset_to_grain_with_agg_time_dim__plan0.sql
@@ -245,7 +245,8 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_6.ds__day AS ds__day
+            subq_9.booking__ds__day AS booking__ds__day
+            , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -321,7 +322,6 @@ FROM (
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_9.booking__ds__day AS booking__ds__day
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_offset_window_metric_filter_and_query_have_different_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_offset_window_metric_filter_and_query_have_different_granularities__plan0.sql
@@ -133,7 +133,9 @@ FROM (
           FROM (
             -- Join to Time Spine Dataset
             SELECT
-              subq_1.ds__day AS ds__day
+              subq_4.metric_time__day AS metric_time__day
+              , subq_4.metric_time__month AS metric_time__month
+              , subq_1.ds__day AS ds__day
               , subq_1.ds__week AS ds__week
               , subq_1.ds__month AS ds__month
               , subq_1.ds__quarter AS ds__quarter
@@ -208,8 +210,6 @@ FROM (
               , subq_1.metric_time__extract_day AS metric_time__extract_day
               , subq_1.metric_time__extract_dow AS metric_time__extract_dow
               , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-              , subq_4.metric_time__day AS metric_time__day
-              , subq_4.metric_time__month AS metric_time__month
               , subq_1.listing AS listing
               , subq_1.guest AS guest
               , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_offset_window_metric_multiple_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_offset_window_metric_multiple_granularities__plan0.sql
@@ -42,7 +42,10 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_1.ds__day AS ds__day
+            subq_4.metric_time__day AS metric_time__day
+            , subq_4.metric_time__month AS metric_time__month
+            , subq_4.metric_time__year AS metric_time__year
+            , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -116,9 +119,6 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_4.metric_time__day AS metric_time__day
-            , subq_4.metric_time__month AS metric_time__month
-            , subq_4.metric_time__year AS metric_time__year
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_offset_window_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_offset_window_with_agg_time_dim__plan0.sql
@@ -245,7 +245,8 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_6.ds__day AS ds__day
+            subq_9.booking__ds__day AS booking__ds__day
+            , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -321,7 +322,6 @@ FROM (
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_9.booking__ds__day AS booking__ds__day
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_time_offset_metric_with_time_constraint__plan0.sql
@@ -125,7 +125,8 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_1.ds__day AS ds__day
+            subq_4.metric_time__day AS metric_time__day
+            , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -201,7 +202,6 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_4.metric_time__day AS metric_time__day
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
@@ -125,7 +125,8 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_4.ds__day AS ds__day
+            subq_7.metric_time__day AS metric_time__day
+            , subq_4.ds__day AS ds__day
             , subq_4.ds__week AS ds__week
             , subq_4.ds__month AS ds__month
             , subq_4.ds__quarter AS ds__quarter
@@ -201,7 +202,6 @@ FROM (
             , subq_4.metric_time__extract_day AS metric_time__extract_day
             , subq_4.metric_time__extract_dow AS metric_time__extract_dow
             , subq_4.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_7.metric_time__day AS metric_time__day
             , subq_4.listing AS listing
             , subq_4.guest AS guest
             , subq_4.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
@@ -24,7 +24,8 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_1.ds__month AS ds__month
+          subq_4.metric_time__month AS metric_time__month
+          , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
           , subq_1.ds__year AS ds__year
           , subq_1.ds__extract_year AS ds__extract_year
@@ -41,7 +42,6 @@ FROM (
           , subq_1.metric_time__extract_year AS metric_time__extract_year
           , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
           , subq_1.metric_time__extract_month AS metric_time__extract_month
-          , subq_4.metric_time__month AS metric_time__month
           , subq_1.listing AS listing
           , subq_1.booking_monthly__listing AS booking_monthly__listing
           , subq_1.bookings_monthly AS bookings_monthly

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_derived_metric_with_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_derived_metric_with_offset_to_grain__plan0.sql
@@ -245,7 +245,8 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_6.ds__day AS ds__day
+            subq_9.metric_time__day AS metric_time__day
+            , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -321,7 +322,6 @@ FROM (
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_9.metric_time__day AS metric_time__day
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_derived_metric_with_offset_to_grain_and_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_derived_metric_with_offset_to_grain_and_granularity__plan0.sql
@@ -245,7 +245,9 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_6.ds__day AS ds__day
+            subq_9.metric_time__day AS metric_time__day
+            , subq_9.metric_time__week AS metric_time__week
+            , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -320,8 +322,6 @@ FROM (
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_9.metric_time__day AS metric_time__day
-            , subq_9.metric_time__week AS metric_time__week
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_derived_metric_with_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_derived_metric_with_offset_window__plan0.sql
@@ -245,7 +245,8 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_6.ds__day AS ds__day
+            subq_9.metric_time__day AS metric_time__day
+            , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -321,7 +322,6 @@ FROM (
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_9.metric_time__day AS metric_time__day
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_derived_metric_with_offset_window_and_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_derived_metric_with_offset_window_and_granularity__plan0.sql
@@ -245,7 +245,9 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_6.ds__day AS ds__day
+            subq_9.metric_time__day AS metric_time__day
+            , subq_9.metric_time__quarter AS metric_time__quarter
+            , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -320,8 +322,6 @@ FROM (
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_9.metric_time__day AS metric_time__day
-            , subq_9.metric_time__quarter AS metric_time__quarter
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
@@ -30,7 +30,8 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_1.ds__day AS ds__day
+            subq_4.metric_time__day AS metric_time__day
+            , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -106,7 +107,6 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_4.metric_time__day AS metric_time__day
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host
@@ -387,7 +387,8 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_10.ds__day AS ds__day
+            subq_13.metric_time__day AS metric_time__day
+            , subq_10.ds__day AS ds__day
             , subq_10.ds__week AS ds__week
             , subq_10.ds__month AS ds__month
             , subq_10.ds__quarter AS ds__quarter
@@ -463,7 +464,6 @@ FROM (
             , subq_10.metric_time__extract_day AS metric_time__extract_day
             , subq_10.metric_time__extract_dow AS metric_time__extract_dow
             , subq_10.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_13.metric_time__day AS metric_time__day
             , subq_10.listing AS listing
             , subq_10.guest AS guest
             , subq_10.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0.sql
@@ -30,7 +30,9 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_1.ds__day AS ds__day
+            subq_4.metric_time__day AS metric_time__day
+            , subq_4.metric_time__year AS metric_time__year
+            , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -105,8 +107,6 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_4.metric_time__day AS metric_time__day
-            , subq_4.metric_time__year AS metric_time__year
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host
@@ -389,7 +389,9 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_10.ds__day AS ds__day
+            subq_13.metric_time__day AS metric_time__day
+            , subq_13.metric_time__year AS metric_time__year
+            , subq_10.ds__day AS ds__day
             , subq_10.ds__week AS ds__week
             , subq_10.ds__month AS ds__month
             , subq_10.ds__quarter AS ds__quarter
@@ -464,8 +466,6 @@ FROM (
             , subq_10.metric_time__extract_day AS metric_time__extract_day
             , subq_10.metric_time__extract_dow AS metric_time__extract_dow
             , subq_10.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_13.metric_time__day AS metric_time__day
-            , subq_13.metric_time__year AS metric_time__year
             , subq_10.listing AS listing
             , subq_10.guest AS guest
             , subq_10.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
@@ -449,7 +449,8 @@ FROM (
           FROM (
             -- Join to Time Spine Dataset
             SELECT
-              subq_7.ds__day AS ds__day
+              subq_10.metric_time__day AS metric_time__day
+              , subq_7.ds__day AS ds__day
               , subq_7.ds__week AS ds__week
               , subq_7.ds__month AS ds__month
               , subq_7.ds__quarter AS ds__quarter
@@ -525,7 +526,6 @@ FROM (
               , subq_7.metric_time__extract_day AS metric_time__extract_day
               , subq_7.metric_time__extract_dow AS metric_time__extract_dow
               , subq_7.metric_time__extract_doy AS metric_time__extract_doy
-              , subq_10.metric_time__day AS metric_time__day
               , subq_7.listing AS listing
               , subq_7.guest AS guest
               , subq_7.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_derived_offset_cumulative_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_derived_offset_cumulative_metric__plan0.sql
@@ -24,7 +24,8 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_4.ds__day AS ds__day
+          subq_7.metric_time__day AS metric_time__day
+          , subq_4.ds__day AS ds__day
           , subq_4.ds__week AS ds__week
           , subq_4.ds__month AS ds__month
           , subq_4.ds__quarter AS ds__quarter
@@ -100,7 +101,6 @@ FROM (
           , subq_4.metric_time__extract_day AS metric_time__extract_day
           , subq_4.metric_time__extract_dow AS metric_time__extract_dow
           , subq_4.metric_time__extract_doy AS metric_time__extract_doy
-          , subq_7.metric_time__day AS metric_time__day
           , subq_4.listing AS listing
           , subq_4.guest AS guest
           , subq_4.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_derived_offset_metric_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_derived_offset_metric_with_agg_time_dim__plan0.sql
@@ -30,7 +30,8 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_1.ds__day AS ds__day
+            subq_4.booking__ds__day AS booking__ds__day
+            , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -106,7 +107,6 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_4.booking__ds__day AS booking__ds__day
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_derived_offset_metric_with_one_input_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_derived_offset_metric_with_one_input_metric__plan0.sql
@@ -24,7 +24,8 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_1.ds__day AS ds__day
+          subq_4.metric_time__day AS metric_time__day
+          , subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
@@ -100,7 +101,6 @@ FROM (
           , subq_1.metric_time__extract_day AS metric_time__extract_day
           , subq_1.metric_time__extract_dow AS metric_time__extract_dow
           , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-          , subq_4.metric_time__day AS metric_time__day
           , subq_1.listing AS listing
           , subq_1.guest AS guest
           , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0.sql
@@ -88,7 +88,8 @@ FROM (
               FROM (
                 -- Join to Time Spine Dataset
                 SELECT
-                  subq_1.ds__day AS ds__day
+                  subq_4.metric_time__day AS metric_time__day
+                  , subq_1.ds__day AS ds__day
                   , subq_1.ds__week AS ds__week
                   , subq_1.ds__month AS ds__month
                   , subq_1.ds__quarter AS ds__quarter
@@ -164,7 +165,6 @@ FROM (
                   , subq_1.metric_time__extract_day AS metric_time__extract_day
                   , subq_1.metric_time__extract_dow AS metric_time__extract_dow
                   , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-                  , subq_4.metric_time__day AS metric_time__day
                   , subq_1.listing AS listing
                   , subq_1.guest AS guest
                   , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_nested_offsets__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_nested_offsets__plan0.sql
@@ -72,7 +72,8 @@ FROM (
           FROM (
             -- Join to Time Spine Dataset
             SELECT
-              subq_1.ds__day AS ds__day
+              subq_4.metric_time__day AS metric_time__day
+              , subq_1.ds__day AS ds__day
               , subq_1.ds__week AS ds__week
               , subq_1.ds__month AS ds__month
               , subq_1.ds__quarter AS ds__quarter
@@ -148,7 +149,6 @@ FROM (
               , subq_1.metric_time__extract_day AS metric_time__extract_day
               , subq_1.metric_time__extract_dow AS metric_time__extract_dow
               , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-              , subq_4.metric_time__day AS metric_time__day
               , subq_1.listing AS listing
               , subq_1.guest AS guest
               , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_nested_offsets_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_nested_offsets_with_time_constraint__plan0.sql
@@ -77,7 +77,8 @@ FROM (
             FROM (
               -- Join to Time Spine Dataset
               SELECT
-                subq_1.ds__day AS ds__day
+                subq_4.metric_time__day AS metric_time__day
+                , subq_1.ds__day AS ds__day
                 , subq_1.ds__week AS ds__week
                 , subq_1.ds__month AS ds__month
                 , subq_1.ds__quarter AS ds__quarter
@@ -153,7 +154,6 @@ FROM (
                 , subq_1.metric_time__extract_day AS metric_time__extract_day
                 , subq_1.metric_time__extract_dow AS metric_time__extract_dow
                 , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-                , subq_4.metric_time__day AS metric_time__day
                 , subq_1.listing AS listing
                 , subq_1.guest AS guest
                 , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_nested_offsets_with_where_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_nested_offsets_with_where_constraint__plan0.sql
@@ -77,7 +77,8 @@ FROM (
             FROM (
               -- Join to Time Spine Dataset
               SELECT
-                subq_1.ds__day AS ds__day
+                subq_4.metric_time__day AS metric_time__day
+                , subq_1.ds__day AS ds__day
                 , subq_1.ds__week AS ds__week
                 , subq_1.ds__month AS ds__month
                 , subq_1.ds__quarter AS ds__quarter
@@ -153,7 +154,6 @@ FROM (
                 , subq_1.metric_time__extract_day AS metric_time__extract_day
                 , subq_1.metric_time__extract_dow AS metric_time__extract_dow
                 , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-                , subq_4.metric_time__day AS metric_time__day
                 , subq_1.listing AS listing
                 , subq_1.guest AS guest
                 , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0.sql
@@ -127,7 +127,9 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_1.ds__day AS ds__day
+            subq_4.metric_time__day AS metric_time__day
+            , subq_4.metric_time__month AS metric_time__month
+            , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -202,8 +204,6 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_4.metric_time__day AS metric_time__day
-            , subq_4.metric_time__month AS metric_time__month
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_offset_to_grain_metric_multiple_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_offset_to_grain_metric_multiple_granularities__plan0.sql
@@ -34,7 +34,10 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_1.ds__day AS ds__day
+          subq_4.metric_time__day AS metric_time__day
+          , subq_4.metric_time__month AS metric_time__month
+          , subq_4.metric_time__year AS metric_time__year
+          , subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
@@ -108,9 +111,6 @@ FROM (
           , subq_1.metric_time__extract_day AS metric_time__extract_day
           , subq_1.metric_time__extract_dow AS metric_time__extract_dow
           , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-          , subq_4.metric_time__day AS metric_time__day
-          , subq_4.metric_time__month AS metric_time__month
-          , subq_4.metric_time__year AS metric_time__year
           , subq_1.listing AS listing
           , subq_1.guest AS guest
           , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_offset_to_grain_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_offset_to_grain_with_agg_time_dim__plan0.sql
@@ -245,7 +245,8 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_6.ds__day AS ds__day
+            subq_9.booking__ds__day AS booking__ds__day
+            , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -321,7 +322,6 @@ FROM (
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_9.booking__ds__day AS booking__ds__day
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_offset_window_metric_filter_and_query_have_different_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_offset_window_metric_filter_and_query_have_different_granularities__plan0.sql
@@ -133,7 +133,9 @@ FROM (
           FROM (
             -- Join to Time Spine Dataset
             SELECT
-              subq_1.ds__day AS ds__day
+              subq_4.metric_time__day AS metric_time__day
+              , subq_4.metric_time__month AS metric_time__month
+              , subq_1.ds__day AS ds__day
               , subq_1.ds__week AS ds__week
               , subq_1.ds__month AS ds__month
               , subq_1.ds__quarter AS ds__quarter
@@ -208,8 +210,6 @@ FROM (
               , subq_1.metric_time__extract_day AS metric_time__extract_day
               , subq_1.metric_time__extract_dow AS metric_time__extract_dow
               , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-              , subq_4.metric_time__day AS metric_time__day
-              , subq_4.metric_time__month AS metric_time__month
               , subq_1.listing AS listing
               , subq_1.guest AS guest
               , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_offset_window_metric_multiple_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_offset_window_metric_multiple_granularities__plan0.sql
@@ -42,7 +42,10 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_1.ds__day AS ds__day
+            subq_4.metric_time__day AS metric_time__day
+            , subq_4.metric_time__month AS metric_time__month
+            , subq_4.metric_time__year AS metric_time__year
+            , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -116,9 +119,6 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_4.metric_time__day AS metric_time__day
-            , subq_4.metric_time__month AS metric_time__month
-            , subq_4.metric_time__year AS metric_time__year
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_offset_window_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_offset_window_with_agg_time_dim__plan0.sql
@@ -245,7 +245,8 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_6.ds__day AS ds__day
+            subq_9.booking__ds__day AS booking__ds__day
+            , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -321,7 +322,6 @@ FROM (
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_9.booking__ds__day AS booking__ds__day
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_time_offset_metric_with_time_constraint__plan0.sql
@@ -125,7 +125,8 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_1.ds__day AS ds__day
+            subq_4.metric_time__day AS metric_time__day
+            , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -201,7 +202,6 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_4.metric_time__day AS metric_time__day
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
@@ -125,7 +125,8 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_4.ds__day AS ds__day
+            subq_7.metric_time__day AS metric_time__day
+            , subq_4.ds__day AS ds__day
             , subq_4.ds__week AS ds__week
             , subq_4.ds__month AS ds__month
             , subq_4.ds__quarter AS ds__quarter
@@ -201,7 +202,6 @@ FROM (
             , subq_4.metric_time__extract_day AS metric_time__extract_day
             , subq_4.metric_time__extract_dow AS metric_time__extract_dow
             , subq_4.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_7.metric_time__day AS metric_time__day
             , subq_4.listing AS listing
             , subq_4.guest AS guest
             , subq_4.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
@@ -24,7 +24,8 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_1.ds__month AS ds__month
+          subq_4.metric_time__month AS metric_time__month
+          , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
           , subq_1.ds__year AS ds__year
           , subq_1.ds__extract_year AS ds__extract_year
@@ -41,7 +42,6 @@ FROM (
           , subq_1.metric_time__extract_year AS metric_time__extract_year
           , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
           , subq_1.metric_time__extract_month AS metric_time__extract_month
-          , subq_4.metric_time__month AS metric_time__month
           , subq_1.listing AS listing
           , subq_1.booking_monthly__listing AS booking_monthly__listing
           , subq_1.bookings_monthly AS bookings_monthly

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_derived_metric_with_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_derived_metric_with_offset_to_grain__plan0.sql
@@ -245,7 +245,8 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_6.ds__day AS ds__day
+            subq_9.metric_time__day AS metric_time__day
+            , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -321,7 +322,6 @@ FROM (
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_9.metric_time__day AS metric_time__day
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_derived_metric_with_offset_to_grain_and_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_derived_metric_with_offset_to_grain_and_granularity__plan0.sql
@@ -245,7 +245,9 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_6.ds__day AS ds__day
+            subq_9.metric_time__day AS metric_time__day
+            , subq_9.metric_time__week AS metric_time__week
+            , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -320,8 +322,6 @@ FROM (
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_9.metric_time__day AS metric_time__day
-            , subq_9.metric_time__week AS metric_time__week
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_derived_metric_with_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_derived_metric_with_offset_window__plan0.sql
@@ -245,7 +245,8 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_6.ds__day AS ds__day
+            subq_9.metric_time__day AS metric_time__day
+            , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -321,7 +322,6 @@ FROM (
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_9.metric_time__day AS metric_time__day
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_derived_metric_with_offset_window_and_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_derived_metric_with_offset_window_and_granularity__plan0.sql
@@ -245,7 +245,9 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_6.ds__day AS ds__day
+            subq_9.metric_time__day AS metric_time__day
+            , subq_9.metric_time__quarter AS metric_time__quarter
+            , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -320,8 +322,6 @@ FROM (
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_9.metric_time__day AS metric_time__day
-            , subq_9.metric_time__quarter AS metric_time__quarter
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
@@ -30,7 +30,8 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_1.ds__day AS ds__day
+            subq_4.metric_time__day AS metric_time__day
+            , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -106,7 +107,6 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_4.metric_time__day AS metric_time__day
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host
@@ -387,7 +387,8 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_10.ds__day AS ds__day
+            subq_13.metric_time__day AS metric_time__day
+            , subq_10.ds__day AS ds__day
             , subq_10.ds__week AS ds__week
             , subq_10.ds__month AS ds__month
             , subq_10.ds__quarter AS ds__quarter
@@ -463,7 +464,6 @@ FROM (
             , subq_10.metric_time__extract_day AS metric_time__extract_day
             , subq_10.metric_time__extract_dow AS metric_time__extract_dow
             , subq_10.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_13.metric_time__day AS metric_time__day
             , subq_10.listing AS listing
             , subq_10.guest AS guest
             , subq_10.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0.sql
@@ -30,7 +30,9 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_1.ds__day AS ds__day
+            subq_4.metric_time__day AS metric_time__day
+            , subq_4.metric_time__year AS metric_time__year
+            , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -105,8 +107,6 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_4.metric_time__day AS metric_time__day
-            , subq_4.metric_time__year AS metric_time__year
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host
@@ -389,7 +389,9 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_10.ds__day AS ds__day
+            subq_13.metric_time__day AS metric_time__day
+            , subq_13.metric_time__year AS metric_time__year
+            , subq_10.ds__day AS ds__day
             , subq_10.ds__week AS ds__week
             , subq_10.ds__month AS ds__month
             , subq_10.ds__quarter AS ds__quarter
@@ -464,8 +466,6 @@ FROM (
             , subq_10.metric_time__extract_day AS metric_time__extract_day
             , subq_10.metric_time__extract_dow AS metric_time__extract_dow
             , subq_10.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_13.metric_time__day AS metric_time__day
-            , subq_13.metric_time__year AS metric_time__year
             , subq_10.listing AS listing
             , subq_10.guest AS guest
             , subq_10.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
@@ -449,7 +449,8 @@ FROM (
           FROM (
             -- Join to Time Spine Dataset
             SELECT
-              subq_7.ds__day AS ds__day
+              subq_10.metric_time__day AS metric_time__day
+              , subq_7.ds__day AS ds__day
               , subq_7.ds__week AS ds__week
               , subq_7.ds__month AS ds__month
               , subq_7.ds__quarter AS ds__quarter
@@ -525,7 +526,6 @@ FROM (
               , subq_7.metric_time__extract_day AS metric_time__extract_day
               , subq_7.metric_time__extract_dow AS metric_time__extract_dow
               , subq_7.metric_time__extract_doy AS metric_time__extract_doy
-              , subq_10.metric_time__day AS metric_time__day
               , subq_7.listing AS listing
               , subq_7.guest AS guest
               , subq_7.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_derived_offset_cumulative_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_derived_offset_cumulative_metric__plan0.sql
@@ -24,7 +24,8 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_4.ds__day AS ds__day
+          subq_7.metric_time__day AS metric_time__day
+          , subq_4.ds__day AS ds__day
           , subq_4.ds__week AS ds__week
           , subq_4.ds__month AS ds__month
           , subq_4.ds__quarter AS ds__quarter
@@ -100,7 +101,6 @@ FROM (
           , subq_4.metric_time__extract_day AS metric_time__extract_day
           , subq_4.metric_time__extract_dow AS metric_time__extract_dow
           , subq_4.metric_time__extract_doy AS metric_time__extract_doy
-          , subq_7.metric_time__day AS metric_time__day
           , subq_4.listing AS listing
           , subq_4.guest AS guest
           , subq_4.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_derived_offset_metric_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_derived_offset_metric_with_agg_time_dim__plan0.sql
@@ -30,7 +30,8 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_1.ds__day AS ds__day
+            subq_4.booking__ds__day AS booking__ds__day
+            , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -106,7 +107,6 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_4.booking__ds__day AS booking__ds__day
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_derived_offset_metric_with_one_input_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_derived_offset_metric_with_one_input_metric__plan0.sql
@@ -24,7 +24,8 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_1.ds__day AS ds__day
+          subq_4.metric_time__day AS metric_time__day
+          , subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
@@ -100,7 +101,6 @@ FROM (
           , subq_1.metric_time__extract_day AS metric_time__extract_day
           , subq_1.metric_time__extract_dow AS metric_time__extract_dow
           , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-          , subq_4.metric_time__day AS metric_time__day
           , subq_1.listing AS listing
           , subq_1.guest AS guest
           , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0.sql
@@ -88,7 +88,8 @@ FROM (
               FROM (
                 -- Join to Time Spine Dataset
                 SELECT
-                  subq_1.ds__day AS ds__day
+                  subq_4.metric_time__day AS metric_time__day
+                  , subq_1.ds__day AS ds__day
                   , subq_1.ds__week AS ds__week
                   , subq_1.ds__month AS ds__month
                   , subq_1.ds__quarter AS ds__quarter
@@ -164,7 +165,6 @@ FROM (
                   , subq_1.metric_time__extract_day AS metric_time__extract_day
                   , subq_1.metric_time__extract_dow AS metric_time__extract_dow
                   , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-                  , subq_4.metric_time__day AS metric_time__day
                   , subq_1.listing AS listing
                   , subq_1.guest AS guest
                   , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_nested_offsets__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_nested_offsets__plan0.sql
@@ -72,7 +72,8 @@ FROM (
           FROM (
             -- Join to Time Spine Dataset
             SELECT
-              subq_1.ds__day AS ds__day
+              subq_4.metric_time__day AS metric_time__day
+              , subq_1.ds__day AS ds__day
               , subq_1.ds__week AS ds__week
               , subq_1.ds__month AS ds__month
               , subq_1.ds__quarter AS ds__quarter
@@ -148,7 +149,6 @@ FROM (
               , subq_1.metric_time__extract_day AS metric_time__extract_day
               , subq_1.metric_time__extract_dow AS metric_time__extract_dow
               , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-              , subq_4.metric_time__day AS metric_time__day
               , subq_1.listing AS listing
               , subq_1.guest AS guest
               , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_nested_offsets_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_nested_offsets_with_time_constraint__plan0.sql
@@ -77,7 +77,8 @@ FROM (
             FROM (
               -- Join to Time Spine Dataset
               SELECT
-                subq_1.ds__day AS ds__day
+                subq_4.metric_time__day AS metric_time__day
+                , subq_1.ds__day AS ds__day
                 , subq_1.ds__week AS ds__week
                 , subq_1.ds__month AS ds__month
                 , subq_1.ds__quarter AS ds__quarter
@@ -153,7 +154,6 @@ FROM (
                 , subq_1.metric_time__extract_day AS metric_time__extract_day
                 , subq_1.metric_time__extract_dow AS metric_time__extract_dow
                 , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-                , subq_4.metric_time__day AS metric_time__day
                 , subq_1.listing AS listing
                 , subq_1.guest AS guest
                 , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_nested_offsets_with_where_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_nested_offsets_with_where_constraint__plan0.sql
@@ -77,7 +77,8 @@ FROM (
             FROM (
               -- Join to Time Spine Dataset
               SELECT
-                subq_1.ds__day AS ds__day
+                subq_4.metric_time__day AS metric_time__day
+                , subq_1.ds__day AS ds__day
                 , subq_1.ds__week AS ds__week
                 , subq_1.ds__month AS ds__month
                 , subq_1.ds__quarter AS ds__quarter
@@ -153,7 +154,6 @@ FROM (
                 , subq_1.metric_time__extract_day AS metric_time__extract_day
                 , subq_1.metric_time__extract_dow AS metric_time__extract_dow
                 , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-                , subq_4.metric_time__day AS metric_time__day
                 , subq_1.listing AS listing
                 , subq_1.guest AS guest
                 , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0.sql
@@ -127,7 +127,9 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_1.ds__day AS ds__day
+            subq_4.metric_time__day AS metric_time__day
+            , subq_4.metric_time__month AS metric_time__month
+            , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -202,8 +204,6 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_4.metric_time__day AS metric_time__day
-            , subq_4.metric_time__month AS metric_time__month
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_offset_to_grain_metric_multiple_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_offset_to_grain_metric_multiple_granularities__plan0.sql
@@ -34,7 +34,10 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_1.ds__day AS ds__day
+          subq_4.metric_time__day AS metric_time__day
+          , subq_4.metric_time__month AS metric_time__month
+          , subq_4.metric_time__year AS metric_time__year
+          , subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
@@ -108,9 +111,6 @@ FROM (
           , subq_1.metric_time__extract_day AS metric_time__extract_day
           , subq_1.metric_time__extract_dow AS metric_time__extract_dow
           , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-          , subq_4.metric_time__day AS metric_time__day
-          , subq_4.metric_time__month AS metric_time__month
-          , subq_4.metric_time__year AS metric_time__year
           , subq_1.listing AS listing
           , subq_1.guest AS guest
           , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_offset_to_grain_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_offset_to_grain_with_agg_time_dim__plan0.sql
@@ -245,7 +245,8 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_6.ds__day AS ds__day
+            subq_9.booking__ds__day AS booking__ds__day
+            , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -321,7 +322,6 @@ FROM (
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_9.booking__ds__day AS booking__ds__day
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_offset_window_metric_filter_and_query_have_different_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_offset_window_metric_filter_and_query_have_different_granularities__plan0.sql
@@ -133,7 +133,9 @@ FROM (
           FROM (
             -- Join to Time Spine Dataset
             SELECT
-              subq_1.ds__day AS ds__day
+              subq_4.metric_time__day AS metric_time__day
+              , subq_4.metric_time__month AS metric_time__month
+              , subq_1.ds__day AS ds__day
               , subq_1.ds__week AS ds__week
               , subq_1.ds__month AS ds__month
               , subq_1.ds__quarter AS ds__quarter
@@ -208,8 +210,6 @@ FROM (
               , subq_1.metric_time__extract_day AS metric_time__extract_day
               , subq_1.metric_time__extract_dow AS metric_time__extract_dow
               , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-              , subq_4.metric_time__day AS metric_time__day
-              , subq_4.metric_time__month AS metric_time__month
               , subq_1.listing AS listing
               , subq_1.guest AS guest
               , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_offset_window_metric_multiple_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_offset_window_metric_multiple_granularities__plan0.sql
@@ -42,7 +42,10 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_1.ds__day AS ds__day
+            subq_4.metric_time__day AS metric_time__day
+            , subq_4.metric_time__month AS metric_time__month
+            , subq_4.metric_time__year AS metric_time__year
+            , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -116,9 +119,6 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_4.metric_time__day AS metric_time__day
-            , subq_4.metric_time__month AS metric_time__month
-            , subq_4.metric_time__year AS metric_time__year
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_offset_window_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_offset_window_with_agg_time_dim__plan0.sql
@@ -245,7 +245,8 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_6.ds__day AS ds__day
+            subq_9.booking__ds__day AS booking__ds__day
+            , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -321,7 +322,6 @@ FROM (
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_9.booking__ds__day AS booking__ds__day
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_time_offset_metric_with_time_constraint__plan0.sql
@@ -125,7 +125,8 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_1.ds__day AS ds__day
+            subq_4.metric_time__day AS metric_time__day
+            , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -201,7 +202,6 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_4.metric_time__day AS metric_time__day
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
@@ -125,7 +125,8 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_4.ds__day AS ds__day
+            subq_7.metric_time__day AS metric_time__day
+            , subq_4.ds__day AS ds__day
             , subq_4.ds__week AS ds__week
             , subq_4.ds__month AS ds__month
             , subq_4.ds__quarter AS ds__quarter
@@ -201,7 +202,6 @@ FROM (
             , subq_4.metric_time__extract_day AS metric_time__extract_day
             , subq_4.metric_time__extract_dow AS metric_time__extract_dow
             , subq_4.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_7.metric_time__day AS metric_time__day
             , subq_4.listing AS listing
             , subq_4.guest AS guest
             , subq_4.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
@@ -24,7 +24,8 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_1.ds__month AS ds__month
+          subq_4.metric_time__month AS metric_time__month
+          , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
           , subq_1.ds__year AS ds__year
           , subq_1.ds__extract_year AS ds__extract_year
@@ -41,7 +42,6 @@ FROM (
           , subq_1.metric_time__extract_year AS metric_time__extract_year
           , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
           , subq_1.metric_time__extract_month AS metric_time__extract_month
-          , subq_4.metric_time__month AS metric_time__month
           , subq_1.listing AS listing
           , subq_1.booking_monthly__listing AS booking_monthly__listing
           , subq_1.bookings_monthly AS bookings_monthly

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_derived_metric_with_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_derived_metric_with_offset_to_grain__plan0.sql
@@ -245,7 +245,8 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_6.ds__day AS ds__day
+            subq_9.metric_time__day AS metric_time__day
+            , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -321,7 +322,6 @@ FROM (
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_9.metric_time__day AS metric_time__day
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_derived_metric_with_offset_to_grain_and_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_derived_metric_with_offset_to_grain_and_granularity__plan0.sql
@@ -245,7 +245,9 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_6.ds__day AS ds__day
+            subq_9.metric_time__day AS metric_time__day
+            , subq_9.metric_time__week AS metric_time__week
+            , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -320,8 +322,6 @@ FROM (
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_9.metric_time__day AS metric_time__day
-            , subq_9.metric_time__week AS metric_time__week
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_derived_metric_with_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_derived_metric_with_offset_window__plan0.sql
@@ -245,7 +245,8 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_6.ds__day AS ds__day
+            subq_9.metric_time__day AS metric_time__day
+            , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -321,7 +322,6 @@ FROM (
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_9.metric_time__day AS metric_time__day
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_derived_metric_with_offset_window_and_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_derived_metric_with_offset_window_and_granularity__plan0.sql
@@ -245,7 +245,9 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_6.ds__day AS ds__day
+            subq_9.metric_time__day AS metric_time__day
+            , subq_9.metric_time__quarter AS metric_time__quarter
+            , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -320,8 +322,6 @@ FROM (
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_9.metric_time__day AS metric_time__day
-            , subq_9.metric_time__quarter AS metric_time__quarter
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
@@ -30,7 +30,8 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_1.ds__day AS ds__day
+            subq_4.metric_time__day AS metric_time__day
+            , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -106,7 +107,6 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_4.metric_time__day AS metric_time__day
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host
@@ -387,7 +387,8 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_10.ds__day AS ds__day
+            subq_13.metric_time__day AS metric_time__day
+            , subq_10.ds__day AS ds__day
             , subq_10.ds__week AS ds__week
             , subq_10.ds__month AS ds__month
             , subq_10.ds__quarter AS ds__quarter
@@ -463,7 +464,6 @@ FROM (
             , subq_10.metric_time__extract_day AS metric_time__extract_day
             , subq_10.metric_time__extract_dow AS metric_time__extract_dow
             , subq_10.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_13.metric_time__day AS metric_time__day
             , subq_10.listing AS listing
             , subq_10.guest AS guest
             , subq_10.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0.sql
@@ -30,7 +30,9 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_1.ds__day AS ds__day
+            subq_4.metric_time__day AS metric_time__day
+            , subq_4.metric_time__year AS metric_time__year
+            , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -105,8 +107,6 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_4.metric_time__day AS metric_time__day
-            , subq_4.metric_time__year AS metric_time__year
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host
@@ -389,7 +389,9 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_10.ds__day AS ds__day
+            subq_13.metric_time__day AS metric_time__day
+            , subq_13.metric_time__year AS metric_time__year
+            , subq_10.ds__day AS ds__day
             , subq_10.ds__week AS ds__week
             , subq_10.ds__month AS ds__month
             , subq_10.ds__quarter AS ds__quarter
@@ -464,8 +466,6 @@ FROM (
             , subq_10.metric_time__extract_day AS metric_time__extract_day
             , subq_10.metric_time__extract_dow AS metric_time__extract_dow
             , subq_10.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_13.metric_time__day AS metric_time__day
-            , subq_13.metric_time__year AS metric_time__year
             , subq_10.listing AS listing
             , subq_10.guest AS guest
             , subq_10.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
@@ -449,7 +449,8 @@ FROM (
           FROM (
             -- Join to Time Spine Dataset
             SELECT
-              subq_7.ds__day AS ds__day
+              subq_10.metric_time__day AS metric_time__day
+              , subq_7.ds__day AS ds__day
               , subq_7.ds__week AS ds__week
               , subq_7.ds__month AS ds__month
               , subq_7.ds__quarter AS ds__quarter
@@ -525,7 +526,6 @@ FROM (
               , subq_7.metric_time__extract_day AS metric_time__extract_day
               , subq_7.metric_time__extract_dow AS metric_time__extract_dow
               , subq_7.metric_time__extract_doy AS metric_time__extract_doy
-              , subq_10.metric_time__day AS metric_time__day
               , subq_7.listing AS listing
               , subq_7.guest AS guest
               , subq_7.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_derived_offset_cumulative_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_derived_offset_cumulative_metric__plan0.sql
@@ -24,7 +24,8 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_4.ds__day AS ds__day
+          subq_7.metric_time__day AS metric_time__day
+          , subq_4.ds__day AS ds__day
           , subq_4.ds__week AS ds__week
           , subq_4.ds__month AS ds__month
           , subq_4.ds__quarter AS ds__quarter
@@ -100,7 +101,6 @@ FROM (
           , subq_4.metric_time__extract_day AS metric_time__extract_day
           , subq_4.metric_time__extract_dow AS metric_time__extract_dow
           , subq_4.metric_time__extract_doy AS metric_time__extract_doy
-          , subq_7.metric_time__day AS metric_time__day
           , subq_4.listing AS listing
           , subq_4.guest AS guest
           , subq_4.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_derived_offset_metric_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_derived_offset_metric_with_agg_time_dim__plan0.sql
@@ -30,7 +30,8 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_1.ds__day AS ds__day
+            subq_4.booking__ds__day AS booking__ds__day
+            , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -106,7 +107,6 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_4.booking__ds__day AS booking__ds__day
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_derived_offset_metric_with_one_input_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_derived_offset_metric_with_one_input_metric__plan0.sql
@@ -24,7 +24,8 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_1.ds__day AS ds__day
+          subq_4.metric_time__day AS metric_time__day
+          , subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
@@ -100,7 +101,6 @@ FROM (
           , subq_1.metric_time__extract_day AS metric_time__extract_day
           , subq_1.metric_time__extract_dow AS metric_time__extract_dow
           , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-          , subq_4.metric_time__day AS metric_time__day
           , subq_1.listing AS listing
           , subq_1.guest AS guest
           , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0.sql
@@ -88,7 +88,8 @@ FROM (
               FROM (
                 -- Join to Time Spine Dataset
                 SELECT
-                  subq_1.ds__day AS ds__day
+                  subq_4.metric_time__day AS metric_time__day
+                  , subq_1.ds__day AS ds__day
                   , subq_1.ds__week AS ds__week
                   , subq_1.ds__month AS ds__month
                   , subq_1.ds__quarter AS ds__quarter
@@ -164,7 +165,6 @@ FROM (
                   , subq_1.metric_time__extract_day AS metric_time__extract_day
                   , subq_1.metric_time__extract_dow AS metric_time__extract_dow
                   , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-                  , subq_4.metric_time__day AS metric_time__day
                   , subq_1.listing AS listing
                   , subq_1.guest AS guest
                   , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_nested_offsets__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_nested_offsets__plan0.sql
@@ -72,7 +72,8 @@ FROM (
           FROM (
             -- Join to Time Spine Dataset
             SELECT
-              subq_1.ds__day AS ds__day
+              subq_4.metric_time__day AS metric_time__day
+              , subq_1.ds__day AS ds__day
               , subq_1.ds__week AS ds__week
               , subq_1.ds__month AS ds__month
               , subq_1.ds__quarter AS ds__quarter
@@ -148,7 +149,6 @@ FROM (
               , subq_1.metric_time__extract_day AS metric_time__extract_day
               , subq_1.metric_time__extract_dow AS metric_time__extract_dow
               , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-              , subq_4.metric_time__day AS metric_time__day
               , subq_1.listing AS listing
               , subq_1.guest AS guest
               , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_nested_offsets_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_nested_offsets_with_time_constraint__plan0.sql
@@ -77,7 +77,8 @@ FROM (
             FROM (
               -- Join to Time Spine Dataset
               SELECT
-                subq_1.ds__day AS ds__day
+                subq_4.metric_time__day AS metric_time__day
+                , subq_1.ds__day AS ds__day
                 , subq_1.ds__week AS ds__week
                 , subq_1.ds__month AS ds__month
                 , subq_1.ds__quarter AS ds__quarter
@@ -153,7 +154,6 @@ FROM (
                 , subq_1.metric_time__extract_day AS metric_time__extract_day
                 , subq_1.metric_time__extract_dow AS metric_time__extract_dow
                 , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-                , subq_4.metric_time__day AS metric_time__day
                 , subq_1.listing AS listing
                 , subq_1.guest AS guest
                 , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_nested_offsets_with_where_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_nested_offsets_with_where_constraint__plan0.sql
@@ -77,7 +77,8 @@ FROM (
             FROM (
               -- Join to Time Spine Dataset
               SELECT
-                subq_1.ds__day AS ds__day
+                subq_4.metric_time__day AS metric_time__day
+                , subq_1.ds__day AS ds__day
                 , subq_1.ds__week AS ds__week
                 , subq_1.ds__month AS ds__month
                 , subq_1.ds__quarter AS ds__quarter
@@ -153,7 +154,6 @@ FROM (
                 , subq_1.metric_time__extract_day AS metric_time__extract_day
                 , subq_1.metric_time__extract_dow AS metric_time__extract_dow
                 , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-                , subq_4.metric_time__day AS metric_time__day
                 , subq_1.listing AS listing
                 , subq_1.guest AS guest
                 , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0.sql
@@ -127,7 +127,9 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_1.ds__day AS ds__day
+            subq_4.metric_time__day AS metric_time__day
+            , subq_4.metric_time__month AS metric_time__month
+            , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -202,8 +204,6 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_4.metric_time__day AS metric_time__day
-            , subq_4.metric_time__month AS metric_time__month
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_offset_to_grain_metric_multiple_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_offset_to_grain_metric_multiple_granularities__plan0.sql
@@ -34,7 +34,10 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_1.ds__day AS ds__day
+          subq_4.metric_time__day AS metric_time__day
+          , subq_4.metric_time__month AS metric_time__month
+          , subq_4.metric_time__year AS metric_time__year
+          , subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
@@ -108,9 +111,6 @@ FROM (
           , subq_1.metric_time__extract_day AS metric_time__extract_day
           , subq_1.metric_time__extract_dow AS metric_time__extract_dow
           , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-          , subq_4.metric_time__day AS metric_time__day
-          , subq_4.metric_time__month AS metric_time__month
-          , subq_4.metric_time__year AS metric_time__year
           , subq_1.listing AS listing
           , subq_1.guest AS guest
           , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_offset_to_grain_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_offset_to_grain_with_agg_time_dim__plan0.sql
@@ -245,7 +245,8 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_6.ds__day AS ds__day
+            subq_9.booking__ds__day AS booking__ds__day
+            , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -321,7 +322,6 @@ FROM (
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_9.booking__ds__day AS booking__ds__day
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_offset_window_metric_filter_and_query_have_different_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_offset_window_metric_filter_and_query_have_different_granularities__plan0.sql
@@ -133,7 +133,9 @@ FROM (
           FROM (
             -- Join to Time Spine Dataset
             SELECT
-              subq_1.ds__day AS ds__day
+              subq_4.metric_time__day AS metric_time__day
+              , subq_4.metric_time__month AS metric_time__month
+              , subq_1.ds__day AS ds__day
               , subq_1.ds__week AS ds__week
               , subq_1.ds__month AS ds__month
               , subq_1.ds__quarter AS ds__quarter
@@ -208,8 +210,6 @@ FROM (
               , subq_1.metric_time__extract_day AS metric_time__extract_day
               , subq_1.metric_time__extract_dow AS metric_time__extract_dow
               , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-              , subq_4.metric_time__day AS metric_time__day
-              , subq_4.metric_time__month AS metric_time__month
               , subq_1.listing AS listing
               , subq_1.guest AS guest
               , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_offset_window_metric_multiple_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_offset_window_metric_multiple_granularities__plan0.sql
@@ -42,7 +42,10 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_1.ds__day AS ds__day
+            subq_4.metric_time__day AS metric_time__day
+            , subq_4.metric_time__month AS metric_time__month
+            , subq_4.metric_time__year AS metric_time__year
+            , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -116,9 +119,6 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_4.metric_time__day AS metric_time__day
-            , subq_4.metric_time__month AS metric_time__month
-            , subq_4.metric_time__year AS metric_time__year
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_offset_window_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_offset_window_with_agg_time_dim__plan0.sql
@@ -245,7 +245,8 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_6.ds__day AS ds__day
+            subq_9.booking__ds__day AS booking__ds__day
+            , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -321,7 +322,6 @@ FROM (
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_9.booking__ds__day AS booking__ds__day
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_time_offset_metric_with_time_constraint__plan0.sql
@@ -125,7 +125,8 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_1.ds__day AS ds__day
+            subq_4.metric_time__day AS metric_time__day
+            , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -201,7 +202,6 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_4.metric_time__day AS metric_time__day
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
@@ -125,7 +125,8 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_4.ds__day AS ds__day
+            subq_7.metric_time__day AS metric_time__day
+            , subq_4.ds__day AS ds__day
             , subq_4.ds__week AS ds__week
             , subq_4.ds__month AS ds__month
             , subq_4.ds__quarter AS ds__quarter
@@ -201,7 +202,6 @@ FROM (
             , subq_4.metric_time__extract_day AS metric_time__extract_day
             , subq_4.metric_time__extract_dow AS metric_time__extract_dow
             , subq_4.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_7.metric_time__day AS metric_time__day
             , subq_4.listing AS listing
             , subq_4.guest AS guest
             , subq_4.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
@@ -24,7 +24,8 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_1.ds__month AS ds__month
+          subq_4.metric_time__month AS metric_time__month
+          , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
           , subq_1.ds__year AS ds__year
           , subq_1.ds__extract_year AS ds__extract_year
@@ -41,7 +42,6 @@ FROM (
           , subq_1.metric_time__extract_year AS metric_time__extract_year
           , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
           , subq_1.metric_time__extract_month AS metric_time__extract_month
-          , subq_4.metric_time__month AS metric_time__month
           , subq_1.listing AS listing
           , subq_1.booking_monthly__listing AS booking_monthly__listing
           , subq_1.bookings_monthly AS bookings_monthly

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_derived_metric_with_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_derived_metric_with_offset_to_grain__plan0.sql
@@ -245,7 +245,8 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_6.ds__day AS ds__day
+            subq_9.metric_time__day AS metric_time__day
+            , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -321,7 +322,6 @@ FROM (
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_9.metric_time__day AS metric_time__day
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_derived_metric_with_offset_to_grain_and_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_derived_metric_with_offset_to_grain_and_granularity__plan0.sql
@@ -245,7 +245,9 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_6.ds__day AS ds__day
+            subq_9.metric_time__day AS metric_time__day
+            , subq_9.metric_time__week AS metric_time__week
+            , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -320,8 +322,6 @@ FROM (
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_9.metric_time__day AS metric_time__day
-            , subq_9.metric_time__week AS metric_time__week
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_derived_metric_with_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_derived_metric_with_offset_window__plan0.sql
@@ -245,7 +245,8 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_6.ds__day AS ds__day
+            subq_9.metric_time__day AS metric_time__day
+            , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -321,7 +322,6 @@ FROM (
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_9.metric_time__day AS metric_time__day
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_derived_metric_with_offset_window_and_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_derived_metric_with_offset_window_and_granularity__plan0.sql
@@ -245,7 +245,9 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_6.ds__day AS ds__day
+            subq_9.metric_time__day AS metric_time__day
+            , subq_9.metric_time__quarter AS metric_time__quarter
+            , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -320,8 +322,6 @@ FROM (
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_9.metric_time__day AS metric_time__day
-            , subq_9.metric_time__quarter AS metric_time__quarter
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
@@ -30,7 +30,8 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_1.ds__day AS ds__day
+            subq_4.metric_time__day AS metric_time__day
+            , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -106,7 +107,6 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_4.metric_time__day AS metric_time__day
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host
@@ -387,7 +387,8 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_10.ds__day AS ds__day
+            subq_13.metric_time__day AS metric_time__day
+            , subq_10.ds__day AS ds__day
             , subq_10.ds__week AS ds__week
             , subq_10.ds__month AS ds__month
             , subq_10.ds__quarter AS ds__quarter
@@ -463,7 +464,6 @@ FROM (
             , subq_10.metric_time__extract_day AS metric_time__extract_day
             , subq_10.metric_time__extract_dow AS metric_time__extract_dow
             , subq_10.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_13.metric_time__day AS metric_time__day
             , subq_10.listing AS listing
             , subq_10.guest AS guest
             , subq_10.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0.sql
@@ -30,7 +30,9 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_1.ds__day AS ds__day
+            subq_4.metric_time__day AS metric_time__day
+            , subq_4.metric_time__year AS metric_time__year
+            , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -105,8 +107,6 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_4.metric_time__day AS metric_time__day
-            , subq_4.metric_time__year AS metric_time__year
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host
@@ -389,7 +389,9 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_10.ds__day AS ds__day
+            subq_13.metric_time__day AS metric_time__day
+            , subq_13.metric_time__year AS metric_time__year
+            , subq_10.ds__day AS ds__day
             , subq_10.ds__week AS ds__week
             , subq_10.ds__month AS ds__month
             , subq_10.ds__quarter AS ds__quarter
@@ -464,8 +466,6 @@ FROM (
             , subq_10.metric_time__extract_day AS metric_time__extract_day
             , subq_10.metric_time__extract_dow AS metric_time__extract_dow
             , subq_10.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_13.metric_time__day AS metric_time__day
-            , subq_13.metric_time__year AS metric_time__year
             , subq_10.listing AS listing
             , subq_10.guest AS guest
             , subq_10.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
@@ -449,7 +449,8 @@ FROM (
           FROM (
             -- Join to Time Spine Dataset
             SELECT
-              subq_7.ds__day AS ds__day
+              subq_10.metric_time__day AS metric_time__day
+              , subq_7.ds__day AS ds__day
               , subq_7.ds__week AS ds__week
               , subq_7.ds__month AS ds__month
               , subq_7.ds__quarter AS ds__quarter
@@ -525,7 +526,6 @@ FROM (
               , subq_7.metric_time__extract_day AS metric_time__extract_day
               , subq_7.metric_time__extract_dow AS metric_time__extract_dow
               , subq_7.metric_time__extract_doy AS metric_time__extract_doy
-              , subq_10.metric_time__day AS metric_time__day
               , subq_7.listing AS listing
               , subq_7.guest AS guest
               , subq_7.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_derived_offset_cumulative_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_derived_offset_cumulative_metric__plan0.sql
@@ -24,7 +24,8 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_4.ds__day AS ds__day
+          subq_7.metric_time__day AS metric_time__day
+          , subq_4.ds__day AS ds__day
           , subq_4.ds__week AS ds__week
           , subq_4.ds__month AS ds__month
           , subq_4.ds__quarter AS ds__quarter
@@ -100,7 +101,6 @@ FROM (
           , subq_4.metric_time__extract_day AS metric_time__extract_day
           , subq_4.metric_time__extract_dow AS metric_time__extract_dow
           , subq_4.metric_time__extract_doy AS metric_time__extract_doy
-          , subq_7.metric_time__day AS metric_time__day
           , subq_4.listing AS listing
           , subq_4.guest AS guest
           , subq_4.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_derived_offset_metric_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_derived_offset_metric_with_agg_time_dim__plan0.sql
@@ -30,7 +30,8 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_1.ds__day AS ds__day
+            subq_4.booking__ds__day AS booking__ds__day
+            , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -106,7 +107,6 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_4.booking__ds__day AS booking__ds__day
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_derived_offset_metric_with_one_input_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_derived_offset_metric_with_one_input_metric__plan0.sql
@@ -24,7 +24,8 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_1.ds__day AS ds__day
+          subq_4.metric_time__day AS metric_time__day
+          , subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
@@ -100,7 +101,6 @@ FROM (
           , subq_1.metric_time__extract_day AS metric_time__extract_day
           , subq_1.metric_time__extract_dow AS metric_time__extract_dow
           , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-          , subq_4.metric_time__day AS metric_time__day
           , subq_1.listing AS listing
           , subq_1.guest AS guest
           , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0.sql
@@ -88,7 +88,8 @@ FROM (
               FROM (
                 -- Join to Time Spine Dataset
                 SELECT
-                  subq_1.ds__day AS ds__day
+                  subq_4.metric_time__day AS metric_time__day
+                  , subq_1.ds__day AS ds__day
                   , subq_1.ds__week AS ds__week
                   , subq_1.ds__month AS ds__month
                   , subq_1.ds__quarter AS ds__quarter
@@ -164,7 +165,6 @@ FROM (
                   , subq_1.metric_time__extract_day AS metric_time__extract_day
                   , subq_1.metric_time__extract_dow AS metric_time__extract_dow
                   , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-                  , subq_4.metric_time__day AS metric_time__day
                   , subq_1.listing AS listing
                   , subq_1.guest AS guest
                   , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_nested_offsets__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_nested_offsets__plan0.sql
@@ -72,7 +72,8 @@ FROM (
           FROM (
             -- Join to Time Spine Dataset
             SELECT
-              subq_1.ds__day AS ds__day
+              subq_4.metric_time__day AS metric_time__day
+              , subq_1.ds__day AS ds__day
               , subq_1.ds__week AS ds__week
               , subq_1.ds__month AS ds__month
               , subq_1.ds__quarter AS ds__quarter
@@ -148,7 +149,6 @@ FROM (
               , subq_1.metric_time__extract_day AS metric_time__extract_day
               , subq_1.metric_time__extract_dow AS metric_time__extract_dow
               , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-              , subq_4.metric_time__day AS metric_time__day
               , subq_1.listing AS listing
               , subq_1.guest AS guest
               , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_nested_offsets_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_nested_offsets_with_time_constraint__plan0.sql
@@ -77,7 +77,8 @@ FROM (
             FROM (
               -- Join to Time Spine Dataset
               SELECT
-                subq_1.ds__day AS ds__day
+                subq_4.metric_time__day AS metric_time__day
+                , subq_1.ds__day AS ds__day
                 , subq_1.ds__week AS ds__week
                 , subq_1.ds__month AS ds__month
                 , subq_1.ds__quarter AS ds__quarter
@@ -153,7 +154,6 @@ FROM (
                 , subq_1.metric_time__extract_day AS metric_time__extract_day
                 , subq_1.metric_time__extract_dow AS metric_time__extract_dow
                 , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-                , subq_4.metric_time__day AS metric_time__day
                 , subq_1.listing AS listing
                 , subq_1.guest AS guest
                 , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_nested_offsets_with_where_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_nested_offsets_with_where_constraint__plan0.sql
@@ -77,7 +77,8 @@ FROM (
             FROM (
               -- Join to Time Spine Dataset
               SELECT
-                subq_1.ds__day AS ds__day
+                subq_4.metric_time__day AS metric_time__day
+                , subq_1.ds__day AS ds__day
                 , subq_1.ds__week AS ds__week
                 , subq_1.ds__month AS ds__month
                 , subq_1.ds__quarter AS ds__quarter
@@ -153,7 +154,6 @@ FROM (
                 , subq_1.metric_time__extract_day AS metric_time__extract_day
                 , subq_1.metric_time__extract_dow AS metric_time__extract_dow
                 , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-                , subq_4.metric_time__day AS metric_time__day
                 , subq_1.listing AS listing
                 , subq_1.guest AS guest
                 , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0.sql
@@ -127,7 +127,9 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_1.ds__day AS ds__day
+            subq_4.metric_time__day AS metric_time__day
+            , subq_4.metric_time__month AS metric_time__month
+            , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -202,8 +204,6 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_4.metric_time__day AS metric_time__day
-            , subq_4.metric_time__month AS metric_time__month
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_offset_to_grain_metric_multiple_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_offset_to_grain_metric_multiple_granularities__plan0.sql
@@ -34,7 +34,10 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_1.ds__day AS ds__day
+          subq_4.metric_time__day AS metric_time__day
+          , subq_4.metric_time__month AS metric_time__month
+          , subq_4.metric_time__year AS metric_time__year
+          , subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
@@ -108,9 +111,6 @@ FROM (
           , subq_1.metric_time__extract_day AS metric_time__extract_day
           , subq_1.metric_time__extract_dow AS metric_time__extract_dow
           , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-          , subq_4.metric_time__day AS metric_time__day
-          , subq_4.metric_time__month AS metric_time__month
-          , subq_4.metric_time__year AS metric_time__year
           , subq_1.listing AS listing
           , subq_1.guest AS guest
           , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_offset_to_grain_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_offset_to_grain_with_agg_time_dim__plan0.sql
@@ -245,7 +245,8 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_6.ds__day AS ds__day
+            subq_9.booking__ds__day AS booking__ds__day
+            , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -321,7 +322,6 @@ FROM (
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_9.booking__ds__day AS booking__ds__day
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_offset_window_metric_filter_and_query_have_different_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_offset_window_metric_filter_and_query_have_different_granularities__plan0.sql
@@ -133,7 +133,9 @@ FROM (
           FROM (
             -- Join to Time Spine Dataset
             SELECT
-              subq_1.ds__day AS ds__day
+              subq_4.metric_time__day AS metric_time__day
+              , subq_4.metric_time__month AS metric_time__month
+              , subq_1.ds__day AS ds__day
               , subq_1.ds__week AS ds__week
               , subq_1.ds__month AS ds__month
               , subq_1.ds__quarter AS ds__quarter
@@ -208,8 +210,6 @@ FROM (
               , subq_1.metric_time__extract_day AS metric_time__extract_day
               , subq_1.metric_time__extract_dow AS metric_time__extract_dow
               , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-              , subq_4.metric_time__day AS metric_time__day
-              , subq_4.metric_time__month AS metric_time__month
               , subq_1.listing AS listing
               , subq_1.guest AS guest
               , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_offset_window_metric_multiple_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_offset_window_metric_multiple_granularities__plan0.sql
@@ -42,7 +42,10 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_1.ds__day AS ds__day
+            subq_4.metric_time__day AS metric_time__day
+            , subq_4.metric_time__month AS metric_time__month
+            , subq_4.metric_time__year AS metric_time__year
+            , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -116,9 +119,6 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_4.metric_time__day AS metric_time__day
-            , subq_4.metric_time__month AS metric_time__month
-            , subq_4.metric_time__year AS metric_time__year
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_offset_window_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_offset_window_with_agg_time_dim__plan0.sql
@@ -245,7 +245,8 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_6.ds__day AS ds__day
+            subq_9.booking__ds__day AS booking__ds__day
+            , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -321,7 +322,6 @@ FROM (
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_9.booking__ds__day AS booking__ds__day
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_time_offset_metric_with_time_constraint__plan0.sql
@@ -125,7 +125,8 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_1.ds__day AS ds__day
+            subq_4.metric_time__day AS metric_time__day
+            , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -201,7 +202,6 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_4.metric_time__day AS metric_time__day
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
@@ -125,7 +125,8 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_4.ds__day AS ds__day
+            subq_7.metric_time__day AS metric_time__day
+            , subq_4.ds__day AS ds__day
             , subq_4.ds__week AS ds__week
             , subq_4.ds__month AS ds__month
             , subq_4.ds__quarter AS ds__quarter
@@ -201,7 +202,6 @@ FROM (
             , subq_4.metric_time__extract_day AS metric_time__extract_day
             , subq_4.metric_time__extract_dow AS metric_time__extract_dow
             , subq_4.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_7.metric_time__day AS metric_time__day
             , subq_4.listing AS listing
             , subq_4.guest AS guest
             , subq_4.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
@@ -24,7 +24,8 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_1.ds__month AS ds__month
+          subq_4.metric_time__month AS metric_time__month
+          , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
           , subq_1.ds__year AS ds__year
           , subq_1.ds__extract_year AS ds__extract_year
@@ -41,7 +42,6 @@ FROM (
           , subq_1.metric_time__extract_year AS metric_time__extract_year
           , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
           , subq_1.metric_time__extract_month AS metric_time__extract_month
-          , subq_4.metric_time__month AS metric_time__month
           , subq_1.listing AS listing
           , subq_1.booking_monthly__listing AS booking_monthly__listing
           , subq_1.bookings_monthly AS bookings_monthly

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_derived_metric_with_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_derived_metric_with_offset_to_grain__plan0.sql
@@ -245,7 +245,8 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_6.ds__day AS ds__day
+            subq_9.metric_time__day AS metric_time__day
+            , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -321,7 +322,6 @@ FROM (
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_9.metric_time__day AS metric_time__day
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_derived_metric_with_offset_to_grain_and_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_derived_metric_with_offset_to_grain_and_granularity__plan0.sql
@@ -245,7 +245,9 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_6.ds__day AS ds__day
+            subq_9.metric_time__day AS metric_time__day
+            , subq_9.metric_time__week AS metric_time__week
+            , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -320,8 +322,6 @@ FROM (
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_9.metric_time__day AS metric_time__day
-            , subq_9.metric_time__week AS metric_time__week
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_derived_metric_with_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_derived_metric_with_offset_window__plan0.sql
@@ -245,7 +245,8 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_6.ds__day AS ds__day
+            subq_9.metric_time__day AS metric_time__day
+            , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -321,7 +322,6 @@ FROM (
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_9.metric_time__day AS metric_time__day
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_derived_metric_with_offset_window_and_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_derived_metric_with_offset_window_and_granularity__plan0.sql
@@ -245,7 +245,9 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_6.ds__day AS ds__day
+            subq_9.metric_time__day AS metric_time__day
+            , subq_9.metric_time__quarter AS metric_time__quarter
+            , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -320,8 +322,6 @@ FROM (
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_9.metric_time__day AS metric_time__day
-            , subq_9.metric_time__quarter AS metric_time__quarter
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
@@ -30,7 +30,8 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_1.ds__day AS ds__day
+            subq_4.metric_time__day AS metric_time__day
+            , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -106,7 +107,6 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_4.metric_time__day AS metric_time__day
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host
@@ -387,7 +387,8 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_10.ds__day AS ds__day
+            subq_13.metric_time__day AS metric_time__day
+            , subq_10.ds__day AS ds__day
             , subq_10.ds__week AS ds__week
             , subq_10.ds__month AS ds__month
             , subq_10.ds__quarter AS ds__quarter
@@ -463,7 +464,6 @@ FROM (
             , subq_10.metric_time__extract_day AS metric_time__extract_day
             , subq_10.metric_time__extract_dow AS metric_time__extract_dow
             , subq_10.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_13.metric_time__day AS metric_time__day
             , subq_10.listing AS listing
             , subq_10.guest AS guest
             , subq_10.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0.sql
@@ -30,7 +30,9 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_1.ds__day AS ds__day
+            subq_4.metric_time__day AS metric_time__day
+            , subq_4.metric_time__year AS metric_time__year
+            , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -105,8 +107,6 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_4.metric_time__day AS metric_time__day
-            , subq_4.metric_time__year AS metric_time__year
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host
@@ -389,7 +389,9 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_10.ds__day AS ds__day
+            subq_13.metric_time__day AS metric_time__day
+            , subq_13.metric_time__year AS metric_time__year
+            , subq_10.ds__day AS ds__day
             , subq_10.ds__week AS ds__week
             , subq_10.ds__month AS ds__month
             , subq_10.ds__quarter AS ds__quarter
@@ -464,8 +466,6 @@ FROM (
             , subq_10.metric_time__extract_day AS metric_time__extract_day
             , subq_10.metric_time__extract_dow AS metric_time__extract_dow
             , subq_10.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_13.metric_time__day AS metric_time__day
-            , subq_13.metric_time__year AS metric_time__year
             , subq_10.listing AS listing
             , subq_10.guest AS guest
             , subq_10.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
@@ -449,7 +449,8 @@ FROM (
           FROM (
             -- Join to Time Spine Dataset
             SELECT
-              subq_7.ds__day AS ds__day
+              subq_10.metric_time__day AS metric_time__day
+              , subq_7.ds__day AS ds__day
               , subq_7.ds__week AS ds__week
               , subq_7.ds__month AS ds__month
               , subq_7.ds__quarter AS ds__quarter
@@ -525,7 +526,6 @@ FROM (
               , subq_7.metric_time__extract_day AS metric_time__extract_day
               , subq_7.metric_time__extract_dow AS metric_time__extract_dow
               , subq_7.metric_time__extract_doy AS metric_time__extract_doy
-              , subq_10.metric_time__day AS metric_time__day
               , subq_7.listing AS listing
               , subq_7.guest AS guest
               , subq_7.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_derived_offset_cumulative_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_derived_offset_cumulative_metric__plan0.sql
@@ -24,7 +24,8 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_4.ds__day AS ds__day
+          subq_7.metric_time__day AS metric_time__day
+          , subq_4.ds__day AS ds__day
           , subq_4.ds__week AS ds__week
           , subq_4.ds__month AS ds__month
           , subq_4.ds__quarter AS ds__quarter
@@ -100,7 +101,6 @@ FROM (
           , subq_4.metric_time__extract_day AS metric_time__extract_day
           , subq_4.metric_time__extract_dow AS metric_time__extract_dow
           , subq_4.metric_time__extract_doy AS metric_time__extract_doy
-          , subq_7.metric_time__day AS metric_time__day
           , subq_4.listing AS listing
           , subq_4.guest AS guest
           , subq_4.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_derived_offset_metric_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_derived_offset_metric_with_agg_time_dim__plan0.sql
@@ -30,7 +30,8 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_1.ds__day AS ds__day
+            subq_4.booking__ds__day AS booking__ds__day
+            , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -106,7 +107,6 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_4.booking__ds__day AS booking__ds__day
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_derived_offset_metric_with_one_input_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_derived_offset_metric_with_one_input_metric__plan0.sql
@@ -24,7 +24,8 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_1.ds__day AS ds__day
+          subq_4.metric_time__day AS metric_time__day
+          , subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
@@ -100,7 +101,6 @@ FROM (
           , subq_1.metric_time__extract_day AS metric_time__extract_day
           , subq_1.metric_time__extract_dow AS metric_time__extract_dow
           , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-          , subq_4.metric_time__day AS metric_time__day
           , subq_1.listing AS listing
           , subq_1.guest AS guest
           , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0.sql
@@ -88,7 +88,8 @@ FROM (
               FROM (
                 -- Join to Time Spine Dataset
                 SELECT
-                  subq_1.ds__day AS ds__day
+                  subq_4.metric_time__day AS metric_time__day
+                  , subq_1.ds__day AS ds__day
                   , subq_1.ds__week AS ds__week
                   , subq_1.ds__month AS ds__month
                   , subq_1.ds__quarter AS ds__quarter
@@ -164,7 +165,6 @@ FROM (
                   , subq_1.metric_time__extract_day AS metric_time__extract_day
                   , subq_1.metric_time__extract_dow AS metric_time__extract_dow
                   , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-                  , subq_4.metric_time__day AS metric_time__day
                   , subq_1.listing AS listing
                   , subq_1.guest AS guest
                   , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_nested_offsets__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_nested_offsets__plan0.sql
@@ -72,7 +72,8 @@ FROM (
           FROM (
             -- Join to Time Spine Dataset
             SELECT
-              subq_1.ds__day AS ds__day
+              subq_4.metric_time__day AS metric_time__day
+              , subq_1.ds__day AS ds__day
               , subq_1.ds__week AS ds__week
               , subq_1.ds__month AS ds__month
               , subq_1.ds__quarter AS ds__quarter
@@ -148,7 +149,6 @@ FROM (
               , subq_1.metric_time__extract_day AS metric_time__extract_day
               , subq_1.metric_time__extract_dow AS metric_time__extract_dow
               , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-              , subq_4.metric_time__day AS metric_time__day
               , subq_1.listing AS listing
               , subq_1.guest AS guest
               , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_nested_offsets_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_nested_offsets_with_time_constraint__plan0.sql
@@ -77,7 +77,8 @@ FROM (
             FROM (
               -- Join to Time Spine Dataset
               SELECT
-                subq_1.ds__day AS ds__day
+                subq_4.metric_time__day AS metric_time__day
+                , subq_1.ds__day AS ds__day
                 , subq_1.ds__week AS ds__week
                 , subq_1.ds__month AS ds__month
                 , subq_1.ds__quarter AS ds__quarter
@@ -153,7 +154,6 @@ FROM (
                 , subq_1.metric_time__extract_day AS metric_time__extract_day
                 , subq_1.metric_time__extract_dow AS metric_time__extract_dow
                 , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-                , subq_4.metric_time__day AS metric_time__day
                 , subq_1.listing AS listing
                 , subq_1.guest AS guest
                 , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_nested_offsets_with_where_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_nested_offsets_with_where_constraint__plan0.sql
@@ -77,7 +77,8 @@ FROM (
             FROM (
               -- Join to Time Spine Dataset
               SELECT
-                subq_1.ds__day AS ds__day
+                subq_4.metric_time__day AS metric_time__day
+                , subq_1.ds__day AS ds__day
                 , subq_1.ds__week AS ds__week
                 , subq_1.ds__month AS ds__month
                 , subq_1.ds__quarter AS ds__quarter
@@ -153,7 +154,6 @@ FROM (
                 , subq_1.metric_time__extract_day AS metric_time__extract_day
                 , subq_1.metric_time__extract_dow AS metric_time__extract_dow
                 , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-                , subq_4.metric_time__day AS metric_time__day
                 , subq_1.listing AS listing
                 , subq_1.guest AS guest
                 , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0.sql
@@ -127,7 +127,9 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_1.ds__day AS ds__day
+            subq_4.metric_time__day AS metric_time__day
+            , subq_4.metric_time__month AS metric_time__month
+            , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -202,8 +204,6 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_4.metric_time__day AS metric_time__day
-            , subq_4.metric_time__month AS metric_time__month
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_offset_to_grain_metric_multiple_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_offset_to_grain_metric_multiple_granularities__plan0.sql
@@ -34,7 +34,10 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_1.ds__day AS ds__day
+          subq_4.metric_time__day AS metric_time__day
+          , subq_4.metric_time__month AS metric_time__month
+          , subq_4.metric_time__year AS metric_time__year
+          , subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
@@ -108,9 +111,6 @@ FROM (
           , subq_1.metric_time__extract_day AS metric_time__extract_day
           , subq_1.metric_time__extract_dow AS metric_time__extract_dow
           , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-          , subq_4.metric_time__day AS metric_time__day
-          , subq_4.metric_time__month AS metric_time__month
-          , subq_4.metric_time__year AS metric_time__year
           , subq_1.listing AS listing
           , subq_1.guest AS guest
           , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_offset_to_grain_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_offset_to_grain_with_agg_time_dim__plan0.sql
@@ -245,7 +245,8 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_6.ds__day AS ds__day
+            subq_9.booking__ds__day AS booking__ds__day
+            , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -321,7 +322,6 @@ FROM (
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_9.booking__ds__day AS booking__ds__day
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_offset_window_metric_filter_and_query_have_different_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_offset_window_metric_filter_and_query_have_different_granularities__plan0.sql
@@ -133,7 +133,9 @@ FROM (
           FROM (
             -- Join to Time Spine Dataset
             SELECT
-              subq_1.ds__day AS ds__day
+              subq_4.metric_time__day AS metric_time__day
+              , subq_4.metric_time__month AS metric_time__month
+              , subq_1.ds__day AS ds__day
               , subq_1.ds__week AS ds__week
               , subq_1.ds__month AS ds__month
               , subq_1.ds__quarter AS ds__quarter
@@ -208,8 +210,6 @@ FROM (
               , subq_1.metric_time__extract_day AS metric_time__extract_day
               , subq_1.metric_time__extract_dow AS metric_time__extract_dow
               , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-              , subq_4.metric_time__day AS metric_time__day
-              , subq_4.metric_time__month AS metric_time__month
               , subq_1.listing AS listing
               , subq_1.guest AS guest
               , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_offset_window_metric_multiple_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_offset_window_metric_multiple_granularities__plan0.sql
@@ -42,7 +42,10 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_1.ds__day AS ds__day
+            subq_4.metric_time__day AS metric_time__day
+            , subq_4.metric_time__month AS metric_time__month
+            , subq_4.metric_time__year AS metric_time__year
+            , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -116,9 +119,6 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_4.metric_time__day AS metric_time__day
-            , subq_4.metric_time__month AS metric_time__month
-            , subq_4.metric_time__year AS metric_time__year
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_offset_window_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_offset_window_with_agg_time_dim__plan0.sql
@@ -245,7 +245,8 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_6.ds__day AS ds__day
+            subq_9.booking__ds__day AS booking__ds__day
+            , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -321,7 +322,6 @@ FROM (
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_9.booking__ds__day AS booking__ds__day
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_time_offset_metric_with_time_constraint__plan0.sql
@@ -125,7 +125,8 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_1.ds__day AS ds__day
+            subq_4.metric_time__day AS metric_time__day
+            , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -201,7 +202,6 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_4.metric_time__day AS metric_time__day
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
@@ -125,7 +125,8 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_4.ds__day AS ds__day
+            subq_7.metric_time__day AS metric_time__day
+            , subq_4.ds__day AS ds__day
             , subq_4.ds__week AS ds__week
             , subq_4.ds__month AS ds__month
             , subq_4.ds__quarter AS ds__quarter
@@ -201,7 +202,6 @@ FROM (
             , subq_4.metric_time__extract_day AS metric_time__extract_day
             , subq_4.metric_time__extract_dow AS metric_time__extract_dow
             , subq_4.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_7.metric_time__day AS metric_time__day
             , subq_4.listing AS listing
             , subq_4.guest AS guest
             , subq_4.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
@@ -24,7 +24,8 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_1.ds__month AS ds__month
+          subq_4.metric_time__month AS metric_time__month
+          , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
           , subq_1.ds__year AS ds__year
           , subq_1.ds__extract_year AS ds__extract_year
@@ -41,7 +42,6 @@ FROM (
           , subq_1.metric_time__extract_year AS metric_time__extract_year
           , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
           , subq_1.metric_time__extract_month AS metric_time__extract_month
-          , subq_4.metric_time__month AS metric_time__month
           , subq_1.listing AS listing
           , subq_1.booking_monthly__listing AS booking_monthly__listing
           , subq_1.bookings_monthly AS bookings_monthly

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_derived_metric_with_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_derived_metric_with_offset_to_grain__plan0.sql
@@ -245,7 +245,8 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_6.ds__day AS ds__day
+            subq_9.metric_time__day AS metric_time__day
+            , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -321,7 +322,6 @@ FROM (
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_9.metric_time__day AS metric_time__day
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_derived_metric_with_offset_to_grain_and_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_derived_metric_with_offset_to_grain_and_granularity__plan0.sql
@@ -245,7 +245,9 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_6.ds__day AS ds__day
+            subq_9.metric_time__day AS metric_time__day
+            , subq_9.metric_time__week AS metric_time__week
+            , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -320,8 +322,6 @@ FROM (
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_9.metric_time__day AS metric_time__day
-            , subq_9.metric_time__week AS metric_time__week
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_derived_metric_with_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_derived_metric_with_offset_window__plan0.sql
@@ -245,7 +245,8 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_6.ds__day AS ds__day
+            subq_9.metric_time__day AS metric_time__day
+            , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -321,7 +322,6 @@ FROM (
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_9.metric_time__day AS metric_time__day
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_derived_metric_with_offset_window_and_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_derived_metric_with_offset_window_and_granularity__plan0.sql
@@ -245,7 +245,9 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_6.ds__day AS ds__day
+            subq_9.metric_time__day AS metric_time__day
+            , subq_9.metric_time__quarter AS metric_time__quarter
+            , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -320,8 +322,6 @@ FROM (
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_9.metric_time__day AS metric_time__day
-            , subq_9.metric_time__quarter AS metric_time__quarter
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
@@ -30,7 +30,8 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_1.ds__day AS ds__day
+            subq_4.metric_time__day AS metric_time__day
+            , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -106,7 +107,6 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_4.metric_time__day AS metric_time__day
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host
@@ -387,7 +387,8 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_10.ds__day AS ds__day
+            subq_13.metric_time__day AS metric_time__day
+            , subq_10.ds__day AS ds__day
             , subq_10.ds__week AS ds__week
             , subq_10.ds__month AS ds__month
             , subq_10.ds__quarter AS ds__quarter
@@ -463,7 +464,6 @@ FROM (
             , subq_10.metric_time__extract_day AS metric_time__extract_day
             , subq_10.metric_time__extract_dow AS metric_time__extract_dow
             , subq_10.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_13.metric_time__day AS metric_time__day
             , subq_10.listing AS listing
             , subq_10.guest AS guest
             , subq_10.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity__plan0.sql
@@ -30,7 +30,9 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_1.ds__day AS ds__day
+            subq_4.metric_time__day AS metric_time__day
+            , subq_4.metric_time__year AS metric_time__year
+            , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -105,8 +107,6 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_4.metric_time__day AS metric_time__day
-            , subq_4.metric_time__year AS metric_time__year
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host
@@ -389,7 +389,9 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_10.ds__day AS ds__day
+            subq_13.metric_time__day AS metric_time__day
+            , subq_13.metric_time__year AS metric_time__year
+            , subq_10.ds__day AS ds__day
             , subq_10.ds__week AS ds__week
             , subq_10.ds__month AS ds__month
             , subq_10.ds__quarter AS ds__quarter
@@ -464,8 +466,6 @@ FROM (
             , subq_10.metric_time__extract_day AS metric_time__extract_day
             , subq_10.metric_time__extract_dow AS metric_time__extract_dow
             , subq_10.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_13.metric_time__day AS metric_time__day
-            , subq_13.metric_time__year AS metric_time__year
             , subq_10.listing AS listing
             , subq_10.guest AS guest
             , subq_10.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
@@ -449,7 +449,8 @@ FROM (
           FROM (
             -- Join to Time Spine Dataset
             SELECT
-              subq_7.ds__day AS ds__day
+              subq_10.metric_time__day AS metric_time__day
+              , subq_7.ds__day AS ds__day
               , subq_7.ds__week AS ds__week
               , subq_7.ds__month AS ds__month
               , subq_7.ds__quarter AS ds__quarter
@@ -525,7 +526,6 @@ FROM (
               , subq_7.metric_time__extract_day AS metric_time__extract_day
               , subq_7.metric_time__extract_dow AS metric_time__extract_dow
               , subq_7.metric_time__extract_doy AS metric_time__extract_doy
-              , subq_10.metric_time__day AS metric_time__day
               , subq_7.listing AS listing
               , subq_7.guest AS guest
               , subq_7.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_derived_offset_cumulative_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_derived_offset_cumulative_metric__plan0.sql
@@ -24,7 +24,8 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_4.ds__day AS ds__day
+          subq_7.metric_time__day AS metric_time__day
+          , subq_4.ds__day AS ds__day
           , subq_4.ds__week AS ds__week
           , subq_4.ds__month AS ds__month
           , subq_4.ds__quarter AS ds__quarter
@@ -100,7 +101,6 @@ FROM (
           , subq_4.metric_time__extract_day AS metric_time__extract_day
           , subq_4.metric_time__extract_dow AS metric_time__extract_dow
           , subq_4.metric_time__extract_doy AS metric_time__extract_doy
-          , subq_7.metric_time__day AS metric_time__day
           , subq_4.listing AS listing
           , subq_4.guest AS guest
           , subq_4.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_derived_offset_metric_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_derived_offset_metric_with_agg_time_dim__plan0.sql
@@ -30,7 +30,8 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_1.ds__day AS ds__day
+            subq_4.booking__ds__day AS booking__ds__day
+            , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -106,7 +107,6 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_4.booking__ds__day AS booking__ds__day
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_derived_offset_metric_with_one_input_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_derived_offset_metric_with_one_input_metric__plan0.sql
@@ -24,7 +24,8 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_1.ds__day AS ds__day
+          subq_4.metric_time__day AS metric_time__day
+          , subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
@@ -100,7 +101,6 @@ FROM (
           , subq_1.metric_time__extract_day AS metric_time__extract_day
           , subq_1.metric_time__extract_dow AS metric_time__extract_dow
           , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-          , subq_4.metric_time__day AS metric_time__day
           , subq_1.listing AS listing
           , subq_1.guest AS guest
           , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0.sql
@@ -88,7 +88,8 @@ FROM (
               FROM (
                 -- Join to Time Spine Dataset
                 SELECT
-                  subq_1.ds__day AS ds__day
+                  subq_4.metric_time__day AS metric_time__day
+                  , subq_1.ds__day AS ds__day
                   , subq_1.ds__week AS ds__week
                   , subq_1.ds__month AS ds__month
                   , subq_1.ds__quarter AS ds__quarter
@@ -164,7 +165,6 @@ FROM (
                   , subq_1.metric_time__extract_day AS metric_time__extract_day
                   , subq_1.metric_time__extract_dow AS metric_time__extract_dow
                   , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-                  , subq_4.metric_time__day AS metric_time__day
                   , subq_1.listing AS listing
                   , subq_1.guest AS guest
                   , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_nested_offsets__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_nested_offsets__plan0.sql
@@ -72,7 +72,8 @@ FROM (
           FROM (
             -- Join to Time Spine Dataset
             SELECT
-              subq_1.ds__day AS ds__day
+              subq_4.metric_time__day AS metric_time__day
+              , subq_1.ds__day AS ds__day
               , subq_1.ds__week AS ds__week
               , subq_1.ds__month AS ds__month
               , subq_1.ds__quarter AS ds__quarter
@@ -148,7 +149,6 @@ FROM (
               , subq_1.metric_time__extract_day AS metric_time__extract_day
               , subq_1.metric_time__extract_dow AS metric_time__extract_dow
               , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-              , subq_4.metric_time__day AS metric_time__day
               , subq_1.listing AS listing
               , subq_1.guest AS guest
               , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_nested_offsets_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_nested_offsets_with_time_constraint__plan0.sql
@@ -77,7 +77,8 @@ FROM (
             FROM (
               -- Join to Time Spine Dataset
               SELECT
-                subq_1.ds__day AS ds__day
+                subq_4.metric_time__day AS metric_time__day
+                , subq_1.ds__day AS ds__day
                 , subq_1.ds__week AS ds__week
                 , subq_1.ds__month AS ds__month
                 , subq_1.ds__quarter AS ds__quarter
@@ -153,7 +154,6 @@ FROM (
                 , subq_1.metric_time__extract_day AS metric_time__extract_day
                 , subq_1.metric_time__extract_dow AS metric_time__extract_dow
                 , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-                , subq_4.metric_time__day AS metric_time__day
                 , subq_1.listing AS listing
                 , subq_1.guest AS guest
                 , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_nested_offsets_with_where_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_nested_offsets_with_where_constraint__plan0.sql
@@ -77,7 +77,8 @@ FROM (
             FROM (
               -- Join to Time Spine Dataset
               SELECT
-                subq_1.ds__day AS ds__day
+                subq_4.metric_time__day AS metric_time__day
+                , subq_1.ds__day AS ds__day
                 , subq_1.ds__week AS ds__week
                 , subq_1.ds__month AS ds__month
                 , subq_1.ds__quarter AS ds__quarter
@@ -153,7 +154,6 @@ FROM (
                 , subq_1.metric_time__extract_day AS metric_time__extract_day
                 , subq_1.metric_time__extract_dow AS metric_time__extract_dow
                 , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-                , subq_4.metric_time__day AS metric_time__day
                 , subq_1.listing AS listing
                 , subq_1.guest AS guest
                 , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0.sql
@@ -127,7 +127,9 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_1.ds__day AS ds__day
+            subq_4.metric_time__day AS metric_time__day
+            , subq_4.metric_time__month AS metric_time__month
+            , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -202,8 +204,6 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_4.metric_time__day AS metric_time__day
-            , subq_4.metric_time__month AS metric_time__month
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_offset_to_grain_metric_multiple_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_offset_to_grain_metric_multiple_granularities__plan0.sql
@@ -34,7 +34,10 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_1.ds__day AS ds__day
+          subq_4.metric_time__day AS metric_time__day
+          , subq_4.metric_time__month AS metric_time__month
+          , subq_4.metric_time__year AS metric_time__year
+          , subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
@@ -108,9 +111,6 @@ FROM (
           , subq_1.metric_time__extract_day AS metric_time__extract_day
           , subq_1.metric_time__extract_dow AS metric_time__extract_dow
           , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-          , subq_4.metric_time__day AS metric_time__day
-          , subq_4.metric_time__month AS metric_time__month
-          , subq_4.metric_time__year AS metric_time__year
           , subq_1.listing AS listing
           , subq_1.guest AS guest
           , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_offset_to_grain_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_offset_to_grain_with_agg_time_dim__plan0.sql
@@ -245,7 +245,8 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_6.ds__day AS ds__day
+            subq_9.booking__ds__day AS booking__ds__day
+            , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -321,7 +322,6 @@ FROM (
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_9.booking__ds__day AS booking__ds__day
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_offset_window_metric_filter_and_query_have_different_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_offset_window_metric_filter_and_query_have_different_granularities__plan0.sql
@@ -133,7 +133,9 @@ FROM (
           FROM (
             -- Join to Time Spine Dataset
             SELECT
-              subq_1.ds__day AS ds__day
+              subq_4.metric_time__day AS metric_time__day
+              , subq_4.metric_time__month AS metric_time__month
+              , subq_1.ds__day AS ds__day
               , subq_1.ds__week AS ds__week
               , subq_1.ds__month AS ds__month
               , subq_1.ds__quarter AS ds__quarter
@@ -208,8 +210,6 @@ FROM (
               , subq_1.metric_time__extract_day AS metric_time__extract_day
               , subq_1.metric_time__extract_dow AS metric_time__extract_dow
               , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-              , subq_4.metric_time__day AS metric_time__day
-              , subq_4.metric_time__month AS metric_time__month
               , subq_1.listing AS listing
               , subq_1.guest AS guest
               , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_offset_window_metric_multiple_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_offset_window_metric_multiple_granularities__plan0.sql
@@ -42,7 +42,10 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_1.ds__day AS ds__day
+            subq_4.metric_time__day AS metric_time__day
+            , subq_4.metric_time__month AS metric_time__month
+            , subq_4.metric_time__year AS metric_time__year
+            , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -116,9 +119,6 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_4.metric_time__day AS metric_time__day
-            , subq_4.metric_time__month AS metric_time__month
-            , subq_4.metric_time__year AS metric_time__year
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_offset_window_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_offset_window_with_agg_time_dim__plan0.sql
@@ -245,7 +245,8 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_6.ds__day AS ds__day
+            subq_9.booking__ds__day AS booking__ds__day
+            , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -321,7 +322,6 @@ FROM (
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_9.booking__ds__day AS booking__ds__day
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_time_offset_metric_with_time_constraint__plan0.sql
@@ -125,7 +125,8 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_1.ds__day AS ds__day
+            subq_4.metric_time__day AS metric_time__day
+            , subq_1.ds__day AS ds__day
             , subq_1.ds__week AS ds__week
             , subq_1.ds__month AS ds__month
             , subq_1.ds__quarter AS ds__quarter
@@ -201,7 +202,6 @@ FROM (
             , subq_1.metric_time__extract_day AS metric_time__extract_day
             , subq_1.metric_time__extract_dow AS metric_time__extract_dow
             , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_4.metric_time__day AS metric_time__day
             , subq_1.listing AS listing
             , subq_1.guest AS guest
             , subq_1.host AS host

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/BigQuery/test_derived_fill_nulls_for_one_input_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/BigQuery/test_derived_fill_nulls_for_one_input_metric__plan0.sql
@@ -291,7 +291,8 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_10.ds__day AS ds__day
+            subq_13.metric_time__day AS metric_time__day
+            , subq_10.ds__day AS ds__day
             , subq_10.ds__week AS ds__week
             , subq_10.ds__month AS ds__month
             , subq_10.ds__quarter AS ds__quarter
@@ -367,7 +368,6 @@ FROM (
             , subq_10.metric_time__extract_day AS metric_time__extract_day
             , subq_10.metric_time__extract_dow AS metric_time__extract_dow
             , subq_10.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_13.metric_time__day AS metric_time__day
             , subq_10.listing AS listing
             , subq_10.guest AS guest
             , subq_10.host AS host

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Databricks/test_derived_fill_nulls_for_one_input_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Databricks/test_derived_fill_nulls_for_one_input_metric__plan0.sql
@@ -291,7 +291,8 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_10.ds__day AS ds__day
+            subq_13.metric_time__day AS metric_time__day
+            , subq_10.ds__day AS ds__day
             , subq_10.ds__week AS ds__week
             , subq_10.ds__month AS ds__month
             , subq_10.ds__quarter AS ds__quarter
@@ -367,7 +368,6 @@ FROM (
             , subq_10.metric_time__extract_day AS metric_time__extract_day
             , subq_10.metric_time__extract_dow AS metric_time__extract_dow
             , subq_10.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_13.metric_time__day AS metric_time__day
             , subq_10.listing AS listing
             , subq_10.guest AS guest
             , subq_10.host AS host

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/DuckDB/test_derived_fill_nulls_for_one_input_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/DuckDB/test_derived_fill_nulls_for_one_input_metric__plan0.sql
@@ -291,7 +291,8 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_10.ds__day AS ds__day
+            subq_13.metric_time__day AS metric_time__day
+            , subq_10.ds__day AS ds__day
             , subq_10.ds__week AS ds__week
             , subq_10.ds__month AS ds__month
             , subq_10.ds__quarter AS ds__quarter
@@ -367,7 +368,6 @@ FROM (
             , subq_10.metric_time__extract_day AS metric_time__extract_day
             , subq_10.metric_time__extract_dow AS metric_time__extract_dow
             , subq_10.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_13.metric_time__day AS metric_time__day
             , subq_10.listing AS listing
             , subq_10.guest AS guest
             , subq_10.host AS host

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Postgres/test_derived_fill_nulls_for_one_input_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Postgres/test_derived_fill_nulls_for_one_input_metric__plan0.sql
@@ -291,7 +291,8 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_10.ds__day AS ds__day
+            subq_13.metric_time__day AS metric_time__day
+            , subq_10.ds__day AS ds__day
             , subq_10.ds__week AS ds__week
             , subq_10.ds__month AS ds__month
             , subq_10.ds__quarter AS ds__quarter
@@ -367,7 +368,6 @@ FROM (
             , subq_10.metric_time__extract_day AS metric_time__extract_day
             , subq_10.metric_time__extract_dow AS metric_time__extract_dow
             , subq_10.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_13.metric_time__day AS metric_time__day
             , subq_10.listing AS listing
             , subq_10.guest AS guest
             , subq_10.host AS host

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Redshift/test_derived_fill_nulls_for_one_input_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Redshift/test_derived_fill_nulls_for_one_input_metric__plan0.sql
@@ -291,7 +291,8 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_10.ds__day AS ds__day
+            subq_13.metric_time__day AS metric_time__day
+            , subq_10.ds__day AS ds__day
             , subq_10.ds__week AS ds__week
             , subq_10.ds__month AS ds__month
             , subq_10.ds__quarter AS ds__quarter
@@ -367,7 +368,6 @@ FROM (
             , subq_10.metric_time__extract_day AS metric_time__extract_day
             , subq_10.metric_time__extract_dow AS metric_time__extract_dow
             , subq_10.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_13.metric_time__day AS metric_time__day
             , subq_10.listing AS listing
             , subq_10.guest AS guest
             , subq_10.host AS host

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Snowflake/test_derived_fill_nulls_for_one_input_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Snowflake/test_derived_fill_nulls_for_one_input_metric__plan0.sql
@@ -291,7 +291,8 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_10.ds__day AS ds__day
+            subq_13.metric_time__day AS metric_time__day
+            , subq_10.ds__day AS ds__day
             , subq_10.ds__week AS ds__week
             , subq_10.ds__month AS ds__month
             , subq_10.ds__quarter AS ds__quarter
@@ -367,7 +368,6 @@ FROM (
             , subq_10.metric_time__extract_day AS metric_time__extract_day
             , subq_10.metric_time__extract_dow AS metric_time__extract_dow
             , subq_10.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_13.metric_time__day AS metric_time__day
             , subq_10.listing AS listing
             , subq_10.guest AS guest
             , subq_10.host AS host

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Trino/test_derived_fill_nulls_for_one_input_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Trino/test_derived_fill_nulls_for_one_input_metric__plan0.sql
@@ -291,7 +291,8 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_10.ds__day AS ds__day
+            subq_13.metric_time__day AS metric_time__day
+            , subq_10.ds__day AS ds__day
             , subq_10.ds__week AS ds__week
             , subq_10.ds__month AS ds__month
             , subq_10.ds__quarter AS ds__quarter
@@ -367,7 +368,6 @@ FROM (
             , subq_10.metric_time__extract_day AS metric_time__extract_day
             , subq_10.metric_time__extract_dow AS metric_time__extract_dow
             , subq_10.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_13.metric_time__day AS metric_time__day
             , subq_10.listing AS listing
             , subq_10.guest AS guest
             , subq_10.host AS host

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/BigQuery/test_offset_window_with_date_part__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/BigQuery/test_offset_window_with_date_part__plan0.sql
@@ -245,7 +245,9 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_6.ds__day AS ds__day
+            subq_9.metric_time__day AS metric_time__day
+            , subq_9.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -320,8 +322,6 @@ FROM (
             , subq_6.metric_time__extract_month AS metric_time__extract_month
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_9.metric_time__day AS metric_time__day
-            , subq_9.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/BigQuery/test_subdaily_offset_to_grain_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/BigQuery/test_subdaily_offset_to_grain_metric__plan0.sql
@@ -24,7 +24,8 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_1.ds__day AS ds__day
+          subq_4.metric_time__hour AS metric_time__hour
+          , subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
@@ -209,7 +210,6 @@ FROM (
           , subq_1.metric_time__extract_day AS metric_time__extract_day
           , subq_1.metric_time__extract_dow AS metric_time__extract_dow
           , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-          , subq_4.metric_time__hour AS metric_time__hour
           , subq_1.user AS user
           , subq_1.home_state AS home_state
           , subq_1.user__home_state AS user__home_state

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/BigQuery/test_subdaily_offset_window_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/BigQuery/test_subdaily_offset_window_metric__plan0.sql
@@ -24,7 +24,8 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_1.ds__day AS ds__day
+          subq_4.metric_time__hour AS metric_time__hour
+          , subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
@@ -209,7 +210,6 @@ FROM (
           , subq_1.metric_time__extract_day AS metric_time__extract_day
           , subq_1.metric_time__extract_dow AS metric_time__extract_dow
           , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-          , subq_4.metric_time__hour AS metric_time__hour
           , subq_1.user AS user
           , subq_1.home_state AS home_state
           , subq_1.user__home_state AS user__home_state

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Databricks/test_offset_window_with_date_part__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Databricks/test_offset_window_with_date_part__plan0.sql
@@ -245,7 +245,9 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_6.ds__day AS ds__day
+            subq_9.metric_time__day AS metric_time__day
+            , subq_9.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -320,8 +322,6 @@ FROM (
             , subq_6.metric_time__extract_month AS metric_time__extract_month
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_9.metric_time__day AS metric_time__day
-            , subq_9.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Databricks/test_subdaily_offset_to_grain_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Databricks/test_subdaily_offset_to_grain_metric__plan0.sql
@@ -24,7 +24,8 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_1.ds__day AS ds__day
+          subq_4.metric_time__hour AS metric_time__hour
+          , subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
@@ -209,7 +210,6 @@ FROM (
           , subq_1.metric_time__extract_day AS metric_time__extract_day
           , subq_1.metric_time__extract_dow AS metric_time__extract_dow
           , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-          , subq_4.metric_time__hour AS metric_time__hour
           , subq_1.user AS user
           , subq_1.home_state AS home_state
           , subq_1.user__home_state AS user__home_state

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Databricks/test_subdaily_offset_window_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Databricks/test_subdaily_offset_window_metric__plan0.sql
@@ -24,7 +24,8 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_1.ds__day AS ds__day
+          subq_4.metric_time__hour AS metric_time__hour
+          , subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
@@ -209,7 +210,6 @@ FROM (
           , subq_1.metric_time__extract_day AS metric_time__extract_day
           , subq_1.metric_time__extract_dow AS metric_time__extract_dow
           , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-          , subq_4.metric_time__hour AS metric_time__hour
           , subq_1.user AS user
           , subq_1.home_state AS home_state
           , subq_1.user__home_state AS user__home_state

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/DuckDB/test_offset_window_with_date_part__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/DuckDB/test_offset_window_with_date_part__plan0.sql
@@ -245,7 +245,9 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_6.ds__day AS ds__day
+            subq_9.metric_time__day AS metric_time__day
+            , subq_9.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -320,8 +322,6 @@ FROM (
             , subq_6.metric_time__extract_month AS metric_time__extract_month
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_9.metric_time__day AS metric_time__day
-            , subq_9.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/DuckDB/test_subdaily_offset_to_grain_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/DuckDB/test_subdaily_offset_to_grain_metric__plan0.sql
@@ -24,7 +24,8 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_1.ds__day AS ds__day
+          subq_4.metric_time__hour AS metric_time__hour
+          , subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
@@ -209,7 +210,6 @@ FROM (
           , subq_1.metric_time__extract_day AS metric_time__extract_day
           , subq_1.metric_time__extract_dow AS metric_time__extract_dow
           , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-          , subq_4.metric_time__hour AS metric_time__hour
           , subq_1.user AS user
           , subq_1.home_state AS home_state
           , subq_1.user__home_state AS user__home_state

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/DuckDB/test_subdaily_offset_window_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/DuckDB/test_subdaily_offset_window_metric__plan0.sql
@@ -24,7 +24,8 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_1.ds__day AS ds__day
+          subq_4.metric_time__hour AS metric_time__hour
+          , subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
@@ -209,7 +210,6 @@ FROM (
           , subq_1.metric_time__extract_day AS metric_time__extract_day
           , subq_1.metric_time__extract_dow AS metric_time__extract_dow
           , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-          , subq_4.metric_time__hour AS metric_time__hour
           , subq_1.user AS user
           , subq_1.home_state AS home_state
           , subq_1.user__home_state AS user__home_state

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Postgres/test_offset_window_with_date_part__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Postgres/test_offset_window_with_date_part__plan0.sql
@@ -245,7 +245,9 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_6.ds__day AS ds__day
+            subq_9.metric_time__day AS metric_time__day
+            , subq_9.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -320,8 +322,6 @@ FROM (
             , subq_6.metric_time__extract_month AS metric_time__extract_month
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_9.metric_time__day AS metric_time__day
-            , subq_9.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Postgres/test_subdaily_offset_to_grain_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Postgres/test_subdaily_offset_to_grain_metric__plan0.sql
@@ -24,7 +24,8 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_1.ds__day AS ds__day
+          subq_4.metric_time__hour AS metric_time__hour
+          , subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
@@ -209,7 +210,6 @@ FROM (
           , subq_1.metric_time__extract_day AS metric_time__extract_day
           , subq_1.metric_time__extract_dow AS metric_time__extract_dow
           , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-          , subq_4.metric_time__hour AS metric_time__hour
           , subq_1.user AS user
           , subq_1.home_state AS home_state
           , subq_1.user__home_state AS user__home_state

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Postgres/test_subdaily_offset_window_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Postgres/test_subdaily_offset_window_metric__plan0.sql
@@ -24,7 +24,8 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_1.ds__day AS ds__day
+          subq_4.metric_time__hour AS metric_time__hour
+          , subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
@@ -209,7 +210,6 @@ FROM (
           , subq_1.metric_time__extract_day AS metric_time__extract_day
           , subq_1.metric_time__extract_dow AS metric_time__extract_dow
           , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-          , subq_4.metric_time__hour AS metric_time__hour
           , subq_1.user AS user
           , subq_1.home_state AS home_state
           , subq_1.user__home_state AS user__home_state

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Redshift/test_offset_window_with_date_part__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Redshift/test_offset_window_with_date_part__plan0.sql
@@ -245,7 +245,9 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_6.ds__day AS ds__day
+            subq_9.metric_time__day AS metric_time__day
+            , subq_9.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -320,8 +322,6 @@ FROM (
             , subq_6.metric_time__extract_month AS metric_time__extract_month
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_9.metric_time__day AS metric_time__day
-            , subq_9.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Redshift/test_subdaily_offset_to_grain_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Redshift/test_subdaily_offset_to_grain_metric__plan0.sql
@@ -24,7 +24,8 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_1.ds__day AS ds__day
+          subq_4.metric_time__hour AS metric_time__hour
+          , subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
@@ -209,7 +210,6 @@ FROM (
           , subq_1.metric_time__extract_day AS metric_time__extract_day
           , subq_1.metric_time__extract_dow AS metric_time__extract_dow
           , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-          , subq_4.metric_time__hour AS metric_time__hour
           , subq_1.user AS user
           , subq_1.home_state AS home_state
           , subq_1.user__home_state AS user__home_state

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Redshift/test_subdaily_offset_window_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Redshift/test_subdaily_offset_window_metric__plan0.sql
@@ -24,7 +24,8 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_1.ds__day AS ds__day
+          subq_4.metric_time__hour AS metric_time__hour
+          , subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
@@ -209,7 +210,6 @@ FROM (
           , subq_1.metric_time__extract_day AS metric_time__extract_day
           , subq_1.metric_time__extract_dow AS metric_time__extract_dow
           , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-          , subq_4.metric_time__hour AS metric_time__hour
           , subq_1.user AS user
           , subq_1.home_state AS home_state
           , subq_1.user__home_state AS user__home_state

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Snowflake/test_offset_window_with_date_part__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Snowflake/test_offset_window_with_date_part__plan0.sql
@@ -245,7 +245,9 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_6.ds__day AS ds__day
+            subq_9.metric_time__day AS metric_time__day
+            , subq_9.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -320,8 +322,6 @@ FROM (
             , subq_6.metric_time__extract_month AS metric_time__extract_month
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_9.metric_time__day AS metric_time__day
-            , subq_9.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Snowflake/test_subdaily_offset_to_grain_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Snowflake/test_subdaily_offset_to_grain_metric__plan0.sql
@@ -24,7 +24,8 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_1.ds__day AS ds__day
+          subq_4.metric_time__hour AS metric_time__hour
+          , subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
@@ -209,7 +210,6 @@ FROM (
           , subq_1.metric_time__extract_day AS metric_time__extract_day
           , subq_1.metric_time__extract_dow AS metric_time__extract_dow
           , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-          , subq_4.metric_time__hour AS metric_time__hour
           , subq_1.user AS user
           , subq_1.home_state AS home_state
           , subq_1.user__home_state AS user__home_state

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Snowflake/test_subdaily_offset_window_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Snowflake/test_subdaily_offset_window_metric__plan0.sql
@@ -24,7 +24,8 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_1.ds__day AS ds__day
+          subq_4.metric_time__hour AS metric_time__hour
+          , subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
@@ -209,7 +210,6 @@ FROM (
           , subq_1.metric_time__extract_day AS metric_time__extract_day
           , subq_1.metric_time__extract_dow AS metric_time__extract_dow
           , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-          , subq_4.metric_time__hour AS metric_time__hour
           , subq_1.user AS user
           , subq_1.home_state AS home_state
           , subq_1.user__home_state AS user__home_state

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Trino/test_offset_window_with_date_part__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Trino/test_offset_window_with_date_part__plan0.sql
@@ -245,7 +245,9 @@ FROM (
         FROM (
           -- Join to Time Spine Dataset
           SELECT
-            subq_6.ds__day AS ds__day
+            subq_9.metric_time__day AS metric_time__day
+            , subq_9.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_6.ds__day AS ds__day
             , subq_6.ds__week AS ds__week
             , subq_6.ds__month AS ds__month
             , subq_6.ds__quarter AS ds__quarter
@@ -320,8 +322,6 @@ FROM (
             , subq_6.metric_time__extract_month AS metric_time__extract_month
             , subq_6.metric_time__extract_day AS metric_time__extract_day
             , subq_6.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_9.metric_time__day AS metric_time__day
-            , subq_9.metric_time__extract_dow AS metric_time__extract_dow
             , subq_6.listing AS listing
             , subq_6.guest AS guest
             , subq_6.host AS host

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Trino/test_subdaily_offset_to_grain_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Trino/test_subdaily_offset_to_grain_metric__plan0.sql
@@ -24,7 +24,8 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_1.ds__day AS ds__day
+          subq_4.metric_time__hour AS metric_time__hour
+          , subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
@@ -209,7 +210,6 @@ FROM (
           , subq_1.metric_time__extract_day AS metric_time__extract_day
           , subq_1.metric_time__extract_dow AS metric_time__extract_dow
           , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-          , subq_4.metric_time__hour AS metric_time__hour
           , subq_1.user AS user
           , subq_1.home_state AS home_state
           , subq_1.user__home_state AS user__home_state

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Trino/test_subdaily_offset_window_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Trino/test_subdaily_offset_window_metric__plan0.sql
@@ -24,7 +24,8 @@ FROM (
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_1.ds__day AS ds__day
+          subq_4.metric_time__hour AS metric_time__hour
+          , subq_1.ds__day AS ds__day
           , subq_1.ds__week AS ds__week
           , subq_1.ds__month AS ds__month
           , subq_1.ds__quarter AS ds__quarter
@@ -209,7 +210,6 @@ FROM (
           , subq_1.metric_time__extract_day AS metric_time__extract_day
           , subq_1.metric_time__extract_dow AS metric_time__extract_dow
           , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-          , subq_4.metric_time__hour AS metric_time__hour
           , subq_1.user AS user
           , subq_1.home_state AS home_state
           , subq_1.user__home_state AS user__home_state

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/BigQuery/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/BigQuery/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
@@ -900,7 +900,8 @@ FROM (
               FROM (
                 -- Join to Time Spine Dataset
                 SELECT
-                  subq_15.ds__day AS ds__day
+                  subq_18.metric_time__day AS metric_time__day
+                  , subq_15.ds__day AS ds__day
                   , subq_15.ds__week AS ds__week
                   , subq_15.ds__month AS ds__month
                   , subq_15.ds__quarter AS ds__quarter
@@ -976,7 +977,6 @@ FROM (
                   , subq_15.metric_time__extract_day AS metric_time__extract_day
                   , subq_15.metric_time__extract_dow AS metric_time__extract_dow
                   , subq_15.metric_time__extract_doy AS metric_time__extract_doy
-                  , subq_18.metric_time__day AS metric_time__day
                   , subq_15.listing AS listing
                   , subq_15.guest AS guest
                   , subq_15.host AS host

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/BigQuery/test_offset_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/BigQuery/test_offset_metric_with_query_time_filters__plan0.sql
@@ -809,7 +809,8 @@ FROM (
             FROM (
               -- Join to Time Spine Dataset
               SELECT
-                subq_11.ds__day AS ds__day
+                subq_14.metric_time__day AS metric_time__day
+                , subq_11.ds__day AS ds__day
                 , subq_11.ds__week AS ds__week
                 , subq_11.ds__month AS ds__month
                 , subq_11.ds__quarter AS ds__quarter
@@ -885,7 +886,6 @@ FROM (
                 , subq_11.metric_time__extract_day AS metric_time__extract_day
                 , subq_11.metric_time__extract_dow AS metric_time__extract_dow
                 , subq_11.metric_time__extract_doy AS metric_time__extract_doy
-                , subq_14.metric_time__day AS metric_time__day
                 , subq_11.listing AS listing
                 , subq_11.guest AS guest
                 , subq_11.host AS host

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Databricks/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Databricks/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
@@ -900,7 +900,8 @@ FROM (
               FROM (
                 -- Join to Time Spine Dataset
                 SELECT
-                  subq_15.ds__day AS ds__day
+                  subq_18.metric_time__day AS metric_time__day
+                  , subq_15.ds__day AS ds__day
                   , subq_15.ds__week AS ds__week
                   , subq_15.ds__month AS ds__month
                   , subq_15.ds__quarter AS ds__quarter
@@ -976,7 +977,6 @@ FROM (
                   , subq_15.metric_time__extract_day AS metric_time__extract_day
                   , subq_15.metric_time__extract_dow AS metric_time__extract_dow
                   , subq_15.metric_time__extract_doy AS metric_time__extract_doy
-                  , subq_18.metric_time__day AS metric_time__day
                   , subq_15.listing AS listing
                   , subq_15.guest AS guest
                   , subq_15.host AS host

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Databricks/test_offset_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Databricks/test_offset_metric_with_query_time_filters__plan0.sql
@@ -809,7 +809,8 @@ FROM (
             FROM (
               -- Join to Time Spine Dataset
               SELECT
-                subq_11.ds__day AS ds__day
+                subq_14.metric_time__day AS metric_time__day
+                , subq_11.ds__day AS ds__day
                 , subq_11.ds__week AS ds__week
                 , subq_11.ds__month AS ds__month
                 , subq_11.ds__quarter AS ds__quarter
@@ -885,7 +886,6 @@ FROM (
                 , subq_11.metric_time__extract_day AS metric_time__extract_day
                 , subq_11.metric_time__extract_dow AS metric_time__extract_dow
                 , subq_11.metric_time__extract_doy AS metric_time__extract_doy
-                , subq_14.metric_time__day AS metric_time__day
                 , subq_11.listing AS listing
                 , subq_11.guest AS guest
                 , subq_11.host AS host

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/DuckDB/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/DuckDB/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
@@ -900,7 +900,8 @@ FROM (
               FROM (
                 -- Join to Time Spine Dataset
                 SELECT
-                  subq_15.ds__day AS ds__day
+                  subq_18.metric_time__day AS metric_time__day
+                  , subq_15.ds__day AS ds__day
                   , subq_15.ds__week AS ds__week
                   , subq_15.ds__month AS ds__month
                   , subq_15.ds__quarter AS ds__quarter
@@ -976,7 +977,6 @@ FROM (
                   , subq_15.metric_time__extract_day AS metric_time__extract_day
                   , subq_15.metric_time__extract_dow AS metric_time__extract_dow
                   , subq_15.metric_time__extract_doy AS metric_time__extract_doy
-                  , subq_18.metric_time__day AS metric_time__day
                   , subq_15.listing AS listing
                   , subq_15.guest AS guest
                   , subq_15.host AS host

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/DuckDB/test_offset_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/DuckDB/test_offset_metric_with_query_time_filters__plan0.sql
@@ -809,7 +809,8 @@ FROM (
             FROM (
               -- Join to Time Spine Dataset
               SELECT
-                subq_11.ds__day AS ds__day
+                subq_14.metric_time__day AS metric_time__day
+                , subq_11.ds__day AS ds__day
                 , subq_11.ds__week AS ds__week
                 , subq_11.ds__month AS ds__month
                 , subq_11.ds__quarter AS ds__quarter
@@ -885,7 +886,6 @@ FROM (
                 , subq_11.metric_time__extract_day AS metric_time__extract_day
                 , subq_11.metric_time__extract_dow AS metric_time__extract_dow
                 , subq_11.metric_time__extract_doy AS metric_time__extract_doy
-                , subq_14.metric_time__day AS metric_time__day
                 , subq_11.listing AS listing
                 , subq_11.guest AS guest
                 , subq_11.host AS host

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Postgres/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Postgres/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
@@ -900,7 +900,8 @@ FROM (
               FROM (
                 -- Join to Time Spine Dataset
                 SELECT
-                  subq_15.ds__day AS ds__day
+                  subq_18.metric_time__day AS metric_time__day
+                  , subq_15.ds__day AS ds__day
                   , subq_15.ds__week AS ds__week
                   , subq_15.ds__month AS ds__month
                   , subq_15.ds__quarter AS ds__quarter
@@ -976,7 +977,6 @@ FROM (
                   , subq_15.metric_time__extract_day AS metric_time__extract_day
                   , subq_15.metric_time__extract_dow AS metric_time__extract_dow
                   , subq_15.metric_time__extract_doy AS metric_time__extract_doy
-                  , subq_18.metric_time__day AS metric_time__day
                   , subq_15.listing AS listing
                   , subq_15.guest AS guest
                   , subq_15.host AS host

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Postgres/test_offset_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Postgres/test_offset_metric_with_query_time_filters__plan0.sql
@@ -809,7 +809,8 @@ FROM (
             FROM (
               -- Join to Time Spine Dataset
               SELECT
-                subq_11.ds__day AS ds__day
+                subq_14.metric_time__day AS metric_time__day
+                , subq_11.ds__day AS ds__day
                 , subq_11.ds__week AS ds__week
                 , subq_11.ds__month AS ds__month
                 , subq_11.ds__quarter AS ds__quarter
@@ -885,7 +886,6 @@ FROM (
                 , subq_11.metric_time__extract_day AS metric_time__extract_day
                 , subq_11.metric_time__extract_dow AS metric_time__extract_dow
                 , subq_11.metric_time__extract_doy AS metric_time__extract_doy
-                , subq_14.metric_time__day AS metric_time__day
                 , subq_11.listing AS listing
                 , subq_11.guest AS guest
                 , subq_11.host AS host

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Redshift/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Redshift/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
@@ -900,7 +900,8 @@ FROM (
               FROM (
                 -- Join to Time Spine Dataset
                 SELECT
-                  subq_15.ds__day AS ds__day
+                  subq_18.metric_time__day AS metric_time__day
+                  , subq_15.ds__day AS ds__day
                   , subq_15.ds__week AS ds__week
                   , subq_15.ds__month AS ds__month
                   , subq_15.ds__quarter AS ds__quarter
@@ -976,7 +977,6 @@ FROM (
                   , subq_15.metric_time__extract_day AS metric_time__extract_day
                   , subq_15.metric_time__extract_dow AS metric_time__extract_dow
                   , subq_15.metric_time__extract_doy AS metric_time__extract_doy
-                  , subq_18.metric_time__day AS metric_time__day
                   , subq_15.listing AS listing
                   , subq_15.guest AS guest
                   , subq_15.host AS host

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Redshift/test_offset_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Redshift/test_offset_metric_with_query_time_filters__plan0.sql
@@ -809,7 +809,8 @@ FROM (
             FROM (
               -- Join to Time Spine Dataset
               SELECT
-                subq_11.ds__day AS ds__day
+                subq_14.metric_time__day AS metric_time__day
+                , subq_11.ds__day AS ds__day
                 , subq_11.ds__week AS ds__week
                 , subq_11.ds__month AS ds__month
                 , subq_11.ds__quarter AS ds__quarter
@@ -885,7 +886,6 @@ FROM (
                 , subq_11.metric_time__extract_day AS metric_time__extract_day
                 , subq_11.metric_time__extract_dow AS metric_time__extract_dow
                 , subq_11.metric_time__extract_doy AS metric_time__extract_doy
-                , subq_14.metric_time__day AS metric_time__day
                 , subq_11.listing AS listing
                 , subq_11.guest AS guest
                 , subq_11.host AS host

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Snowflake/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Snowflake/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
@@ -900,7 +900,8 @@ FROM (
               FROM (
                 -- Join to Time Spine Dataset
                 SELECT
-                  subq_15.ds__day AS ds__day
+                  subq_18.metric_time__day AS metric_time__day
+                  , subq_15.ds__day AS ds__day
                   , subq_15.ds__week AS ds__week
                   , subq_15.ds__month AS ds__month
                   , subq_15.ds__quarter AS ds__quarter
@@ -976,7 +977,6 @@ FROM (
                   , subq_15.metric_time__extract_day AS metric_time__extract_day
                   , subq_15.metric_time__extract_dow AS metric_time__extract_dow
                   , subq_15.metric_time__extract_doy AS metric_time__extract_doy
-                  , subq_18.metric_time__day AS metric_time__day
                   , subq_15.listing AS listing
                   , subq_15.guest AS guest
                   , subq_15.host AS host

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Snowflake/test_offset_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Snowflake/test_offset_metric_with_query_time_filters__plan0.sql
@@ -809,7 +809,8 @@ FROM (
             FROM (
               -- Join to Time Spine Dataset
               SELECT
-                subq_11.ds__day AS ds__day
+                subq_14.metric_time__day AS metric_time__day
+                , subq_11.ds__day AS ds__day
                 , subq_11.ds__week AS ds__week
                 , subq_11.ds__month AS ds__month
                 , subq_11.ds__quarter AS ds__quarter
@@ -885,7 +886,6 @@ FROM (
                 , subq_11.metric_time__extract_day AS metric_time__extract_day
                 , subq_11.metric_time__extract_dow AS metric_time__extract_dow
                 , subq_11.metric_time__extract_doy AS metric_time__extract_doy
-                , subq_14.metric_time__day AS metric_time__day
                 , subq_11.listing AS listing
                 , subq_11.guest AS guest
                 , subq_11.host AS host

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Trino/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Trino/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
@@ -900,7 +900,8 @@ FROM (
               FROM (
                 -- Join to Time Spine Dataset
                 SELECT
-                  subq_15.ds__day AS ds__day
+                  subq_18.metric_time__day AS metric_time__day
+                  , subq_15.ds__day AS ds__day
                   , subq_15.ds__week AS ds__week
                   , subq_15.ds__month AS ds__month
                   , subq_15.ds__quarter AS ds__quarter
@@ -976,7 +977,6 @@ FROM (
                   , subq_15.metric_time__extract_day AS metric_time__extract_day
                   , subq_15.metric_time__extract_dow AS metric_time__extract_dow
                   , subq_15.metric_time__extract_doy AS metric_time__extract_doy
-                  , subq_18.metric_time__day AS metric_time__day
                   , subq_15.listing AS listing
                   , subq_15.guest AS guest
                   , subq_15.host AS host

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Trino/test_offset_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Trino/test_offset_metric_with_query_time_filters__plan0.sql
@@ -809,7 +809,8 @@ FROM (
             FROM (
               -- Join to Time Spine Dataset
               SELECT
-                subq_11.ds__day AS ds__day
+                subq_14.metric_time__day AS metric_time__day
+                , subq_11.ds__day AS ds__day
                 , subq_11.ds__week AS ds__week
                 , subq_11.ds__month AS ds__month
                 , subq_11.ds__quarter AS ds__quarter
@@ -885,7 +886,6 @@ FROM (
                 , subq_11.metric_time__extract_day AS metric_time__extract_day
                 , subq_11.metric_time__extract_dow AS metric_time__extract_dow
                 , subq_11.metric_time__extract_doy AS metric_time__extract_doy
-                , subq_14.metric_time__day AS metric_time__day
                 , subq_11.listing AS listing
                 , subq_11.guest AS guest
                 , subq_11.host AS host


### PR DESCRIPTION
This is the dataflow plan that will be used if the custom grain is queried with any grains that aren't the same as the grain used in the offset window. There will be a simpler dataflow plan used for queries using only the same grain as what's used in the offset window.