### PR TITLE
Update `hatchling` to `1.27.0`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling~=1.14.0", "hatch-requirements-txt >= 0.4.1, <0.5.0"]
+requires = ["hatchling>=1.27.0,<1.28.0", "hatch-requirements-txt >= 0.4.1, <0.5.0"]
 build-backend = "hatchling.build"
 
 [project]


### PR DESCRIPTION
Updating the version of `hatchling` resolves an issue in the workflow to publish the package to Pypi:

```
ERROR    InvalidDistribution: Invalid distribution metadata: license-expression 
         introduced in metadata version 2.4, not 2.1     
```