### PR TITLE
Cache Python Environments in CI

### DIFF
--- a/.github/actions/run-mf-tests/action.yaml
+++ b/.github/actions/run-mf-tests/action.yaml
@@ -25,6 +25,17 @@ inputs:
     description: "Additional options to pass into pytest."
     required: false
     default: ""
+  hatch-environment-cache-config-json:
+    description: "Configuration JSON to be passed into the script to install `hatch` environments for caching."
+    required: false
+    default: >-
+      {
+        "configs": [
+          {"hatch_project_directory": ".", "hatch_environment_name": "dev-env"},
+          {"hatch_project_directory": "./metricflow-semantics", "hatch_environment_name": "dev-env"}
+        ]
+      }
+
 runs:
   using: "composite"
   steps:
@@ -32,6 +43,7 @@ runs:
     uses: ./.github/actions/setup-python-env
     with:
       python-version: "${{ inputs.python-version }}"
+      hatch-environment-cache-config-json: "${{ inputs.hatch-environment-cache-config-json }}"
   - name: Run Tests
     shell: bash
     run: >

--- a/.github/actions/setup-python-env/action.yaml
+++ b/.github/actions/setup-python-env/action.yaml
@@ -6,6 +6,17 @@ inputs:
     description: "Version of Python to use for testing"
     required: false
     default: "3.8"
+  hatch-environment-cache-config-json:
+    description: "Configuration JSON to be passed into the script to install `hatch` environments for caching."
+    required: false
+    default: >-
+      {
+        "configs": []
+      }
+  cache-pre-commit-environment:
+    description: "Whether to cache the pre-commit-environment."
+    required: false
+    default: "false"
 
 runs:
   using: "composite"
@@ -14,10 +25,15 @@ runs:
   - name: Set Linux Release Environment Variable
     shell: bash
     run: echo "LINUX_RELEASE=$(lsb_release -rs)" >> $GITHUB_ENV
+
   - name: Set up Python ${{ inputs.python_version }}
     uses: actions/setup-python@v4
     with:
       python-version: "${{ inputs.python-version }}"
+
+  - name: Create a JSON File With the `hatch` Environment Cache Configuration
+    shell: bash
+    run: "echo '${{ inputs.hatch-environment-cache-config-json }}' > hatch-environment-cache-config.json"
 
   # Cache the dependencies installed by Hatch so that we don't need to reinstall them on every run.
   - uses: actions/cache@v3
@@ -37,11 +53,17 @@ runs:
       # `manual_update_key` can be changed to manually force the cache action to create a new cache.
       key: >-
         python_location: "${{ env.pythonLocation }}" AND
-        pyproject_hash: "${{ hashFiles('pyproject.toml') }}" AND
-        extra_hatch_configuration_hash: "${{ hashFiles('**/extra-hatch-configuration/*') }}" AND
-        precommit_config_hash: "${{ hashFiles('.pre-commit-config.yaml') }}" AND
-        linux_release: "${{ env.LINUX_RELEASE }}"
-        manual_update_key: 3
+        files_hash: "${{
+          hashFiles(
+            'pyproject.toml'
+            , '**/extra-hatch-configuration/*'
+            , '.pre-commit-config.yaml'
+            , 'hatch-environment-cache-config.json'
+          )
+        }}" AND
+        linux_release: "${{ env.LINUX_RELEASE }}" AND
+        cache-pre-commit-environment: "${{ inputs.cache-pre-commit-environment }}" AND
+        manual_update_key: 2
 
   - name: Install Hatch
     shell: bash
@@ -49,11 +71,15 @@ runs:
 
   # Running any command will install the dependencies for the project. Add this step so that the `hatch` environment is
   # cached.
-  - name: Install Dependencies for `dev-env` Hatch Environments
+  - name: Install Dependencies for Hatch Environment
     shell: bash
-    run: "hatch run dev-env:true && cd metricflow-semantics && hatch run dev-env:true"
+    run: >-
+      PYTHONPATH=.
+      python scripts/ci_tests/install_hatch_environments.py
+      --json-config-file 'hatch-environment-cache-config.json'
 
   # Add this step to cache the `pre-commit` environment.
   - name: Install `pre-commit` Environment
     shell: bash
+    if: ${{ inputs.cache-pre-commit-environment == 'true' }}
     run: "hatch run dev-env:pre-commit install-hooks"

--- a/.github/actions/setup-python-env/action.yaml
+++ b/.github/actions/setup-python-env/action.yaml
@@ -44,3 +44,9 @@ runs:
   - name: Install Hatch
     shell: bash
     run: pip3 install hatch
+
+  # Running any command will install the dependencies for the project. Add this step so that the `hatch` environment is
+  # cached.
+  - name: Install Dependencies for `dev-env` Hatch Environments
+    shell: bash
+    run: "hatch run dev-env:true && cd metricflow-semantics && hatch run dev-env:true"

--- a/.github/actions/setup-python-env/action.yaml
+++ b/.github/actions/setup-python-env/action.yaml
@@ -50,3 +50,8 @@ runs:
   - name: Install Dependencies for `dev-env` Hatch Environments
     shell: bash
     run: "hatch run dev-env:true && cd metricflow-semantics && hatch run dev-env:true"
+
+  # Add this step to cache the `pre-commit` environment.
+  - name: Install `pre-commit` Environment
+    shell: bash
+    run: "hatch run dev-env:pre-commit install-hooks"

--- a/.github/actions/setup-python-env/action.yaml
+++ b/.github/actions/setup-python-env/action.yaml
@@ -34,12 +34,14 @@ runs:
         ~/.cache/pre-commit
       # >- means combine all lines to a single line
       # The cache key can be any string. The format used here is just for readability.
+      # `manual_update_key` can be changed to manually force the cache action to create a new cache.
       key: >-
         python_location: "${{ env.pythonLocation }}" AND
         pyproject_hash: "${{ hashFiles('pyproject.toml') }}" AND
         extra_hatch_configuration_hash: "${{ hashFiles('**/extra-hatch-configuration/*') }}" AND
         precommit_config_hash: "${{ hashFiles('.pre-commit-config.yaml') }}" AND
         linux_release: "${{ env.LINUX_RELEASE }}"
+        manual_update_key: 3
 
   - name: Install Hatch
     shell: bash

--- a/.github/workflows/cd-sql-engine-tests.yaml
+++ b/.github/workflows/cd-sql-engine-tests.yaml
@@ -34,6 +34,12 @@ jobs:
           parallelism: ${{ env.EXTERNAL_ENGINE_TEST_PARALLELISM }}
           additional-pytest-options: ${{ env.ADDITIONAL_PYTEST_OPTIONS }}
           make-target: "test-snowflake"
+          hatch-environment-cache-config-json: >-
+            {
+              "configs": [
+                {"hatch_project_directory": ".", "hatch_environment_name": "snowflake-env"}
+              ]
+            }
 
   redshift-tests:
     environment: DW_INTEGRATION_TESTS
@@ -53,6 +59,13 @@ jobs:
           parallelism: ${{ env.EXTERNAL_ENGINE_TEST_PARALLELISM }}
           additional-pytest-options: ${{ env.ADDITIONAL_PYTEST_OPTIONS }}
           make-target: "test-redshift"
+          hatch-environment-cache-config-json: >-
+            {
+              "configs": [
+                {"hatch_project_directory": ".", "hatch_environment_name": "redshift-env"}
+              ]
+            }
+
   bigquery-tests:
     environment: DW_INTEGRATION_TESTS
     name: BigQuery Tests
@@ -71,6 +84,12 @@ jobs:
           parallelism: ${{ env.EXTERNAL_ENGINE_TEST_PARALLELISM }}
           additional-pytest-options: ${{ env.ADDITIONAL_PYTEST_OPTIONS }}
           make-target: "test-bigquery"
+          hatch-environment-cache-config-json: >-
+            {
+              "configs": [
+                {"hatch_project_directory": ".", "hatch_environment_name": "bigquery-env"}
+              ]
+            }
 
   databricks-tests:
     environment: DW_INTEGRATION_TESTS
@@ -90,6 +109,12 @@ jobs:
           parallelism: ${{ env.EXTERNAL_ENGINE_TEST_PARALLELISM }}
           additional-pytest-options: ${{ env.ADDITIONAL_PYTEST_OPTIONS }}
           make-target: "test-databricks"
+          hatch-environment-cache-config-json: >-
+            {
+              "configs": [
+                {"hatch_project_directory": ".", "hatch_environment_name": "databricks-env"}
+              ]
+            }
 
   trino-tests:
     # Trino tests run on a local service container, which obviates the need for separate Environment hosting.
@@ -113,6 +138,12 @@ jobs:
         with:
           python-version: "3.12"
           make-target: "test-trino"
+          hatch-environment-cache-config-json: >-
+            {
+              "configs": [
+                {"hatch_project_directory": ".", "hatch_environment_name": "trino-env"}
+              ]
+            }
 
   remove-label:
     name: Remove Label After Running Tests

--- a/.github/workflows/ci-linting.yaml
+++ b/.github/workflows/ci-linting.yaml
@@ -28,8 +28,14 @@ jobs:
         uses: ./.github/actions/setup-python-env
         with:
           python-version: "${{ env.python-version }}"
+          hatch-environment-cache-config-json: >-
+            {
+              "configs": [
+                {"hatch_project_directory": ".", "hatch_environment_name": "dev-env"}
+              ]
+            }
+          cache-pre-commit-environment: true
 
       - name: Run Linter
         run: >
-          hatch -v run dev-env:pre-commit run --show-diff-on-failure --color=always --all-files
-          || (cat /home/runner/.cache/pre-commit/pre-commit.log && false)
+          hatch -v run dev-env:pre-commit run --verbose --show-diff-on-failure --color=always --all-files

--- a/.github/workflows/ci-metricflow-unit-tests.yaml
+++ b/.github/workflows/ci-metricflow-unit-tests.yaml
@@ -52,6 +52,12 @@ jobs:
         with:
           python-version: "3.12"
           make-target: "test-postgresql"
+          hatch-environment-cache-config-json: >-
+            {
+              "configs": [
+                {"hatch_project_directory": ".", "hatch_environment_name": "postgres-env"}
+              ]
+            }
 
   metricflow-unit-tests:
     name: MetricFlow Unit Tests
@@ -78,6 +84,13 @@ jobs:
         uses: ./.github/actions/setup-python-env
         with:
           python-version: "${{ matrix.python-version }}"
+          hatch-environment-cache-config-json: >-
+            {
+              "configs": [
+                {"hatch_project_directory": ".", "hatch_environment_name": "dev-env"},
+                {"hatch_project_directory": "./metricflow-semantics", "hatch_environment_name": "dev-env"}
+              ]
+            }
 
       - name: Run Package-Build Tests
         run: "make test-build-packages"

--- a/scripts/ci_tests/install_hatch_environments.py
+++ b/scripts/ci_tests/install_hatch_environments.py
@@ -1,0 +1,51 @@
+"""Script to call from a Github Action to test that packages build properly.
+
+This script should run without installing additional Python packages.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from pathlib import Path
+
+from scripts.mf_script_helper import MetricFlowScriptHelper
+
+logger = logging.getLogger(__name__)
+
+
+def _install_hatch_environment_dependencies(hatch_project_directory: Path, hatch_environment_name: str) -> None:
+    """Install hatch environment dependencies for caching in Github Actions."""
+    logger.info(
+        f"Installing dependencies for  `hatch` environment {hatch_environment_name!r} in {str(hatch_project_directory)!r}"
+    )
+
+    MetricFlowScriptHelper.run_command(
+        ["hatch", "--verbose", "--env", hatch_environment_name, "run", "true"],
+        working_directory=hatch_project_directory,
+    )
+
+
+if __name__ == "__main__":
+    MetricFlowScriptHelper.setup_logging()
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--json-config-file",
+        help="Path to text file containing a JSON object that describes the environments to install",
+        required=True,
+    )
+    args = parser.parse_args()
+
+    with open(args.json_config_file, "r") as fp:
+        config_file_contents = fp.read()
+        logger.info(f"config_file_contents:\n{config_file_contents}")
+        environment_config_json = json.loads(config_file_contents)
+
+    logger.info(f"Using {environment_config_json=}")
+
+    # Install dependencies for `hatch` environments.
+    for config in environment_config_json["configs"]:
+        hatch_project_directory = config["hatch_project_directory"]
+        hatch_environment_name = config["hatch_environment_name"]
+        _install_hatch_environment_dependencies(Path(hatch_project_directory).resolve(), hatch_environment_name)

--- a/scripts/ci_tests/run_package_build_tests.py
+++ b/scripts/ci_tests/run_package_build_tests.py
@@ -41,7 +41,7 @@ def _run_package_build_test(package_directory: Path, package_test_script: Path) 
             python_executable = Path(venv_directory, "bin/python")
 
             logger.info(f"Building package at {str(package_directory)!r}")
-            MetricFlowScriptHelper.run_command(["hatch", "clean"], working_directory=package_directory)
+            logger.info(f"Running package build test for {str(package_directory)!r} using {str(package_test_script)!r}")
             MetricFlowScriptHelper.run_command(["hatch", "build"], working_directory=package_directory)
 
             logger.info("Installing package using generated wheels")

--- a/scripts/mf_script_helper.py
+++ b/scripts/mf_script_helper.py
@@ -23,7 +23,10 @@ class MetricFlowScriptHelper:
 
     @staticmethod
     def run_command(
-        command: Sequence[str], working_directory: Optional[Path] = None, raise_exception_on_error: bool = True
+        command: Sequence[str],
+        working_directory: Optional[Path] = None,
+        raise_exception_on_error: bool = True,
+        capture_output: bool = False,
     ) -> CompletedProcess:
         """Thin wrapper around `subprocess.run` with more string types and log statements.
 
@@ -31,6 +34,7 @@ class MetricFlowScriptHelper:
             command: Command / arguments as a sequence of strings.
             working_directory: The working directory where the command should be run.
             raise_exception_on_error: If the command fails, raise an exception.
+            capture_output: Same as the argument for `subprocess.run`.
 
         Returns: The `CompletedProcess` similar to `subprocess.run`
         """
@@ -38,7 +42,9 @@ class MetricFlowScriptHelper:
             logger.info(f"Running {command=}")
         else:
             logger.info(f"In {str(working_directory)!r}: Running {command=}")
-        return subprocess.run(command, cwd=working_directory, check=raise_exception_on_error)
+        return subprocess.run(
+            command, cwd=working_directory, check=raise_exception_on_error, capture_output=capture_output
+        )
 
     @staticmethod
     def run_shell_command(


### PR DESCRIPTION
I noticed that some CI checks were a bit slow on occasion, and found that the root cause was that those checks were installing their dependencies during the run. It seems the associated environment was not getting cached, so this PR updates the action to do so.