### PR TITLE
For `SqlRewritingSubQueryReducer`, add support for CTEs defined in sub-queries

### DIFF
--- a/metricflow/sql/optimizer/rewriting_sub_query_reducer.py
+++ b/metricflow/sql/optimizer/rewriting_sub_query_reducer.py
@@ -218,7 +218,7 @@ class SqlRewritingSubQueryReducerVisitor(SqlPlanNodeVisitor[SqlPlanNode]):
 
         # If the parent node defines CTEs, don't reduce for simplicity. It's possible to improve this by keeping track
         # of the CTE-alias mapping as the SQL plan is traversed and then allowing for reduction if there are no
-        # alias collections (e.g. with other CTEs or the alias in the FROM clause).
+        # alias collisions (e.g. with other CTEs or the alias in the FROM clause).
         from_clause_node = node.from_source.as_select_node
         if from_clause_node is not None:
             if len(from_clause_node.cte_sources) > 0:

--- a/metricflow/sql/optimizer/rewriting_sub_query_reducer.py
+++ b/metricflow/sql/optimizer/rewriting_sub_query_reducer.py
@@ -216,6 +216,14 @@ class SqlRewritingSubQueryReducerVisitor(SqlPlanNodeVisitor[SqlPlanNode]):
         if len(node.join_descs) > 0:
             return False
 
+        # If the parent node defines CTEs, don't reduce for simplicity. It's possible to improve this by keeping track
+        # of the CTE-alias mapping as the SQL plan is traversed and then allowing for reduction if there are no
+        # alias collections (e.g. with other CTEs or the alias in the FROM clause).
+        from_clause_node = node.from_source.as_select_node
+        if from_clause_node is not None:
+            if len(from_clause_node.cte_sources) > 0:
+                return False
+
         # If the parent node is not a SELECT statement, then this can't be collapsed. e.g. with a table as a parent like
         # SELECT foo FROM bar
         from_source_node_as_select_node = node.from_source.as_select_node
@@ -598,7 +606,10 @@ class SqlRewritingSubQueryReducerVisitor(SqlPlanNodeVisitor[SqlPlanNode]):
 
     @override
     def visit_cte_node(self, node: SqlCteNode) -> SqlPlanNode:
-        raise NotImplementedError
+        return SqlCteNode.create(
+            select_statement=node.accept(self),
+            cte_alias=node.cte_alias,
+        )
 
     def visit_select_statement_node(self, node: SqlSelectStatementNode) -> SqlPlanNode:  # noqa: D102
         node_with_reduced_parents = self._reduce_parents(node)

--- a/tests_metricflow/snapshots/test_cte_rewriting_sub_query_reducer.py/str/test_cte_in_subquery_not_reduced__result.txt
+++ b/tests_metricflow/snapshots/test_cte_rewriting_sub_query_reducer.py/str/test_cte_in_subquery_not_reduced__result.txt
@@ -1,0 +1,46 @@
+test_name: test_cte_in_subquery_not_reduced
+test_filename: test_cte_rewriting_sub_query_reducer.py
+docstring:
+  This tests that in cases where there is a CTE defined in a sub-query, it is not reduced.
+expectation_description:
+  A sub-query containing CTEs should not result in the top-level query being merged with the sub-query. For
+  this case, the SQL should be the same before / after optimization.
+---
+optimizer:
+  SqlRewritingSubQueryReducer
+
+sql_before_optimizing:
+  -- top_level_select
+  SELECT
+    from_source_alias.from_source__col_0 AS top_level__col_0
+  FROM (
+    -- from_sub_query
+    WITH cte_source AS (
+      -- CTE source
+      SELECT
+        test_table_alias.col_0 AS cte_source__col_0
+      FROM test_schema.test_table test_table_alias
+    )
+
+    SELECT
+      from_source_alias.cte_source__col_0 AS from_source__col_0
+    FROM cte_source from_source_alias
+  ) from_source_alias
+
+sql_after_optimizing:
+  -- top_level_select
+  SELECT
+    from_source_alias.from_source__col_0 AS top_level__col_0
+  FROM (
+    -- from_sub_query
+    WITH cte_source AS (
+      -- CTE source
+      SELECT
+        test_table_alias.col_0 AS cte_source__col_0
+      FROM test_schema.test_table test_table_alias
+    )
+
+    SELECT
+      from_source_alias.cte_source__col_0 AS from_source__col_0
+    FROM cte_source from_source_alias
+  ) from_source_alias


### PR DESCRIPTION
Similar to https://github.com/dbt-labs/metricflow/pull/1613, but for `SqlRewritingSubQueryReducer`.