### PR TITLE
Bug fix: don't erase order by for metric alias query

### DIFF
--- a/metricflow-semantics/metricflow_semantics/query/query_resolver.py
+++ b/metricflow-semantics/metricflow_semantics/query/query_resolver.py
@@ -464,7 +464,7 @@ class MetricFlowQueryResolver:
         # Resolve order by.
         resolve_order_by_result = MetricFlowQueryResolver._resolve_order_by(
             resolver_inputs_for_order_by_items=order_by_item_inputs,
-            metric_specs=metric_specs,
+            metric_specs=tuple(metric_spec.with_alias(None) for metric_spec in metric_specs),
             group_by_item_specs=group_by_item_specs,
             query_resolution_path=query_resolution_path,
         )

--- a/metricflow-semantics/metricflow_semantics/sql/sql_exprs.py
+++ b/metricflow-semantics/metricflow_semantics/sql/sql_exprs.py
@@ -62,6 +62,11 @@ class SqlExpressionNode(DagNode["SqlExpressionNode"], Visitable, ABC):
         return None
 
     @property
+    def as_column_alias_reference_expression(self) -> Optional[SqlColumnAliasReferenceExpression]:
+        """If this is a column alias reference expression, return self."""
+        return None
+
+    @property
     def as_string_expression(self) -> Optional[SqlStringExpression]:
         """If this is a string expression, return self."""
         return None
@@ -588,8 +593,8 @@ class SqlColumnAliasReferenceExpression(SqlExpressionNode):
         return False
 
     @property
-    def as_column_reference_expression(self) -> Optional[SqlColumnReferenceExpression]:  # noqa: D102
-        return None
+    def as_column_alias_reference_expression(self) -> Optional[SqlColumnAliasReferenceExpression]:  # noqa: D102
+        return self
 
     def rewrite(  # noqa: D102
         self,

--- a/tests_metricflow/integration/query_output/test_query_output.py
+++ b/tests_metricflow/integration/query_output/test_query_output.py
@@ -23,7 +23,7 @@ def test_metric_alias(  # noqa: D103
         MetricFlowQueryRequest.create_with_random_request_id(
             metrics=(MetricParameter(name="bookings", alias="bookings_alias"),),
             group_by_names=["metric_time__day"],
-            order_by_names=["metric_time__day"],
+            order_by_names=["metric_time__day", "bookings"],
             where_constraints=("{{ Metric('bookings', ['listing']) }} > 2",),
         )
     )

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/DuckDB/test_derived_metric_alias__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/DuckDB/test_derived_metric_alias__plan0.sql
@@ -670,5 +670,5 @@ FROM (
       ) subq_12
     ) subq_13
   ) subq_14
-  ORDER BY subq_14.bookings_alias
+  ORDER BY subq_14.booking_fees
 ) subq_15

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/DuckDB/test_derived_metric_alias__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/DuckDB/test_derived_metric_alias__plan0_optimized.sql
@@ -4,6 +4,7 @@ docstring:
   Tests a plan with an aliased metric.
 sql_engine: DuckDB
 ---
+-- Compute Metrics via Expressions
 -- Order By ['booking_fees']
 -- Change Column Aliases
 WITH sma_28009_cte AS (
@@ -18,51 +19,46 @@ WITH sma_28009_cte AS (
 
 SELECT
   metric_time__day AS metric_time__day
-  , booking_fees AS bookings_alias
+  , booking_value * 0.05 AS bookings_alias
 FROM (
+  -- Constrain Output with WHERE
+  -- Pass Only Elements: ['booking_value', 'metric_time__day']
+  -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT
     metric_time__day
-    , booking_value * 0.05 AS booking_fees
+    , SUM(booking_value) AS booking_value
   FROM (
-    -- Constrain Output with WHERE
-    -- Pass Only Elements: ['booking_value', 'metric_time__day']
-    -- Aggregate Measures
-    -- Compute Metrics via Expressions
+    -- Join Standard Outputs
     SELECT
-      metric_time__day
-      , SUM(booking_value) AS booking_value
-    FROM (
-      -- Join Standard Outputs
+      subq_23.listing__booking_fees AS listing__booking_fees
+      , sma_28009_cte.metric_time__day AS metric_time__day
+      , sma_28009_cte.booking_value AS booking_value
+    FROM sma_28009_cte sma_28009_cte
+    LEFT OUTER JOIN (
+      -- Compute Metrics via Expressions
+      -- Pass Only Elements: ['listing', 'listing__booking_fees']
       SELECT
-        subq_23.listing__booking_fees AS listing__booking_fees
-        , sma_28009_cte.metric_time__day AS metric_time__day
-        , sma_28009_cte.booking_value AS booking_value
-      FROM sma_28009_cte sma_28009_cte
-      LEFT OUTER JOIN (
+        listing
+        , booking_value * 0.05 AS listing__booking_fees
+      FROM (
+        -- Read From CTE For node_id=sma_28009
+        -- Pass Only Elements: ['booking_value', 'listing']
+        -- Aggregate Measures
         -- Compute Metrics via Expressions
-        -- Pass Only Elements: ['listing', 'listing__booking_fees']
         SELECT
           listing
-          , booking_value * 0.05 AS listing__booking_fees
-        FROM (
-          -- Read From CTE For node_id=sma_28009
-          -- Pass Only Elements: ['booking_value', 'listing']
-          -- Aggregate Measures
-          -- Compute Metrics via Expressions
-          SELECT
-            listing
-            , SUM(booking_value) AS booking_value
-          FROM sma_28009_cte sma_28009_cte
-          GROUP BY
-            listing
-        ) subq_21
-      ) subq_23
-      ON
-        sma_28009_cte.listing = subq_23.listing
-    ) subq_24
-    WHERE listing__booking_fees > 2
-    GROUP BY
-      metric_time__day
-  ) subq_28
-) subq_29
+          , SUM(booking_value) AS booking_value
+        FROM sma_28009_cte sma_28009_cte
+        GROUP BY
+          listing
+      ) subq_21
+    ) subq_23
+    ON
+      sma_28009_cte.listing = subq_23.listing
+  ) subq_24
+  WHERE listing__booking_fees > 2
+  GROUP BY
+    metric_time__day
+) subq_28
+ORDER BY bookings_alias

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/DuckDB/test_metric_alias__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/DuckDB/test_metric_alias__plan0.sql
@@ -658,5 +658,5 @@ FROM (
         subq_10.metric_time__month
     ) subq_11
   ) subq_12
-  ORDER BY subq_12.bookings_alias
+  ORDER BY subq_12.bookings
 ) subq_13

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/DuckDB/test_metric_alias__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/DuckDB/test_metric_alias__plan0_optimized.sql
@@ -4,6 +4,10 @@ docstring:
   Tests a plan with an aliased metric.
 sql_engine: DuckDB
 ---
+-- Constrain Output with WHERE
+-- Pass Only Elements: ['bookings', 'metric_time__month']
+-- Aggregate Measures
+-- Compute Metrics via Expressions
 -- Order By ['bookings']
 -- Change Column Aliases
 WITH sma_28009_cte AS (
@@ -18,46 +22,38 @@ WITH sma_28009_cte AS (
 
 SELECT
   metric_time__month AS metric_time__month
-  , bookings AS bookings_alias
+  , SUM(bookings) AS bookings_alias
 FROM (
-  -- Constrain Output with WHERE
-  -- Pass Only Elements: ['bookings', 'metric_time__month']
-  -- Aggregate Measures
-  -- Compute Metrics via Expressions
+  -- Join Standard Outputs
   SELECT
-    metric_time__month
-    , SUM(bookings) AS bookings
+    subq_20.listing__bookings AS listing__bookings
+    , subq_15.metric_time__month AS metric_time__month
+    , subq_15.bookings AS bookings
   FROM (
-    -- Join Standard Outputs
+    -- Read From CTE For node_id=sma_28009
     SELECT
-      subq_20.listing__bookings AS listing__bookings
-      , subq_15.metric_time__month AS metric_time__month
-      , subq_15.bookings AS bookings
-    FROM (
-      -- Read From CTE For node_id=sma_28009
-      SELECT
-        metric_time__month
-        , listing
-        , bookings
-      FROM sma_28009_cte sma_28009_cte
-    ) subq_15
-    LEFT OUTER JOIN (
-      -- Read From CTE For node_id=sma_28009
-      -- Pass Only Elements: ['bookings', 'listing']
-      -- Aggregate Measures
-      -- Compute Metrics via Expressions
-      -- Pass Only Elements: ['listing', 'listing__bookings']
-      SELECT
-        listing
-        , SUM(bookings) AS listing__bookings
-      FROM sma_28009_cte sma_28009_cte
-      GROUP BY
-        listing
-    ) subq_20
-    ON
-      subq_15.listing = subq_20.listing
-  ) subq_21
-  WHERE listing__bookings > 2
-  GROUP BY
-    metric_time__month
-) subq_25
+      metric_time__month
+      , listing
+      , bookings
+    FROM sma_28009_cte sma_28009_cte
+  ) subq_15
+  LEFT OUTER JOIN (
+    -- Read From CTE For node_id=sma_28009
+    -- Pass Only Elements: ['bookings', 'listing']
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    -- Pass Only Elements: ['listing', 'listing__bookings']
+    SELECT
+      listing
+      , SUM(bookings) AS listing__bookings
+    FROM sma_28009_cte sma_28009_cte
+    GROUP BY
+      listing
+  ) subq_20
+  ON
+    subq_15.listing = subq_20.listing
+) subq_21
+WHERE listing__bookings > 2
+GROUP BY
+  metric_time__month
+ORDER BY bookings_alias


### PR DESCRIPTION
Previously, when applying the `SqlRewritingSubQueryReducer`, we would allow the child order bys to overwrite the parent order bys. This was never a problem because order bys were only present in the outermost SQL query (due to our existing dataflow plans). With the recent change to allow metric aliases, order bys may now be in a parent subquery. This revealed the bug in which they were being erased. This PR fixes that issue.