### PR TITLE
Update package version definitions to `*.dev0`

### DIFF
--- a/dbt-metricflow/dbt_metricflow/__about__.py
+++ b/dbt-metricflow/dbt_metricflow/__about__.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-__version__ = "0.8.0"
+__version__ = "0.9.0.dev0"

--- a/metricflow-semantics/pyproject.toml
+++ b/metricflow-semantics/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "metricflow-semantics"
-version = "0.2.0"
+version = "0.3.0.dev0"
 description = "Modules for semantic understanding of a MetricFlow query."
 readme = "README.md"
 requires-python = ">=3.9,<3.13"

--- a/metricflow/__about__.py
+++ b/metricflow/__about__.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-__version__ = "0.207.0"
+__version__ = "0.208.0.dev0"


### PR DESCRIPTION
The defined version for packages should generally have a `*.dev123` suffix in `main`.