### PR TITLE
Allow direct references for `dbt-metricfow` dependencies

### DIFF
--- a/dbt-metricflow/pyproject.toml
+++ b/dbt-metricflow/pyproject.toml
@@ -30,6 +30,9 @@ dynamic = ["version", "dependencies", "optional-dependencies"]
 [tool.hatch.version]
 path = "dbt_metricflow/__about__.py"
 
+[tool.hatch.metadata]
+allow-direct-references = true
+
 [tool.hatch.metadata.hooks.requirements_txt]
 files = [
   "extra-hatch-configuration/requirements-cli.txt",


### PR DESCRIPTION
The `pyproject.toml` file for `dbt-metricflow` contains a dependency using a git SHA, so the `allow-direct-references` option needs to be enabled.