### PR TITLE
Fix `JoinToTimeSpineNode.with_new_parents()`

### DIFF
--- a/metricflow/dataflow/dataflow_plan.py
+++ b/metricflow/dataflow/dataflow_plan.py
@@ -72,6 +72,9 @@ class DataflowPlanNode(DagNode["DataflowPlanNode"], Visitable, ABC):
     def with_new_parents(self: NodeSelfT, new_parent_nodes: Sequence[DataflowPlanNode]) -> NodeSelfT:
         """Creates a node with the same behavior as this node, but with a different set of parents.
 
+        Callers are required to call this method with new parent nodes that are of the appropriate type and order as
+        required by the subclass.
+
         typing.Self would be useful here, but not available in Python 3.8.
         """
         raise NotImplementedError

--- a/metricflow/dataflow/nodes/join_to_time_spine.py
+++ b/metricflow/dataflow/nodes/join_to_time_spine.py
@@ -107,10 +107,12 @@ class JoinToTimeSpineNode(DataflowPlanNode, ABC):
         )
 
     def with_new_parents(self, new_parent_nodes: Sequence[DataflowPlanNode]) -> JoinToTimeSpineNode:  # noqa: D102
-        assert len(new_parent_nodes) == 1
+        assert len(new_parent_nodes) == 2
+        metric_source_node = new_parent_nodes[0]
+        time_spine_node = new_parent_nodes[1]
         return JoinToTimeSpineNode.create(
-            metric_source_node=self.metric_source_node,
-            time_spine_node=self.time_spine_node,
+            metric_source_node=metric_source_node,
+            time_spine_node=time_spine_node,
             requested_agg_time_dimension_specs=self.requested_agg_time_dimension_specs,
             standard_offset_window=self.standard_offset_window,
             offset_to_grain=self.offset_to_grain,


### PR DESCRIPTION
This PR fixes an issue with `JoinToTimeSpineNode.with_new_parents()` where it was not using the new parents.