### PR TITLE
Use `__about__.py` to define `metricflow-semantics` package version

### DIFF
--- a/metricflow-semantics/metricflow_semantics/__about__.py
+++ b/metricflow-semantics/metricflow_semantics/__about__.py
@@ -1,0 +1,3 @@
+from __future__ import annotations
+
+__version__ = "0.3.0.dev0"

--- a/metricflow-semantics/pyproject.toml
+++ b/metricflow-semantics/pyproject.toml
@@ -4,7 +4,6 @@ build-backend = "hatchling.build"
 
 [project]
 name = "metricflow-semantics"
-version = "0.3.0.dev0"
 description = "Modules for semantic understanding of a MetricFlow query."
 readme = "README.md"
 requires-python = ">=3.9,<3.13"
@@ -25,7 +24,10 @@ classifiers = [
 ]
 
 # Dependencies are specified through the `hatch-requirements-txt` plug-in.
-dynamic = ["dependencies"]
+dynamic = ["dependencies", "version"]
+
+[tool.hatch.version]
+path = "metricflow_semantics/__about__.py"
 
 [tool.hatch.metadata.hooks.requirements_txt]
 files = [


### PR DESCRIPTION
This PR updates how the package version for `metricflow-semantics` is set to follow the style for `metricflow`.