### PR TITLE
Update Pypi publish workflow to use Python 3.9

### DIFF
--- a/.github/actions/setup-python-env/action.yaml
+++ b/.github/actions/setup-python-env/action.yaml
@@ -5,7 +5,7 @@ inputs:
   python-version:
     description: "Version of Python to use for testing"
     required: false
-    default: "3.8"
+    default: "3.9"
 
 runs:
   using: "composite"

--- a/.github/workflows/cd-push-metricflow-to-pypi.yaml
+++ b/.github/workflows/cd-push-metricflow-to-pypi.yaml
@@ -8,7 +8,7 @@ on:
       - "v[0-9]+.[0-9]+.[0-9]+*"
 
 env:
-  PYTHON_VERSION: "3.8"
+  PYTHON_VERSION: "3.9"
 
 jobs:
   pypi-publish:


### PR DESCRIPTION
Got this error while trying to publish in the workflow:

```
ERROR    InvalidDistribution: Invalid distribution metadata: license-expression 
         introduced in metadata version 2.4, not 2.1     
```

Might be caused by something else, but fixing the Python version to rule it out.