### PR TITLE
Skip CLI setup in tests

### DIFF
--- a/tests_metricflow/fixtures/cli_fixtures.py
+++ b/tests_metricflow/fixtures/cli_fixtures.py
@@ -38,6 +38,11 @@ class FakeCLIConfiguration(CLIConfiguration):
         self._semantic_manifest_lookup: Optional[SemanticManifestLookup] = None
         self._log_file_path: Optional[pathlib.Path] = None
 
+    @override
+    def setup(self) -> None:
+        # For tests, a dbt project is not needed, so don't try to configure it.
+        return
+
     @property
     @override
     def dbt_artifacts(self) -> dbtArtifacts:


### PR DESCRIPTION
The setup for the dbt project should be skipped, as otherwise, devs could see unusual errors if they have a dbt project configured while running tests.