### PR TITLE
Add config to get_measures_for_metrics response

### DIFF
--- a/.changes/unreleased/Fixes-20250116-124630.yaml
+++ b/.changes/unreleased/Fixes-20250116-124630.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Add config to get_measures_for_metrics response
+time: 2025-01-16T12:46:30.196593-06:00
+custom:
+    Author: DevonFulcher
+    Issue: None

--- a/metricflow/engine/metricflow_engine.py
+++ b/metricflow/engine/metricflow_engine.py
@@ -570,6 +570,7 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
                         description=measure.description,
                         expr=measure.expr,
                         agg_params=measure.agg_params,
+                        config=measure.config,
                     )
                 )
         return list(measures)


### PR DESCRIPTION
This method constructs its response with `__ini__` where others use `from_pydantic`. So, this field has to be added manually so that it MFS can gain access to it.