### PR TITLE
Move metric alias details from `MetricSpecPattern` to `ResolverInputForMetric`

### DIFF
--- a/metricflow-semantics/metricflow_semantics/naming/metric_scheme.py
+++ b/metricflow-semantics/metricflow_semantics/naming/metric_scheme.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 from typing import Optional
 
+from dbt_semantic_interfaces.references import MetricReference
 from typing_extensions import override
 
 from metricflow_semantics.model.semantic_manifest_lookup import SemanticManifestLookup
 from metricflow_semantics.naming.naming_scheme import QueryItemNamingScheme
 from metricflow_semantics.specs.instance_spec import InstanceSpec
-from metricflow_semantics.specs.patterns.entity_link_pattern import ParameterSetField, SpecPatternParameterSet
 from metricflow_semantics.specs.patterns.metric_pattern import MetricSpecPattern
 from metricflow_semantics.specs.spec_set import group_spec_by_type
 
@@ -30,11 +30,7 @@ class MetricNamingScheme(QueryItemNamingScheme):
         input_str = input_str.lower()
         if not self.input_str_follows_scheme(input_str, semantic_manifest_lookup=semantic_manifest_lookup):
             raise RuntimeError(f"{repr(input_str)} does not follow this scheme.")
-        return MetricSpecPattern(
-            parameter_set=SpecPatternParameterSet.from_parameters(
-                fields_to_compare=(ParameterSetField.ELEMENT_NAME,), element_name=input_str
-            )
-        )
+        return MetricSpecPattern(metric_reference=MetricReference(element_name=input_str))
 
     @override
     def input_str_follows_scheme(self, input_str: str, semantic_manifest_lookup: SemanticManifestLookup) -> bool:

--- a/metricflow-semantics/metricflow_semantics/query/query_resolver.py
+++ b/metricflow-semantics/metricflow_semantics/query/query_resolver.py
@@ -182,7 +182,7 @@ class MetricFlowQueryResolver:
             matching_specs = metric_input.spec_pattern.match(available_metric_specs)
             if len(matching_specs) == 1:
                 matching_spec = matching_specs[0]
-                alias = metric_input.spec_pattern.parameter_set.alias
+                alias = metric_input.alias
                 if alias:
                     matching_spec = matching_spec.with_alias(alias)
                 metric_specs.append(matching_spec)
@@ -397,11 +397,7 @@ class MetricFlowQueryResolver:
         query_resolution_path = MetricFlowQueryResolutionPath.from_path_item(
             QueryGroupByItemResolutionNode.create(
                 parent_nodes=(),
-                metrics_in_query=tuple(
-                    MetricReference(metric_input.spec_pattern.parameter_set.element_name)
-                    for metric_input in metric_inputs
-                    if metric_input.spec_pattern.parameter_set.element_name  # for type checker
-                ),
+                metrics_in_query=tuple(metric_input.spec_pattern.metric_reference for metric_input in metric_inputs),
                 where_filter_intersection=query_level_filter_input.where_filter_intersection,
             )
         )

--- a/metricflow-semantics/metricflow_semantics/query/resolver_inputs/query_resolver_inputs.py
+++ b/metricflow-semantics/metricflow_semantics/query/resolver_inputs/query_resolver_inputs.py
@@ -3,6 +3,7 @@
 The naming of these classes is a little odd as they have the "For.." suffix. But using the "*ResolverInput" leads to
 some confusing names like "ResolverInputForQuery" -> "QueryResolverInput". Improved naming for these classes is TBD.
 """
+
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -44,6 +45,7 @@ class ResolverInputForMetric(MetricFlowQueryResolverInput):
     input_obj: Union[MetricQueryParameter, str]
     naming_scheme: MetricNamingScheme
     spec_pattern: MetricSpecPattern
+    alias: Optional[str] = None
 
     @property
     @override

--- a/metricflow-semantics/metricflow_semantics/specs/patterns/entity_link_pattern.py
+++ b/metricflow-semantics/metricflow_semantics/specs/patterns/entity_link_pattern.py
@@ -30,7 +30,6 @@ class ParameterSetField(Enum):
     TIME_GRANULARITY = "time_granularity_name"
     DATE_PART = "date_part"
     METRIC_SUBQUERY_ENTITY_LINKS = "metric_subquery_entity_links"
-    ALIAS = "alias"
 
     def __lt__(self, other: Any) -> bool:  # type: ignore[misc]
         """Allow for ordering so that a sequence of these can be consistently represented for test snapshots."""
@@ -55,7 +54,6 @@ class SpecPatternParameterSet:
     time_granularity_name: Optional[str] = None
     date_part: Optional[DatePart] = None
     metric_subquery_entity_links: Optional[Tuple[EntityReference, ...]] = None
-    alias: Optional[str] = None
 
     @staticmethod
     def from_parameters(  # noqa: D102
@@ -65,7 +63,6 @@ class SpecPatternParameterSet:
         time_granularity_name: Optional[str] = None,
         date_part: Optional[DatePart] = None,
         metric_subquery_entity_links: Optional[Tuple[EntityReference, ...]] = None,
-        alias: Optional[str] = None,
     ) -> SpecPatternParameterSet:
         return SpecPatternParameterSet(
             fields_to_compare=tuple(sorted(fields_to_compare)),
@@ -74,7 +71,6 @@ class SpecPatternParameterSet:
             time_granularity_name=time_granularity_name,
             date_part=date_part,
             metric_subquery_entity_links=metric_subquery_entity_links,
-            alias=alias,
         )
 
     def __post_init__(self) -> None:

--- a/metricflow-semantics/metricflow_semantics/specs/patterns/metric_pattern.py
+++ b/metricflow-semantics/metricflow_semantics/specs/patterns/metric_pattern.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import List, Sequence
+from typing import Sequence
 
+from dbt_semantic_interfaces.references import MetricReference
 from typing_extensions import override
 
 from metricflow_semantics.specs.instance_spec import InstanceSpec
 from metricflow_semantics.specs.metric_spec import MetricSpec
-from metricflow_semantics.specs.patterns.entity_link_pattern import SpecPatternParameterSet
 from metricflow_semantics.specs.patterns.spec_pattern import SpecPattern
 from metricflow_semantics.specs.spec_set import group_specs_by_type
 
@@ -16,18 +16,11 @@ from metricflow_semantics.specs.spec_set import group_specs_by_type
 class MetricSpecPattern(SpecPattern):
     """Matches MetricSpecs that have the given metric_reference."""
 
-    parameter_set: SpecPatternParameterSet
+    metric_reference: MetricReference
 
     @override
     def match(self, candidate_specs: Sequence[InstanceSpec]) -> Sequence[MetricSpec]:
-        filtered_candidate_specs = group_specs_by_type(candidate_specs).metric_specs
-        keys_to_check = set(field_to_compare.value for field_to_compare in self.parameter_set.fields_to_compare)
-
-        matching_specs: List[MetricSpec] = []
-        parameter_set_values = tuple(getattr(self.parameter_set, key_to_check) for key_to_check in keys_to_check)
-        for spec in filtered_candidate_specs:
-            spec_values = tuple(getattr(spec, key_to_check, None) for key_to_check in keys_to_check)
-            if spec_values == parameter_set_values:
-                matching_specs.append(spec)
-
-        return matching_specs
+        spec_set = group_specs_by_type(candidate_specs)
+        return tuple(
+            metric_name for metric_name in spec_set.metric_specs if metric_name.reference == self.metric_reference
+        )

--- a/metricflow-semantics/metricflow_semantics/specs/query_param_implementations.py
+++ b/metricflow-semantics/metricflow_semantics/specs/query_param_implementations.py
@@ -30,7 +30,6 @@ from metricflow_semantics.specs.patterns.entity_link_pattern import (
     ParameterSetField,
     SpecPatternParameterSet,
 )
-from metricflow_semantics.specs.patterns.metric_pattern import MetricSpecPattern
 
 
 @dataclass(frozen=True)
@@ -141,13 +140,8 @@ class MetricParameter(ProtocolHint[MetricQueryParameter]):
         return ResolverInputForMetric(
             input_obj=self,
             naming_scheme=naming_scheme,
-            spec_pattern=MetricSpecPattern(
-                SpecPatternParameterSet.from_parameters(
-                    fields_to_compare=(ParameterSetField.ELEMENT_NAME,),
-                    element_name=self.name.lower(),
-                    alias=self.alias,
-                )
-            ),
+            spec_pattern=naming_scheme.spec_pattern(self.name, semantic_manifest_lookup=semantic_manifest_lookup),
+            alias=self.alias,
         )
 
 


### PR DESCRIPTION
This addresses [some feedback](https://github.com/dbt-labs/metricflow/pull/1573#pullrequestreview-2518180663) that did not get addressed before merging [this PR](https://github.com/dbt-labs/metricflow/pull/1573) - specifically:

> Since the alias in this case is describing user inputs, can it be added as a field to ResolverInputForMetric?