### PR TITLE
Allow for a one-line representation in `mf_pformat_dict()`

### DIFF
--- a/metricflow-semantics/metricflow_semantics/mf_logging/pretty_print.py
+++ b/metricflow-semantics/metricflow_semantics/mf_logging/pretty_print.py
@@ -514,28 +514,11 @@ def _as_one_line(description: Optional[str], str_converted_dict: Dict[str, str],
         a: 1
         b: 2
     """
-    if description is not None and "\n" in description:
-        return None
-
-    # Keep track of the total length of the keys and values to see if it can be printed on one line.
-    total_key_length = 0
-    total_value_length = 0
-
-    for key_str, value_str in str_converted_dict.items():
-        if "\n" in key_str or "\n" in value_str:
-            return None
-        total_key_length += len(key_str)
-        total_value_length += len(value_str)
-
-    one_line_length = (
-        len(description or "") + 1 + 2 + 2 * len(str_converted_dict) + total_key_length + total_value_length
-    )
-    if one_line_length > max_line_length:
-        return None
-
     items = tuple(f"{key_str}={value_str}" for key_str, value_str in str_converted_dict.items())
-    if len(items) == 0:
-        return description
-
     value_in_parenthesis = ", ".join(items)
-    return f"{description} ({value_in_parenthesis})"
+    result = f"{description}" + (f" ({value_in_parenthesis})" if len(value_in_parenthesis) > 0 else "")
+
+    if "\n" in result or len(result) > max_line_length:
+        return None
+
+    return result

--- a/metricflow-semantics/metricflow_semantics/mf_logging/pretty_print.py
+++ b/metricflow-semantics/metricflow_semantics/mf_logging/pretty_print.py
@@ -534,5 +534,8 @@ def _as_one_line(description: Optional[str], str_converted_dict: Dict[str, str],
         return None
 
     items = tuple(f"{key_str}={value_str}" for key_str, value_str in str_converted_dict.items())
+    if len(items) == 0:
+        return description
+
     value_in_parenthesis = ", ".join(items)
     return f"{description} ({value_in_parenthesis})"

--- a/metricflow-semantics/tests_metricflow_semantics/mf_logging/test_lazy_format.py
+++ b/metricflow-semantics/tests_metricflow_semantics/mf_logging/test_lazy_format.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 
-from metricflow_semantics.formatting.formatting_helpers import mf_dedent
 from metricflow_semantics.mf_logging.lazy_formattable import LazyFormat
 from typing_extensions import override
 
@@ -19,12 +18,8 @@ def test_log_kwargs() -> None:
         recorded_logger.debug(
             LazyFormat("Found candidates.", matches=[1, 2, 3], parameters={"field_0": "value_0", "field_1": "value_1"})
         )
-        assert handler.get_last_message() == mf_dedent(
-            """
-            Found candidates.
-              matches: [1, 2, 3]
-              parameters: {'field_0': 'value_0', 'field_1': 'value_1'}
-            """
+        assert handler.get_last_message() == (
+            "Found candidates. (matches=[1, 2, 3], parameters={'field_0': 'value_0', 'field_1': 'value_1'})"
         )
 
 

--- a/metricflow-semantics/tests_metricflow_semantics/mf_logging/test_pformat_dict.py
+++ b/metricflow-semantics/tests_metricflow_semantics/mf_logging/test_pformat_dict.py
@@ -10,7 +10,9 @@ logger = logging.getLogger(__name__)
 
 
 def test_pformat_many() -> None:  # noqa: D103
-    result = mf_pformat_dict("Example description:", obj_dict={"object_0": (1, 2, 3), "object_1": {4: 5}})
+    result = mf_pformat_dict(
+        "Example description:", obj_dict={"object_0": (1, 2, 3), "object_1": {4: 5}}, max_line_length=30
+    )
 
     assert (
         textwrap.dedent(
@@ -25,7 +27,9 @@ def test_pformat_many() -> None:  # noqa: D103
 
 
 def test_pformat_many_with_raw_strings() -> None:  # noqa: D103
-    result = mf_pformat_dict("Example description:", obj_dict={"object_0": "foo\nbar"}, preserve_raw_strings=True)
+    result = mf_pformat_dict(
+        "Example description:", obj_dict={"object_0": "foo\nbar"}, preserve_raw_strings=True, max_line_length=30
+    )
 
     assert (
         textwrap.dedent(
@@ -42,7 +46,7 @@ def test_pformat_many_with_raw_strings() -> None:  # noqa: D103
 
 def test_pformat_dict_with_empty_message() -> None:
     """Test `mf_pformat_dict` without a description."""
-    result = mf_pformat_dict(obj_dict={"object_0": (1, 2, 3), "object_1": {4: 5}})
+    result = mf_pformat_dict(obj_dict={"object_0": (1, 2, 3), "object_1": {4: 5}}, max_line_length=30)
 
     assert (
         mf_dedent(
@@ -57,7 +61,9 @@ def test_pformat_dict_with_empty_message() -> None:
 
 def test_pformat_dict_with_pad_sections_with_newline() -> None:
     """Test `mf_pformat_dict` with new lines between sections."""
-    result = mf_pformat_dict(obj_dict={"object_0": (1, 2, 3), "object_1": {4: 5}}, pad_items_with_newlines=True)
+    result = mf_pformat_dict(
+        obj_dict={"object_0": (1, 2, 3), "object_1": {4: 5}}, pad_items_with_newlines=True, max_line_length=30
+    )
 
     assert (
         mf_dedent(
@@ -72,7 +78,7 @@ def test_pformat_dict_with_pad_sections_with_newline() -> None:
 
 
 def test_pformat_many_with_strings() -> None:  # noqa: D103
-    result = mf_pformat_dict("Example description:", obj_dict={"object_0": "foo\nbar"})
+    result = mf_pformat_dict("Example description:", obj_dict={"object_0": "foo\nbar"}, max_line_length=30)
     assert (
         textwrap.dedent(
             """\
@@ -96,4 +102,4 @@ def test_minimal_length() -> None:
 
 def test_one_line() -> None:
     """Test formatting as a one-line string if possible."""
-    assert mf_pformat_dict("Example output", {"a": 1, "b": 2}) == "Example output (a=1, b=2)"
+    assert mf_pformat_dict("Example output", {"a": 1, "b": 2}, max_line_length=80) == "Example output (a=1, b=2)"

--- a/metricflow-semantics/tests_metricflow_semantics/mf_logging/test_pformat_dict.py
+++ b/metricflow-semantics/tests_metricflow_semantics/mf_logging/test_pformat_dict.py
@@ -92,3 +92,8 @@ def test_minimal_length() -> None:
           foo: 'bar'
         """
     )
+
+
+def test_one_line() -> None:
+    """Test formatting as a one-line string if possible."""
+    assert mf_pformat_dict("Example output", {"a": 1, "b": 2}) == "Example output (a=1, b=2)"


### PR DESCRIPTION
This PR enables small objects with a short string representation to be formatted on one line.