### PR TITLE
Allow for lazy-evaluation of arguments in `LazyFormat`

### DIFF
--- a/metricflow/dataflow/optimizer/source_scan/source_scan_optimizer.py
+++ b/metricflow/dataflow/optimizer/source_scan/source_scan_optimizer.py
@@ -328,8 +328,8 @@ class SourceScanOptimizer(
         logger.debug(
             LazyFormat(
                 "Optimized dataflow plan",
-                original_plan=dataflow_plan.sink_node.structure_text(),
-                optimized_plan=optimized_result.optimized_branch.structure_text(),
+                original_plan=dataflow_plan.sink_node.structure_text,
+                optimized_plan=optimized_result.optimized_branch.structure_text,
             )
         )
 

--- a/metricflow/sql/optimizer/column_pruning/column_pruner.py
+++ b/metricflow/sql/optimizer/column_pruning/column_pruner.py
@@ -113,7 +113,7 @@ class SqlColumnPrunerOptimizer(SqlPlanOptimizer):
             logger.error(
                 LazyFormat(
                     "The columns required at this node can't be determined, so skipping column pruning",
-                    node=node.structure_text(),
+                    node=node.structure_text,
                     required_select_columns=required_select_columns,
                 )
             )


### PR DESCRIPTION
When creating a `LazyFormat` object, the keyword argument values may be constructed from expensive methods. Similar to allowing a function to be passed in for the `message` argument, this PR enables methods to be passed in for the keyword argument values so that they can be lazily evaluated.

There were some logging calls that were found in performance profiling to be expensive because lazy-evaluation was not done, so this PR updates a few of those call sites as well. An alternative approach would have been to implement `MetricFlowPrettyFormattable` for those objects.