### PR TITLE
Fix reuse of `SelectStatementNode` for semi-additive join SQL

### DIFF
--- a/metricflow/plan_conversion/dataflow_to_sql.py
+++ b/metricflow/plan_conversion/dataflow_to_sql.py
@@ -1405,7 +1405,7 @@ class DataflowNodeToSqlSubqueryVisitor(DataflowPlanNodeVisitor[SqlDataSet]):
         if queried_time_dimension_select_column:
             row_filter_group_bys += (queried_time_dimension_select_column,)
         # Construct SelectNode for Row filtering
-        row_filter_sql_select_node = SqlSelectStatementNode.create(
+        right_source_select_node = SqlSelectStatementNode.create(
             description=f"Filter row on {node.agg_by_function.name}({time_dimension_column_name})",
             select_columns=row_filter_group_bys + (time_dimension_select_column,),
             from_source=from_data_set.checked_sql_select_node,
@@ -1415,7 +1415,7 @@ class DataflowNodeToSqlSubqueryVisitor(DataflowPlanNodeVisitor[SqlDataSet]):
 
         join_data_set_alias = self._next_unique_table_alias()
         sql_join_desc = SqlPlanJoinBuilder.make_column_equality_sql_join_description(
-            right_source_node=row_filter_sql_select_node,
+            right_source_node=right_source_select_node,
             left_source_alias=from_data_set_alias,
             right_source_alias=join_data_set_alias,
             column_equality_descriptions=column_equality_descriptions,

--- a/metricflow/plan_conversion/dataflow_to_sql.py
+++ b/metricflow/plan_conversion/dataflow_to_sql.py
@@ -1413,11 +1413,11 @@ class DataflowNodeToSqlSubqueryVisitor(DataflowPlanNodeVisitor[SqlDataSet]):
             group_bys=row_filter_group_bys,
         )
 
-        join_data_set_alias = self._next_unique_table_alias()
+        right_source_alias = self._next_unique_table_alias()
         sql_join_desc = SqlPlanJoinBuilder.make_column_equality_sql_join_description(
             right_source_node=right_source_select_node,
             left_source_alias=from_data_set_alias,
-            right_source_alias=join_data_set_alias,
+            right_source_alias=right_source_alias,
             column_equality_descriptions=column_equality_descriptions,
             join_type=SqlJoinType.INNER,
         )

--- a/metricflow/plan_conversion/dataflow_to_sql.py
+++ b/metricflow/plan_conversion/dataflow_to_sql.py
@@ -533,7 +533,7 @@ class DataflowNodeToSqlSubqueryVisitor(DataflowPlanNodeVisitor[SqlDataSet]):
             # `ReadSqlSourceNode` may be used multiple times in the plan, create a copy of the SELECT.
             # `SqlColumnPrunerOptimizer` relies on this assumption to keep track of what columns are required at each
             # node.
-            sql_select_node=node.data_set.checked_sql_select_node.create_copy(),
+            sql_select_node=node.data_set.checked_sql_select_node.copy(),
             instance_set=node.data_set.instance_set,
         )
 

--- a/metricflow/plan_conversion/dataflow_to_sql.py
+++ b/metricflow/plan_conversion/dataflow_to_sql.py
@@ -1408,7 +1408,7 @@ class DataflowNodeToSqlSubqueryVisitor(DataflowPlanNodeVisitor[SqlDataSet]):
         right_source_select_node = SqlSelectStatementNode.create(
             description=f"Filter row on {node.agg_by_function.name}({time_dimension_column_name})",
             select_columns=row_filter_group_bys + (time_dimension_select_column,),
-            from_source=from_data_set.checked_sql_select_node,
+            from_source=from_data_set.checked_sql_select_node.copy(),
             from_source_alias=inner_join_data_set_alias,
             group_bys=row_filter_group_bys,
         )

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/test_semi_additive_join_node__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/test_semi_additive_join_node__plan0.xml
@@ -6,7 +6,7 @@ docstring:
 <SqlPlan>
     <SqlSelectStatementNode>
         <!-- description = 'Join on MIN(ds) and [] grouping by None' -->
-        <!-- node_id = NodeId(id_str='ss_2') -->
+        <!-- node_id = NodeId(id_str='ss_3') -->
         <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_9), column_alias='ds__day') -->
         <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_10), column_alias='ds__week') -->
         <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_11), column_alias='ds__month') -->
@@ -101,7 +101,7 @@ docstring:
         <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
         <!-- join_0 =                                                 -->
         <!--   SqlJoinDescription(                                    -->
-        <!--     right_source=SqlSelectStatementNode(node_id=ss_1),   -->
+        <!--     right_source=SqlSelectStatementNode(node_id=ss_2),   -->
         <!--     right_source_alias='subq_2',                         -->
         <!--     join_type=INNER,                                     -->
         <!--     on_condition=SqlComparisonExpression(node_id=cmp_0), -->
@@ -219,18 +219,18 @@ docstring:
         </SqlSelectStatementNode>
         <SqlSelectStatementNode>
             <!-- description = 'Filter row on MIN(ds__day)' -->
-            <!-- node_id = NodeId(id_str='ss_1') -->
+            <!-- node_id = NodeId(id_str='ss_2') -->
             <!-- col0 =                                                                    -->
             <!--   SqlSelectColumn(                                                        -->
             <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_0, sql_function=MIN), -->
             <!--     column_alias='ds__day__complete',                                     -->
             <!--   )                                                                       -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
             <!-- where = None -->
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = "Read Elements From Semantic Model 'accounts_source'" -->
-                <!-- node_id = NodeId(id_str='ss_0') -->
+                <!-- node_id = NodeId(id_str='ss_1') -->
                 <!-- col0 =                                                   -->
                 <!--   SqlSelectColumn(                                       -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_28000), -->

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/test_semi_additive_join_node_with_grouping__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/test_semi_additive_join_node_with_grouping__plan0.xml
@@ -6,7 +6,7 @@ docstring:
 <SqlPlan>
     <SqlSelectStatementNode>
         <!-- description = "Join on MAX(ds) and ['user'] grouping by None" -->
-        <!-- node_id = NodeId(id_str='ss_2') -->
+        <!-- node_id = NodeId(id_str='ss_3') -->
         <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_12), column_alias='ds__day') -->
         <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_13), column_alias='ds__week') -->
         <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_14), column_alias='ds__month') -->
@@ -101,7 +101,7 @@ docstring:
         <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
         <!-- join_0 =                                               -->
         <!--   SqlJoinDescription(                                  -->
-        <!--     right_source=SqlSelectStatementNode(node_id=ss_1), -->
+        <!--     right_source=SqlSelectStatementNode(node_id=ss_2), -->
         <!--     right_source_alias='subq_2',                       -->
         <!--     join_type=INNER,                                   -->
         <!--     on_condition=SqlLogicalExpression(node_id=lo_0),   -->
@@ -219,20 +219,20 @@ docstring:
         </SqlSelectStatementNode>
         <SqlSelectStatementNode>
             <!-- description = 'Filter row on MAX(ds__day)' -->
-            <!-- node_id = NodeId(id_str='ss_1') -->
+            <!-- node_id = NodeId(id_str='ss_2') -->
             <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_1), column_alias='user') -->
             <!-- col1 =                                                                    -->
             <!--   SqlSelectColumn(                                                        -->
             <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_0, sql_function=MAX), -->
             <!--     column_alias='ds__day__complete',                                     -->
             <!--   )                                                                       -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
             <!-- group_by0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_1), column_alias='user') -->
             <!-- where = None -->
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = "Read Elements From Semantic Model 'accounts_source'" -->
-                <!-- node_id = NodeId(id_str='ss_0') -->
+                <!-- node_id = NodeId(id_str='ss_1') -->
                 <!-- col0 =                                                   -->
                 <!--   SqlSelectColumn(                                       -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_28000), -->

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/test_semi_additive_join_node_with_queried_group_by__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/test_semi_additive_join_node_with_queried_group_by__plan0.xml
@@ -6,7 +6,7 @@ docstring:
 <SqlPlan>
     <SqlSelectStatementNode>
         <!-- description = 'Join on MIN(ds) and [] grouping by ds' -->
-        <!-- node_id = NodeId(id_str='ss_2') -->
+        <!-- node_id = NodeId(id_str='ss_3') -->
         <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_10), column_alias='ds__day') -->
         <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_11), column_alias='ds__week') -->
         <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_12), column_alias='ds__month') -->
@@ -101,7 +101,7 @@ docstring:
         <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
         <!-- join_0 =                                                 -->
         <!--   SqlJoinDescription(                                    -->
-        <!--     right_source=SqlSelectStatementNode(node_id=ss_1),   -->
+        <!--     right_source=SqlSelectStatementNode(node_id=ss_2),   -->
         <!--     right_source_alias='subq_2',                         -->
         <!--     join_type=INNER,                                     -->
         <!--     on_condition=SqlComparisonExpression(node_id=cmp_0), -->
@@ -219,20 +219,20 @@ docstring:
         </SqlSelectStatementNode>
         <SqlSelectStatementNode>
             <!-- description = 'Filter row on MIN(ds__day)' -->
-            <!-- node_id = NodeId(id_str='ss_1') -->
+            <!-- node_id = NodeId(id_str='ss_2') -->
             <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_1), column_alias='ds__week') -->
             <!-- col1 =                                                                    -->
             <!--   SqlSelectColumn(                                                        -->
             <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_0, sql_function=MIN), -->
             <!--     column_alias='ds__day__complete',                                     -->
             <!--   )                                                                       -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
             <!-- group_by0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_1), column_alias='ds__week') -->
             <!-- where = None -->
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = "Read Elements From Semantic Model 'accounts_source'" -->
-                <!-- node_id = NodeId(id_str='ss_0') -->
+                <!-- node_id = NodeId(id_str='ss_1') -->
                 <!-- col0 =                                                   -->
                 <!--   SqlSelectColumn(                                       -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_28000), -->


### PR DESCRIPTION
This PR fixes a case of `SelectStatementNode` reuse when generating the SQL for a semi-additive join node. There are a few renames in here that increase the diff, but the actual change is small. Please view by commit.