### PR TITLE
Update Github actions to use the default Python version

### DIFF
--- a/.github/actions/run-mf-tests/action.yaml
+++ b/.github/actions/run-mf-tests/action.yaml
@@ -4,7 +4,8 @@ description: Runs MetricFlow using the specified Python version and engine setti
 inputs:
   python-version:
     description: "Version of Python to use for testing."
-    required: true
+    required: False
+    default: "3.9"
   mf_sql_engine_url:
     description: "URL for configuring SQL engine connection."
     required: false
@@ -39,12 +40,11 @@ inputs:
 runs:
   using: "composite"
   steps:
-  - name: Setup Python ${{ inputs.python-version }} Environment
-    uses: ./.github/actions/setup-python-env
+  - uses: ./.github/actions/setup-python-env
     with:
       python-version: "${{ inputs.python-version }}"
       hatch-environment-cache-config-json: "${{ inputs.hatch-environment-cache-config-json }}"
-  - name: Run Tests
+  - name: Run Tests w/ Python ${{ inputs.python-version }}
     shell: bash
     run: >
       make -e

--- a/.github/workflows/cd-push-dbt-metricflow-to-pypi.yaml
+++ b/.github/workflows/cd-push-dbt-metricflow-to-pypi.yaml
@@ -6,9 +6,6 @@ on:
     tags:
       - "dbt-metricflow/v[0-9]+.[0-9]+.[0-9]+*"
 
-env:
-  PYTHON_VERSION: "3.9"
-
 jobs:
   pypi-publish:
     runs-on: ubuntu-latest
@@ -21,10 +18,7 @@ jobs:
       - name: Check-out the repo
         uses: actions/checkout@v4
 
-      - name: Setup Python ${{ env.PYTHON_VERSION }} Environment
-        uses: ./.github/actions/setup-python-env
-        with:
-          python-version: "${{ env.PYTHON_VERSION }}"
+      - uses: ./.github/actions/setup-python-env
 
       - name: Build `dbt-metricflow` package
         working-directory: ./dbt-metricflow

--- a/.github/workflows/cd-push-metricflow-to-pypi.yaml
+++ b/.github/workflows/cd-push-metricflow-to-pypi.yaml
@@ -7,9 +7,6 @@ on:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+*"
 
-env:
-  PYTHON_VERSION: "3.9"
-
 jobs:
   pypi-publish:
     runs-on: ubuntu-latest
@@ -22,10 +19,7 @@ jobs:
       - name: Check-out the repo
         uses: actions/checkout@v4
 
-      - name: Setup Python ${{ env.PYTHON_VERSION }} Environment
-        uses: ./.github/actions/setup-python-env
-        with:
-          python-version: "${{ env.PYTHON_VERSION }}"
+      - uses: ./.github/actions/setup-python-env
 
       - name: Build `metricflow` package
         run: hatch build

--- a/.github/workflows/cd-sql-engine-populate-persistent-source-schema.yaml
+++ b/.github/workflows/cd-sql-engine-populate-persistent-source-schema.yaml
@@ -15,7 +15,6 @@ on:
 
 env:
   # Unclear on how to make 'Reload Test Data in SQL Engines' a constant here as it does not work here.
-  PYTHON_VERSION: "3.8"
   ADDITIONAL_PYTEST_OPTIONS: "--log-cli-level info"
 
 jobs:
@@ -28,10 +27,9 @@ jobs:
       - name: Check-out the repo
         uses: actions/checkout@v4
 
-      - name: Populate w/Python ${{ env.PYTHON_VERSION }}
+      - name: Populate Snowflake
         uses: ./.github/actions/run-mf-tests
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
           mf_sql_engine_url: ${{ secrets.MF_SNOWFLAKE_URL }}
           mf_sql_engine_password: ${{ secrets.MF_SNOWFLAKE_PWD }}
           parallelism: 1
@@ -47,10 +45,9 @@ jobs:
       - name: Check-out the repo
         uses: actions/checkout@v4
 
-      - name: Populate w/Python ${{ env.PYTHON_VERSION }}
+      - name: Populate Redshift
         uses: ./.github/actions/run-mf-tests
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
           mf_sql_engine_url: ${{ secrets.MF_REDSHIFT_URL }}
           mf_sql_engine_password: ${{ secrets.MF_REDSHIFT_PWD }}
           parallelism: 1
@@ -66,10 +63,9 @@ jobs:
       - name: Check-out the repo
         uses: actions/checkout@v4
 
-      - name: Populate w/Python ${{ env.PYTHON_VERSION }}
+      - name: Populate BigQuery
         uses: ./.github/actions/run-mf-tests
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
           MF_SQL_ENGINE_URL: ${{ secrets.MF_BIGQUERY_URL }}
           MF_SQL_ENGINE_PASSWORD: ${{ secrets.MF_BIGQUERY_PWD }}
           parallelism: 1
@@ -85,10 +81,9 @@ jobs:
       - name: Check-out the repo
         uses: actions/checkout@v4
 
-      - name: Populate w/Python ${{ env.PYTHON_VERSION }}
+      - name: Populate Databricks
         uses: ./.github/actions/run-mf-tests
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
           mf_sql_engine_url: ${{ secrets.MF_DATABRICKS_URL }}
           mf_sql_engine_password: ${{ secrets.MF_DATABRICKS_PWD }}
           parallelism: 1

--- a/.github/workflows/cd-sql-engine-tests.yaml
+++ b/.github/workflows/cd-sql-engine-tests.yaml
@@ -9,7 +9,6 @@ on:
     types: [labeled]
 
 env:
-  PYTHON_VERSION: "3.8"
   EXTERNAL_ENGINE_TEST_PARALLELISM: 8
   ADDITIONAL_PYTEST_OPTIONS: "--use-persistent-source-schema"
 
@@ -25,10 +24,8 @@ jobs:
       - name: Check-out the repo
         uses: actions/checkout@v4
 
-      - name: Test w/ Python ${{ env.PYTHON_VERSION }}
-        uses: ./.github/actions/run-mf-tests
+      - uses: ./.github/actions/run-mf-tests
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
           mf_sql_engine_url: ${{ secrets.MF_SNOWFLAKE_URL }}
           mf_sql_engine_password: ${{ secrets.MF_SNOWFLAKE_PWD }}
           parallelism: ${{ env.EXTERNAL_ENGINE_TEST_PARALLELISM }}
@@ -50,10 +47,8 @@ jobs:
       - name: Check-out the repo
         uses: actions/checkout@v4
 
-      - name: Test w/ Python ${{ env.PYTHON_VERSION }}
-        uses: ./.github/actions/run-mf-tests
+      - uses: ./.github/actions/run-mf-tests
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
           mf_sql_engine_url: ${{ secrets.MF_REDSHIFT_URL }}
           mf_sql_engine_password: ${{ secrets.MF_REDSHIFT_PWD }}
           parallelism: ${{ env.EXTERNAL_ENGINE_TEST_PARALLELISM }}
@@ -75,10 +70,8 @@ jobs:
       - name: Check-out the repo
         uses: actions/checkout@v4
 
-      - name: Test w/ Python ${{ env.PYTHON_VERSION }}
-        uses: ./.github/actions/run-mf-tests
+      - uses: ./.github/actions/run-mf-tests
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
           MF_SQL_ENGINE_URL: ${{ secrets.MF_BIGQUERY_URL }}
           MF_SQL_ENGINE_PASSWORD: ${{ secrets.MF_BIGQUERY_PWD }}
           parallelism: ${{ env.EXTERNAL_ENGINE_TEST_PARALLELISM }}
@@ -100,10 +93,8 @@ jobs:
       - name: Check-out the repo
         uses: actions/checkout@v4
 
-      - name: Test w/ Python ${{ env.PYTHON_VERSION }}
-        uses: ./.github/actions/run-mf-tests
+      - uses: ./.github/actions/run-mf-tests
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
           mf_sql_engine_url: ${{ secrets.MF_DATABRICKS_URL }}
           mf_sql_engine_password: ${{ secrets.MF_DATABRICKS_PWD }}
           parallelism: ${{ env.EXTERNAL_ENGINE_TEST_PARALLELISM }}
@@ -133,10 +124,8 @@ jobs:
       - name: Check-out the repo
         uses: actions/checkout@v4
 
-      - name: Test w/ Python 3.12
-        uses: ./.github/actions/run-mf-tests
+      - uses: ./.github/actions/run-mf-tests
         with:
-          python-version: "3.12"
           make-target: "test-trino"
           hatch-environment-cache-config-json: >-
             {

--- a/.github/workflows/ci-linting.yaml
+++ b/.github/workflows/ci-linting.yaml
@@ -17,17 +17,13 @@ jobs:
   pre-commit:
     name: Run Pre-Commit Linting Hooks
     runs-on: ubuntu-latest
-    env:
-      python-version: "3.8"
     steps:
 
       - name: Check-out the repo
         uses: actions/checkout@v4
 
-      - name: Setup Python ${{ env.python-version }} Environment
-        uses: ./.github/actions/setup-python-env
+      - uses: ./.github/actions/setup-python-env
         with:
-          python-version: "${{ env.python-version }}"
           hatch-environment-cache-config-json: >-
             {
               "configs": [

--- a/.github/workflows/ci-metricflow-unit-tests.yaml
+++ b/.github/workflows/ci-metricflow-unit-tests.yaml
@@ -19,8 +19,7 @@ jobs:
       - name: Check-out the repo
         uses: actions/checkout@v4
 
-      - name: Test w/ Python ${{ matrix.python-version }}
-        uses: ./.github/actions/run-mf-tests
+      - uses: ./.github/actions/run-mf-tests
         with:
           python-version: ${{ matrix.python-version }}
           make-target: "test-include-slow"
@@ -47,10 +46,8 @@ jobs:
       - name: Check-out the repo
         uses: actions/checkout@v4
 
-      - name: Test w/ Python 3.12
-        uses: ./.github/actions/run-mf-tests
+      - uses: ./.github/actions/run-mf-tests
         with:
-          python-version: "3.12"
           make-target: "test-postgresql"
           hatch-environment-cache-config-json: >-
             {


### PR DESCRIPTION
I found there were still more actions using Python 3.8. We should be using Python 3.9, and using the older version affects how actions are cached. To simplify management, this removes places that specify a Python version so that the default version (3.9) is used.

There were places where Python 3.12 was specified, but it was unclear why that was the case. Changed those to use the default version as well.