### PR TITLE
Add `actionlint` to pre-commit hooks

### DIFF
--- a/.github/workflows/cd-push-dbt-metricflow-to-pypi.yaml
+++ b/.github/workflows/cd-push-dbt-metricflow-to-pypi.yaml
@@ -19,7 +19,7 @@ jobs:
       id-token: write
     steps:
       - name: Check-out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Python ${{ env.PYTHON_VERSION }} Environment
         uses: ./.github/actions/setup-python-env

--- a/.github/workflows/cd-push-metricflow-to-pypi.yaml
+++ b/.github/workflows/cd-push-metricflow-to-pypi.yaml
@@ -20,7 +20,7 @@ jobs:
       id-token: write
     steps:
       - name: Check-out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Python ${{ env.PYTHON_VERSION }} Environment
         uses: ./.github/actions/setup-python-env

--- a/.github/workflows/cd-sql-engine-populate-persistent-source-schema.yaml
+++ b/.github/workflows/cd-sql-engine-populate-persistent-source-schema.yaml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check-out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Populate w/Python ${{ env.PYTHON_VERSION }}
         uses: ./.github/actions/run-mf-tests
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check-out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Populate w/Python ${{ env.PYTHON_VERSION }}
         uses: ./.github/actions/run-mf-tests
@@ -64,7 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check-out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Populate w/Python ${{ env.PYTHON_VERSION }}
         uses: ./.github/actions/run-mf-tests
@@ -83,7 +83,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check-out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Populate w/Python ${{ env.PYTHON_VERSION }}
         uses: ./.github/actions/run-mf-tests

--- a/.github/workflows/cd-sql-engine-tests.yaml
+++ b/.github/workflows/cd-sql-engine-tests.yaml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check-out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Test w/ Python ${{ env.PYTHON_VERSION }}
         uses: ./.github/actions/run-mf-tests
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check-out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Test w/ Python ${{ env.PYTHON_VERSION }}
         uses: ./.github/actions/run-mf-tests
@@ -60,7 +60,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check-out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Test w/ Python ${{ env.PYTHON_VERSION }}
         uses: ./.github/actions/run-mf-tests
@@ -79,7 +79,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check-out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Test w/ Python ${{ env.PYTHON_VERSION }}
         uses: ./.github/actions/run-mf-tests
@@ -106,7 +106,7 @@ jobs:
           - 8080:8080
     steps:
       - name: Check-out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Test w/ Python 3.12
         uses: ./.github/actions/run-mf-tests

--- a/.github/workflows/ci-linting.yaml
+++ b/.github/workflows/ci-linting.yaml
@@ -22,7 +22,7 @@ jobs:
     steps:
 
       - name: Check-out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Python ${{ env.python-version }} Environment
         uses: ./.github/actions/setup-python-env

--- a/.github/workflows/ci-metricflow-unit-tests.yaml
+++ b/.github/workflows/ci-metricflow-unit-tests.yaml
@@ -17,7 +17,7 @@ jobs:
         python-version: ["3.9", "3.12"]
     steps:
       - name: Check-out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Test w/ Python ${{ matrix.python-version }}
         uses: ./.github/actions/run-mf-tests
@@ -45,7 +45,7 @@ jobs:
     steps:
 
       - name: Check-out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Test w/ Python 3.12
         uses: ./.github/actions/run-mf-tests
@@ -72,9 +72,9 @@ jobs:
     steps:
 
       - name: Check-out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Setup Python ${{ inputs.python-version }} Environment
+      - name: Setup Python ${{ matrix.python-version }} Environment
         uses: ./.github/actions/setup-python-env
         with:
           python-version: "${{ matrix.python-version }}"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,3 +37,9 @@ repos:
         # pre-commit. This is set for mypy to use the specified package dependencies in Hatch (assuming pre-commit is
         # run with hatch run ...). Seems like pre-commit calls the mypy on the command line with this settings.
         language: system
+
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.6
+    hooks:
+      - id: actionlint
+        files: ^\.github/workflows/


### PR DESCRIPTION
## Description

This PR adds [actionlint](https://github.com/rhysd/actionlint/) to our pre-commit hooks. It will run whenever something has changed under `.github/workflows/`.

As the name suggests, actionlint is a Github Actions file linter, and it checks for things such as non-conformance to the YAML schema, referencing non-existing steps/outputs or running some security audits. It also runs [shellcheck](https://github.com/koalaman/shellcheck) to ensure the shell scripts in our actions files have no glaring issues.

After adding actionlint, I ran it over the entire repo to fix the issues it found with our actions.

You can review by commit.