### PR TITLE
Update `SqlPlanNode.copy()` to copy ancestor nodes

### DIFF
--- a/metricflow/plan_conversion/to_sql_plan/dataflow_to_subquery.py
+++ b/metricflow/plan_conversion/to_sql_plan/dataflow_to_subquery.py
@@ -175,7 +175,9 @@ class DataflowNodeToSqlSubqueryVisitor(DataflowPlanNodeVisitor[SqlDataSet]):
         # TODO: The cache needs to be pruned, but has not yet been an issue.
         """
         if node not in self._node_to_output_data_set:
-            self._node_to_output_data_set[node] = node.accept(self)
+            result = node.accept(self)
+            self._node_to_output_data_set[node] = result
+            return result
 
         return self._node_to_output_data_set[node].with_copied_sql_node()
 

--- a/metricflow/sql/sql_ctas_node.py
+++ b/metricflow/sql/sql_ctas_node.py
@@ -69,4 +69,4 @@ class SqlCreateTableAsNode(SqlPlanNode):
 
     @override
     def copy(self) -> SqlCreateTableAsNode:
-        return SqlCreateTableAsNode(parent_nodes=self.parent_nodes, sql_table=self.sql_table)
+        return SqlCreateTableAsNode.create(parent_node=self.parent_node.copy(), sql_table=self.sql_table)

--- a/metricflow/sql/sql_cte_node.py
+++ b/metricflow/sql/sql_cte_node.py
@@ -70,9 +70,8 @@ class SqlCteNode(SqlPlanNode):
 
     @override
     def copy(self) -> SqlCteNode:
-        return SqlCteNode(
-            parent_nodes=self.parent_nodes,
-            select_statement=self.select_statement,
+        return SqlCteNode.create(
+            select_statement=self.select_statement.copy(),
             cte_alias=self.cte_alias,
         )
 

--- a/metricflow/sql/sql_plan.py
+++ b/metricflow/sql/sql_plan.py
@@ -72,7 +72,10 @@ class SqlPlanNode(DagNode["SqlPlanNode"], ABC):
 
     @abstractmethod
     def copy(self) -> Self:
-        """Create a shallow copy of this node."""
+        """Return a copy of the branch represented by this node.
+
+        The node fields are copied by reference, similar to shallow copying.
+        """
         raise NotImplementedError
 
 

--- a/metricflow/sql/sql_select_node.py
+++ b/metricflow/sql/sql_select_node.py
@@ -142,14 +142,15 @@ class SqlSelectStatementNode(SqlPlanNode):
 
     @override
     def copy(self) -> SqlSelectStatementNode:
-        return SqlSelectStatementNode(
-            parent_nodes=self.parent_nodes,
-            _description=self._description,
+        return SqlSelectStatementNode.create(
+            description=self._description,
             select_columns=self.select_columns,
-            from_source=self.from_source,
+            from_source=self.from_source.copy(),
             from_source_alias=self.from_source_alias,
-            cte_sources=self.cte_sources,
-            join_descs=self.join_descs,
+            cte_sources=tuple(node.copy() for node in self.cte_sources),
+            join_descs=tuple(
+                join_desc.with_right_source(join_desc.right_source.copy()) for join_desc in self.join_descs
+            ),
             group_bys=self.group_bys,
             order_bys=self.order_bys,
             where=self.where,

--- a/metricflow/sql/sql_select_text_node.py
+++ b/metricflow/sql/sql_select_text_node.py
@@ -56,4 +56,6 @@ class SqlSelectTextNode(SqlPlanNode):
 
     @override
     def copy(self) -> SqlSelectTextNode:
-        return SqlSelectTextNode(parent_nodes=self.parent_nodes, select_query=self.select_query)
+        return SqlSelectTextNode(
+            parent_nodes=tuple(node.copy() for node in self.parent_nodes), select_query=self.select_query
+        )

--- a/metricflow/sql/sql_table_node.py
+++ b/metricflow/sql/sql_table_node.py
@@ -64,7 +64,6 @@ class SqlTableNode(SqlPlanNode):
 
     @override
     def copy(self) -> SqlTableNode:
-        return SqlTableNode(
-            parent_nodes=self.parent_nodes,
+        return SqlTableNode.create(
             sql_table=self.sql_table,
         )

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/test_conversion_count_with_no_group_by__plan0.xml
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/test_conversion_count_with_no_group_by__plan0.xml
@@ -6,15 +6,15 @@ docstring:
 <SqlPlan>
     <SqlSelectStatementNode>
         <!-- description = 'Compute Metrics via Expressions' -->
-        <!-- node_id = NodeId(id_str='ss_133') -->
+        <!-- node_id = NodeId(id_str='ss_207') -->
         <!-- col0 =                                                                                                     -->
         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_180), column_alias='visit_buy_conversions') -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_130) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_206) -->
         <!-- where = None -->
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = 'Combine Aggregated Outputs' -->
-            <!-- node_id = NodeId(id_str='ss_130') -->
+            <!-- node_id = NodeId(id_str='ss_206') -->
             <!-- col0 =                                                                    -->
             <!--   SqlSelectColumn(                                                        -->
             <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_2, sql_function=MAX), -->
@@ -25,10 +25,10 @@ docstring:
             <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_4, sql_function=COALESCE), -->
             <!--     column_alias='buys',                                                       -->
             <!--   )                                                                            -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_112) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_195) -->
             <!-- join_0 =                                                 -->
             <!--   SqlJoinDescription(                                    -->
-            <!--     right_source=SqlSelectStatementNode(node_id=ss_128), -->
+            <!--     right_source=SqlSelectStatementNode(node_id=ss_205), -->
             <!--     right_source_alias='subq_12',                        -->
             <!--     join_type=CROSS_JOIN,                                -->
             <!--   )                                                      -->
@@ -36,25 +36,25 @@ docstring:
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = 'Aggregate Measures' -->
-                <!-- node_id = NodeId(id_str='ss_112') -->
+                <!-- node_id = NodeId(id_str='ss_195') -->
                 <!-- col0 =                                                                    -->
                 <!--   SqlSelectColumn(                                                        -->
                 <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_0, sql_function=SUM), -->
                 <!--     column_alias='visits',                                                -->
                 <!--   )                                                                       -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_110) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_194) -->
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = "Pass Only Elements: ['visits',]" -->
-                    <!-- node_id = NodeId(id_str='ss_110') -->
+                    <!-- node_id = NodeId(id_str='ss_194') -->
                     <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_41), column_alias='visits') -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_108) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_193) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = "Metric Time Dimension 'ds'" -->
-                        <!-- node_id = NodeId(id_str='ss_108') -->
+                        <!-- node_id = NodeId(id_str='ss_193') -->
                         <!-- col0 =                                                                                     -->
                         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_4), column_alias='ds__day') -->
                         <!-- col1 =                                                                                      -->
@@ -236,12 +236,12 @@ docstring:
                         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_0), column_alias='visits') -->
                         <!-- col40 =                                                                                     -->
                         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_1), column_alias='visitors') -->
-                        <!-- from_source = SqlSelectStatementNode(node_id=ss_106) -->
+                        <!-- from_source = SqlSelectStatementNode(node_id=ss_192) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
                         <SqlSelectStatementNode>
                             <!-- description = "Read Elements From Semantic Model 'visits_source'" -->
-                            <!-- node_id = NodeId(id_str='ss_106') -->
+                            <!-- node_id = NodeId(id_str='ss_192') -->
                             <!-- col0 =                                                      -->
                             <!--   SqlSelectColumn(                                          -->
                             <!--     expr=SqlStringExpression(node_id=str_28010 sql_expr=1), -->
@@ -383,12 +383,12 @@ docstring:
                             <!--     expr=SqlColumnReferenceExpression(node_id=cr_28123), -->
                             <!--     column_alias='visit__session',                       -->
                             <!--   )                                                      -->
-                            <!-- from_source = SqlTableNode(node_id=tfc_28011) -->
+                            <!-- from_source = SqlTableNode(node_id=tfc_105) -->
                             <!-- where = None -->
                             <!-- distinct = False -->
                             <SqlTableNode>
                                 <!-- description = 'Read from ***************************.fct_visits' -->
-                                <!-- node_id = NodeId(id_str='tfc_28011') -->
+                                <!-- node_id = NodeId(id_str='tfc_105') -->
                                 <!-- table_id = '***************************.fct_visits' -->
                             </SqlTableNode>
                         </SqlSelectStatementNode>
@@ -397,25 +397,25 @@ docstring:
             </SqlSelectStatementNode>
             <SqlSelectStatementNode>
                 <!-- description = 'Aggregate Measures' -->
-                <!-- node_id = NodeId(id_str='ss_128') -->
+                <!-- node_id = NodeId(id_str='ss_205') -->
                 <!-- col0 =                                                                    -->
                 <!--   SqlSelectColumn(                                                        -->
                 <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_1, sql_function=SUM), -->
                 <!--     column_alias='buys',                                                  -->
                 <!--   )                                                                       -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_126) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_204) -->
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = "Pass Only Elements: ['buys',]" -->
-                    <!-- node_id = NodeId(id_str='ss_126') -->
+                    <!-- node_id = NodeId(id_str='ss_204') -->
                     <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_176), column_alias='buys') -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_124) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_203) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = 'Find conversions for user within the range of 7 day' -->
-                        <!-- node_id = NodeId(id_str='ss_124') -->
+                        <!-- node_id = NodeId(id_str='ss_203') -->
                         <!-- col0 =                                                 -->
                         <!--   SqlSelectColumn(                                     -->
                         <!--     expr=SqlColumnReferenceExpression(node_id=cr_174), -->
@@ -427,12 +427,12 @@ docstring:
                         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_172), column_alias='buys') -->
                         <!-- col3 =                                                                                      -->
                         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_173), column_alias='visits') -->
-                        <!-- from_source = SqlSelectStatementNode(node_id=ss_122) -->
+                        <!-- from_source = SqlSelectStatementNode(node_id=ss_202) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
                         <SqlSelectStatementNode>
                             <!-- description = 'Dedupe the fanout with mf_internal_uuid in the conversion data set' -->
-                            <!-- node_id = NodeId(id_str='ss_122') -->
+                            <!-- node_id = NodeId(id_str='ss_202') -->
                             <!-- col0 =                                                                          -->
                             <!--   SqlSelectColumn(                                                              -->
                             <!--     expr=SqlWindowFunctionExpression(node_id=wfnc_0, sql_function=FIRST_VALUE), -->
@@ -455,10 +455,10 @@ docstring:
                             <!--   )                                                    -->
                             <!-- col4 =                                                                                    -->
                             <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_171), column_alias='buys') -->
-                            <!-- from_source = SqlSelectStatementNode(node_id=ss_115) -->
+                            <!-- from_source = SqlSelectStatementNode(node_id=ss_198) -->
                             <!-- join_0 =                                                 -->
                             <!--   SqlJoinDescription(                                    -->
-                            <!--     right_source=SqlSelectStatementNode(node_id=ss_121), -->
+                            <!--     right_source=SqlSelectStatementNode(node_id=ss_201), -->
                             <!--     right_source_alias='subq_8',                         -->
                             <!--     join_type=INNER,                                     -->
                             <!--     on_condition=SqlLogicalExpression(node_id=lo_1),     -->
@@ -467,7 +467,7 @@ docstring:
                             <!-- distinct = True -->
                             <SqlSelectStatementNode>
                                 <!-- description = "Pass Only Elements: ['visits', 'metric_time__day', 'user']" -->
-                                <!-- node_id = NodeId(id_str='ss_115') -->
+                                <!-- node_id = NodeId(id_str='ss_198') -->
                                 <!-- col0 =                                                -->
                                 <!--   SqlSelectColumn(                                    -->
                                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_44), -->
@@ -483,12 +483,12 @@ docstring:
                                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_43), -->
                                 <!--     column_alias='visits',                            -->
                                 <!--   )                                                   -->
-                                <!-- from_source = SqlSelectStatementNode(node_id=ss_113) -->
+                                <!-- from_source = SqlSelectStatementNode(node_id=ss_197) -->
                                 <!-- where = None -->
                                 <!-- distinct = False -->
                                 <SqlSelectStatementNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->
-                                    <!-- node_id = NodeId(id_str='ss_113') -->
+                                    <!-- node_id = NodeId(id_str='ss_197') -->
                                     <!-- col0 =                                               -->
                                     <!--   SqlSelectColumn(                                   -->
                                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_4), -->
@@ -694,12 +694,12 @@ docstring:
                                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_1), -->
                                     <!--     column_alias='visitors',                         -->
                                     <!--   )                                                  -->
-                                    <!-- from_source = SqlSelectStatementNode(node_id=ss_106) -->
+                                    <!-- from_source = SqlSelectStatementNode(node_id=ss_196) -->
                                     <!-- where = None -->
                                     <!-- distinct = False -->
                                     <SqlSelectStatementNode>
                                         <!-- description = "Read Elements From Semantic Model 'visits_source'" -->
-                                        <!-- node_id = NodeId(id_str='ss_106') -->
+                                        <!-- node_id = NodeId(id_str='ss_196') -->
                                         <!-- col0 =                                                      -->
                                         <!--   SqlSelectColumn(                                          -->
                                         <!--     expr=SqlStringExpression(node_id=str_28010 sql_expr=1), -->
@@ -850,12 +850,12 @@ docstring:
                                         <!--     expr=SqlColumnReferenceExpression(node_id=cr_28123), -->
                                         <!--     column_alias='visit__session',                       -->
                                         <!--   )                                                      -->
-                                        <!-- from_source = SqlTableNode(node_id=tfc_28011) -->
+                                        <!-- from_source = SqlTableNode(node_id=tfc_106) -->
                                         <!-- where = None -->
                                         <!-- distinct = False -->
                                         <SqlTableNode>
                                             <!-- description = 'Read from ***************************.fct_visits' -->
-                                            <!-- node_id = NodeId(id_str='tfc_28011') -->
+                                            <!-- node_id = NodeId(id_str='tfc_106') -->
                                             <!-- table_id = '***************************.fct_visits' -->
                                         </SqlTableNode>
                                     </SqlSelectStatementNode>
@@ -863,7 +863,7 @@ docstring:
                             </SqlSelectStatementNode>
                             <SqlSelectStatementNode>
                                 <!-- description = 'Add column with generated UUID' -->
-                                <!-- node_id = NodeId(id_str='ss_121') -->
+                                <!-- node_id = NodeId(id_str='ss_201') -->
                                 <!-- col0 =                                                -->
                                 <!--   SqlSelectColumn(                                    -->
                                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_99), -->
@@ -1124,12 +1124,12 @@ docstring:
                                 <!--     expr=SqlGenerateUuidExpression(node_id=uuid_0), -->
                                 <!--     column_alias='mf_internal_uuid',                -->
                                 <!--   )                                                 -->
-                                <!-- from_source = SqlSelectStatementNode(node_id=ss_119) -->
+                                <!-- from_source = SqlSelectStatementNode(node_id=ss_200) -->
                                 <!-- where = None -->
                                 <!-- distinct = False -->
                                 <SqlSelectStatementNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->
-                                    <!-- node_id = NodeId(id_str='ss_119') -->
+                                    <!-- node_id = NodeId(id_str='ss_200') -->
                                     <!-- col0 =                                                -->
                                     <!--   SqlSelectColumn(                                    -->
                                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_48), -->
@@ -1385,12 +1385,12 @@ docstring:
                                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_47), -->
                                     <!--     column_alias='buyers',                            -->
                                     <!--   )                                                   -->
-                                    <!-- from_source = SqlSelectStatementNode(node_id=ss_117) -->
+                                    <!-- from_source = SqlSelectStatementNode(node_id=ss_199) -->
                                     <!-- where = None -->
                                     <!-- distinct = False -->
                                     <SqlSelectStatementNode>
                                         <!-- description = "Read Elements From Semantic Model 'buys_source'" -->
-                                        <!-- node_id = NodeId(id_str='ss_117') -->
+                                        <!-- node_id = NodeId(id_str='ss_199') -->
                                         <!-- col0 =                                                      -->
                                         <!--   SqlSelectColumn(                                          -->
                                         <!--     expr=SqlStringExpression(node_id=str_28003 sql_expr=1), -->
@@ -1596,12 +1596,12 @@ docstring:
                                         <!--     expr=SqlColumnReferenceExpression(node_id=cr_28045), -->
                                         <!--     column_alias='buy__session_id',                      -->
                                         <!--   )                                                      -->
-                                        <!-- from_source = SqlTableNode(node_id=tfc_28002) -->
+                                        <!-- from_source = SqlTableNode(node_id=tfc_107) -->
                                         <!-- where = None -->
                                         <!-- distinct = False -->
                                         <SqlTableNode>
                                             <!-- description = 'Read from ***************************.fct_buys' -->
-                                            <!-- node_id = NodeId(id_str='tfc_28002') -->
+                                            <!-- node_id = NodeId(id_str='tfc_107') -->
                                             <!-- table_id = '***************************.fct_buys' -->
                                         </SqlTableNode>
                                     </SqlSelectStatementNode>

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/test_conversion_metric_join_to_timespine_and_fill_nulls_with_0__plan0.xml
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/test_conversion_metric_join_to_timespine_and_fill_nulls_with_0__plan0.xml
@@ -6,19 +6,19 @@ docstring:
 <SqlPlan>
     <SqlSelectStatementNode>
         <!-- description = 'Compute Metrics via Expressions' -->
-        <!-- node_id = NodeId(id_str='ss_150') -->
+        <!-- node_id = NodeId(id_str='ss_217') -->
         <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_222), column_alias='metric_time__day') -->
         <!-- col1 =                                                                -->
         <!--   SqlSelectColumn(                                                    -->
         <!--     expr=SqlRatioComputationExpression(node_id=rc_0),                 -->
         <!--     column_alias='visit_buy_conversion_rate_7days_fill_nulls_with_0', -->
         <!--   )                                                                   -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_147) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_216) -->
         <!-- where = None -->
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = 'Combine Aggregated Outputs' -->
-            <!-- node_id = NodeId(id_str='ss_147') -->
+            <!-- node_id = NodeId(id_str='ss_216') -->
             <!-- col0 =                                                                         -->
             <!--   SqlSelectColumn(                                                             -->
             <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_6, sql_function=COALESCE), -->
@@ -34,10 +34,10 @@ docstring:
             <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_5, sql_function=COALESCE), -->
             <!--     column_alias='buys',                                                       -->
             <!--   )                                                                            -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_122) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_201) -->
             <!-- join_0 =                                                 -->
             <!--   SqlJoinDescription(                                    -->
-            <!--     right_source=SqlSelectStatementNode(node_id=ss_145), -->
+            <!--     right_source=SqlSelectStatementNode(node_id=ss_215), -->
             <!--     right_source_alias='subq_20',                        -->
             <!--     join_type=FULL_OUTER,                                -->
             <!--     on_condition=SqlComparisonExpression(node_id=cmp_5), -->
@@ -51,14 +51,14 @@ docstring:
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = 'Join to Time Spine Dataset' -->
-                <!-- node_id = NodeId(id_str='ss_122') -->
+                <!-- node_id = NodeId(id_str='ss_201') -->
                 <!-- col0 =                                                                                               -->
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_60), column_alias='metric_time__day') -->
                 <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_61), column_alias='visits') -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_120) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_200) -->
                 <!-- join_0 =                                                 -->
                 <!--   SqlJoinDescription(                                    -->
-                <!--     right_source=SqlSelectStatementNode(node_id=ss_114), -->
+                <!--     right_source=SqlSelectStatementNode(node_id=ss_197), -->
                 <!--     right_source_alias='subq_3',                         -->
                 <!--     join_type=LEFT_OUTER,                                -->
                 <!--     on_condition=SqlComparisonExpression(node_id=cmp_0), -->
@@ -67,18 +67,18 @@ docstring:
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = "Pass Only Elements: ['metric_time__day',]" -->
-                    <!-- node_id = NodeId(id_str='ss_120') -->
+                    <!-- node_id = NodeId(id_str='ss_200') -->
                     <!-- col0 =                                                -->
                     <!--   SqlSelectColumn(                                    -->
                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_57), -->
                     <!--     column_alias='metric_time__day',                  -->
                     <!--   )                                                   -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_118) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_199) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = 'Change Column Aliases' -->
-                        <!-- node_id = NodeId(id_str='ss_118') -->
+                        <!-- node_id = NodeId(id_str='ss_199') -->
                         <!-- col0 =                                                -->
                         <!--   SqlSelectColumn(                                    -->
                         <!--     expr=SqlColumnReferenceExpression(node_id=cr_45), -->
@@ -130,12 +130,12 @@ docstring:
                         <!--     expr=SqlColumnReferenceExpression(node_id=cr_56), -->
                         <!--     column_alias='ds__alien_day',                     -->
                         <!--   )                                                   -->
-                        <!-- from_source = SqlSelectStatementNode(node_id=ss_116) -->
+                        <!-- from_source = SqlSelectStatementNode(node_id=ss_198) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
                         <SqlSelectStatementNode>
                             <!-- description = "Read From Time Spine 'mf_time_spine'" -->
-                            <!-- node_id = NodeId(id_str='ss_116') -->
+                            <!-- node_id = NodeId(id_str='ss_198') -->
                             <!-- col0 =                                                   -->
                             <!--   SqlSelectColumn(                                       -->
                             <!--     expr=SqlColumnReferenceExpression(node_id=cr_28130), -->
@@ -190,12 +190,12 @@ docstring:
                             <!--     expr=SqlColumnReferenceExpression(node_id=cr_28131), -->
                             <!--     column_alias='ds__alien_day',                        -->
                             <!--   )                                                      -->
-                            <!-- from_source = SqlTableNode(node_id=tfc_28018) -->
+                            <!-- from_source = SqlTableNode(node_id=tfc_108) -->
                             <!-- where = None -->
                             <!-- distinct = False -->
                             <SqlTableNode>
                                 <!-- description = 'Read from ***************************.mf_time_spine' -->
-                                <!-- node_id = NodeId(id_str='tfc_28018') -->
+                                <!-- node_id = NodeId(id_str='tfc_108') -->
                                 <!-- table_id = '***************************.mf_time_spine' -->
                             </SqlTableNode>
                         </SqlSelectStatementNode>
@@ -203,7 +203,7 @@ docstring:
                 </SqlSelectStatementNode>
                 <SqlSelectStatementNode>
                     <!-- description = 'Aggregate Measures' -->
-                    <!-- node_id = NodeId(id_str='ss_114') -->
+                    <!-- node_id = NodeId(id_str='ss_197') -->
                     <!-- col0 =                                                -->
                     <!--   SqlSelectColumn(                                    -->
                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_44), -->
@@ -214,7 +214,7 @@ docstring:
                     <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_0, sql_function=SUM), -->
                     <!--     column_alias='visits',                                                -->
                     <!--   )                                                                       -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_112) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_196) -->
                     <!-- group_by0 =                                           -->
                     <!--   SqlSelectColumn(                                    -->
                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_44), -->
@@ -224,7 +224,7 @@ docstring:
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = "Pass Only Elements: ['visits', 'metric_time__day']" -->
-                        <!-- node_id = NodeId(id_str='ss_112') -->
+                        <!-- node_id = NodeId(id_str='ss_196') -->
                         <!-- col0 =                                                -->
                         <!--   SqlSelectColumn(                                    -->
                         <!--     expr=SqlColumnReferenceExpression(node_id=cr_42), -->
@@ -232,12 +232,12 @@ docstring:
                         <!--   )                                                   -->
                         <!-- col1 =                                                                                     -->
                         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_41), column_alias='visits') -->
-                        <!-- from_source = SqlSelectStatementNode(node_id=ss_110) -->
+                        <!-- from_source = SqlSelectStatementNode(node_id=ss_195) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
                         <SqlSelectStatementNode>
                             <!-- description = "Metric Time Dimension 'ds'" -->
-                            <!-- node_id = NodeId(id_str='ss_110') -->
+                            <!-- node_id = NodeId(id_str='ss_195') -->
                             <!-- col0 =                                               -->
                             <!--   SqlSelectColumn(                                   -->
                             <!--     expr=SqlColumnReferenceExpression(node_id=cr_4), -->
@@ -437,12 +437,12 @@ docstring:
                             <!--     expr=SqlColumnReferenceExpression(node_id=cr_1), -->
                             <!--     column_alias='visitors',                         -->
                             <!--   )                                                  -->
-                            <!-- from_source = SqlSelectStatementNode(node_id=ss_108) -->
+                            <!-- from_source = SqlSelectStatementNode(node_id=ss_194) -->
                             <!-- where = None -->
                             <!-- distinct = False -->
                             <SqlSelectStatementNode>
                                 <!-- description = "Read Elements From Semantic Model 'visits_source'" -->
-                                <!-- node_id = NodeId(id_str='ss_108') -->
+                                <!-- node_id = NodeId(id_str='ss_194') -->
                                 <!-- col0 =                                                      -->
                                 <!--   SqlSelectColumn(                                          -->
                                 <!--     expr=SqlStringExpression(node_id=str_28010 sql_expr=1), -->
@@ -593,12 +593,12 @@ docstring:
                                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_28123), -->
                                 <!--     column_alias='visit__session',                       -->
                                 <!--   )                                                      -->
-                                <!-- from_source = SqlTableNode(node_id=tfc_28011) -->
+                                <!-- from_source = SqlTableNode(node_id=tfc_107) -->
                                 <!-- where = None -->
                                 <!-- distinct = False -->
                                 <SqlTableNode>
                                     <!-- description = 'Read from ***************************.fct_visits' -->
-                                    <!-- node_id = NodeId(id_str='tfc_28011') -->
+                                    <!-- node_id = NodeId(id_str='tfc_107') -->
                                     <!-- table_id = '***************************.fct_visits' -->
                                 </SqlTableNode>
                             </SqlSelectStatementNode>
@@ -608,14 +608,14 @@ docstring:
             </SqlSelectStatementNode>
             <SqlSelectStatementNode>
                 <!-- description = 'Join to Time Spine Dataset' -->
-                <!-- node_id = NodeId(id_str='ss_145') -->
+                <!-- node_id = NodeId(id_str='ss_215') -->
                 <!-- col0 =                                                                                                -->
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_214), column_alias='metric_time__day') -->
                 <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_215), column_alias='buys') -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_143) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_214) -->
                 <!-- join_0 =                                                 -->
                 <!--   SqlJoinDescription(                                    -->
-                <!--     right_source=SqlSelectStatementNode(node_id=ss_138), -->
+                <!--     right_source=SqlSelectStatementNode(node_id=ss_211), -->
                 <!--     right_source_alias='subq_16',                        -->
                 <!--     join_type=LEFT_OUTER,                                -->
                 <!--     on_condition=SqlComparisonExpression(node_id=cmp_4), -->
@@ -624,18 +624,18 @@ docstring:
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = "Pass Only Elements: ['metric_time__day',]" -->
-                    <!-- node_id = NodeId(id_str='ss_143') -->
+                    <!-- node_id = NodeId(id_str='ss_214') -->
                     <!-- col0 =                                                 -->
                     <!--   SqlSelectColumn(                                     -->
                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_211), -->
                     <!--     column_alias='metric_time__day',                   -->
                     <!--   )                                                    -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_141) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_213) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = 'Change Column Aliases' -->
-                        <!-- node_id = NodeId(id_str='ss_141') -->
+                        <!-- node_id = NodeId(id_str='ss_213') -->
                         <!-- col0 =                                                 -->
                         <!--   SqlSelectColumn(                                     -->
                         <!--     expr=SqlColumnReferenceExpression(node_id=cr_199), -->
@@ -690,12 +690,12 @@ docstring:
                         <!--     expr=SqlColumnReferenceExpression(node_id=cr_210), -->
                         <!--     column_alias='ds__alien_day',                      -->
                         <!--   )                                                    -->
-                        <!-- from_source = SqlSelectStatementNode(node_id=ss_139) -->
+                        <!-- from_source = SqlSelectStatementNode(node_id=ss_212) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
                         <SqlSelectStatementNode>
                             <!-- description = "Read From Time Spine 'mf_time_spine'" -->
-                            <!-- node_id = NodeId(id_str='ss_139') -->
+                            <!-- node_id = NodeId(id_str='ss_212') -->
                             <!-- col0 =                                                   -->
                             <!--   SqlSelectColumn(                                       -->
                             <!--     expr=SqlColumnReferenceExpression(node_id=cr_28130), -->
@@ -750,12 +750,12 @@ docstring:
                             <!--     expr=SqlColumnReferenceExpression(node_id=cr_28131), -->
                             <!--     column_alias='ds__alien_day',                        -->
                             <!--   )                                                      -->
-                            <!-- from_source = SqlTableNode(node_id=tfc_28018) -->
+                            <!-- from_source = SqlTableNode(node_id=tfc_111) -->
                             <!-- where = None -->
                             <!-- distinct = False -->
                             <SqlTableNode>
                                 <!-- description = 'Read from ***************************.mf_time_spine' -->
-                                <!-- node_id = NodeId(id_str='tfc_28018') -->
+                                <!-- node_id = NodeId(id_str='tfc_111') -->
                                 <!-- table_id = '***************************.mf_time_spine' -->
                             </SqlTableNode>
                         </SqlSelectStatementNode>
@@ -763,7 +763,7 @@ docstring:
                 </SqlSelectStatementNode>
                 <SqlSelectStatementNode>
                     <!-- description = 'Aggregate Measures' -->
-                    <!-- node_id = NodeId(id_str='ss_138') -->
+                    <!-- node_id = NodeId(id_str='ss_211') -->
                     <!-- col0 =                                                 -->
                     <!--   SqlSelectColumn(                                     -->
                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_198), -->
@@ -774,7 +774,7 @@ docstring:
                     <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_1, sql_function=SUM), -->
                     <!--     column_alias='buys',                                                  -->
                     <!--   )                                                                       -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_136) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_210) -->
                     <!-- group_by0 =                                            -->
                     <!--   SqlSelectColumn(                                     -->
                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_198), -->
@@ -784,7 +784,7 @@ docstring:
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = "Pass Only Elements: ['buys', 'metric_time__day']" -->
-                        <!-- node_id = NodeId(id_str='ss_136') -->
+                        <!-- node_id = NodeId(id_str='ss_210') -->
                         <!-- col0 =                                                 -->
                         <!--   SqlSelectColumn(                                     -->
                         <!--     expr=SqlColumnReferenceExpression(node_id=cr_196), -->
@@ -792,12 +792,12 @@ docstring:
                         <!--   )                                                    -->
                         <!-- col1 =                                                                                    -->
                         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_195), column_alias='buys') -->
-                        <!-- from_source = SqlSelectStatementNode(node_id=ss_134) -->
+                        <!-- from_source = SqlSelectStatementNode(node_id=ss_209) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
                         <SqlSelectStatementNode>
                             <!-- description = 'Find conversions for user within the range of 7 day' -->
-                            <!-- node_id = NodeId(id_str='ss_134') -->
+                            <!-- node_id = NodeId(id_str='ss_209') -->
                             <!-- col0 =                                                 -->
                             <!--   SqlSelectColumn(                                     -->
                             <!--     expr=SqlColumnReferenceExpression(node_id=cr_193), -->
@@ -812,12 +812,12 @@ docstring:
                             <!--     expr=SqlColumnReferenceExpression(node_id=cr_192), -->
                             <!--     column_alias='visits',                             -->
                             <!--   )                                                    -->
-                            <!-- from_source = SqlSelectStatementNode(node_id=ss_132) -->
+                            <!-- from_source = SqlSelectStatementNode(node_id=ss_208) -->
                             <!-- where = None -->
                             <!-- distinct = False -->
                             <SqlSelectStatementNode>
                                 <!-- description = 'Dedupe the fanout with mf_internal_uuid in the conversion data set' -->
-                                <!-- node_id = NodeId(id_str='ss_132') -->
+                                <!-- node_id = NodeId(id_str='ss_208') -->
                                 <!-- col0 =                                                                          -->
                                 <!--   SqlSelectColumn(                                                              -->
                                 <!--     expr=SqlWindowFunctionExpression(node_id=wfnc_0, sql_function=FIRST_VALUE), -->
@@ -843,10 +843,10 @@ docstring:
                                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_190), -->
                                 <!--     column_alias='buys',                               -->
                                 <!--   )                                                    -->
-                                <!-- from_source = SqlSelectStatementNode(node_id=ss_125) -->
+                                <!-- from_source = SqlSelectStatementNode(node_id=ss_204) -->
                                 <!-- join_0 =                                                 -->
                                 <!--   SqlJoinDescription(                                    -->
-                                <!--     right_source=SqlSelectStatementNode(node_id=ss_131), -->
+                                <!--     right_source=SqlSelectStatementNode(node_id=ss_207), -->
                                 <!--     right_source_alias='subq_12',                        -->
                                 <!--     join_type=INNER,                                     -->
                                 <!--     on_condition=SqlLogicalExpression(node_id=lo_1),     -->
@@ -855,7 +855,7 @@ docstring:
                                 <!-- distinct = True -->
                                 <SqlSelectStatementNode>
                                     <!-- description = "Pass Only Elements: ['visits', 'metric_time__day', 'user']" -->
-                                    <!-- node_id = NodeId(id_str='ss_125') -->
+                                    <!-- node_id = NodeId(id_str='ss_204') -->
                                     <!-- col0 =                                                -->
                                     <!--   SqlSelectColumn(                                    -->
                                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_63), -->
@@ -871,12 +871,12 @@ docstring:
                                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_62), -->
                                     <!--     column_alias='visits',                            -->
                                     <!--   )                                                   -->
-                                    <!-- from_source = SqlSelectStatementNode(node_id=ss_123) -->
+                                    <!-- from_source = SqlSelectStatementNode(node_id=ss_203) -->
                                     <!-- where = None -->
                                     <!-- distinct = False -->
                                     <SqlSelectStatementNode>
                                         <!-- description = "Metric Time Dimension 'ds'" -->
-                                        <!-- node_id = NodeId(id_str='ss_123') -->
+                                        <!-- node_id = NodeId(id_str='ss_203') -->
                                         <!-- col0 =                                               -->
                                         <!--   SqlSelectColumn(                                   -->
                                         <!--     expr=SqlColumnReferenceExpression(node_id=cr_4), -->
@@ -1082,12 +1082,12 @@ docstring:
                                         <!--     expr=SqlColumnReferenceExpression(node_id=cr_1), -->
                                         <!--     column_alias='visitors',                         -->
                                         <!--   )                                                  -->
-                                        <!-- from_source = SqlSelectStatementNode(node_id=ss_108) -->
+                                        <!-- from_source = SqlSelectStatementNode(node_id=ss_202) -->
                                         <!-- where = None -->
                                         <!-- distinct = False -->
                                         <SqlSelectStatementNode>
                                             <!-- description = "Read Elements From Semantic Model 'visits_source'" -->
-                                            <!-- node_id = NodeId(id_str='ss_108') -->
+                                            <!-- node_id = NodeId(id_str='ss_202') -->
                                             <!-- col0 =                                                      -->
                                             <!--   SqlSelectColumn(                                          -->
                                             <!--     expr=SqlStringExpression(node_id=str_28010 sql_expr=1), -->
@@ -1238,12 +1238,12 @@ docstring:
                                             <!--     expr=SqlColumnReferenceExpression(node_id=cr_28123), -->
                                             <!--     column_alias='visit__session',                       -->
                                             <!--   )                                                      -->
-                                            <!-- from_source = SqlTableNode(node_id=tfc_28011) -->
+                                            <!-- from_source = SqlTableNode(node_id=tfc_109) -->
                                             <!-- where = None -->
                                             <!-- distinct = False -->
                                             <SqlTableNode>
                                                 <!-- description = 'Read from ***************************.fct_visits' -->
-                                                <!-- node_id = NodeId(id_str='tfc_28011') -->
+                                                <!-- node_id = NodeId(id_str='tfc_109') -->
                                                 <!-- table_id = '***************************.fct_visits' -->
                                             </SqlTableNode>
                                         </SqlSelectStatementNode>
@@ -1251,7 +1251,7 @@ docstring:
                                 </SqlSelectStatementNode>
                                 <SqlSelectStatementNode>
                                     <!-- description = 'Add column with generated UUID' -->
-                                    <!-- node_id = NodeId(id_str='ss_131') -->
+                                    <!-- node_id = NodeId(id_str='ss_207') -->
                                     <!-- col0 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
                                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_118), -->
@@ -1512,12 +1512,12 @@ docstring:
                                     <!--     expr=SqlGenerateUuidExpression(node_id=uuid_0), -->
                                     <!--     column_alias='mf_internal_uuid',                -->
                                     <!--   )                                                 -->
-                                    <!-- from_source = SqlSelectStatementNode(node_id=ss_129) -->
+                                    <!-- from_source = SqlSelectStatementNode(node_id=ss_206) -->
                                     <!-- where = None -->
                                     <!-- distinct = False -->
                                     <SqlSelectStatementNode>
                                         <!-- description = "Metric Time Dimension 'ds'" -->
-                                        <!-- node_id = NodeId(id_str='ss_129') -->
+                                        <!-- node_id = NodeId(id_str='ss_206') -->
                                         <!-- col0 =                                                -->
                                         <!--   SqlSelectColumn(                                    -->
                                         <!--     expr=SqlColumnReferenceExpression(node_id=cr_67), -->
@@ -1773,12 +1773,12 @@ docstring:
                                         <!--     expr=SqlColumnReferenceExpression(node_id=cr_66), -->
                                         <!--     column_alias='buyers',                            -->
                                         <!--   )                                                   -->
-                                        <!-- from_source = SqlSelectStatementNode(node_id=ss_127) -->
+                                        <!-- from_source = SqlSelectStatementNode(node_id=ss_205) -->
                                         <!-- where = None -->
                                         <!-- distinct = False -->
                                         <SqlSelectStatementNode>
                                             <!-- description = "Read Elements From Semantic Model 'buys_source'" -->
-                                            <!-- node_id = NodeId(id_str='ss_127') -->
+                                            <!-- node_id = NodeId(id_str='ss_205') -->
                                             <!-- col0 =                                                      -->
                                             <!--   SqlSelectColumn(                                          -->
                                             <!--     expr=SqlStringExpression(node_id=str_28003 sql_expr=1), -->
@@ -1984,12 +1984,12 @@ docstring:
                                             <!--     expr=SqlColumnReferenceExpression(node_id=cr_28045), -->
                                             <!--     column_alias='buy__session_id',                      -->
                                             <!--   )                                                      -->
-                                            <!-- from_source = SqlTableNode(node_id=tfc_28002) -->
+                                            <!-- from_source = SqlTableNode(node_id=tfc_110) -->
                                             <!-- where = None -->
                                             <!-- distinct = False -->
                                             <SqlTableNode>
                                                 <!-- description = 'Read from ***************************.fct_buys' -->
-                                                <!-- node_id = NodeId(id_str='tfc_28002') -->
+                                                <!-- node_id = NodeId(id_str='tfc_110') -->
                                                 <!-- table_id = '***************************.fct_buys' -->
                                             </SqlTableNode>
                                         </SqlSelectStatementNode>

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/test_conversion_rate__plan0.xml
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/test_conversion_rate__plan0.xml
@@ -6,17 +6,17 @@ docstring:
 <SqlPlan>
     <SqlSelectStatementNode>
         <!-- description = 'Compute Metrics via Expressions' -->
-        <!-- node_id = NodeId(id_str='ss_137') -->
+        <!-- node_id = NodeId(id_str='ss_215') -->
         <!-- col0 =                                                                                                  -->
         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_196), column_alias='visit__referrer_id') -->
         <!-- col1 =                                                                                                        -->
         <!--   SqlSelectColumn(expr=SqlRatioComputationExpression(node_id=rc_0), column_alias='visit_buy_conversion_rate') -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_134) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_214) -->
         <!-- where = None -->
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = 'Combine Aggregated Outputs' -->
-            <!-- node_id = NodeId(id_str='ss_134') -->
+            <!-- node_id = NodeId(id_str='ss_214') -->
             <!-- col0 =                                                                         -->
             <!--   SqlSelectColumn(                                                             -->
             <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_4, sql_function=COALESCE), -->
@@ -32,10 +32,10 @@ docstring:
             <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_3, sql_function=MAX), -->
             <!--     column_alias='buys',                                                  -->
             <!--   )                                                                       -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_116) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_203) -->
             <!-- join_0 =                                                 -->
             <!--   SqlJoinDescription(                                    -->
-            <!--     right_source=SqlSelectStatementNode(node_id=ss_132), -->
+            <!--     right_source=SqlSelectStatementNode(node_id=ss_213), -->
             <!--     right_source_alias='subq_12',                        -->
             <!--     join_type=FULL_OUTER,                                -->
             <!--     on_condition=SqlComparisonExpression(node_id=cmp_2), -->
@@ -49,7 +49,7 @@ docstring:
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = 'Aggregate Measures' -->
-                <!-- node_id = NodeId(id_str='ss_116') -->
+                <!-- node_id = NodeId(id_str='ss_203') -->
                 <!-- col0 =                                                -->
                 <!--   SqlSelectColumn(                                    -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_44), -->
@@ -60,7 +60,7 @@ docstring:
                 <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_0, sql_function=SUM), -->
                 <!--     column_alias='visits',                                                -->
                 <!--   )                                                                       -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_114) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_202) -->
                 <!-- group_by0 =                                           -->
                 <!--   SqlSelectColumn(                                    -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_44), -->
@@ -70,19 +70,19 @@ docstring:
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = "Pass Only Elements: ['visits', 'visit__referrer_id']" -->
-                    <!-- node_id = NodeId(id_str='ss_114') -->
+                    <!-- node_id = NodeId(id_str='ss_202') -->
                     <!-- col0 =                                                -->
                     <!--   SqlSelectColumn(                                    -->
                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_42), -->
                     <!--     column_alias='visit__referrer_id',                -->
                     <!--   )                                                   -->
                     <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_41), column_alias='visits') -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_112) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_201) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = "Metric Time Dimension 'ds'" -->
-                        <!-- node_id = NodeId(id_str='ss_112') -->
+                        <!-- node_id = NodeId(id_str='ss_201') -->
                         <!-- col0 =                                                                                     -->
                         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_4), column_alias='ds__day') -->
                         <!-- col1 =                                                                                      -->
@@ -264,12 +264,12 @@ docstring:
                         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_0), column_alias='visits') -->
                         <!-- col40 =                                                                                     -->
                         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_1), column_alias='visitors') -->
-                        <!-- from_source = SqlSelectStatementNode(node_id=ss_110) -->
+                        <!-- from_source = SqlSelectStatementNode(node_id=ss_200) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
                         <SqlSelectStatementNode>
                             <!-- description = "Read Elements From Semantic Model 'visits_source'" -->
-                            <!-- node_id = NodeId(id_str='ss_110') -->
+                            <!-- node_id = NodeId(id_str='ss_200') -->
                             <!-- col0 =                                                      -->
                             <!--   SqlSelectColumn(                                          -->
                             <!--     expr=SqlStringExpression(node_id=str_28010 sql_expr=1), -->
@@ -411,12 +411,12 @@ docstring:
                             <!--     expr=SqlColumnReferenceExpression(node_id=cr_28123), -->
                             <!--     column_alias='visit__session',                       -->
                             <!--   )                                                      -->
-                            <!-- from_source = SqlTableNode(node_id=tfc_28011) -->
+                            <!-- from_source = SqlTableNode(node_id=tfc_109) -->
                             <!-- where = None -->
                             <!-- distinct = False -->
                             <SqlTableNode>
                                 <!-- description = 'Read from ***************************.fct_visits' -->
-                                <!-- node_id = NodeId(id_str='tfc_28011') -->
+                                <!-- node_id = NodeId(id_str='tfc_109') -->
                                 <!-- table_id = '***************************.fct_visits' -->
                             </SqlTableNode>
                         </SqlSelectStatementNode>
@@ -425,7 +425,7 @@ docstring:
             </SqlSelectStatementNode>
             <SqlSelectStatementNode>
                 <!-- description = 'Aggregate Measures' -->
-                <!-- node_id = NodeId(id_str='ss_132') -->
+                <!-- node_id = NodeId(id_str='ss_213') -->
                 <!-- col0 =                                                 -->
                 <!--   SqlSelectColumn(                                     -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_189), -->
@@ -436,7 +436,7 @@ docstring:
                 <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_1, sql_function=SUM), -->
                 <!--     column_alias='buys',                                                  -->
                 <!--   )                                                                       -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_130) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_212) -->
                 <!-- group_by0 =                                            -->
                 <!--   SqlSelectColumn(                                     -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_189), -->
@@ -446,19 +446,19 @@ docstring:
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = "Pass Only Elements: ['buys', 'visit__referrer_id']" -->
-                    <!-- node_id = NodeId(id_str='ss_130') -->
+                    <!-- node_id = NodeId(id_str='ss_212') -->
                     <!-- col0 =                                                 -->
                     <!--   SqlSelectColumn(                                     -->
                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_187), -->
                     <!--     column_alias='visit__referrer_id',                 -->
                     <!--   )                                                    -->
                     <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_186), column_alias='buys') -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_128) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_211) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = 'Find conversions for user within the range of INF' -->
-                        <!-- node_id = NodeId(id_str='ss_128') -->
+                        <!-- node_id = NodeId(id_str='ss_211') -->
                         <!-- col0 =                                                 -->
                         <!--   SqlSelectColumn(                                     -->
                         <!--     expr=SqlColumnReferenceExpression(node_id=cr_184), -->
@@ -475,12 +475,12 @@ docstring:
                         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_181), column_alias='buys') -->
                         <!-- col4 =                                                                                      -->
                         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_182), column_alias='visits') -->
-                        <!-- from_source = SqlSelectStatementNode(node_id=ss_126) -->
+                        <!-- from_source = SqlSelectStatementNode(node_id=ss_210) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
                         <SqlSelectStatementNode>
                             <!-- description = 'Dedupe the fanout with mf_internal_uuid in the conversion data set' -->
-                            <!-- node_id = NodeId(id_str='ss_126') -->
+                            <!-- node_id = NodeId(id_str='ss_210') -->
                             <!-- col0 =                                                                          -->
                             <!--   SqlSelectColumn(                                                              -->
                             <!--     expr=SqlWindowFunctionExpression(node_id=wfnc_0, sql_function=FIRST_VALUE), -->
@@ -508,10 +508,10 @@ docstring:
                             <!--   )                                                    -->
                             <!-- col5 =                                                                                    -->
                             <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_180), column_alias='buys') -->
-                            <!-- from_source = SqlSelectStatementNode(node_id=ss_119) -->
+                            <!-- from_source = SqlSelectStatementNode(node_id=ss_206) -->
                             <!-- join_0 =                                                 -->
                             <!--   SqlJoinDescription(                                    -->
-                            <!--     right_source=SqlSelectStatementNode(node_id=ss_125), -->
+                            <!--     right_source=SqlSelectStatementNode(node_id=ss_209), -->
                             <!--     right_source_alias='subq_8',                         -->
                             <!--     join_type=INNER,                                     -->
                             <!--     on_condition=SqlLogicalExpression(node_id=lo_1),     -->
@@ -521,7 +521,7 @@ docstring:
                             <SqlSelectStatementNode>
                                 <!-- description =                                                                        -->
                                 <!--   "Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user']" -->
-                                <!-- node_id = NodeId(id_str='ss_119') -->
+                                <!-- node_id = NodeId(id_str='ss_206') -->
                                 <!-- col0 =                                                -->
                                 <!--   SqlSelectColumn(                                    -->
                                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_47), -->
@@ -542,12 +542,12 @@ docstring:
                                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_45), -->
                                 <!--     column_alias='visits',                            -->
                                 <!--   )                                                   -->
-                                <!-- from_source = SqlSelectStatementNode(node_id=ss_117) -->
+                                <!-- from_source = SqlSelectStatementNode(node_id=ss_205) -->
                                 <!-- where = None -->
                                 <!-- distinct = False -->
                                 <SqlSelectStatementNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->
-                                    <!-- node_id = NodeId(id_str='ss_117') -->
+                                    <!-- node_id = NodeId(id_str='ss_205') -->
                                     <!-- col0 =                                               -->
                                     <!--   SqlSelectColumn(                                   -->
                                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_4), -->
@@ -753,12 +753,12 @@ docstring:
                                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_1), -->
                                     <!--     column_alias='visitors',                         -->
                                     <!--   )                                                  -->
-                                    <!-- from_source = SqlSelectStatementNode(node_id=ss_110) -->
+                                    <!-- from_source = SqlSelectStatementNode(node_id=ss_204) -->
                                     <!-- where = None -->
                                     <!-- distinct = False -->
                                     <SqlSelectStatementNode>
                                         <!-- description = "Read Elements From Semantic Model 'visits_source'" -->
-                                        <!-- node_id = NodeId(id_str='ss_110') -->
+                                        <!-- node_id = NodeId(id_str='ss_204') -->
                                         <!-- col0 =                                                      -->
                                         <!--   SqlSelectColumn(                                          -->
                                         <!--     expr=SqlStringExpression(node_id=str_28010 sql_expr=1), -->
@@ -909,12 +909,12 @@ docstring:
                                         <!--     expr=SqlColumnReferenceExpression(node_id=cr_28123), -->
                                         <!--     column_alias='visit__session',                       -->
                                         <!--   )                                                      -->
-                                        <!-- from_source = SqlTableNode(node_id=tfc_28011) -->
+                                        <!-- from_source = SqlTableNode(node_id=tfc_110) -->
                                         <!-- where = None -->
                                         <!-- distinct = False -->
                                         <SqlTableNode>
                                             <!-- description = 'Read from ***************************.fct_visits' -->
-                                            <!-- node_id = NodeId(id_str='tfc_28011') -->
+                                            <!-- node_id = NodeId(id_str='tfc_110') -->
                                             <!-- table_id = '***************************.fct_visits' -->
                                         </SqlTableNode>
                                     </SqlSelectStatementNode>
@@ -922,7 +922,7 @@ docstring:
                             </SqlSelectStatementNode>
                             <SqlSelectStatementNode>
                                 <!-- description = 'Add column with generated UUID' -->
-                                <!-- node_id = NodeId(id_str='ss_125') -->
+                                <!-- node_id = NodeId(id_str='ss_209') -->
                                 <!-- col0 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
                                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_102), -->
@@ -1183,12 +1183,12 @@ docstring:
                                 <!--     expr=SqlGenerateUuidExpression(node_id=uuid_0), -->
                                 <!--     column_alias='mf_internal_uuid',                -->
                                 <!--   )                                                 -->
-                                <!-- from_source = SqlSelectStatementNode(node_id=ss_123) -->
+                                <!-- from_source = SqlSelectStatementNode(node_id=ss_208) -->
                                 <!-- where = None -->
                                 <!-- distinct = False -->
                                 <SqlSelectStatementNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->
-                                    <!-- node_id = NodeId(id_str='ss_123') -->
+                                    <!-- node_id = NodeId(id_str='ss_208') -->
                                     <!-- col0 =                                                -->
                                     <!--   SqlSelectColumn(                                    -->
                                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_51), -->
@@ -1444,12 +1444,12 @@ docstring:
                                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_50), -->
                                     <!--     column_alias='buyers',                            -->
                                     <!--   )                                                   -->
-                                    <!-- from_source = SqlSelectStatementNode(node_id=ss_121) -->
+                                    <!-- from_source = SqlSelectStatementNode(node_id=ss_207) -->
                                     <!-- where = None -->
                                     <!-- distinct = False -->
                                     <SqlSelectStatementNode>
                                         <!-- description = "Read Elements From Semantic Model 'buys_source'" -->
-                                        <!-- node_id = NodeId(id_str='ss_121') -->
+                                        <!-- node_id = NodeId(id_str='ss_207') -->
                                         <!-- col0 =                                                      -->
                                         <!--   SqlSelectColumn(                                          -->
                                         <!--     expr=SqlStringExpression(node_id=str_28003 sql_expr=1), -->
@@ -1655,12 +1655,12 @@ docstring:
                                         <!--     expr=SqlColumnReferenceExpression(node_id=cr_28045), -->
                                         <!--     column_alias='buy__session_id',                      -->
                                         <!--   )                                                      -->
-                                        <!-- from_source = SqlTableNode(node_id=tfc_28002) -->
+                                        <!-- from_source = SqlTableNode(node_id=tfc_111) -->
                                         <!-- where = None -->
                                         <!-- distinct = False -->
                                         <SqlTableNode>
                                             <!-- description = 'Read from ***************************.fct_buys' -->
-                                            <!-- node_id = NodeId(id_str='tfc_28002') -->
+                                            <!-- node_id = NodeId(id_str='tfc_111') -->
                                             <!-- table_id = '***************************.fct_buys' -->
                                         </SqlTableNode>
                                     </SqlSelectStatementNode>

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/test_conversion_rate_with_constant_properties__plan0.xml
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/test_conversion_rate_with_constant_properties__plan0.xml
@@ -6,7 +6,7 @@ docstring:
 <SqlPlan>
     <SqlSelectStatementNode>
         <!-- description = 'Compute Metrics via Expressions' -->
-        <!-- node_id = NodeId(id_str='ss_137') -->
+        <!-- node_id = NodeId(id_str='ss_215') -->
         <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_220), column_alias='metric_time__day') -->
         <!-- col1 =                                                                                                  -->
         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_219), column_alias='visit__referrer_id') -->
@@ -15,12 +15,12 @@ docstring:
         <!--     expr=SqlRatioComputationExpression(node_id=rc_0),    -->
         <!--     column_alias='visit_buy_conversion_rate_by_session', -->
         <!--   )                                                      -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_134) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_214) -->
         <!-- where = None -->
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = 'Combine Aggregated Outputs' -->
-            <!-- node_id = NodeId(id_str='ss_134') -->
+            <!-- node_id = NodeId(id_str='ss_214') -->
             <!-- col0 =                                                                         -->
             <!--   SqlSelectColumn(                                                             -->
             <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_5, sql_function=COALESCE), -->
@@ -41,10 +41,10 @@ docstring:
             <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_3, sql_function=MAX), -->
             <!--     column_alias='buys',                                                  -->
             <!--   )                                                                       -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_116) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_203) -->
             <!-- join_0 =                                                 -->
             <!--   SqlJoinDescription(                                    -->
-            <!--     right_source=SqlSelectStatementNode(node_id=ss_132), -->
+            <!--     right_source=SqlSelectStatementNode(node_id=ss_213), -->
             <!--     right_source_alias='subq_12',                        -->
             <!--     join_type=FULL_OUTER,                                -->
             <!--     on_condition=SqlLogicalExpression(node_id=lo_2),     -->
@@ -63,7 +63,7 @@ docstring:
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = 'Aggregate Measures' -->
-                <!-- node_id = NodeId(id_str='ss_116') -->
+                <!-- node_id = NodeId(id_str='ss_203') -->
                 <!-- col0 =                                                                                               -->
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_46), column_alias='metric_time__day') -->
                 <!-- col1 =                                                -->
@@ -76,7 +76,7 @@ docstring:
                 <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_0, sql_function=SUM), -->
                 <!--     column_alias='visits',                                                -->
                 <!--   )                                                                       -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_114) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_202) -->
                 <!-- group_by0 =                                                                                          -->
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_46), column_alias='metric_time__day') -->
                 <!-- group_by1 =                                           -->
@@ -88,7 +88,7 @@ docstring:
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = "Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']" -->
-                    <!-- node_id = NodeId(id_str='ss_114') -->
+                    <!-- node_id = NodeId(id_str='ss_202') -->
                     <!-- col0 =                                                -->
                     <!--   SqlSelectColumn(                                    -->
                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_43), -->
@@ -100,12 +100,12 @@ docstring:
                     <!--     column_alias='visit__referrer_id',                -->
                     <!--   )                                                   -->
                     <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_41), column_alias='visits') -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_112) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_201) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = "Metric Time Dimension 'ds'" -->
-                        <!-- node_id = NodeId(id_str='ss_112') -->
+                        <!-- node_id = NodeId(id_str='ss_201') -->
                         <!-- col0 =                                                                                     -->
                         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_4), column_alias='ds__day') -->
                         <!-- col1 =                                                                                      -->
@@ -287,12 +287,12 @@ docstring:
                         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_0), column_alias='visits') -->
                         <!-- col40 =                                                                                     -->
                         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_1), column_alias='visitors') -->
-                        <!-- from_source = SqlSelectStatementNode(node_id=ss_110) -->
+                        <!-- from_source = SqlSelectStatementNode(node_id=ss_200) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
                         <SqlSelectStatementNode>
                             <!-- description = "Read Elements From Semantic Model 'visits_source'" -->
-                            <!-- node_id = NodeId(id_str='ss_110') -->
+                            <!-- node_id = NodeId(id_str='ss_200') -->
                             <!-- col0 =                                                      -->
                             <!--   SqlSelectColumn(                                          -->
                             <!--     expr=SqlStringExpression(node_id=str_28010 sql_expr=1), -->
@@ -434,12 +434,12 @@ docstring:
                             <!--     expr=SqlColumnReferenceExpression(node_id=cr_28123), -->
                             <!--     column_alias='visit__session',                       -->
                             <!--   )                                                      -->
-                            <!-- from_source = SqlTableNode(node_id=tfc_28011) -->
+                            <!-- from_source = SqlTableNode(node_id=tfc_109) -->
                             <!-- where = None -->
                             <!-- distinct = False -->
                             <SqlTableNode>
                                 <!-- description = 'Read from ***************************.fct_visits' -->
-                                <!-- node_id = NodeId(id_str='tfc_28011') -->
+                                <!-- node_id = NodeId(id_str='tfc_109') -->
                                 <!-- table_id = '***************************.fct_visits' -->
                             </SqlTableNode>
                         </SqlSelectStatementNode>
@@ -448,7 +448,7 @@ docstring:
             </SqlSelectStatementNode>
             <SqlSelectStatementNode>
                 <!-- description = 'Aggregate Measures' -->
-                <!-- node_id = NodeId(id_str='ss_132') -->
+                <!-- node_id = NodeId(id_str='ss_213') -->
                 <!-- col0 =                                                                                                -->
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_208), column_alias='metric_time__day') -->
                 <!-- col1 =                                                 -->
@@ -461,7 +461,7 @@ docstring:
                 <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_1, sql_function=SUM), -->
                 <!--     column_alias='buys',                                                  -->
                 <!--   )                                                                       -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_130) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_212) -->
                 <!-- group_by0 =                                                                                           -->
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_208), column_alias='metric_time__day') -->
                 <!-- group_by1 =                                            -->
@@ -473,7 +473,7 @@ docstring:
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = "Pass Only Elements: ['buys', 'visit__referrer_id', 'metric_time__day']" -->
-                    <!-- node_id = NodeId(id_str='ss_130') -->
+                    <!-- node_id = NodeId(id_str='ss_212') -->
                     <!-- col0 =                                                 -->
                     <!--   SqlSelectColumn(                                     -->
                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_205), -->
@@ -485,12 +485,12 @@ docstring:
                     <!--     column_alias='visit__referrer_id',                 -->
                     <!--   )                                                    -->
                     <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_203), column_alias='buys') -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_128) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_211) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = 'Find conversions for user within the range of 7 day' -->
-                        <!-- node_id = NodeId(id_str='ss_128') -->
+                        <!-- node_id = NodeId(id_str='ss_211') -->
                         <!-- col0 =                                                 -->
                         <!--   SqlSelectColumn(                                     -->
                         <!--     expr=SqlColumnReferenceExpression(node_id=cr_200), -->
@@ -509,12 +509,12 @@ docstring:
                         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_197), column_alias='buys') -->
                         <!-- col5 =                                                                                      -->
                         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_198), column_alias='visits') -->
-                        <!-- from_source = SqlSelectStatementNode(node_id=ss_126) -->
+                        <!-- from_source = SqlSelectStatementNode(node_id=ss_210) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
                         <SqlSelectStatementNode>
                             <!-- description = 'Dedupe the fanout with mf_internal_uuid in the conversion data set' -->
-                            <!-- node_id = NodeId(id_str='ss_126') -->
+                            <!-- node_id = NodeId(id_str='ss_210') -->
                             <!-- col0 =                                                                          -->
                             <!--   SqlSelectColumn(                                                              -->
                             <!--     expr=SqlWindowFunctionExpression(node_id=wfnc_0, sql_function=FIRST_VALUE), -->
@@ -547,10 +547,10 @@ docstring:
                             <!--   )                                                    -->
                             <!-- col6 =                                                                                    -->
                             <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_196), column_alias='buys') -->
-                            <!-- from_source = SqlSelectStatementNode(node_id=ss_119) -->
+                            <!-- from_source = SqlSelectStatementNode(node_id=ss_206) -->
                             <!-- join_0 =                                                 -->
                             <!--   SqlJoinDescription(                                    -->
-                            <!--     right_source=SqlSelectStatementNode(node_id=ss_125), -->
+                            <!--     right_source=SqlSelectStatementNode(node_id=ss_209), -->
                             <!--     right_source_alias='subq_8',                         -->
                             <!--     join_type=INNER,                                     -->
                             <!--     on_condition=SqlLogicalExpression(node_id=lo_1),     -->
@@ -561,7 +561,7 @@ docstring:
                                 <!-- description =                                                                  -->
                                 <!--   ("Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', " -->
                                 <!--    "'user', 'session']")                                                       -->
-                                <!-- node_id = NodeId(id_str='ss_119') -->
+                                <!-- node_id = NodeId(id_str='ss_206') -->
                                 <!-- col0 =                                                -->
                                 <!--   SqlSelectColumn(                                    -->
                                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_49), -->
@@ -587,12 +587,12 @@ docstring:
                                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_47), -->
                                 <!--     column_alias='visits',                            -->
                                 <!--   )                                                   -->
-                                <!-- from_source = SqlSelectStatementNode(node_id=ss_117) -->
+                                <!-- from_source = SqlSelectStatementNode(node_id=ss_205) -->
                                 <!-- where = None -->
                                 <!-- distinct = False -->
                                 <SqlSelectStatementNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->
-                                    <!-- node_id = NodeId(id_str='ss_117') -->
+                                    <!-- node_id = NodeId(id_str='ss_205') -->
                                     <!-- col0 =                                               -->
                                     <!--   SqlSelectColumn(                                   -->
                                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_4), -->
@@ -798,12 +798,12 @@ docstring:
                                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_1), -->
                                     <!--     column_alias='visitors',                         -->
                                     <!--   )                                                  -->
-                                    <!-- from_source = SqlSelectStatementNode(node_id=ss_110) -->
+                                    <!-- from_source = SqlSelectStatementNode(node_id=ss_204) -->
                                     <!-- where = None -->
                                     <!-- distinct = False -->
                                     <SqlSelectStatementNode>
                                         <!-- description = "Read Elements From Semantic Model 'visits_source'" -->
-                                        <!-- node_id = NodeId(id_str='ss_110') -->
+                                        <!-- node_id = NodeId(id_str='ss_204') -->
                                         <!-- col0 =                                                      -->
                                         <!--   SqlSelectColumn(                                          -->
                                         <!--     expr=SqlStringExpression(node_id=str_28010 sql_expr=1), -->
@@ -954,12 +954,12 @@ docstring:
                                         <!--     expr=SqlColumnReferenceExpression(node_id=cr_28123), -->
                                         <!--     column_alias='visit__session',                       -->
                                         <!--   )                                                      -->
-                                        <!-- from_source = SqlTableNode(node_id=tfc_28011) -->
+                                        <!-- from_source = SqlTableNode(node_id=tfc_110) -->
                                         <!-- where = None -->
                                         <!-- distinct = False -->
                                         <SqlTableNode>
                                             <!-- description = 'Read from ***************************.fct_visits' -->
-                                            <!-- node_id = NodeId(id_str='tfc_28011') -->
+                                            <!-- node_id = NodeId(id_str='tfc_110') -->
                                             <!-- table_id = '***************************.fct_visits' -->
                                         </SqlTableNode>
                                     </SqlSelectStatementNode>
@@ -967,7 +967,7 @@ docstring:
                             </SqlSelectStatementNode>
                             <SqlSelectStatementNode>
                                 <!-- description = 'Add column with generated UUID' -->
-                                <!-- node_id = NodeId(id_str='ss_125') -->
+                                <!-- node_id = NodeId(id_str='ss_209') -->
                                 <!-- col0 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
                                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_105), -->
@@ -1228,12 +1228,12 @@ docstring:
                                 <!--     expr=SqlGenerateUuidExpression(node_id=uuid_0), -->
                                 <!--     column_alias='mf_internal_uuid',                -->
                                 <!--   )                                                 -->
-                                <!-- from_source = SqlSelectStatementNode(node_id=ss_123) -->
+                                <!-- from_source = SqlSelectStatementNode(node_id=ss_208) -->
                                 <!-- where = None -->
                                 <!-- distinct = False -->
                                 <SqlSelectStatementNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->
-                                    <!-- node_id = NodeId(id_str='ss_123') -->
+                                    <!-- node_id = NodeId(id_str='ss_208') -->
                                     <!-- col0 =                                                -->
                                     <!--   SqlSelectColumn(                                    -->
                                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_54), -->
@@ -1489,12 +1489,12 @@ docstring:
                                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_53), -->
                                     <!--     column_alias='buyers',                            -->
                                     <!--   )                                                   -->
-                                    <!-- from_source = SqlSelectStatementNode(node_id=ss_121) -->
+                                    <!-- from_source = SqlSelectStatementNode(node_id=ss_207) -->
                                     <!-- where = None -->
                                     <!-- distinct = False -->
                                     <SqlSelectStatementNode>
                                         <!-- description = "Read Elements From Semantic Model 'buys_source'" -->
-                                        <!-- node_id = NodeId(id_str='ss_121') -->
+                                        <!-- node_id = NodeId(id_str='ss_207') -->
                                         <!-- col0 =                                                      -->
                                         <!--   SqlSelectColumn(                                          -->
                                         <!--     expr=SqlStringExpression(node_id=str_28003 sql_expr=1), -->
@@ -1700,12 +1700,12 @@ docstring:
                                         <!--     expr=SqlColumnReferenceExpression(node_id=cr_28045), -->
                                         <!--     column_alias='buy__session_id',                      -->
                                         <!--   )                                                      -->
-                                        <!-- from_source = SqlTableNode(node_id=tfc_28002) -->
+                                        <!-- from_source = SqlTableNode(node_id=tfc_111) -->
                                         <!-- where = None -->
                                         <!-- distinct = False -->
                                         <SqlTableNode>
                                             <!-- description = 'Read from ***************************.fct_buys' -->
-                                            <!-- node_id = NodeId(id_str='tfc_28002') -->
+                                            <!-- node_id = NodeId(id_str='tfc_111') -->
                                             <!-- table_id = '***************************.fct_buys' -->
                                         </SqlTableNode>
                                     </SqlSelectStatementNode>

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/test_conversion_rate_with_no_group_by__plan0.xml
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/test_conversion_rate_with_no_group_by__plan0.xml
@@ -6,18 +6,18 @@ docstring:
 <SqlPlan>
     <SqlSelectStatementNode>
         <!-- description = 'Compute Metrics via Expressions' -->
-        <!-- node_id = NodeId(id_str='ss_133') -->
+        <!-- node_id = NodeId(id_str='ss_207') -->
         <!-- col0 =                                                -->
         <!--   SqlSelectColumn(                                    -->
         <!--     expr=SqlRatioComputationExpression(node_id=rc_0), -->
         <!--     column_alias='visit_buy_conversion_rate_7days',   -->
         <!--   )                                                   -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_130) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_206) -->
         <!-- where = None -->
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = 'Combine Aggregated Outputs' -->
-            <!-- node_id = NodeId(id_str='ss_130') -->
+            <!-- node_id = NodeId(id_str='ss_206') -->
             <!-- col0 =                                                                    -->
             <!--   SqlSelectColumn(                                                        -->
             <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_2, sql_function=MAX), -->
@@ -28,10 +28,10 @@ docstring:
             <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_3, sql_function=MAX), -->
             <!--     column_alias='buys',                                                  -->
             <!--   )                                                                       -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_112) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_195) -->
             <!-- join_0 =                                                 -->
             <!--   SqlJoinDescription(                                    -->
-            <!--     right_source=SqlSelectStatementNode(node_id=ss_128), -->
+            <!--     right_source=SqlSelectStatementNode(node_id=ss_205), -->
             <!--     right_source_alias='subq_12',                        -->
             <!--     join_type=CROSS_JOIN,                                -->
             <!--   )                                                      -->
@@ -39,25 +39,25 @@ docstring:
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = 'Aggregate Measures' -->
-                <!-- node_id = NodeId(id_str='ss_112') -->
+                <!-- node_id = NodeId(id_str='ss_195') -->
                 <!-- col0 =                                                                    -->
                 <!--   SqlSelectColumn(                                                        -->
                 <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_0, sql_function=SUM), -->
                 <!--     column_alias='visits',                                                -->
                 <!--   )                                                                       -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_110) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_194) -->
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = "Pass Only Elements: ['visits',]" -->
-                    <!-- node_id = NodeId(id_str='ss_110') -->
+                    <!-- node_id = NodeId(id_str='ss_194') -->
                     <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_41), column_alias='visits') -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_108) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_193) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = "Metric Time Dimension 'ds'" -->
-                        <!-- node_id = NodeId(id_str='ss_108') -->
+                        <!-- node_id = NodeId(id_str='ss_193') -->
                         <!-- col0 =                                                                                     -->
                         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_4), column_alias='ds__day') -->
                         <!-- col1 =                                                                                      -->
@@ -239,12 +239,12 @@ docstring:
                         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_0), column_alias='visits') -->
                         <!-- col40 =                                                                                     -->
                         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_1), column_alias='visitors') -->
-                        <!-- from_source = SqlSelectStatementNode(node_id=ss_106) -->
+                        <!-- from_source = SqlSelectStatementNode(node_id=ss_192) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
                         <SqlSelectStatementNode>
                             <!-- description = "Read Elements From Semantic Model 'visits_source'" -->
-                            <!-- node_id = NodeId(id_str='ss_106') -->
+                            <!-- node_id = NodeId(id_str='ss_192') -->
                             <!-- col0 =                                                      -->
                             <!--   SqlSelectColumn(                                          -->
                             <!--     expr=SqlStringExpression(node_id=str_28010 sql_expr=1), -->
@@ -386,12 +386,12 @@ docstring:
                             <!--     expr=SqlColumnReferenceExpression(node_id=cr_28123), -->
                             <!--     column_alias='visit__session',                       -->
                             <!--   )                                                      -->
-                            <!-- from_source = SqlTableNode(node_id=tfc_28011) -->
+                            <!-- from_source = SqlTableNode(node_id=tfc_105) -->
                             <!-- where = None -->
                             <!-- distinct = False -->
                             <SqlTableNode>
                                 <!-- description = 'Read from ***************************.fct_visits' -->
-                                <!-- node_id = NodeId(id_str='tfc_28011') -->
+                                <!-- node_id = NodeId(id_str='tfc_105') -->
                                 <!-- table_id = '***************************.fct_visits' -->
                             </SqlTableNode>
                         </SqlSelectStatementNode>
@@ -400,25 +400,25 @@ docstring:
             </SqlSelectStatementNode>
             <SqlSelectStatementNode>
                 <!-- description = 'Aggregate Measures' -->
-                <!-- node_id = NodeId(id_str='ss_128') -->
+                <!-- node_id = NodeId(id_str='ss_205') -->
                 <!-- col0 =                                                                    -->
                 <!--   SqlSelectColumn(                                                        -->
                 <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_1, sql_function=SUM), -->
                 <!--     column_alias='buys',                                                  -->
                 <!--   )                                                                       -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_126) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_204) -->
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = "Pass Only Elements: ['buys',]" -->
-                    <!-- node_id = NodeId(id_str='ss_126') -->
+                    <!-- node_id = NodeId(id_str='ss_204') -->
                     <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_176), column_alias='buys') -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_124) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_203) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = 'Find conversions for user within the range of 7 day' -->
-                        <!-- node_id = NodeId(id_str='ss_124') -->
+                        <!-- node_id = NodeId(id_str='ss_203') -->
                         <!-- col0 =                                                 -->
                         <!--   SqlSelectColumn(                                     -->
                         <!--     expr=SqlColumnReferenceExpression(node_id=cr_174), -->
@@ -430,12 +430,12 @@ docstring:
                         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_172), column_alias='buys') -->
                         <!-- col3 =                                                                                      -->
                         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_173), column_alias='visits') -->
-                        <!-- from_source = SqlSelectStatementNode(node_id=ss_122) -->
+                        <!-- from_source = SqlSelectStatementNode(node_id=ss_202) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
                         <SqlSelectStatementNode>
                             <!-- description = 'Dedupe the fanout with mf_internal_uuid in the conversion data set' -->
-                            <!-- node_id = NodeId(id_str='ss_122') -->
+                            <!-- node_id = NodeId(id_str='ss_202') -->
                             <!-- col0 =                                                                          -->
                             <!--   SqlSelectColumn(                                                              -->
                             <!--     expr=SqlWindowFunctionExpression(node_id=wfnc_0, sql_function=FIRST_VALUE), -->
@@ -458,10 +458,10 @@ docstring:
                             <!--   )                                                    -->
                             <!-- col4 =                                                                                    -->
                             <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_171), column_alias='buys') -->
-                            <!-- from_source = SqlSelectStatementNode(node_id=ss_115) -->
+                            <!-- from_source = SqlSelectStatementNode(node_id=ss_198) -->
                             <!-- join_0 =                                                 -->
                             <!--   SqlJoinDescription(                                    -->
-                            <!--     right_source=SqlSelectStatementNode(node_id=ss_121), -->
+                            <!--     right_source=SqlSelectStatementNode(node_id=ss_201), -->
                             <!--     right_source_alias='subq_8',                         -->
                             <!--     join_type=INNER,                                     -->
                             <!--     on_condition=SqlLogicalExpression(node_id=lo_1),     -->
@@ -470,7 +470,7 @@ docstring:
                             <!-- distinct = True -->
                             <SqlSelectStatementNode>
                                 <!-- description = "Pass Only Elements: ['visits', 'metric_time__day', 'user']" -->
-                                <!-- node_id = NodeId(id_str='ss_115') -->
+                                <!-- node_id = NodeId(id_str='ss_198') -->
                                 <!-- col0 =                                                -->
                                 <!--   SqlSelectColumn(                                    -->
                                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_44), -->
@@ -486,12 +486,12 @@ docstring:
                                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_43), -->
                                 <!--     column_alias='visits',                            -->
                                 <!--   )                                                   -->
-                                <!-- from_source = SqlSelectStatementNode(node_id=ss_113) -->
+                                <!-- from_source = SqlSelectStatementNode(node_id=ss_197) -->
                                 <!-- where = None -->
                                 <!-- distinct = False -->
                                 <SqlSelectStatementNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->
-                                    <!-- node_id = NodeId(id_str='ss_113') -->
+                                    <!-- node_id = NodeId(id_str='ss_197') -->
                                     <!-- col0 =                                               -->
                                     <!--   SqlSelectColumn(                                   -->
                                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_4), -->
@@ -697,12 +697,12 @@ docstring:
                                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_1), -->
                                     <!--     column_alias='visitors',                         -->
                                     <!--   )                                                  -->
-                                    <!-- from_source = SqlSelectStatementNode(node_id=ss_106) -->
+                                    <!-- from_source = SqlSelectStatementNode(node_id=ss_196) -->
                                     <!-- where = None -->
                                     <!-- distinct = False -->
                                     <SqlSelectStatementNode>
                                         <!-- description = "Read Elements From Semantic Model 'visits_source'" -->
-                                        <!-- node_id = NodeId(id_str='ss_106') -->
+                                        <!-- node_id = NodeId(id_str='ss_196') -->
                                         <!-- col0 =                                                      -->
                                         <!--   SqlSelectColumn(                                          -->
                                         <!--     expr=SqlStringExpression(node_id=str_28010 sql_expr=1), -->
@@ -853,12 +853,12 @@ docstring:
                                         <!--     expr=SqlColumnReferenceExpression(node_id=cr_28123), -->
                                         <!--     column_alias='visit__session',                       -->
                                         <!--   )                                                      -->
-                                        <!-- from_source = SqlTableNode(node_id=tfc_28011) -->
+                                        <!-- from_source = SqlTableNode(node_id=tfc_106) -->
                                         <!-- where = None -->
                                         <!-- distinct = False -->
                                         <SqlTableNode>
                                             <!-- description = 'Read from ***************************.fct_visits' -->
-                                            <!-- node_id = NodeId(id_str='tfc_28011') -->
+                                            <!-- node_id = NodeId(id_str='tfc_106') -->
                                             <!-- table_id = '***************************.fct_visits' -->
                                         </SqlTableNode>
                                     </SqlSelectStatementNode>
@@ -866,7 +866,7 @@ docstring:
                             </SqlSelectStatementNode>
                             <SqlSelectStatementNode>
                                 <!-- description = 'Add column with generated UUID' -->
-                                <!-- node_id = NodeId(id_str='ss_121') -->
+                                <!-- node_id = NodeId(id_str='ss_201') -->
                                 <!-- col0 =                                                -->
                                 <!--   SqlSelectColumn(                                    -->
                                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_99), -->
@@ -1127,12 +1127,12 @@ docstring:
                                 <!--     expr=SqlGenerateUuidExpression(node_id=uuid_0), -->
                                 <!--     column_alias='mf_internal_uuid',                -->
                                 <!--   )                                                 -->
-                                <!-- from_source = SqlSelectStatementNode(node_id=ss_119) -->
+                                <!-- from_source = SqlSelectStatementNode(node_id=ss_200) -->
                                 <!-- where = None -->
                                 <!-- distinct = False -->
                                 <SqlSelectStatementNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->
-                                    <!-- node_id = NodeId(id_str='ss_119') -->
+                                    <!-- node_id = NodeId(id_str='ss_200') -->
                                     <!-- col0 =                                                -->
                                     <!--   SqlSelectColumn(                                    -->
                                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_48), -->
@@ -1388,12 +1388,12 @@ docstring:
                                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_47), -->
                                     <!--     column_alias='buyers',                            -->
                                     <!--   )                                                   -->
-                                    <!-- from_source = SqlSelectStatementNode(node_id=ss_117) -->
+                                    <!-- from_source = SqlSelectStatementNode(node_id=ss_199) -->
                                     <!-- where = None -->
                                     <!-- distinct = False -->
                                     <SqlSelectStatementNode>
                                         <!-- description = "Read Elements From Semantic Model 'buys_source'" -->
-                                        <!-- node_id = NodeId(id_str='ss_117') -->
+                                        <!-- node_id = NodeId(id_str='ss_199') -->
                                         <!-- col0 =                                                      -->
                                         <!--   SqlSelectColumn(                                          -->
                                         <!--     expr=SqlStringExpression(node_id=str_28003 sql_expr=1), -->
@@ -1599,12 +1599,12 @@ docstring:
                                         <!--     expr=SqlColumnReferenceExpression(node_id=cr_28045), -->
                                         <!--     column_alias='buy__session_id',                      -->
                                         <!--   )                                                      -->
-                                        <!-- from_source = SqlTableNode(node_id=tfc_28002) -->
+                                        <!-- from_source = SqlTableNode(node_id=tfc_107) -->
                                         <!-- where = None -->
                                         <!-- distinct = False -->
                                         <SqlTableNode>
                                             <!-- description = 'Read from ***************************.fct_buys' -->
-                                            <!-- node_id = NodeId(id_str='tfc_28002') -->
+                                            <!-- node_id = NodeId(id_str='tfc_107') -->
                                             <!-- table_id = '***************************.fct_buys' -->
                                         </SqlTableNode>
                                     </SqlSelectStatementNode>

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/test_conversion_rate_with_window__plan0.xml
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/test_conversion_rate_with_window__plan0.xml
@@ -6,7 +6,7 @@ docstring:
 <SqlPlan>
     <SqlSelectStatementNode>
         <!-- description = 'Compute Metrics via Expressions' -->
-        <!-- node_id = NodeId(id_str='ss_137') -->
+        <!-- node_id = NodeId(id_str='ss_215') -->
         <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_205), column_alias='metric_time__day') -->
         <!-- col1 =                                                                                                  -->
         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_204), column_alias='visit__referrer_id') -->
@@ -15,12 +15,12 @@ docstring:
         <!--     expr=SqlRatioComputationExpression(node_id=rc_0), -->
         <!--     column_alias='visit_buy_conversion_rate_7days',   -->
         <!--   )                                                   -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_134) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_214) -->
         <!-- where = None -->
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = 'Combine Aggregated Outputs' -->
-            <!-- node_id = NodeId(id_str='ss_134') -->
+            <!-- node_id = NodeId(id_str='ss_214') -->
             <!-- col0 =                                                                         -->
             <!--   SqlSelectColumn(                                                             -->
             <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_5, sql_function=COALESCE), -->
@@ -41,10 +41,10 @@ docstring:
             <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_3, sql_function=MAX), -->
             <!--     column_alias='buys',                                                  -->
             <!--   )                                                                       -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_116) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_203) -->
             <!-- join_0 =                                                 -->
             <!--   SqlJoinDescription(                                    -->
-            <!--     right_source=SqlSelectStatementNode(node_id=ss_132), -->
+            <!--     right_source=SqlSelectStatementNode(node_id=ss_213), -->
             <!--     right_source_alias='subq_12',                        -->
             <!--     join_type=FULL_OUTER,                                -->
             <!--     on_condition=SqlLogicalExpression(node_id=lo_2),     -->
@@ -63,7 +63,7 @@ docstring:
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = 'Aggregate Measures' -->
-                <!-- node_id = NodeId(id_str='ss_116') -->
+                <!-- node_id = NodeId(id_str='ss_203') -->
                 <!-- col0 =                                                                                               -->
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_46), column_alias='metric_time__day') -->
                 <!-- col1 =                                                -->
@@ -76,7 +76,7 @@ docstring:
                 <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_0, sql_function=SUM), -->
                 <!--     column_alias='visits',                                                -->
                 <!--   )                                                                       -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_114) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_202) -->
                 <!-- group_by0 =                                                                                          -->
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_46), column_alias='metric_time__day') -->
                 <!-- group_by1 =                                           -->
@@ -88,7 +88,7 @@ docstring:
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = "Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']" -->
-                    <!-- node_id = NodeId(id_str='ss_114') -->
+                    <!-- node_id = NodeId(id_str='ss_202') -->
                     <!-- col0 =                                                -->
                     <!--   SqlSelectColumn(                                    -->
                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_43), -->
@@ -100,12 +100,12 @@ docstring:
                     <!--     column_alias='visit__referrer_id',                -->
                     <!--   )                                                   -->
                     <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_41), column_alias='visits') -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_112) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_201) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = "Metric Time Dimension 'ds'" -->
-                        <!-- node_id = NodeId(id_str='ss_112') -->
+                        <!-- node_id = NodeId(id_str='ss_201') -->
                         <!-- col0 =                                                                                     -->
                         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_4), column_alias='ds__day') -->
                         <!-- col1 =                                                                                      -->
@@ -287,12 +287,12 @@ docstring:
                         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_0), column_alias='visits') -->
                         <!-- col40 =                                                                                     -->
                         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_1), column_alias='visitors') -->
-                        <!-- from_source = SqlSelectStatementNode(node_id=ss_110) -->
+                        <!-- from_source = SqlSelectStatementNode(node_id=ss_200) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
                         <SqlSelectStatementNode>
                             <!-- description = "Read Elements From Semantic Model 'visits_source'" -->
-                            <!-- node_id = NodeId(id_str='ss_110') -->
+                            <!-- node_id = NodeId(id_str='ss_200') -->
                             <!-- col0 =                                                      -->
                             <!--   SqlSelectColumn(                                          -->
                             <!--     expr=SqlStringExpression(node_id=str_28010 sql_expr=1), -->
@@ -434,12 +434,12 @@ docstring:
                             <!--     expr=SqlColumnReferenceExpression(node_id=cr_28123), -->
                             <!--     column_alias='visit__session',                       -->
                             <!--   )                                                      -->
-                            <!-- from_source = SqlTableNode(node_id=tfc_28011) -->
+                            <!-- from_source = SqlTableNode(node_id=tfc_109) -->
                             <!-- where = None -->
                             <!-- distinct = False -->
                             <SqlTableNode>
                                 <!-- description = 'Read from ***************************.fct_visits' -->
-                                <!-- node_id = NodeId(id_str='tfc_28011') -->
+                                <!-- node_id = NodeId(id_str='tfc_109') -->
                                 <!-- table_id = '***************************.fct_visits' -->
                             </SqlTableNode>
                         </SqlSelectStatementNode>
@@ -448,7 +448,7 @@ docstring:
             </SqlSelectStatementNode>
             <SqlSelectStatementNode>
                 <!-- description = 'Aggregate Measures' -->
-                <!-- node_id = NodeId(id_str='ss_132') -->
+                <!-- node_id = NodeId(id_str='ss_213') -->
                 <!-- col0 =                                                                                                -->
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_193), column_alias='metric_time__day') -->
                 <!-- col1 =                                                 -->
@@ -461,7 +461,7 @@ docstring:
                 <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_1, sql_function=SUM), -->
                 <!--     column_alias='buys',                                                  -->
                 <!--   )                                                                       -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_130) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_212) -->
                 <!-- group_by0 =                                                                                           -->
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_193), column_alias='metric_time__day') -->
                 <!-- group_by1 =                                            -->
@@ -473,7 +473,7 @@ docstring:
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = "Pass Only Elements: ['buys', 'visit__referrer_id', 'metric_time__day']" -->
-                    <!-- node_id = NodeId(id_str='ss_130') -->
+                    <!-- node_id = NodeId(id_str='ss_212') -->
                     <!-- col0 =                                                 -->
                     <!--   SqlSelectColumn(                                     -->
                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_190), -->
@@ -485,12 +485,12 @@ docstring:
                     <!--     column_alias='visit__referrer_id',                 -->
                     <!--   )                                                    -->
                     <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_188), column_alias='buys') -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_128) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_211) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = 'Find conversions for user within the range of 7 day' -->
-                        <!-- node_id = NodeId(id_str='ss_128') -->
+                        <!-- node_id = NodeId(id_str='ss_211') -->
                         <!-- col0 =                                                 -->
                         <!--   SqlSelectColumn(                                     -->
                         <!--     expr=SqlColumnReferenceExpression(node_id=cr_186), -->
@@ -507,12 +507,12 @@ docstring:
                         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_183), column_alias='buys') -->
                         <!-- col4 =                                                                                      -->
                         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_184), column_alias='visits') -->
-                        <!-- from_source = SqlSelectStatementNode(node_id=ss_126) -->
+                        <!-- from_source = SqlSelectStatementNode(node_id=ss_210) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
                         <SqlSelectStatementNode>
                             <!-- description = 'Dedupe the fanout with mf_internal_uuid in the conversion data set' -->
-                            <!-- node_id = NodeId(id_str='ss_126') -->
+                            <!-- node_id = NodeId(id_str='ss_210') -->
                             <!-- col0 =                                                                          -->
                             <!--   SqlSelectColumn(                                                              -->
                             <!--     expr=SqlWindowFunctionExpression(node_id=wfnc_0, sql_function=FIRST_VALUE), -->
@@ -540,10 +540,10 @@ docstring:
                             <!--   )                                                    -->
                             <!-- col5 =                                                                                    -->
                             <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_182), column_alias='buys') -->
-                            <!-- from_source = SqlSelectStatementNode(node_id=ss_119) -->
+                            <!-- from_source = SqlSelectStatementNode(node_id=ss_206) -->
                             <!-- join_0 =                                                 -->
                             <!--   SqlJoinDescription(                                    -->
-                            <!--     right_source=SqlSelectStatementNode(node_id=ss_125), -->
+                            <!--     right_source=SqlSelectStatementNode(node_id=ss_209), -->
                             <!--     right_source_alias='subq_8',                         -->
                             <!--     join_type=INNER,                                     -->
                             <!--     on_condition=SqlLogicalExpression(node_id=lo_1),     -->
@@ -553,7 +553,7 @@ docstring:
                             <SqlSelectStatementNode>
                                 <!-- description =                                                                        -->
                                 <!--   "Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user']" -->
-                                <!-- node_id = NodeId(id_str='ss_119') -->
+                                <!-- node_id = NodeId(id_str='ss_206') -->
                                 <!-- col0 =                                                -->
                                 <!--   SqlSelectColumn(                                    -->
                                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_49), -->
@@ -574,12 +574,12 @@ docstring:
                                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_47), -->
                                 <!--     column_alias='visits',                            -->
                                 <!--   )                                                   -->
-                                <!-- from_source = SqlSelectStatementNode(node_id=ss_117) -->
+                                <!-- from_source = SqlSelectStatementNode(node_id=ss_205) -->
                                 <!-- where = None -->
                                 <!-- distinct = False -->
                                 <SqlSelectStatementNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->
-                                    <!-- node_id = NodeId(id_str='ss_117') -->
+                                    <!-- node_id = NodeId(id_str='ss_205') -->
                                     <!-- col0 =                                               -->
                                     <!--   SqlSelectColumn(                                   -->
                                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_4), -->
@@ -785,12 +785,12 @@ docstring:
                                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_1), -->
                                     <!--     column_alias='visitors',                         -->
                                     <!--   )                                                  -->
-                                    <!-- from_source = SqlSelectStatementNode(node_id=ss_110) -->
+                                    <!-- from_source = SqlSelectStatementNode(node_id=ss_204) -->
                                     <!-- where = None -->
                                     <!-- distinct = False -->
                                     <SqlSelectStatementNode>
                                         <!-- description = "Read Elements From Semantic Model 'visits_source'" -->
-                                        <!-- node_id = NodeId(id_str='ss_110') -->
+                                        <!-- node_id = NodeId(id_str='ss_204') -->
                                         <!-- col0 =                                                      -->
                                         <!--   SqlSelectColumn(                                          -->
                                         <!--     expr=SqlStringExpression(node_id=str_28010 sql_expr=1), -->
@@ -941,12 +941,12 @@ docstring:
                                         <!--     expr=SqlColumnReferenceExpression(node_id=cr_28123), -->
                                         <!--     column_alias='visit__session',                       -->
                                         <!--   )                                                      -->
-                                        <!-- from_source = SqlTableNode(node_id=tfc_28011) -->
+                                        <!-- from_source = SqlTableNode(node_id=tfc_110) -->
                                         <!-- where = None -->
                                         <!-- distinct = False -->
                                         <SqlTableNode>
                                             <!-- description = 'Read from ***************************.fct_visits' -->
-                                            <!-- node_id = NodeId(id_str='tfc_28011') -->
+                                            <!-- node_id = NodeId(id_str='tfc_110') -->
                                             <!-- table_id = '***************************.fct_visits' -->
                                         </SqlTableNode>
                                     </SqlSelectStatementNode>
@@ -954,7 +954,7 @@ docstring:
                             </SqlSelectStatementNode>
                             <SqlSelectStatementNode>
                                 <!-- description = 'Add column with generated UUID' -->
-                                <!-- node_id = NodeId(id_str='ss_125') -->
+                                <!-- node_id = NodeId(id_str='ss_209') -->
                                 <!-- col0 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
                                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_104), -->
@@ -1215,12 +1215,12 @@ docstring:
                                 <!--     expr=SqlGenerateUuidExpression(node_id=uuid_0), -->
                                 <!--     column_alias='mf_internal_uuid',                -->
                                 <!--   )                                                 -->
-                                <!-- from_source = SqlSelectStatementNode(node_id=ss_123) -->
+                                <!-- from_source = SqlSelectStatementNode(node_id=ss_208) -->
                                 <!-- where = None -->
                                 <!-- distinct = False -->
                                 <SqlSelectStatementNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->
-                                    <!-- node_id = NodeId(id_str='ss_123') -->
+                                    <!-- node_id = NodeId(id_str='ss_208') -->
                                     <!-- col0 =                                                -->
                                     <!--   SqlSelectColumn(                                    -->
                                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_53), -->
@@ -1476,12 +1476,12 @@ docstring:
                                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_52), -->
                                     <!--     column_alias='buyers',                            -->
                                     <!--   )                                                   -->
-                                    <!-- from_source = SqlSelectStatementNode(node_id=ss_121) -->
+                                    <!-- from_source = SqlSelectStatementNode(node_id=ss_207) -->
                                     <!-- where = None -->
                                     <!-- distinct = False -->
                                     <SqlSelectStatementNode>
                                         <!-- description = "Read Elements From Semantic Model 'buys_source'" -->
-                                        <!-- node_id = NodeId(id_str='ss_121') -->
+                                        <!-- node_id = NodeId(id_str='ss_207') -->
                                         <!-- col0 =                                                      -->
                                         <!--   SqlSelectColumn(                                          -->
                                         <!--     expr=SqlStringExpression(node_id=str_28003 sql_expr=1), -->
@@ -1687,12 +1687,12 @@ docstring:
                                         <!--     expr=SqlColumnReferenceExpression(node_id=cr_28045), -->
                                         <!--     column_alias='buy__session_id',                      -->
                                         <!--   )                                                      -->
-                                        <!-- from_source = SqlTableNode(node_id=tfc_28002) -->
+                                        <!-- from_source = SqlTableNode(node_id=tfc_111) -->
                                         <!-- where = None -->
                                         <!-- distinct = False -->
                                         <SqlTableNode>
                                             <!-- description = 'Read from ***************************.fct_buys' -->
-                                            <!-- node_id = NodeId(id_str='tfc_28002') -->
+                                            <!-- node_id = NodeId(id_str='tfc_111') -->
                                             <!-- table_id = '***************************.fct_buys' -->
                                         </SqlTableNode>
                                     </SqlSelectStatementNode>

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/test_combine_output_node__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/test_combine_output_node__plan0.xml
@@ -6,7 +6,7 @@ docstring:
 <SqlPlan>
     <SqlSelectStatementNode>
         <!-- description = 'Combine Aggregated Outputs' -->
-        <!-- node_id = NodeId(id_str='ss_12') -->
+        <!-- node_id = NodeId(id_str='ss_6') -->
         <!-- col0 =                                                                         -->
         <!--   SqlSelectColumn(                                                             -->
         <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_8, sql_function=COALESCE), -->
@@ -27,10 +27,10 @@ docstring:
         <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_7, sql_function=COALESCE), -->
         <!--     column_alias='bookers',                                                    -->
         <!--   )                                                                            -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_5) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_2) -->
         <!-- join_0 =                                                 -->
         <!--   SqlJoinDescription(                                    -->
-        <!--     right_source=SqlSelectStatementNode(node_id=ss_10),  -->
+        <!--     right_source=SqlSelectStatementNode(node_id=ss_5),   -->
         <!--     right_source_alias='subq_5',                         -->
         <!--     join_type=FULL_OUTER,                                -->
         <!--     on_condition=SqlComparisonExpression(node_id=cmp_0), -->
@@ -44,28 +44,28 @@ docstring:
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = 'Aggregate Measures' -->
-            <!-- node_id = NodeId(id_str='ss_5') -->
+            <!-- node_id = NodeId(id_str='ss_2') -->
             <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_3), column_alias='is_instant') -->
             <!-- col1 =                                                                    -->
             <!--   SqlSelectColumn(                                                        -->
             <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_0, sql_function=SUM), -->
             <!--     column_alias='bookings',                                              -->
             <!--   )                                                                       -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_3) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
             <!-- group_by0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_3), column_alias='is_instant') -->
             <!-- where = None -->
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = "Pass Only Elements: ['bookings', 'is_instant']" -->
-                <!-- node_id = NodeId(id_str='ss_3') -->
+                <!-- node_id = NodeId(id_str='ss_1') -->
                 <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_1), column_alias='is_instant') -->
                 <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_0), column_alias='bookings') -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = "Read Elements From Semantic Model 'bookings_source'" -->
-                    <!-- node_id = NodeId(id_str='ss_1') -->
+                    <!-- node_id = NodeId(id_str='ss_0') -->
                     <!-- col0 =                                                      -->
                     <!--   SqlSelectColumn(                                          -->
                     <!--     expr=SqlStringExpression(node_id=str_28000 sql_expr=1), -->
@@ -440,12 +440,12 @@ docstring:
                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_28036), -->
                     <!--     column_alias='booking__host',                        -->
                     <!--   )                                                      -->
-                    <!-- from_source = SqlTableNode(node_id=tfc_28001) -->
+                    <!-- from_source = SqlTableNode(node_id=tfc_0) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlTableNode>
                         <!-- description = 'Read from ***************************.fct_bookings' -->
-                        <!-- node_id = NodeId(id_str='tfc_28001') -->
+                        <!-- node_id = NodeId(id_str='tfc_0') -->
                         <!-- table_id = '***************************.fct_bookings' -->
                     </SqlTableNode>
                 </SqlSelectStatementNode>
@@ -453,7 +453,7 @@ docstring:
         </SqlSelectStatementNode>
         <SqlSelectStatementNode>
             <!-- description = 'Aggregate Measures' -->
-            <!-- node_id = NodeId(id_str='ss_10') -->
+            <!-- node_id = NodeId(id_str='ss_5') -->
             <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_9), column_alias='is_instant') -->
             <!-- col1 =                                                                    -->
             <!--   SqlSelectColumn(                                                        -->
@@ -465,23 +465,23 @@ docstring:
             <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_2, sql_function=COUNT_DISTINCT), -->
             <!--     column_alias='bookers',                                                          -->
             <!--   )                                                                                  -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_8) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_4) -->
             <!-- group_by0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_9), column_alias='is_instant') -->
             <!-- where = None -->
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = "Pass Only Elements: ['instant_bookings', 'bookers', 'is_instant']" -->
-                <!-- node_id = NodeId(id_str='ss_8') -->
+                <!-- node_id = NodeId(id_str='ss_4') -->
                 <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_6), column_alias='is_instant') -->
                 <!-- col1 =                                                                                              -->
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_4), column_alias='instant_bookings') -->
                 <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_5), column_alias='bookers') -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_6) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_3) -->
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = "Read Elements From Semantic Model 'bookings_source'" -->
-                    <!-- node_id = NodeId(id_str='ss_6') -->
+                    <!-- node_id = NodeId(id_str='ss_3') -->
                     <!-- col0 =                                                      -->
                     <!--   SqlSelectColumn(                                          -->
                     <!--     expr=SqlStringExpression(node_id=str_28000 sql_expr=1), -->
@@ -856,12 +856,12 @@ docstring:
                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_28036), -->
                     <!--     column_alias='booking__host',                        -->
                     <!--   )                                                      -->
-                    <!-- from_source = SqlTableNode(node_id=tfc_28001) -->
+                    <!-- from_source = SqlTableNode(node_id=tfc_1) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlTableNode>
                         <!-- description = 'Read from ***************************.fct_bookings' -->
-                        <!-- node_id = NodeId(id_str='tfc_28001') -->
+                        <!-- node_id = NodeId(id_str='tfc_1') -->
                         <!-- table_id = '***************************.fct_bookings' -->
                     </SqlTableNode>
                 </SqlSelectStatementNode>

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/test_compute_metrics_node__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/test_compute_metrics_node__plan0.xml
@@ -6,17 +6,17 @@ docstring:
 <SqlPlan>
     <SqlSelectStatementNode>
         <!-- description = 'Compute Metrics via Expressions' -->
-        <!-- node_id = NodeId(id_str='ss_13') -->
+        <!-- node_id = NodeId(id_str='ss_6') -->
         <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_13), column_alias='listing') -->
         <!-- col1 =                                                                                                      -->
         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_12), column_alias='listing__country_latest') -->
         <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_14), column_alias='bookings') -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_11) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_5) -->
         <!-- where = None -->
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = 'Aggregate Measures' -->
-            <!-- node_id = NodeId(id_str='ss_11') -->
+            <!-- node_id = NodeId(id_str='ss_5') -->
             <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_11), column_alias='listing') -->
             <!-- col1 =                                                -->
             <!--   SqlSelectColumn(                                    -->
@@ -28,7 +28,7 @@ docstring:
             <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_0, sql_function=SUM), -->
             <!--     column_alias='bookings',                                              -->
             <!--   )                                                                       -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_9) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_4) -->
             <!-- group_by0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_11), column_alias='listing') -->
             <!-- group_by1 =                                           -->
             <!--   SqlSelectColumn(                                    -->
@@ -39,7 +39,7 @@ docstring:
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = 'Join Standard Outputs' -->
-                <!-- node_id = NodeId(id_str='ss_9') -->
+                <!-- node_id = NodeId(id_str='ss_4') -->
                 <!-- col0 =                                               -->
                 <!--   SqlSelectColumn(                                   -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_6), -->
@@ -47,10 +47,10 @@ docstring:
                 <!--   )                                                  -->
                 <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_8), column_alias='listing') -->
                 <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_7), column_alias='bookings') -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_3) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
                 <!-- join_0 =                                                 -->
                 <!--   SqlJoinDescription(                                    -->
-                <!--     right_source=SqlSelectStatementNode(node_id=ss_7),   -->
+                <!--     right_source=SqlSelectStatementNode(node_id=ss_3),   -->
                 <!--     right_source_alias='subq_3',                         -->
                 <!--     join_type=LEFT_OUTER,                                -->
                 <!--     on_condition=SqlComparisonExpression(node_id=cmp_0), -->
@@ -59,16 +59,16 @@ docstring:
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = "Pass Only Elements: ['bookings', 'listing']" -->
-                    <!-- node_id = NodeId(id_str='ss_3') -->
+                    <!-- node_id = NodeId(id_str='ss_1') -->
                     <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_1), column_alias='listing') -->
                     <!-- col1 =                                                                                      -->
                     <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_0), column_alias='bookings') -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = "Read Elements From Semantic Model 'bookings_source'" -->
-                        <!-- node_id = NodeId(id_str='ss_1') -->
+                        <!-- node_id = NodeId(id_str='ss_0') -->
                         <!-- col0 =                                                      -->
                         <!--   SqlSelectColumn(                                          -->
                         <!--     expr=SqlStringExpression(node_id=str_28000 sql_expr=1), -->
@@ -485,28 +485,28 @@ docstring:
                         <!--     expr=SqlColumnReferenceExpression(node_id=cr_28036), -->
                         <!--     column_alias='booking__host',                        -->
                         <!--   )                                                      -->
-                        <!-- from_source = SqlTableNode(node_id=tfc_28001) -->
+                        <!-- from_source = SqlTableNode(node_id=tfc_0) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
                         <SqlTableNode>
                             <!-- description = 'Read from ***************************.fct_bookings' -->
-                            <!-- node_id = NodeId(id_str='tfc_28001') -->
+                            <!-- node_id = NodeId(id_str='tfc_0') -->
                             <!-- table_id = '***************************.fct_bookings' -->
                         </SqlTableNode>
                     </SqlSelectStatementNode>
                 </SqlSelectStatementNode>
                 <SqlSelectStatementNode>
                     <!-- description = "Pass Only Elements: ['country_latest', 'listing']" -->
-                    <!-- node_id = NodeId(id_str='ss_7') -->
+                    <!-- node_id = NodeId(id_str='ss_3') -->
                     <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_3), column_alias='listing') -->
                     <!-- col1 =                                                                                            -->
                     <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_2), column_alias='country_latest') -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_5) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_2) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = "Read Elements From Semantic Model 'listings_latest'" -->
-                        <!-- node_id = NodeId(id_str='ss_5') -->
+                        <!-- node_id = NodeId(id_str='ss_2') -->
                         <!-- col0 =                                                      -->
                         <!--   SqlSelectColumn(                                          -->
                         <!--     expr=SqlStringExpression(node_id=str_28006 sql_expr=1), -->
@@ -769,12 +769,12 @@ docstring:
                         <!--     expr=SqlColumnReferenceExpression(node_id=cr_28076), -->
                         <!--     column_alias='listing__user',                        -->
                         <!--   )                                                      -->
-                        <!-- from_source = SqlTableNode(node_id=tfc_28005) -->
+                        <!-- from_source = SqlTableNode(node_id=tfc_1) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
                         <SqlTableNode>
                             <!-- description = 'Read from ***************************.dim_listings_latest' -->
-                            <!-- node_id = NodeId(id_str='tfc_28005') -->
+                            <!-- node_id = NodeId(id_str='tfc_1') -->
                             <!-- table_id = '***************************.dim_listings_latest' -->
                         </SqlTableNode>
                     </SqlSelectStatementNode>

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0.xml
@@ -6,17 +6,17 @@ docstring:
 <SqlPlan>
     <SqlSelectStatementNode>
         <!-- description = 'Compute Metrics via Expressions' -->
-        <!-- node_id = NodeId(id_str='ss_163') -->
+        <!-- node_id = NodeId(id_str='ss_255') -->
         <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_422), column_alias='ds__day') -->
         <!-- col1 =                                                                                                       -->
         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_421), column_alias='listing__country_latest') -->
         <!-- col2 = SqlSelectColumn(expr=SqlRatioComputationExpression(node_id=rc_0), column_alias='bookings_per_view') -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_160) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_254) -->
         <!-- where = None -->
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = 'Combine Aggregated Outputs' -->
-            <!-- node_id = NodeId(id_str='ss_160') -->
+            <!-- node_id = NodeId(id_str='ss_254') -->
             <!-- col0 =                                                                         -->
             <!--   SqlSelectColumn(                                                             -->
             <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_5, sql_function=COALESCE), -->
@@ -37,10 +37,10 @@ docstring:
             <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_3, sql_function=MAX), -->
             <!--     column_alias='views',                                                 -->
             <!--   )                                                                       -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_143) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_244) -->
             <!-- join_0 =                                                 -->
             <!--   SqlJoinDescription(                                    -->
-            <!--     right_source=SqlSelectStatementNode(node_id=ss_158), -->
+            <!--     right_source=SqlSelectStatementNode(node_id=ss_253), -->
             <!--     right_source_alias='subq_16',                        -->
             <!--     join_type=FULL_OUTER,                                -->
             <!--     on_condition=SqlLogicalExpression(node_id=lo_0),     -->
@@ -59,7 +59,7 @@ docstring:
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = 'Compute Metrics via Expressions' -->
-                <!-- node_id = NodeId(id_str='ss_143') -->
+                <!-- node_id = NodeId(id_str='ss_244') -->
                 <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_275), column_alias='ds__day') -->
                 <!-- col1 =                                                 -->
                 <!--   SqlSelectColumn(                                     -->
@@ -67,12 +67,12 @@ docstring:
                 <!--     column_alias='listing__country_latest',            -->
                 <!--   )                                                    -->
                 <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_276), column_alias='bookings') -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_141) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_243) -->
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = 'Aggregate Measures' -->
-                    <!-- node_id = NodeId(id_str='ss_141') -->
+                    <!-- node_id = NodeId(id_str='ss_243') -->
                     <!-- col0 =                                                                                       -->
                     <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_273), column_alias='ds__day') -->
                     <!-- col1 =                                                 -->
@@ -85,7 +85,7 @@ docstring:
                     <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_0, sql_function=SUM), -->
                     <!--     column_alias='bookings',                                              -->
                     <!--   )                                                                       -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_139) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_242) -->
                     <!-- group_by0 =                                                                                  -->
                     <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_273), column_alias='ds__day') -->
                     <!-- group_by1 =                                            -->
@@ -97,7 +97,7 @@ docstring:
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = "Pass Only Elements: ['bookings', 'listing__country_latest', 'ds__day']" -->
-                        <!-- node_id = NodeId(id_str='ss_139') -->
+                        <!-- node_id = NodeId(id_str='ss_242') -->
                         <!-- col0 =                                                                                       -->
                         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_270), column_alias='ds__day') -->
                         <!-- col1 =                                                 -->
@@ -107,12 +107,12 @@ docstring:
                         <!--   )                                                    -->
                         <!-- col2 =                                                                                        -->
                         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_268), column_alias='bookings') -->
-                        <!-- from_source = SqlSelectStatementNode(node_id=ss_137) -->
+                        <!-- from_source = SqlSelectStatementNode(node_id=ss_241) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
                         <SqlSelectStatementNode>
                             <!-- description = 'Join Standard Outputs' -->
-                            <!-- node_id = NodeId(id_str='ss_137') -->
+                            <!-- node_id = NodeId(id_str='ss_241') -->
                             <!-- col0 =                                                 -->
                             <!--   SqlSelectColumn(                                     -->
                             <!--     expr=SqlColumnReferenceExpression(node_id=cr_169), -->
@@ -605,10 +605,10 @@ docstring:
                             <!--     expr=SqlColumnReferenceExpression(node_id=cr_182),     -->
                             <!--     column_alias='approximate_discrete_booking_value_p99', -->
                             <!--   )                                                        -->
-                            <!-- from_source = SqlSelectStatementNode(node_id=ss_129) -->
+                            <!-- from_source = SqlSelectStatementNode(node_id=ss_237) -->
                             <!-- join_0 =                                                 -->
                             <!--   SqlJoinDescription(                                    -->
-                            <!--     right_source=SqlSelectStatementNode(node_id=ss_135), -->
+                            <!--     right_source=SqlSelectStatementNode(node_id=ss_240), -->
                             <!--     right_source_alias='subq_4',                         -->
                             <!--     join_type=LEFT_OUTER,                                -->
                             <!--     on_condition=SqlComparisonExpression(node_id=cmp_0), -->
@@ -617,7 +617,7 @@ docstring:
                             <!-- distinct = False -->
                             <SqlSelectStatementNode>
                                 <!-- description = "Metric Time Dimension 'ds'" -->
-                                <!-- node_id = NodeId(id_str='ss_129') -->
+                                <!-- node_id = NodeId(id_str='ss_237') -->
                                 <!-- col0 =                                                -->
                                 <!--   SqlSelectColumn(                                    -->
                                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_15), -->
@@ -1108,12 +1108,12 @@ docstring:
                                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_12),      -->
                                 <!--     column_alias='approximate_discrete_booking_value_p99', -->
                                 <!--   )                                                        -->
-                                <!-- from_source = SqlSelectStatementNode(node_id=ss_127) -->
+                                <!-- from_source = SqlSelectStatementNode(node_id=ss_236) -->
                                 <!-- where = None -->
                                 <!-- distinct = False -->
                                 <SqlSelectStatementNode>
                                     <!-- description = "Read Elements From Semantic Model 'bookings_source'" -->
-                                    <!-- node_id = NodeId(id_str='ss_127') -->
+                                    <!-- node_id = NodeId(id_str='ss_236') -->
                                     <!-- col0 =                                                      -->
                                     <!--   SqlSelectColumn(                                          -->
                                     <!--     expr=SqlStringExpression(node_id=str_28000 sql_expr=1), -->
@@ -1554,19 +1554,19 @@ docstring:
                                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_28036), -->
                                     <!--     column_alias='booking__host',                        -->
                                     <!--   )                                                      -->
-                                    <!-- from_source = SqlTableNode(node_id=tfc_28001) -->
+                                    <!-- from_source = SqlTableNode(node_id=tfc_126) -->
                                     <!-- where = None -->
                                     <!-- distinct = False -->
                                     <SqlTableNode>
                                         <!-- description = 'Read from ***************************.fct_bookings' -->
-                                        <!-- node_id = NodeId(id_str='tfc_28001') -->
+                                        <!-- node_id = NodeId(id_str='tfc_126') -->
                                         <!-- table_id = '***************************.fct_bookings' -->
                                     </SqlTableNode>
                                 </SqlSelectStatementNode>
                             </SqlSelectStatementNode>
                             <SqlSelectStatementNode>
                                 <!-- description = "Pass Only Elements: ['country_latest', 'listing']" -->
-                                <!-- node_id = NodeId(id_str='ss_135') -->
+                                <!-- node_id = NodeId(id_str='ss_240') -->
                                 <!-- col0 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
                                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_166), -->
@@ -1577,12 +1577,12 @@ docstring:
                                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_165), -->
                                 <!--     column_alias='country_latest',                     -->
                                 <!--   )                                                    -->
-                                <!-- from_source = SqlSelectStatementNode(node_id=ss_133) -->
+                                <!-- from_source = SqlSelectStatementNode(node_id=ss_239) -->
                                 <!-- where = None -->
                                 <!-- distinct = False -->
                                 <SqlSelectStatementNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->
-                                    <!-- node_id = NodeId(id_str='ss_133') -->
+                                    <!-- node_id = NodeId(id_str='ss_239') -->
                                     <!-- col0 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
                                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_107), -->
@@ -1918,12 +1918,12 @@ docstring:
                                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_100), -->
                                     <!--     column_alias='smallest_listing',                   -->
                                     <!--   )                                                    -->
-                                    <!-- from_source = SqlSelectStatementNode(node_id=ss_131) -->
+                                    <!-- from_source = SqlSelectStatementNode(node_id=ss_238) -->
                                     <!-- where = None -->
                                     <!-- distinct = False -->
                                     <SqlSelectStatementNode>
                                         <!-- description = "Read Elements From Semantic Model 'listings_latest'" -->
-                                        <!-- node_id = NodeId(id_str='ss_131') -->
+                                        <!-- node_id = NodeId(id_str='ss_238') -->
                                         <!-- col0 =                                                      -->
                                         <!--   SqlSelectColumn(                                          -->
                                         <!--     expr=SqlStringExpression(node_id=str_28006 sql_expr=1), -->
@@ -2204,13 +2204,13 @@ docstring:
                                         <!--     expr=SqlColumnReferenceExpression(node_id=cr_28076), -->
                                         <!--     column_alias='listing__user',                        -->
                                         <!--   )                                                      -->
-                                        <!-- from_source = SqlTableNode(node_id=tfc_28005) -->
+                                        <!-- from_source = SqlTableNode(node_id=tfc_127) -->
                                         <!-- where = None -->
                                         <!-- distinct = False -->
                                         <SqlTableNode>
                                             <!-- description =                                                 -->
                                             <!--   'Read from ***************************.dim_listings_latest' -->
-                                            <!-- node_id = NodeId(id_str='tfc_28005') -->
+                                            <!-- node_id = NodeId(id_str='tfc_127') -->
                                             <!-- table_id = '***************************.dim_listings_latest' -->
                                         </SqlTableNode>
                                     </SqlSelectStatementNode>
@@ -2222,7 +2222,7 @@ docstring:
             </SqlSelectStatementNode>
             <SqlSelectStatementNode>
                 <!-- description = 'Compute Metrics via Expressions' -->
-                <!-- node_id = NodeId(id_str='ss_158') -->
+                <!-- node_id = NodeId(id_str='ss_253') -->
                 <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_409), column_alias='ds__day') -->
                 <!-- col1 =                                                 -->
                 <!--   SqlSelectColumn(                                     -->
@@ -2230,12 +2230,12 @@ docstring:
                 <!--     column_alias='listing__country_latest',            -->
                 <!--   )                                                    -->
                 <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_410), column_alias='views') -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_156) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_252) -->
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = 'Aggregate Measures' -->
-                    <!-- node_id = NodeId(id_str='ss_156') -->
+                    <!-- node_id = NodeId(id_str='ss_252') -->
                     <!-- col0 =                                                                                       -->
                     <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_407), column_alias='ds__day') -->
                     <!-- col1 =                                                 -->
@@ -2248,7 +2248,7 @@ docstring:
                     <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_1, sql_function=SUM), -->
                     <!--     column_alias='views',                                                 -->
                     <!--   )                                                                       -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_154) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_251) -->
                     <!-- group_by0 =                                                                                  -->
                     <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_407), column_alias='ds__day') -->
                     <!-- group_by1 =                                            -->
@@ -2260,7 +2260,7 @@ docstring:
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = "Pass Only Elements: ['views', 'listing__country_latest', 'ds__day']" -->
-                        <!-- node_id = NodeId(id_str='ss_154') -->
+                        <!-- node_id = NodeId(id_str='ss_251') -->
                         <!-- col0 =                                                                                       -->
                         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_404), column_alias='ds__day') -->
                         <!-- col1 =                                                 -->
@@ -2270,12 +2270,12 @@ docstring:
                         <!--   )                                                    -->
                         <!-- col2 =                                                                                     -->
                         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_402), column_alias='views') -->
-                        <!-- from_source = SqlSelectStatementNode(node_id=ss_152) -->
+                        <!-- from_source = SqlSelectStatementNode(node_id=ss_250) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
                         <SqlSelectStatementNode>
                             <!-- description = 'Join Standard Outputs' -->
-                            <!-- node_id = NodeId(id_str='ss_152') -->
+                            <!-- node_id = NodeId(id_str='ss_250') -->
                             <!-- col0 =                                                 -->
                             <!--   SqlSelectColumn(                                     -->
                             <!--     expr=SqlColumnReferenceExpression(node_id=cr_341), -->
@@ -2578,10 +2578,10 @@ docstring:
                             <!--     expr=SqlColumnReferenceExpression(node_id=cr_342), -->
                             <!--     column_alias='views',                              -->
                             <!--   )                                                    -->
-                            <!-- from_source = SqlSelectStatementNode(node_id=ss_147) -->
+                            <!-- from_source = SqlSelectStatementNode(node_id=ss_246) -->
                             <!-- join_0 =                                                 -->
                             <!--   SqlJoinDescription(                                    -->
-                            <!--     right_source=SqlSelectStatementNode(node_id=ss_150), -->
+                            <!--     right_source=SqlSelectStatementNode(node_id=ss_249), -->
                             <!--     right_source_alias='subq_12',                        -->
                             <!--     join_type=LEFT_OUTER,                                -->
                             <!--     on_condition=SqlComparisonExpression(node_id=cmp_1), -->
@@ -2590,7 +2590,7 @@ docstring:
                             <!-- distinct = False -->
                             <SqlSelectStatementNode>
                                 <!-- description = "Metric Time Dimension 'ds'" -->
-                                <!-- node_id = NodeId(id_str='ss_147') -->
+                                <!-- node_id = NodeId(id_str='ss_246') -->
                                 <!-- col0 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
                                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_278), -->
@@ -2891,12 +2891,12 @@ docstring:
                                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_277), -->
                                 <!--     column_alias='views',                              -->
                                 <!--   )                                                    -->
-                                <!-- from_source = SqlSelectStatementNode(node_id=ss_145) -->
+                                <!-- from_source = SqlSelectStatementNode(node_id=ss_245) -->
                                 <!-- where = None -->
                                 <!-- distinct = False -->
                                 <SqlSelectStatementNode>
                                     <!-- description = "Read Elements From Semantic Model 'views_source'" -->
-                                    <!-- node_id = NodeId(id_str='ss_145') -->
+                                    <!-- node_id = NodeId(id_str='ss_245') -->
                                     <!-- col0 =                                                      -->
                                     <!--   SqlSelectColumn(                                          -->
                                     <!--     expr=SqlStringExpression(node_id=str_28009 sql_expr=1), -->
@@ -3142,19 +3142,19 @@ docstring:
                                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_28114), -->
                                     <!--     column_alias='view__user',                           -->
                                     <!--   )                                                      -->
-                                    <!-- from_source = SqlTableNode(node_id=tfc_28010) -->
+                                    <!-- from_source = SqlTableNode(node_id=tfc_128) -->
                                     <!-- where = None -->
                                     <!-- distinct = False -->
                                     <SqlTableNode>
                                         <!-- description = 'Read from ***************************.fct_views' -->
-                                        <!-- node_id = NodeId(id_str='tfc_28010') -->
+                                        <!-- node_id = NodeId(id_str='tfc_128') -->
                                         <!-- table_id = '***************************.fct_views' -->
                                     </SqlTableNode>
                                 </SqlSelectStatementNode>
                             </SqlSelectStatementNode>
                             <SqlSelectStatementNode>
                                 <!-- description = "Pass Only Elements: ['country_latest', 'listing']" -->
-                                <!-- node_id = NodeId(id_str='ss_150') -->
+                                <!-- node_id = NodeId(id_str='ss_249') -->
                                 <!-- col0 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
                                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_338), -->
@@ -3165,12 +3165,12 @@ docstring:
                                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_337), -->
                                 <!--     column_alias='country_latest',                     -->
                                 <!--   )                                                    -->
-                                <!-- from_source = SqlSelectStatementNode(node_id=ss_148) -->
+                                <!-- from_source = SqlSelectStatementNode(node_id=ss_248) -->
                                 <!-- where = None -->
                                 <!-- distinct = False -->
                                 <SqlSelectStatementNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->
-                                    <!-- node_id = NodeId(id_str='ss_148') -->
+                                    <!-- node_id = NodeId(id_str='ss_248') -->
                                     <!-- col0 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
                                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_107), -->
@@ -3506,12 +3506,12 @@ docstring:
                                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_100), -->
                                     <!--     column_alias='smallest_listing',                   -->
                                     <!--   )                                                    -->
-                                    <!-- from_source = SqlSelectStatementNode(node_id=ss_131) -->
+                                    <!-- from_source = SqlSelectStatementNode(node_id=ss_247) -->
                                     <!-- where = None -->
                                     <!-- distinct = False -->
                                     <SqlSelectStatementNode>
                                         <!-- description = "Read Elements From Semantic Model 'listings_latest'" -->
-                                        <!-- node_id = NodeId(id_str='ss_131') -->
+                                        <!-- node_id = NodeId(id_str='ss_247') -->
                                         <!-- col0 =                                                      -->
                                         <!--   SqlSelectColumn(                                          -->
                                         <!--     expr=SqlStringExpression(node_id=str_28006 sql_expr=1), -->
@@ -3792,13 +3792,13 @@ docstring:
                                         <!--     expr=SqlColumnReferenceExpression(node_id=cr_28076), -->
                                         <!--     column_alias='listing__user',                        -->
                                         <!--   )                                                      -->
-                                        <!-- from_source = SqlTableNode(node_id=tfc_28005) -->
+                                        <!-- from_source = SqlTableNode(node_id=tfc_129) -->
                                         <!-- where = None -->
                                         <!-- distinct = False -->
                                         <SqlTableNode>
                                             <!-- description =                                                 -->
                                             <!--   'Read from ***************************.dim_listings_latest' -->
-                                            <!-- node_id = NodeId(id_str='tfc_28005') -->
+                                            <!-- node_id = NodeId(id_str='tfc_129') -->
                                             <!-- table_id = '***************************.dim_listings_latest' -->
                                         </SqlTableNode>
                                     </SqlSelectStatementNode>

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/test_compute_metrics_node_ratio_from_single_semantic_model__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/test_compute_metrics_node_ratio_from_single_semantic_model__plan0.xml
@@ -6,18 +6,18 @@ docstring:
 <SqlPlan>
     <SqlSelectStatementNode>
         <!-- description = 'Compute Metrics via Expressions' -->
-        <!-- node_id = NodeId(id_str='ss_13') -->
+        <!-- node_id = NodeId(id_str='ss_6') -->
         <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_16), column_alias='listing') -->
         <!-- col1 =                                                                                                      -->
         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_15), column_alias='listing__country_latest') -->
         <!-- col2 =                                                                                                  -->
         <!--   SqlSelectColumn(expr=SqlRatioComputationExpression(node_id=rc_0), column_alias='bookings_per_booker') -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_11) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_5) -->
         <!-- where = None -->
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = 'Aggregate Measures' -->
-            <!-- node_id = NodeId(id_str='ss_11') -->
+            <!-- node_id = NodeId(id_str='ss_5') -->
             <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_14), column_alias='listing') -->
             <!-- col1 =                                                -->
             <!--   SqlSelectColumn(                                    -->
@@ -34,7 +34,7 @@ docstring:
             <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_1, sql_function=COUNT_DISTINCT), -->
             <!--     column_alias='bookers',                                                          -->
             <!--   )                                                                                  -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_9) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_4) -->
             <!-- group_by0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_14), column_alias='listing') -->
             <!-- group_by1 =                                           -->
             <!--   SqlSelectColumn(                                    -->
@@ -45,7 +45,7 @@ docstring:
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = 'Join Standard Outputs' -->
-                <!-- node_id = NodeId(id_str='ss_9') -->
+                <!-- node_id = NodeId(id_str='ss_4') -->
                 <!-- col0 =                                               -->
                 <!--   SqlSelectColumn(                                   -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_7), -->
@@ -54,10 +54,10 @@ docstring:
                 <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_10), column_alias='listing') -->
                 <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_8), column_alias='bookings') -->
                 <!-- col3 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_9), column_alias='bookers') -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_3) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
                 <!-- join_0 =                                                 -->
                 <!--   SqlJoinDescription(                                    -->
-                <!--     right_source=SqlSelectStatementNode(node_id=ss_7),   -->
+                <!--     right_source=SqlSelectStatementNode(node_id=ss_3),   -->
                 <!--     right_source_alias='subq_3',                         -->
                 <!--     join_type=LEFT_OUTER,                                -->
                 <!--     on_condition=SqlComparisonExpression(node_id=cmp_0), -->
@@ -66,17 +66,17 @@ docstring:
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = "Pass Only Elements: ['bookings', 'bookers', 'listing']" -->
-                    <!-- node_id = NodeId(id_str='ss_3') -->
+                    <!-- node_id = NodeId(id_str='ss_1') -->
                     <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_2), column_alias='listing') -->
                     <!-- col1 =                                                                                      -->
                     <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_0), column_alias='bookings') -->
                     <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_1), column_alias='bookers') -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = "Read Elements From Semantic Model 'bookings_source'" -->
-                        <!-- node_id = NodeId(id_str='ss_1') -->
+                        <!-- node_id = NodeId(id_str='ss_0') -->
                         <!-- col0 =                                                      -->
                         <!--   SqlSelectColumn(                                          -->
                         <!--     expr=SqlStringExpression(node_id=str_28000 sql_expr=1), -->
@@ -493,28 +493,28 @@ docstring:
                         <!--     expr=SqlColumnReferenceExpression(node_id=cr_28036), -->
                         <!--     column_alias='booking__host',                        -->
                         <!--   )                                                      -->
-                        <!-- from_source = SqlTableNode(node_id=tfc_28001) -->
+                        <!-- from_source = SqlTableNode(node_id=tfc_0) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
                         <SqlTableNode>
                             <!-- description = 'Read from ***************************.fct_bookings' -->
-                            <!-- node_id = NodeId(id_str='tfc_28001') -->
+                            <!-- node_id = NodeId(id_str='tfc_0') -->
                             <!-- table_id = '***************************.fct_bookings' -->
                         </SqlTableNode>
                     </SqlSelectStatementNode>
                 </SqlSelectStatementNode>
                 <SqlSelectStatementNode>
                     <!-- description = "Pass Only Elements: ['country_latest', 'listing']" -->
-                    <!-- node_id = NodeId(id_str='ss_7') -->
+                    <!-- node_id = NodeId(id_str='ss_3') -->
                     <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_4), column_alias='listing') -->
                     <!-- col1 =                                                                                            -->
                     <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_3), column_alias='country_latest') -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_5) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_2) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = "Read Elements From Semantic Model 'listings_latest'" -->
-                        <!-- node_id = NodeId(id_str='ss_5') -->
+                        <!-- node_id = NodeId(id_str='ss_2') -->
                         <!-- col0 =                                                      -->
                         <!--   SqlSelectColumn(                                          -->
                         <!--     expr=SqlStringExpression(node_id=str_28006 sql_expr=1), -->
@@ -777,12 +777,12 @@ docstring:
                         <!--     expr=SqlColumnReferenceExpression(node_id=cr_28076), -->
                         <!--     column_alias='listing__user',                        -->
                         <!--   )                                                      -->
-                        <!-- from_source = SqlTableNode(node_id=tfc_28005) -->
+                        <!-- from_source = SqlTableNode(node_id=tfc_1) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
                         <SqlTableNode>
                             <!-- description = 'Read from ***************************.dim_listings_latest' -->
-                            <!-- node_id = NodeId(id_str='tfc_28005') -->
+                            <!-- node_id = NodeId(id_str='tfc_1') -->
                             <!-- table_id = '***************************.dim_listings_latest' -->
                         </SqlTableNode>
                     </SqlSelectStatementNode>

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/test_compute_metrics_node_simple_expr__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/test_compute_metrics_node_simple_expr__plan0.xml
@@ -6,7 +6,7 @@ docstring:
 <SqlPlan>
     <SqlSelectStatementNode>
         <!-- description = 'Compute Metrics via Expressions' -->
-        <!-- node_id = NodeId(id_str='ss_13') -->
+        <!-- node_id = NodeId(id_str='ss_6') -->
         <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_13), column_alias='listing') -->
         <!-- col1 =                                                                                                      -->
         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_12), column_alias='listing__country_latest') -->
@@ -15,12 +15,12 @@ docstring:
         <!--     expr=SqlStringExpression(node_id=str_0 sql_expr=booking_value * 0.05), -->
         <!--     column_alias='booking_fees',                                           -->
         <!--   )                                                                        -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_11) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_5) -->
         <!-- where = None -->
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = 'Aggregate Measures' -->
-            <!-- node_id = NodeId(id_str='ss_11') -->
+            <!-- node_id = NodeId(id_str='ss_5') -->
             <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_11), column_alias='listing') -->
             <!-- col1 =                                                -->
             <!--   SqlSelectColumn(                                    -->
@@ -32,7 +32,7 @@ docstring:
             <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_0, sql_function=SUM), -->
             <!--     column_alias='booking_value',                                         -->
             <!--   )                                                                       -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_9) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_4) -->
             <!-- group_by0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_11), column_alias='listing') -->
             <!-- group_by1 =                                           -->
             <!--   SqlSelectColumn(                                    -->
@@ -43,7 +43,7 @@ docstring:
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = 'Join Standard Outputs' -->
-                <!-- node_id = NodeId(id_str='ss_9') -->
+                <!-- node_id = NodeId(id_str='ss_4') -->
                 <!-- col0 =                                               -->
                 <!--   SqlSelectColumn(                                   -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_6), -->
@@ -52,10 +52,10 @@ docstring:
                 <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_8), column_alias='listing') -->
                 <!-- col2 =                                                                                           -->
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_7), column_alias='booking_value') -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_3) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
                 <!-- join_0 =                                                 -->
                 <!--   SqlJoinDescription(                                    -->
-                <!--     right_source=SqlSelectStatementNode(node_id=ss_7),   -->
+                <!--     right_source=SqlSelectStatementNode(node_id=ss_3),   -->
                 <!--     right_source_alias='subq_3',                         -->
                 <!--     join_type=LEFT_OUTER,                                -->
                 <!--     on_condition=SqlComparisonExpression(node_id=cmp_0), -->
@@ -64,16 +64,16 @@ docstring:
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = "Pass Only Elements: ['booking_value', 'listing']" -->
-                    <!-- node_id = NodeId(id_str='ss_3') -->
+                    <!-- node_id = NodeId(id_str='ss_1') -->
                     <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_1), column_alias='listing') -->
                     <!-- col1 =                                                                                           -->
                     <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_0), column_alias='booking_value') -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = "Read Elements From Semantic Model 'bookings_source'" -->
-                        <!-- node_id = NodeId(id_str='ss_1') -->
+                        <!-- node_id = NodeId(id_str='ss_0') -->
                         <!-- col0 =                                                      -->
                         <!--   SqlSelectColumn(                                          -->
                         <!--     expr=SqlStringExpression(node_id=str_28000 sql_expr=1), -->
@@ -490,28 +490,28 @@ docstring:
                         <!--     expr=SqlColumnReferenceExpression(node_id=cr_28036), -->
                         <!--     column_alias='booking__host',                        -->
                         <!--   )                                                      -->
-                        <!-- from_source = SqlTableNode(node_id=tfc_28001) -->
+                        <!-- from_source = SqlTableNode(node_id=tfc_0) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
                         <SqlTableNode>
                             <!-- description = 'Read from ***************************.fct_bookings' -->
-                            <!-- node_id = NodeId(id_str='tfc_28001') -->
+                            <!-- node_id = NodeId(id_str='tfc_0') -->
                             <!-- table_id = '***************************.fct_bookings' -->
                         </SqlTableNode>
                     </SqlSelectStatementNode>
                 </SqlSelectStatementNode>
                 <SqlSelectStatementNode>
                     <!-- description = "Pass Only Elements: ['country_latest', 'listing']" -->
-                    <!-- node_id = NodeId(id_str='ss_7') -->
+                    <!-- node_id = NodeId(id_str='ss_3') -->
                     <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_3), column_alias='listing') -->
                     <!-- col1 =                                                                                            -->
                     <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_2), column_alias='country_latest') -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_5) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_2) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = "Read Elements From Semantic Model 'listings_latest'" -->
-                        <!-- node_id = NodeId(id_str='ss_5') -->
+                        <!-- node_id = NodeId(id_str='ss_2') -->
                         <!-- col0 =                                                      -->
                         <!--   SqlSelectColumn(                                          -->
                         <!--     expr=SqlStringExpression(node_id=str_28006 sql_expr=1), -->
@@ -774,12 +774,12 @@ docstring:
                         <!--     expr=SqlColumnReferenceExpression(node_id=cr_28076), -->
                         <!--     column_alias='listing__user',                        -->
                         <!--   )                                                      -->
-                        <!-- from_source = SqlTableNode(node_id=tfc_28005) -->
+                        <!-- from_source = SqlTableNode(node_id=tfc_1) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
                         <SqlTableNode>
                             <!-- description = 'Read from ***************************.dim_listings_latest' -->
-                            <!-- node_id = NodeId(id_str='tfc_28005') -->
+                            <!-- node_id = NodeId(id_str='tfc_1') -->
                             <!-- table_id = '***************************.dim_listings_latest' -->
                         </SqlTableNode>
                     </SqlSelectStatementNode>

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/test_constrain_time_range_node__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/test_constrain_time_range_node__plan0.xml
@@ -6,34 +6,34 @@ docstring:
 <SqlPlan>
     <SqlSelectStatementNode>
         <!-- description = 'Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]' -->
-        <!-- node_id = NodeId(id_str='ss_7') -->
+        <!-- node_id = NodeId(id_str='ss_3') -->
         <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_7), column_alias='ds__day') -->
         <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_8), column_alias='metric_time__day') -->
         <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_6), column_alias='bookings') -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_5) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_2) -->
         <!-- where = SqlBetweenExpression(node_id=betw_0) -->
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = "Metric Time Dimension 'ds'" -->
-            <!-- node_id = NodeId(id_str='ss_5') -->
+            <!-- node_id = NodeId(id_str='ss_2') -->
             <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_3), column_alias='ds__day') -->
             <!-- col1 =                                                                                              -->
             <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_4), column_alias='metric_time__day') -->
             <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_2), column_alias='bookings') -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_3) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
             <!-- where = None -->
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = "Pass Only Elements: ['bookings', 'ds__day']" -->
-                <!-- node_id = NodeId(id_str='ss_3') -->
+                <!-- node_id = NodeId(id_str='ss_1') -->
                 <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_1), column_alias='ds__day') -->
                 <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_0), column_alias='bookings') -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = "Read Elements From Semantic Model 'bookings_source'" -->
-                    <!-- node_id = NodeId(id_str='ss_1') -->
+                    <!-- node_id = NodeId(id_str='ss_0') -->
                     <!-- col0 =                                                      -->
                     <!--   SqlSelectColumn(                                          -->
                     <!--     expr=SqlStringExpression(node_id=str_28000 sql_expr=1), -->
@@ -408,12 +408,12 @@ docstring:
                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_28036), -->
                     <!--     column_alias='booking__host',                        -->
                     <!--   )                                                      -->
-                    <!-- from_source = SqlTableNode(node_id=tfc_28001) -->
+                    <!-- from_source = SqlTableNode(node_id=tfc_0) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlTableNode>
                         <!-- description = 'Read from ***************************.fct_bookings' -->
-                        <!-- node_id = NodeId(id_str='tfc_28001') -->
+                        <!-- node_id = NodeId(id_str='tfc_0') -->
                         <!-- table_id = '***************************.fct_bookings' -->
                     </SqlTableNode>
                 </SqlSelectStatementNode>

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/test_dimension_with_joined_where_constraint__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/test_dimension_with_joined_where_constraint__plan0.xml
@@ -6,17 +6,17 @@ docstring:
 <SqlPlan>
     <SqlSelectStatementNode>
         <!-- description = "Pass Only Elements: ['user__home_state_latest',]" -->
-        <!-- node_id = NodeId(id_str='ss_78') -->
+        <!-- node_id = NodeId(id_str='ss_71') -->
         <!-- col0 =                                                                                                       -->
         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_118), column_alias='user__home_state_latest') -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_75) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_70) -->
         <!-- group_by0 =                                                                                                  -->
         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_118), column_alias='user__home_state_latest') -->
         <!-- where = None -->
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = 'Constrain Output with WHERE' -->
-            <!-- node_id = NodeId(id_str='ss_75') -->
+            <!-- node_id = NodeId(id_str='ss_70') -->
             <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_71), column_alias='ds__day') -->
             <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_72), column_alias='ds__week') -->
             <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_73), column_alias='ds__month') -->
@@ -203,12 +203,12 @@ docstring:
             <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_62), column_alias='largest_listing') -->
             <!-- col56 =                                                                                              -->
             <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_63), column_alias='smallest_listing') -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_73) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_69) -->
             <!-- where = SqlStringExpression(node_id=str_0 sql_expr=listing__country_latest = 'us') -->
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = 'Join Standard Outputs' -->
-                <!-- node_id = NodeId(id_str='ss_73') -->
+                <!-- node_id = NodeId(id_str='ss_69') -->
                 <!-- col0 =                                               -->
                 <!--   SqlSelectColumn(                                   -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_4), -->
@@ -409,10 +409,10 @@ docstring:
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_6), column_alias='largest_listing') -->
                 <!-- col56 =                                                                                             -->
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_7), column_alias='smallest_listing') -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_67) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_66) -->
                 <!-- join_0 =                                                 -->
                 <!--   SqlJoinDescription(                                    -->
-                <!--     right_source=SqlSelectStatementNode(node_id=ss_71),  -->
+                <!--     right_source=SqlSelectStatementNode(node_id=ss_68),  -->
                 <!--     right_source_alias='subq_2',                         -->
                 <!--     join_type=FULL_OUTER,                                -->
                 <!--     on_condition=SqlComparisonExpression(node_id=cmp_0), -->
@@ -421,7 +421,7 @@ docstring:
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = "Read Elements From Semantic Model 'listings_latest'" -->
-                    <!-- node_id = NodeId(id_str='ss_67') -->
+                    <!-- node_id = NodeId(id_str='ss_66') -->
                     <!-- col0 =                                                      -->
                     <!--   SqlSelectColumn(                                          -->
                     <!--     expr=SqlStringExpression(node_id=str_28006 sql_expr=1), -->
@@ -650,30 +650,30 @@ docstring:
                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_28076), -->
                     <!--     column_alias='listing__user',                        -->
                     <!--   )                                                      -->
-                    <!-- from_source = SqlTableNode(node_id=tfc_28005) -->
+                    <!-- from_source = SqlTableNode(node_id=tfc_66) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlTableNode>
                         <!-- description = 'Read from ***************************.dim_listings_latest' -->
-                        <!-- node_id = NodeId(id_str='tfc_28005') -->
+                        <!-- node_id = NodeId(id_str='tfc_66') -->
                         <!-- table_id = '***************************.dim_listings_latest' -->
                     </SqlTableNode>
                 </SqlSelectStatementNode>
                 <SqlSelectStatementNode>
                     <!-- description = "Pass Only Elements: ['home_state_latest', 'user']" -->
-                    <!-- node_id = NodeId(id_str='ss_71') -->
+                    <!-- node_id = NodeId(id_str='ss_68') -->
                     <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_1), column_alias='user') -->
                     <!-- col1 =                                               -->
                     <!--   SqlSelectColumn(                                   -->
                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_0), -->
                     <!--     column_alias='home_state_latest',                -->
                     <!--   )                                                  -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_69) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_67) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = "Read Elements From Semantic Model 'users_latest'" -->
-                        <!-- node_id = NodeId(id_str='ss_69') -->
+                        <!-- node_id = NodeId(id_str='ss_67') -->
                         <!-- col0 =                                             -->
                         <!--   SqlSelectColumn(                                 -->
                         <!--     expr=SqlDateTruncExpression(node_id=dt_28202), -->
@@ -796,12 +796,12 @@ docstring:
                         <!--   )                                                      -->
                         <!-- col24 =                                                                                     -->
                         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28106), column_alias='user') -->
-                        <!-- from_source = SqlTableNode(node_id=tfc_28009) -->
+                        <!-- from_source = SqlTableNode(node_id=tfc_67) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
                         <SqlTableNode>
                             <!-- description = 'Read from ***************************.dim_users_latest' -->
-                            <!-- node_id = NodeId(id_str='tfc_28009') -->
+                            <!-- node_id = NodeId(id_str='tfc_67') -->
                             <!-- table_id = '***************************.dim_users_latest' -->
                         </SqlTableNode>
                     </SqlSelectStatementNode>

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/test_dimensions_requiring_join__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/test_dimensions_requiring_join__plan0.xml
@@ -6,12 +6,12 @@ docstring:
 <SqlPlan>
     <SqlSelectStatementNode>
         <!-- description = "Pass Only Elements: ['user__home_state_latest', 'listing__is_lux_latest']" -->
-        <!-- node_id = NodeId(id_str='ss_76') -->
+        <!-- node_id = NodeId(id_str='ss_70') -->
         <!-- col0 =                                                                                                     -->
         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_61), column_alias='listing__is_lux_latest') -->
         <!-- col1 =                                                                                                      -->
         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_62), column_alias='user__home_state_latest') -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_73) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_69) -->
         <!-- group_by0 =                                                                                                -->
         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_61), column_alias='listing__is_lux_latest') -->
         <!-- group_by1 =                                                                                                 -->
@@ -20,7 +20,7 @@ docstring:
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = 'Join Standard Outputs' -->
-            <!-- node_id = NodeId(id_str='ss_73') -->
+            <!-- node_id = NodeId(id_str='ss_69') -->
             <!-- col0 =                                               -->
             <!--   SqlSelectColumn(                                   -->
             <!--     expr=SqlColumnReferenceExpression(node_id=cr_4), -->
@@ -205,10 +205,10 @@ docstring:
             <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_6), column_alias='largest_listing') -->
             <!-- col56 =                                                                                             -->
             <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_7), column_alias='smallest_listing') -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_67) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_66) -->
             <!-- join_0 =                                                 -->
             <!--   SqlJoinDescription(                                    -->
-            <!--     right_source=SqlSelectStatementNode(node_id=ss_71),  -->
+            <!--     right_source=SqlSelectStatementNode(node_id=ss_68),  -->
             <!--     right_source_alias='subq_2',                         -->
             <!--     join_type=FULL_OUTER,                                -->
             <!--     on_condition=SqlComparisonExpression(node_id=cmp_0), -->
@@ -217,7 +217,7 @@ docstring:
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = "Read Elements From Semantic Model 'listings_latest'" -->
-                <!-- node_id = NodeId(id_str='ss_67') -->
+                <!-- node_id = NodeId(id_str='ss_66') -->
                 <!-- col0 =                                                                                             -->
                 <!--   SqlSelectColumn(expr=SqlStringExpression(node_id=str_28006 sql_expr=1), column_alias='listings') -->
                 <!-- col1 =                                                   -->
@@ -411,27 +411,27 @@ docstring:
                 <!-- col54 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28075), column_alias='user') -->
                 <!-- col55 =                                                                                              -->
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28076), column_alias='listing__user') -->
-                <!-- from_source = SqlTableNode(node_id=tfc_28005) -->
+                <!-- from_source = SqlTableNode(node_id=tfc_66) -->
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlTableNode>
                     <!-- description = 'Read from ***************************.dim_listings_latest' -->
-                    <!-- node_id = NodeId(id_str='tfc_28005') -->
+                    <!-- node_id = NodeId(id_str='tfc_66') -->
                     <!-- table_id = '***************************.dim_listings_latest' -->
                 </SqlTableNode>
             </SqlSelectStatementNode>
             <SqlSelectStatementNode>
                 <!-- description = "Pass Only Elements: ['home_state_latest', 'user']" -->
-                <!-- node_id = NodeId(id_str='ss_71') -->
+                <!-- node_id = NodeId(id_str='ss_68') -->
                 <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_1), column_alias='user') -->
                 <!-- col1 =                                                                                               -->
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_0), column_alias='home_state_latest') -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_69) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_67) -->
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = "Read Elements From Semantic Model 'users_latest'" -->
-                    <!-- node_id = NodeId(id_str='ss_69') -->
+                    <!-- node_id = NodeId(id_str='ss_67') -->
                     <!-- col0 =                                                                                          -->
                     <!--   SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_28202), column_alias='ds_latest__day') -->
                     <!-- col1 =                                                                                           -->
@@ -542,12 +542,12 @@ docstring:
                     <!--   )                                                      -->
                     <!-- col24 =                                                                                     -->
                     <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28106), column_alias='user') -->
-                    <!-- from_source = SqlTableNode(node_id=tfc_28009) -->
+                    <!-- from_source = SqlTableNode(node_id=tfc_67) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlTableNode>
                         <!-- description = 'Read from ***************************.dim_users_latest' -->
-                        <!-- node_id = NodeId(id_str='tfc_28009') -->
+                        <!-- node_id = NodeId(id_str='tfc_67') -->
                         <!-- table_id = '***************************.dim_users_latest' -->
                     </SqlTableNode>
                 </SqlSelectStatementNode>

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/test_filter_node__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/test_filter_node__plan0.xml
@@ -6,14 +6,14 @@ docstring:
 <SqlPlan>
     <SqlSelectStatementNode>
         <!-- description = "Pass Only Elements: ['bookings',]" -->
-        <!-- node_id = NodeId(id_str='ss_3') -->
+        <!-- node_id = NodeId(id_str='ss_1') -->
         <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_0), column_alias='bookings') -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
         <!-- where = None -->
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = "Read Elements From Semantic Model 'bookings_source'" -->
-            <!-- node_id = NodeId(id_str='ss_1') -->
+            <!-- node_id = NodeId(id_str='ss_0') -->
             <!-- col0 = SqlSelectColumn(expr=SqlStringExpression(node_id=str_28000 sql_expr=1), column_alias='bookings') -->
             <!-- col1 =                                                                                           -->
             <!--   SqlSelectColumn(                                                                               -->
@@ -267,12 +267,12 @@ docstring:
             <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28035), column_alias='booking__guest') -->
             <!-- col87 =                                                                                              -->
             <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28036), column_alias='booking__host') -->
-            <!-- from_source = SqlTableNode(node_id=tfc_28001) -->
+            <!-- from_source = SqlTableNode(node_id=tfc_0) -->
             <!-- where = None -->
             <!-- distinct = False -->
             <SqlTableNode>
                 <!-- description = 'Read from ***************************.fct_bookings' -->
-                <!-- node_id = NodeId(id_str='tfc_28001') -->
+                <!-- node_id = NodeId(id_str='tfc_0') -->
                 <!-- table_id = '***************************.fct_bookings' -->
             </SqlTableNode>
         </SqlSelectStatementNode>

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/test_filter_with_where_constraint_node__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/test_filter_with_where_constraint_node__plan0.xml
@@ -6,23 +6,23 @@ docstring:
 <SqlPlan>
     <SqlSelectStatementNode>
         <!-- description = 'Constrain Output with WHERE' -->
-        <!-- node_id = NodeId(id_str='ss_5') -->
+        <!-- node_id = NodeId(id_str='ss_2') -->
         <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_3), column_alias='ds__day') -->
         <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_2), column_alias='bookings') -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_3) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
         <!-- where = SqlStringExpression(node_id=str_0 sql_expr=booking__ds__day = '2020-01-01') -->
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = "Pass Only Elements: ['bookings', 'ds__day']" -->
-            <!-- node_id = NodeId(id_str='ss_3') -->
+            <!-- node_id = NodeId(id_str='ss_1') -->
             <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_1), column_alias='ds__day') -->
             <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_0), column_alias='bookings') -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
             <!-- where = None -->
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = "Read Elements From Semantic Model 'bookings_source'" -->
-                <!-- node_id = NodeId(id_str='ss_1') -->
+                <!-- node_id = NodeId(id_str='ss_0') -->
                 <!-- col0 =                                                                                             -->
                 <!--   SqlSelectColumn(expr=SqlStringExpression(node_id=str_28000 sql_expr=1), column_alias='bookings') -->
                 <!-- col1 =                                                                                           -->
@@ -340,12 +340,12 @@ docstring:
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28035), column_alias='booking__guest') -->
                 <!-- col87 =                                                                                              -->
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28036), column_alias='booking__host') -->
-                <!-- from_source = SqlTableNode(node_id=tfc_28001) -->
+                <!-- from_source = SqlTableNode(node_id=tfc_0) -->
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlTableNode>
                     <!-- description = 'Read from ***************************.fct_bookings' -->
-                    <!-- node_id = NodeId(id_str='tfc_28001') -->
+                    <!-- node_id = NodeId(id_str='tfc_0') -->
                     <!-- table_id = '***************************.fct_bookings' -->
                 </SqlTableNode>
             </SqlSelectStatementNode>

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/test_measure_aggregation_node__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/test_measure_aggregation_node__plan0.xml
@@ -8,7 +8,7 @@ docstring:
 <SqlPlan>
     <SqlSelectStatementNode>
         <!-- description = 'Aggregate Measures' -->
-        <!-- node_id = NodeId(id_str='ss_5') -->
+        <!-- node_id = NodeId(id_str='ss_2') -->
         <!-- col0 =                                                                    -->
         <!--   SqlSelectColumn(                                                        -->
         <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_0, sql_function=SUM), -->
@@ -29,25 +29,25 @@ docstring:
         <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_3, sql_function=AVERAGE), -->
         <!--     column_alias='average_booking_value',                                     -->
         <!--   )                                                                           -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_3) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
         <!-- where = None -->
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description =                                                                                -->
             <!--   "Pass Only Elements: ['bookings', 'instant_bookings', 'average_booking_value', 'bookers']" -->
-            <!-- node_id = NodeId(id_str='ss_3') -->
+            <!-- node_id = NodeId(id_str='ss_1') -->
             <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_0), column_alias='bookings') -->
             <!-- col1 =                                                                                              -->
             <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_1), column_alias='instant_bookings') -->
             <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_2), column_alias='bookers') -->
             <!-- col3 =                                                                                                   -->
             <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_3), column_alias='average_booking_value') -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
             <!-- where = None -->
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = "Read Elements From Semantic Model 'bookings_source'" -->
-                <!-- node_id = NodeId(id_str='ss_1') -->
+                <!-- node_id = NodeId(id_str='ss_0') -->
                 <!-- col0 =                                                                                             -->
                 <!--   SqlSelectColumn(expr=SqlStringExpression(node_id=str_28000 sql_expr=1), column_alias='bookings') -->
                 <!-- col1 =                                                                                           -->
@@ -365,12 +365,12 @@ docstring:
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28035), column_alias='booking__guest') -->
                 <!-- col87 =                                                                                              -->
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28036), column_alias='booking__host') -->
-                <!-- from_source = SqlTableNode(node_id=tfc_28001) -->
+                <!-- from_source = SqlTableNode(node_id=tfc_0) -->
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlTableNode>
                     <!-- description = 'Read from ***************************.fct_bookings' -->
-                    <!-- node_id = NodeId(id_str='tfc_28001') -->
+                    <!-- node_id = NodeId(id_str='tfc_0') -->
                     <!-- table_id = '***************************.fct_bookings' -->
                 </SqlTableNode>
             </SqlSelectStatementNode>

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/test_multi_join_node__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/test_multi_join_node__plan0.xml
@@ -6,24 +6,24 @@ docstring:
 <SqlPlan>
     <SqlSelectStatementNode>
         <!-- description = 'Join Standard Outputs' -->
-        <!-- node_id = NodeId(id_str='ss_10') -->
+        <!-- node_id = NodeId(id_str='ss_6') -->
         <!-- col0 =                                                                                                     -->
         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_6), column_alias='listing__country_latest') -->
         <!-- col1 =                                                                                                     -->
         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_9), column_alias='listing__country_latest') -->
         <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_11), column_alias='listing') -->
         <!-- col3 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_10), column_alias='bookings') -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_3) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
         <!-- join_0 =                                                 -->
         <!--   SqlJoinDescription(                                    -->
-        <!--     right_source=SqlSelectStatementNode(node_id=ss_7),   -->
+        <!--     right_source=SqlSelectStatementNode(node_id=ss_3),   -->
         <!--     right_source_alias='subq_3',                         -->
         <!--     join_type=LEFT_OUTER,                                -->
         <!--     on_condition=SqlComparisonExpression(node_id=cmp_0), -->
         <!--   )                                                      -->
         <!-- join_1 =                                                 -->
         <!--   SqlJoinDescription(                                    -->
-        <!--     right_source=SqlSelectStatementNode(node_id=ss_8),   -->
+        <!--     right_source=SqlSelectStatementNode(node_id=ss_5),   -->
         <!--     right_source_alias='subq_4',                         -->
         <!--     join_type=LEFT_OUTER,                                -->
         <!--     on_condition=SqlComparisonExpression(node_id=cmp_1), -->
@@ -32,15 +32,15 @@ docstring:
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = "Pass Only Elements: ['bookings', 'listing']" -->
-            <!-- node_id = NodeId(id_str='ss_3') -->
+            <!-- node_id = NodeId(id_str='ss_1') -->
             <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_1), column_alias='listing') -->
             <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_0), column_alias='bookings') -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
             <!-- where = None -->
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = "Read Elements From Semantic Model 'bookings_source'" -->
-                <!-- node_id = NodeId(id_str='ss_1') -->
+                <!-- node_id = NodeId(id_str='ss_0') -->
                 <!-- col0 =                                                                                             -->
                 <!--   SqlSelectColumn(expr=SqlStringExpression(node_id=str_28000 sql_expr=1), column_alias='bookings') -->
                 <!-- col1 =                                                                                           -->
@@ -358,27 +358,27 @@ docstring:
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28035), column_alias='booking__guest') -->
                 <!-- col87 =                                                                                              -->
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28036), column_alias='booking__host') -->
-                <!-- from_source = SqlTableNode(node_id=tfc_28001) -->
+                <!-- from_source = SqlTableNode(node_id=tfc_0) -->
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlTableNode>
                     <!-- description = 'Read from ***************************.fct_bookings' -->
-                    <!-- node_id = NodeId(id_str='tfc_28001') -->
+                    <!-- node_id = NodeId(id_str='tfc_0') -->
                     <!-- table_id = '***************************.fct_bookings' -->
                 </SqlTableNode>
             </SqlSelectStatementNode>
         </SqlSelectStatementNode>
         <SqlSelectStatementNode>
             <!-- description = "Pass Only Elements: ['country_latest', 'listing']" -->
-            <!-- node_id = NodeId(id_str='ss_7') -->
+            <!-- node_id = NodeId(id_str='ss_3') -->
             <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_3), column_alias='listing') -->
             <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_2), column_alias='country_latest') -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_5) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_2) -->
             <!-- where = None -->
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = "Read Elements From Semantic Model 'listings_latest'" -->
-                <!-- node_id = NodeId(id_str='ss_5') -->
+                <!-- node_id = NodeId(id_str='ss_2') -->
                 <!-- col0 =                                                                                             -->
                 <!--   SqlSelectColumn(expr=SqlStringExpression(node_id=str_28006 sql_expr=1), column_alias='listings') -->
                 <!-- col1 =                                                   -->
@@ -572,27 +572,27 @@ docstring:
                 <!-- col54 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28075), column_alias='user') -->
                 <!-- col55 =                                                                                              -->
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28076), column_alias='listing__user') -->
-                <!-- from_source = SqlTableNode(node_id=tfc_28005) -->
+                <!-- from_source = SqlTableNode(node_id=tfc_1) -->
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlTableNode>
                     <!-- description = 'Read from ***************************.dim_listings_latest' -->
-                    <!-- node_id = NodeId(id_str='tfc_28005') -->
+                    <!-- node_id = NodeId(id_str='tfc_1') -->
                     <!-- table_id = '***************************.dim_listings_latest' -->
                 </SqlTableNode>
             </SqlSelectStatementNode>
         </SqlSelectStatementNode>
         <SqlSelectStatementNode>
             <!-- description = "Pass Only Elements: ['country_latest', 'listing']" -->
-            <!-- node_id = NodeId(id_str='ss_8') -->
+            <!-- node_id = NodeId(id_str='ss_5') -->
             <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_3), column_alias='listing') -->
             <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_2), column_alias='country_latest') -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_5) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_4) -->
             <!-- where = None -->
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = "Read Elements From Semantic Model 'listings_latest'" -->
-                <!-- node_id = NodeId(id_str='ss_5') -->
+                <!-- node_id = NodeId(id_str='ss_4') -->
                 <!-- col0 =                                                                                             -->
                 <!--   SqlSelectColumn(expr=SqlStringExpression(node_id=str_28006 sql_expr=1), column_alias='listings') -->
                 <!-- col1 =                                                   -->
@@ -786,12 +786,12 @@ docstring:
                 <!-- col54 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28075), column_alias='user') -->
                 <!-- col55 =                                                                                              -->
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28076), column_alias='listing__user') -->
-                <!-- from_source = SqlTableNode(node_id=tfc_28005) -->
+                <!-- from_source = SqlTableNode(node_id=tfc_2) -->
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlTableNode>
                     <!-- description = 'Read from ***************************.dim_listings_latest' -->
-                    <!-- node_id = NodeId(id_str='tfc_28005') -->
+                    <!-- node_id = NodeId(id_str='tfc_2') -->
                     <!-- table_id = '***************************.dim_listings_latest' -->
                 </SqlTableNode>
             </SqlSelectStatementNode>

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/test_offset_by_custom_granularity_node__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/test_offset_by_custom_granularity_node__plan0.xml
@@ -4,21 +4,21 @@ test_filename: test_dataflow_to_sql_plan.py
 <SqlPlan>
     <SqlSelectStatementNode>
         <!-- description = 'Apply Requested Granularities' -->
-        <!-- node_id = NodeId(id_str='ss_7') -->
+        <!-- node_id = NodeId(id_str='ss_5') -->
         <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_15), column_alias='ds__day') -->
         <!-- col1 = SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_0), column_alias='metric_time__month') -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_5) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_4) -->
         <!-- where = None -->
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = 'Offset Base Granularity By Custom Granularity Period(s)' -->
-            <!-- node_id = NodeId(id_str='ss_5') -->
+            <!-- node_id = NodeId(id_str='ss_4') -->
             <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_11), column_alias='ds__day') -->
             <!-- col1 = SqlSelectColumn(expr=SqlCaseExpression(node_id=case_0), column_alias='ds__day__lead') -->
-            <!-- from_source = SqlTableNode(node_id=tfc_1) -->
+            <!-- from_source = SqlTableNode(node_id=tfc_2) -->
             <!-- join_0 =                                                 -->
             <!--   SqlJoinDescription(                                    -->
-            <!--     right_source=SqlSelectStatementNode(node_id=ss_4),   -->
+            <!--     right_source=SqlSelectStatementNode(node_id=ss_3),   -->
             <!--     right_source_alias='subq_2',                         -->
             <!--     join_type=INNER,                                     -->
             <!--     on_condition=SqlComparisonExpression(node_id=cmp_1), -->
@@ -27,12 +27,12 @@ test_filename: test_dataflow_to_sql_plan.py
             <!-- distinct = False -->
             <SqlTableNode>
                 <!-- description = 'Read from cte_0' -->
-                <!-- node_id = NodeId(id_str='tfc_1') -->
+                <!-- node_id = NodeId(id_str='tfc_2') -->
                 <!-- table_id = 'cte_0' -->
             </SqlTableNode>
             <SqlSelectStatementNode>
                 <!-- description = 'Offset Custom Granularity Bounds' -->
-                <!-- node_id = NodeId(id_str='ss_4') -->
+                <!-- node_id = NodeId(id_str='ss_3') -->
                 <!-- col0 =                                                                                           -->
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_5), column_alias='ds__alien_day') -->
                 <!-- col1 =                                                                   -->
@@ -45,12 +45,12 @@ test_filename: test_dataflow_to_sql_plan.py
                 <!--     expr=SqlWindowFunctionExpression(node_id=wfnc_4, sql_function=LEAD), -->
                 <!--     column_alias='ds__alien_day__last_value__lead',                      -->
                 <!--   )                                                                      -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_3) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_2) -->
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = 'Get Unique Rows for Custom Granularity Bounds' -->
-                    <!-- node_id = NodeId(id_str='ss_3') -->
+                    <!-- node_id = NodeId(id_str='ss_2') -->
                     <!-- col0 =                                                                                           -->
                     <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_2), column_alias='ds__alien_day') -->
                     <!-- col1 =                                               -->
@@ -63,7 +63,7 @@ test_filename: test_dataflow_to_sql_plan.py
                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_4), -->
                     <!--     column_alias='ds__alien_day__last_value',        -->
                     <!--   )                                                  -->
-                    <!-- from_source = SqlTableNode(node_id=tfc_0) -->
+                    <!-- from_source = SqlTableNode(node_id=tfc_1) -->
                     <!-- group_by0 =                                                                                      -->
                     <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_2), column_alias='ds__alien_day') -->
                     <!-- group_by1 =                                          -->
@@ -80,7 +80,7 @@ test_filename: test_dataflow_to_sql_plan.py
                     <!-- distinct = False -->
                     <SqlTableNode>
                         <!-- description = 'Read from cte_0' -->
-                        <!-- node_id = NodeId(id_str='tfc_0') -->
+                        <!-- node_id = NodeId(id_str='tfc_1') -->
                         <!-- table_id = 'cte_0' -->
                     </SqlTableNode>
                 </SqlSelectStatementNode>
@@ -90,7 +90,7 @@ test_filename: test_dataflow_to_sql_plan.py
                 <!-- node_id = NodeId(id_str='cte_1') -->
                 <SqlSelectStatementNode>
                     <!-- description = 'Get Custom Granularity Bounds' -->
-                    <!-- node_id = NodeId(id_str='ss_2') -->
+                    <!-- node_id = NodeId(id_str='ss_1') -->
                     <!-- col0 =                                                                                         -->
                     <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28130), column_alias='ds__day') -->
                     <!-- col1 = SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_28287), column_alias='ds__week') -->
@@ -133,12 +133,12 @@ test_filename: test_dataflow_to_sql_plan.py
                     <!--     expr=SqlWindowFunctionExpression(node_id=wfnc_2, sql_function=ROW_NUMBER), -->
                     <!--     column_alias='ds__day__row_number',                                        -->
                     <!--   )                                                                            -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = "Read From Time Spine 'mf_time_spine'" -->
-                        <!-- node_id = NodeId(id_str='ss_1') -->
+                        <!-- node_id = NodeId(id_str='ss_0') -->
                         <!-- col0 =                                                   -->
                         <!--   SqlSelectColumn(                                       -->
                         <!--     expr=SqlColumnReferenceExpression(node_id=cr_28130), -->
@@ -187,12 +187,12 @@ test_filename: test_dataflow_to_sql_plan.py
                         <!--     expr=SqlColumnReferenceExpression(node_id=cr_28131), -->
                         <!--     column_alias='ds__alien_day',                        -->
                         <!--   )                                                      -->
-                        <!-- from_source = SqlTableNode(node_id=tfc_28018) -->
+                        <!-- from_source = SqlTableNode(node_id=tfc_0) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
                         <SqlTableNode>
                             <!-- description = 'Read from ***************************.mf_time_spine' -->
-                            <!-- node_id = NodeId(id_str='tfc_28018') -->
+                            <!-- node_id = NodeId(id_str='tfc_0') -->
                             <!-- table_id = '***************************.mf_time_spine' -->
                         </SqlTableNode>
                     </SqlSelectStatementNode>

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/test_offset_custom_granularity_node__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/test_offset_custom_granularity_node__plan0.xml
@@ -4,14 +4,14 @@ test_filename: test_dataflow_to_sql_plan.py
 <SqlPlan>
     <SqlSelectStatementNode>
         <!-- description = 'Join Offset Custom Granularity to Base Granularity' -->
-        <!-- node_id = NodeId(id_str='ss_4') -->
+        <!-- node_id = NodeId(id_str='ss_2') -->
         <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_2), column_alias='ds__day') -->
         <!-- col1 =                                                                                                    -->
         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_3), column_alias='metric_time__alien_day') -->
-        <!-- from_source = SqlTableNode(node_id=tfc_1) -->
+        <!-- from_source = SqlTableNode(node_id=tfc_2) -->
         <!-- join_0 =                                                 -->
         <!--   SqlJoinDescription(                                    -->
-        <!--     right_source=SqlSelectStatementNode(node_id=ss_2),   -->
+        <!--     right_source=SqlSelectStatementNode(node_id=ss_1),   -->
         <!--     right_source_alias='subq_0',                         -->
         <!--     join_type=INNER,                                     -->
         <!--     on_condition=SqlComparisonExpression(node_id=cmp_0), -->
@@ -20,26 +20,26 @@ test_filename: test_dataflow_to_sql_plan.py
         <!-- distinct = False -->
         <SqlTableNode>
             <!-- description = 'Read from cte_0' -->
-            <!-- node_id = NodeId(id_str='tfc_1') -->
+            <!-- node_id = NodeId(id_str='tfc_2') -->
             <!-- table_id = 'cte_0' -->
         </SqlTableNode>
         <SqlSelectStatementNode>
             <!-- description = 'Offset Custom Granularity' -->
-            <!-- node_id = NodeId(id_str='ss_2') -->
+            <!-- node_id = NodeId(id_str='ss_1') -->
             <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_0), column_alias='ds__alien_day') -->
             <!-- col1 =                                                                   -->
             <!--   SqlSelectColumn(                                                       -->
             <!--     expr=SqlWindowFunctionExpression(node_id=wfnc_0, sql_function=LEAD), -->
             <!--     column_alias='ds__alien_day__lead',                                  -->
             <!--   )                                                                      -->
-            <!-- from_source = SqlTableNode(node_id=tfc_0) -->
+            <!-- from_source = SqlTableNode(node_id=tfc_1) -->
             <!-- group_by0 =                                                                                      -->
             <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_0), column_alias='ds__alien_day') -->
             <!-- where = None -->
             <!-- distinct = False -->
             <SqlTableNode>
                 <!-- description = 'Read from cte_0' -->
-                <!-- node_id = NodeId(id_str='tfc_0') -->
+                <!-- node_id = NodeId(id_str='tfc_1') -->
                 <!-- table_id = 'cte_0' -->
             </SqlTableNode>
         </SqlSelectStatementNode>
@@ -48,7 +48,7 @@ test_filename: test_dataflow_to_sql_plan.py
             <!-- node_id = NodeId(id_str='cte_1') -->
             <SqlSelectStatementNode>
                 <!-- description = "Read From Time Spine 'mf_time_spine'" -->
-                <!-- node_id = NodeId(id_str='ss_1') -->
+                <!-- node_id = NodeId(id_str='ss_0') -->
                 <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28130), column_alias='ds__day') -->
                 <!-- col1 = SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_28287), column_alias='ds__week') -->
                 <!-- col2 = SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_28288), column_alias='ds__month') -->
@@ -66,12 +66,12 @@ test_filename: test_dataflow_to_sql_plan.py
                 <!--   SqlSelectColumn(expr=SqlExtractExpression(node_id=ex_28305), column_alias='ds__extract_doy') -->
                 <!-- col11 =                                                                                              -->
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28131), column_alias='ds__alien_day') -->
-                <!-- from_source = SqlTableNode(node_id=tfc_28018) -->
+                <!-- from_source = SqlTableNode(node_id=tfc_0) -->
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlTableNode>
                     <!-- description = 'Read from ***************************.mf_time_spine' -->
-                    <!-- node_id = NodeId(id_str='tfc_28018') -->
+                    <!-- node_id = NodeId(id_str='tfc_0') -->
                     <!-- table_id = '***************************.mf_time_spine' -->
                 </SqlTableNode>
             </SqlSelectStatementNode>

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/test_order_by_node__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/test_order_by_node__plan0.xml
@@ -6,27 +6,27 @@ docstring:
 <SqlPlan>
     <SqlSelectStatementNode>
         <!-- description = "Order By ['ds__day', 'bookings']" -->
-        <!-- node_id = NodeId(id_str='ss_9') -->
+        <!-- node_id = NodeId(id_str='ss_4') -->
         <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_13), column_alias='ds__day') -->
         <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_12), column_alias='is_instant') -->
         <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_11), column_alias='bookings') -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_7) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_3) -->
         <!-- where = None -->
         <!-- order_by0 = SqlOrderByDescription(expr=SqlColumnReferenceExpression(node_id=cr_9), desc=False) -->
         <!-- order_by1 = SqlOrderByDescription(expr=SqlColumnReferenceExpression(node_id=cr_10), desc=True) -->
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = 'Compute Metrics via Expressions' -->
-            <!-- node_id = NodeId(id_str='ss_7') -->
+            <!-- node_id = NodeId(id_str='ss_3') -->
             <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_7), column_alias='ds__day') -->
             <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_6), column_alias='is_instant') -->
             <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_8), column_alias='bookings') -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_5) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_2) -->
             <!-- where = None -->
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = 'Aggregate Measures' -->
-                <!-- node_id = NodeId(id_str='ss_5') -->
+                <!-- node_id = NodeId(id_str='ss_2') -->
                 <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_5), column_alias='ds__day') -->
                 <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_4), column_alias='is_instant') -->
                 <!-- col2 =                                                                    -->
@@ -34,7 +34,7 @@ docstring:
                 <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_0, sql_function=SUM), -->
                 <!--     column_alias='bookings',                                              -->
                 <!--   )                                                                       -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_3) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
                 <!-- group_by0 =                                                                                -->
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_5), column_alias='ds__day') -->
                 <!-- group_by1 =                                                                                   -->
@@ -43,18 +43,18 @@ docstring:
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = "Pass Only Elements: ['bookings', 'is_instant', 'ds__day']" -->
-                    <!-- node_id = NodeId(id_str='ss_3') -->
+                    <!-- node_id = NodeId(id_str='ss_1') -->
                     <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_2), column_alias='ds__day') -->
                     <!-- col1 =                                                                                        -->
                     <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_1), column_alias='is_instant') -->
                     <!-- col2 =                                                                                      -->
                     <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_0), column_alias='bookings') -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = "Read Elements From Semantic Model 'bookings_source'" -->
-                        <!-- node_id = NodeId(id_str='ss_1') -->
+                        <!-- node_id = NodeId(id_str='ss_0') -->
                         <!-- col0 =                                                      -->
                         <!--   SqlSelectColumn(                                          -->
                         <!--     expr=SqlStringExpression(node_id=str_28000 sql_expr=1), -->
@@ -471,12 +471,12 @@ docstring:
                         <!--     expr=SqlColumnReferenceExpression(node_id=cr_28036), -->
                         <!--     column_alias='booking__host',                        -->
                         <!--   )                                                      -->
-                        <!-- from_source = SqlTableNode(node_id=tfc_28001) -->
+                        <!-- from_source = SqlTableNode(node_id=tfc_0) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
                         <SqlTableNode>
                             <!-- description = 'Read from ***************************.fct_bookings' -->
-                            <!-- node_id = NodeId(id_str='tfc_28001') -->
+                            <!-- node_id = NodeId(id_str='tfc_0') -->
                             <!-- table_id = '***************************.fct_bookings' -->
                         </SqlTableNode>
                     </SqlSelectStatementNode>

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/test_semi_additive_join_node__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/test_semi_additive_join_node__plan0.xml
@@ -6,7 +6,7 @@ docstring:
 <SqlPlan>
     <SqlSelectStatementNode>
         <!-- description = 'Join on MIN(ds) and [] grouping by None' -->
-        <!-- node_id = NodeId(id_str='ss_5') -->
+        <!-- node_id = NodeId(id_str='ss_3') -->
         <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_9), column_alias='ds__day') -->
         <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_10), column_alias='ds__week') -->
         <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_11), column_alias='ds__month') -->
@@ -98,10 +98,10 @@ docstring:
         <!--     expr=SqlColumnReferenceExpression(node_id=cr_6),         -->
         <!--     column_alias='total_account_balance_first_day_of_month', -->
         <!--   )                                                          -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
         <!-- join_0 =                                                 -->
         <!--   SqlJoinDescription(                                    -->
-        <!--     right_source=SqlSelectStatementNode(node_id=ss_3),   -->
+        <!--     right_source=SqlSelectStatementNode(node_id=ss_2),   -->
         <!--     right_source_alias='subq_2',                         -->
         <!--     join_type=INNER,                                     -->
         <!--     on_condition=SqlComparisonExpression(node_id=cmp_0), -->
@@ -110,7 +110,7 @@ docstring:
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = "Read Elements From Semantic Model 'accounts_source'" -->
-            <!-- node_id = NodeId(id_str='ss_1') -->
+            <!-- node_id = NodeId(id_str='ss_0') -->
             <!-- col0 =                                                                                                 -->
             <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28000), column_alias='account_balance') -->
             <!-- col1 =                                                   -->
@@ -208,29 +208,29 @@ docstring:
             <!-- col40 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28010), column_alias='user') -->
             <!-- col41 =                                                                                              -->
             <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28011), column_alias='account__user') -->
-            <!-- from_source = SqlTableNode(node_id=tfc_28000) -->
+            <!-- from_source = SqlTableNode(node_id=tfc_0) -->
             <!-- where = None -->
             <!-- distinct = False -->
             <SqlTableNode>
                 <!-- description = 'Read from ***************************.fct_accounts' -->
-                <!-- node_id = NodeId(id_str='tfc_28000') -->
+                <!-- node_id = NodeId(id_str='tfc_0') -->
                 <!-- table_id = '***************************.fct_accounts' -->
             </SqlTableNode>
         </SqlSelectStatementNode>
         <SqlSelectStatementNode>
             <!-- description = 'Filter row on MIN(ds__day)' -->
-            <!-- node_id = NodeId(id_str='ss_3') -->
+            <!-- node_id = NodeId(id_str='ss_2') -->
             <!-- col0 =                                                                    -->
             <!--   SqlSelectColumn(                                                        -->
             <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_0, sql_function=MIN), -->
             <!--     column_alias='ds__day__complete',                                     -->
             <!--   )                                                                       -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_2) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
             <!-- where = None -->
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = "Read Elements From Semantic Model 'accounts_source'" -->
-                <!-- node_id = NodeId(id_str='ss_2') -->
+                <!-- node_id = NodeId(id_str='ss_1') -->
                 <!-- col0 =                                                   -->
                 <!--   SqlSelectColumn(                                       -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_28000), -->
@@ -366,12 +366,12 @@ docstring:
                 <!-- col40 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28010), column_alias='user') -->
                 <!-- col41 =                                                                                              -->
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28011), column_alias='account__user') -->
-                <!-- from_source = SqlTableNode(node_id=tfc_28000) -->
+                <!-- from_source = SqlTableNode(node_id=tfc_1) -->
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlTableNode>
                     <!-- description = 'Read from ***************************.fct_accounts' -->
-                    <!-- node_id = NodeId(id_str='tfc_28000') -->
+                    <!-- node_id = NodeId(id_str='tfc_1') -->
                     <!-- table_id = '***************************.fct_accounts' -->
                 </SqlTableNode>
             </SqlSelectStatementNode>

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/test_semi_additive_join_node_with_grouping__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/test_semi_additive_join_node_with_grouping__plan0.xml
@@ -6,7 +6,7 @@ docstring:
 <SqlPlan>
     <SqlSelectStatementNode>
         <!-- description = "Join on MAX(ds) and ['user'] grouping by None" -->
-        <!-- node_id = NodeId(id_str='ss_5') -->
+        <!-- node_id = NodeId(id_str='ss_3') -->
         <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_12), column_alias='ds__day') -->
         <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_13), column_alias='ds__week') -->
         <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_14), column_alias='ds__month') -->
@@ -98,10 +98,10 @@ docstring:
         <!--     expr=SqlColumnReferenceExpression(node_id=cr_9),         -->
         <!--     column_alias='total_account_balance_first_day_of_month', -->
         <!--   )                                                          -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
         <!-- join_0 =                                               -->
         <!--   SqlJoinDescription(                                  -->
-        <!--     right_source=SqlSelectStatementNode(node_id=ss_3), -->
+        <!--     right_source=SqlSelectStatementNode(node_id=ss_2), -->
         <!--     right_source_alias='subq_2',                       -->
         <!--     join_type=INNER,                                   -->
         <!--     on_condition=SqlLogicalExpression(node_id=lo_0),   -->
@@ -110,7 +110,7 @@ docstring:
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = "Read Elements From Semantic Model 'accounts_source'" -->
-            <!-- node_id = NodeId(id_str='ss_1') -->
+            <!-- node_id = NodeId(id_str='ss_0') -->
             <!-- col0 =                                                                                                 -->
             <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28000), column_alias='account_balance') -->
             <!-- col1 =                                                   -->
@@ -208,31 +208,31 @@ docstring:
             <!-- col40 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28010), column_alias='user') -->
             <!-- col41 =                                                                                              -->
             <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28011), column_alias='account__user') -->
-            <!-- from_source = SqlTableNode(node_id=tfc_28000) -->
+            <!-- from_source = SqlTableNode(node_id=tfc_0) -->
             <!-- where = None -->
             <!-- distinct = False -->
             <SqlTableNode>
                 <!-- description = 'Read from ***************************.fct_accounts' -->
-                <!-- node_id = NodeId(id_str='tfc_28000') -->
+                <!-- node_id = NodeId(id_str='tfc_0') -->
                 <!-- table_id = '***************************.fct_accounts' -->
             </SqlTableNode>
         </SqlSelectStatementNode>
         <SqlSelectStatementNode>
             <!-- description = 'Filter row on MAX(ds__day)' -->
-            <!-- node_id = NodeId(id_str='ss_3') -->
+            <!-- node_id = NodeId(id_str='ss_2') -->
             <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_1), column_alias='user') -->
             <!-- col1 =                                                                    -->
             <!--   SqlSelectColumn(                                                        -->
             <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_0, sql_function=MAX), -->
             <!--     column_alias='ds__day__complete',                                     -->
             <!--   )                                                                       -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_2) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
             <!-- group_by0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_1), column_alias='user') -->
             <!-- where = None -->
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = "Read Elements From Semantic Model 'accounts_source'" -->
-                <!-- node_id = NodeId(id_str='ss_2') -->
+                <!-- node_id = NodeId(id_str='ss_1') -->
                 <!-- col0 =                                                   -->
                 <!--   SqlSelectColumn(                                       -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_28000), -->
@@ -368,12 +368,12 @@ docstring:
                 <!-- col40 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28010), column_alias='user') -->
                 <!-- col41 =                                                                                              -->
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28011), column_alias='account__user') -->
-                <!-- from_source = SqlTableNode(node_id=tfc_28000) -->
+                <!-- from_source = SqlTableNode(node_id=tfc_1) -->
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlTableNode>
                     <!-- description = 'Read from ***************************.fct_accounts' -->
-                    <!-- node_id = NodeId(id_str='tfc_28000') -->
+                    <!-- node_id = NodeId(id_str='tfc_1') -->
                     <!-- table_id = '***************************.fct_accounts' -->
                 </SqlTableNode>
             </SqlSelectStatementNode>

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/test_semi_additive_join_node_with_queried_group_by__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/test_semi_additive_join_node_with_queried_group_by__plan0.xml
@@ -6,7 +6,7 @@ docstring:
 <SqlPlan>
     <SqlSelectStatementNode>
         <!-- description = 'Join on MIN(ds) and [] grouping by ds' -->
-        <!-- node_id = NodeId(id_str='ss_5') -->
+        <!-- node_id = NodeId(id_str='ss_3') -->
         <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_10), column_alias='ds__day') -->
         <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_11), column_alias='ds__week') -->
         <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_12), column_alias='ds__month') -->
@@ -98,10 +98,10 @@ docstring:
         <!--     expr=SqlColumnReferenceExpression(node_id=cr_7),         -->
         <!--     column_alias='total_account_balance_first_day_of_month', -->
         <!--   )                                                          -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
         <!-- join_0 =                                                 -->
         <!--   SqlJoinDescription(                                    -->
-        <!--     right_source=SqlSelectStatementNode(node_id=ss_3),   -->
+        <!--     right_source=SqlSelectStatementNode(node_id=ss_2),   -->
         <!--     right_source_alias='subq_2',                         -->
         <!--     join_type=INNER,                                     -->
         <!--     on_condition=SqlComparisonExpression(node_id=cmp_0), -->
@@ -110,7 +110,7 @@ docstring:
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = "Read Elements From Semantic Model 'accounts_source'" -->
-            <!-- node_id = NodeId(id_str='ss_1') -->
+            <!-- node_id = NodeId(id_str='ss_0') -->
             <!-- col0 =                                                                                                 -->
             <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28000), column_alias='account_balance') -->
             <!-- col1 =                                                   -->
@@ -208,31 +208,31 @@ docstring:
             <!-- col40 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28010), column_alias='user') -->
             <!-- col41 =                                                                                              -->
             <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28011), column_alias='account__user') -->
-            <!-- from_source = SqlTableNode(node_id=tfc_28000) -->
+            <!-- from_source = SqlTableNode(node_id=tfc_0) -->
             <!-- where = None -->
             <!-- distinct = False -->
             <SqlTableNode>
                 <!-- description = 'Read from ***************************.fct_accounts' -->
-                <!-- node_id = NodeId(id_str='tfc_28000') -->
+                <!-- node_id = NodeId(id_str='tfc_0') -->
                 <!-- table_id = '***************************.fct_accounts' -->
             </SqlTableNode>
         </SqlSelectStatementNode>
         <SqlSelectStatementNode>
             <!-- description = 'Filter row on MIN(ds__day)' -->
-            <!-- node_id = NodeId(id_str='ss_3') -->
+            <!-- node_id = NodeId(id_str='ss_2') -->
             <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_1), column_alias='ds__week') -->
             <!-- col1 =                                                                    -->
             <!--   SqlSelectColumn(                                                        -->
             <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_0, sql_function=MIN), -->
             <!--     column_alias='ds__day__complete',                                     -->
             <!--   )                                                                       -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_2) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
             <!-- group_by0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_1), column_alias='ds__week') -->
             <!-- where = None -->
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = "Read Elements From Semantic Model 'accounts_source'" -->
-                <!-- node_id = NodeId(id_str='ss_2') -->
+                <!-- node_id = NodeId(id_str='ss_1') -->
                 <!-- col0 =                                                   -->
                 <!--   SqlSelectColumn(                                       -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_28000), -->
@@ -368,12 +368,12 @@ docstring:
                 <!-- col40 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28010), column_alias='user') -->
                 <!-- col41 =                                                                                              -->
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28011), column_alias='account__user') -->
-                <!-- from_source = SqlTableNode(node_id=tfc_28000) -->
+                <!-- from_source = SqlTableNode(node_id=tfc_1) -->
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlTableNode>
                     <!-- description = 'Read from ***************************.fct_accounts' -->
-                    <!-- node_id = NodeId(id_str='tfc_28000') -->
+                    <!-- node_id = NodeId(id_str='tfc_1') -->
                     <!-- table_id = '***************************.fct_accounts' -->
                 </SqlTableNode>
             </SqlSelectStatementNode>

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/test_single_join_node__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/test_single_join_node__plan0.xml
@@ -6,13 +6,13 @@ docstring:
 <SqlPlan>
     <SqlSelectStatementNode>
         <!-- description = 'Join Standard Outputs' -->
-        <!-- node_id = NodeId(id_str='ss_9') -->
+        <!-- node_id = NodeId(id_str='ss_4') -->
         <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_7), column_alias='listing') -->
         <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_6), column_alias='bookings') -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_3) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
         <!-- join_0 =                                                 -->
         <!--   SqlJoinDescription(                                    -->
-        <!--     right_source=SqlSelectStatementNode(node_id=ss_7),   -->
+        <!--     right_source=SqlSelectStatementNode(node_id=ss_3),   -->
         <!--     right_source_alias='subq_3',                         -->
         <!--     join_type=LEFT_OUTER,                                -->
         <!--     on_condition=SqlComparisonExpression(node_id=cmp_0), -->
@@ -21,15 +21,15 @@ docstring:
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = "Pass Only Elements: ['bookings', 'listing']" -->
-            <!-- node_id = NodeId(id_str='ss_3') -->
+            <!-- node_id = NodeId(id_str='ss_1') -->
             <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_1), column_alias='listing') -->
             <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_0), column_alias='bookings') -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
             <!-- where = None -->
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = "Read Elements From Semantic Model 'bookings_source'" -->
-                <!-- node_id = NodeId(id_str='ss_1') -->
+                <!-- node_id = NodeId(id_str='ss_0') -->
                 <!-- col0 =                                                                                             -->
                 <!--   SqlSelectColumn(expr=SqlStringExpression(node_id=str_28000 sql_expr=1), column_alias='bookings') -->
                 <!-- col1 =                                                                                           -->
@@ -347,31 +347,31 @@ docstring:
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28035), column_alias='booking__guest') -->
                 <!-- col87 =                                                                                              -->
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28036), column_alias='booking__host') -->
-                <!-- from_source = SqlTableNode(node_id=tfc_28001) -->
+                <!-- from_source = SqlTableNode(node_id=tfc_0) -->
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlTableNode>
                     <!-- description = 'Read from ***************************.fct_bookings' -->
-                    <!-- node_id = NodeId(id_str='tfc_28001') -->
+                    <!-- node_id = NodeId(id_str='tfc_0') -->
                     <!-- table_id = '***************************.fct_bookings' -->
                 </SqlTableNode>
             </SqlSelectStatementNode>
         </SqlSelectStatementNode>
         <SqlSelectStatementNode>
             <!-- description = "Pass Only Elements: ['listing__country_latest', 'listing']" -->
-            <!-- node_id = NodeId(id_str='ss_7') -->
+            <!-- node_id = NodeId(id_str='ss_3') -->
             <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_3), column_alias='listing') -->
             <!-- col1 =                                               -->
             <!--   SqlSelectColumn(                                   -->
             <!--     expr=SqlColumnReferenceExpression(node_id=cr_2), -->
             <!--     column_alias='listing__country_latest',          -->
             <!--   )                                                  -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_5) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_2) -->
             <!-- where = None -->
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = "Read Elements From Semantic Model 'listings_latest'" -->
-                <!-- node_id = NodeId(id_str='ss_5') -->
+                <!-- node_id = NodeId(id_str='ss_2') -->
                 <!-- col0 =                                                                                             -->
                 <!--   SqlSelectColumn(expr=SqlStringExpression(node_id=str_28006 sql_expr=1), column_alias='listings') -->
                 <!-- col1 =                                                   -->
@@ -565,12 +565,12 @@ docstring:
                 <!-- col54 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28075), column_alias='user') -->
                 <!-- col55 =                                                                                              -->
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28076), column_alias='listing__user') -->
-                <!-- from_source = SqlTableNode(node_id=tfc_28005) -->
+                <!-- from_source = SqlTableNode(node_id=tfc_1) -->
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlTableNode>
                     <!-- description = 'Read from ***************************.dim_listings_latest' -->
-                    <!-- node_id = NodeId(id_str='tfc_28005') -->
+                    <!-- node_id = NodeId(id_str='tfc_1') -->
                     <!-- table_id = '***************************.dim_listings_latest' -->
                 </SqlTableNode>
             </SqlSelectStatementNode>

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/test_source_node__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/test_source_node__plan0.xml
@@ -6,7 +6,7 @@ docstring:
 <SqlPlan>
     <SqlSelectStatementNode>
         <!-- description = "Read Elements From Semantic Model 'bookings_source'" -->
-        <!-- node_id = NodeId(id_str='ss_1') -->
+        <!-- node_id = NodeId(id_str='ss_0') -->
         <!-- col0 = SqlSelectColumn(expr=SqlStringExpression(node_id=str_28000 sql_expr=1), column_alias='bookings') -->
         <!-- col1 =                                                                                           -->
         <!--   SqlSelectColumn(                                                                               -->
@@ -199,12 +199,12 @@ docstring:
         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28034), column_alias='booking__listing') -->
         <!-- col86 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28035), column_alias='booking__guest') -->
         <!-- col87 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28036), column_alias='booking__host') -->
-        <!-- from_source = SqlTableNode(node_id=tfc_28001) -->
+        <!-- from_source = SqlTableNode(node_id=tfc_0) -->
         <!-- where = None -->
         <!-- distinct = False -->
         <SqlTableNode>
             <!-- description = 'Read from ***************************.fct_bookings' -->
-            <!-- node_id = NodeId(id_str='tfc_28001') -->
+            <!-- node_id = NodeId(id_str='tfc_0') -->
             <!-- table_id = '***************************.fct_bookings' -->
         </SqlTableNode>
     </SqlSelectStatementNode>

--- a/tests_metricflow/snapshots/test_distinct_values_to_sql.py/SqlPlan/test_dimension_values_with_a_join_and_a_filter__plan0.xml
+++ b/tests_metricflow/snapshots/test_distinct_values_to_sql.py/SqlPlan/test_dimension_values_with_a_join_and_a_filter__plan0.xml
@@ -6,12 +6,12 @@ docstring:
 <SqlPlan>
     <SqlSelectStatementNode>
         <!-- description = "Pass Only Elements: ['user__home_state_latest', 'listing__is_lux_latest']" -->
-        <!-- node_id = NodeId(id_str='ss_78') -->
+        <!-- node_id = NodeId(id_str='ss_71') -->
         <!-- col0 =                                                                                                      -->
         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_118), column_alias='listing__is_lux_latest') -->
         <!-- col1 =                                                                                                       -->
         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_119), column_alias='user__home_state_latest') -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_75) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_70) -->
         <!-- group_by0 =                                                                                                 -->
         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_118), column_alias='listing__is_lux_latest') -->
         <!-- group_by1 =                                                                                                  -->
@@ -20,7 +20,7 @@ docstring:
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = 'Constrain Output with WHERE' -->
-            <!-- node_id = NodeId(id_str='ss_75') -->
+            <!-- node_id = NodeId(id_str='ss_70') -->
             <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_71), column_alias='ds__day') -->
             <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_72), column_alias='ds__week') -->
             <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_73), column_alias='ds__month') -->
@@ -207,12 +207,12 @@ docstring:
             <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_62), column_alias='largest_listing') -->
             <!-- col56 =                                                                                              -->
             <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_63), column_alias='smallest_listing') -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_73) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_69) -->
             <!-- where = SqlStringExpression(node_id=str_0 sql_expr=user__home_state_latest = 'us') -->
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = 'Join Standard Outputs' -->
-                <!-- node_id = NodeId(id_str='ss_73') -->
+                <!-- node_id = NodeId(id_str='ss_69') -->
                 <!-- col0 =                                               -->
                 <!--   SqlSelectColumn(                                   -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_4), -->
@@ -413,10 +413,10 @@ docstring:
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_6), column_alias='largest_listing') -->
                 <!-- col56 =                                                                                             -->
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_7), column_alias='smallest_listing') -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_67) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_66) -->
                 <!-- join_0 =                                                 -->
                 <!--   SqlJoinDescription(                                    -->
-                <!--     right_source=SqlSelectStatementNode(node_id=ss_71),  -->
+                <!--     right_source=SqlSelectStatementNode(node_id=ss_68),  -->
                 <!--     right_source_alias='subq_2',                         -->
                 <!--     join_type=FULL_OUTER,                                -->
                 <!--     on_condition=SqlComparisonExpression(node_id=cmp_0), -->
@@ -425,7 +425,7 @@ docstring:
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = "Read Elements From Semantic Model 'listings_latest'" -->
-                    <!-- node_id = NodeId(id_str='ss_67') -->
+                    <!-- node_id = NodeId(id_str='ss_66') -->
                     <!-- col0 =                                                      -->
                     <!--   SqlSelectColumn(                                          -->
                     <!--     expr=SqlStringExpression(node_id=str_28006 sql_expr=1), -->
@@ -654,30 +654,30 @@ docstring:
                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_28076), -->
                     <!--     column_alias='listing__user',                        -->
                     <!--   )                                                      -->
-                    <!-- from_source = SqlTableNode(node_id=tfc_28005) -->
+                    <!-- from_source = SqlTableNode(node_id=tfc_66) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlTableNode>
                         <!-- description = 'Read from ***************************.dim_listings_latest' -->
-                        <!-- node_id = NodeId(id_str='tfc_28005') -->
+                        <!-- node_id = NodeId(id_str='tfc_66') -->
                         <!-- table_id = '***************************.dim_listings_latest' -->
                     </SqlTableNode>
                 </SqlSelectStatementNode>
                 <SqlSelectStatementNode>
                     <!-- description = "Pass Only Elements: ['home_state_latest', 'user']" -->
-                    <!-- node_id = NodeId(id_str='ss_71') -->
+                    <!-- node_id = NodeId(id_str='ss_68') -->
                     <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_1), column_alias='user') -->
                     <!-- col1 =                                               -->
                     <!--   SqlSelectColumn(                                   -->
                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_0), -->
                     <!--     column_alias='home_state_latest',                -->
                     <!--   )                                                  -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_69) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_67) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = "Read Elements From Semantic Model 'users_latest'" -->
-                        <!-- node_id = NodeId(id_str='ss_69') -->
+                        <!-- node_id = NodeId(id_str='ss_67') -->
                         <!-- col0 =                                             -->
                         <!--   SqlSelectColumn(                                 -->
                         <!--     expr=SqlDateTruncExpression(node_id=dt_28202), -->
@@ -800,12 +800,12 @@ docstring:
                         <!--   )                                                      -->
                         <!-- col24 =                                                                                     -->
                         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28106), column_alias='user') -->
-                        <!-- from_source = SqlTableNode(node_id=tfc_28009) -->
+                        <!-- from_source = SqlTableNode(node_id=tfc_67) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
                         <SqlTableNode>
                             <!-- description = 'Read from ***************************.dim_users_latest' -->
-                            <!-- node_id = NodeId(id_str='tfc_28009') -->
+                            <!-- node_id = NodeId(id_str='tfc_67') -->
                             <!-- table_id = '***************************.dim_users_latest' -->
                         </SqlTableNode>
                     </SqlSelectStatementNode>

--- a/tests_metricflow/snapshots/test_distinct_values_to_sql.py/SqlPlan/test_dimensions_requiring_join__plan0.xml
+++ b/tests_metricflow/snapshots/test_distinct_values_to_sql.py/SqlPlan/test_dimensions_requiring_join__plan0.xml
@@ -6,12 +6,12 @@ docstring:
 <SqlPlan>
     <SqlSelectStatementNode>
         <!-- description = "Pass Only Elements: ['user__home_state_latest', 'listing__is_lux_latest']" -->
-        <!-- node_id = NodeId(id_str='ss_76') -->
+        <!-- node_id = NodeId(id_str='ss_70') -->
         <!-- col0 =                                                                                                     -->
         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_61), column_alias='listing__is_lux_latest') -->
         <!-- col1 =                                                                                                      -->
         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_62), column_alias='user__home_state_latest') -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_73) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_69) -->
         <!-- group_by0 =                                                                                                -->
         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_61), column_alias='listing__is_lux_latest') -->
         <!-- group_by1 =                                                                                                 -->
@@ -20,7 +20,7 @@ docstring:
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = 'Join Standard Outputs' -->
-            <!-- node_id = NodeId(id_str='ss_73') -->
+            <!-- node_id = NodeId(id_str='ss_69') -->
             <!-- col0 =                                               -->
             <!--   SqlSelectColumn(                                   -->
             <!--     expr=SqlColumnReferenceExpression(node_id=cr_4), -->
@@ -205,10 +205,10 @@ docstring:
             <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_6), column_alias='largest_listing') -->
             <!-- col56 =                                                                                             -->
             <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_7), column_alias='smallest_listing') -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_67) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_66) -->
             <!-- join_0 =                                                 -->
             <!--   SqlJoinDescription(                                    -->
-            <!--     right_source=SqlSelectStatementNode(node_id=ss_71),  -->
+            <!--     right_source=SqlSelectStatementNode(node_id=ss_68),  -->
             <!--     right_source_alias='subq_2',                         -->
             <!--     join_type=FULL_OUTER,                                -->
             <!--     on_condition=SqlComparisonExpression(node_id=cmp_0), -->
@@ -217,7 +217,7 @@ docstring:
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = "Read Elements From Semantic Model 'listings_latest'" -->
-                <!-- node_id = NodeId(id_str='ss_67') -->
+                <!-- node_id = NodeId(id_str='ss_66') -->
                 <!-- col0 =                                                                                             -->
                 <!--   SqlSelectColumn(expr=SqlStringExpression(node_id=str_28006 sql_expr=1), column_alias='listings') -->
                 <!-- col1 =                                                   -->
@@ -411,27 +411,27 @@ docstring:
                 <!-- col54 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28075), column_alias='user') -->
                 <!-- col55 =                                                                                              -->
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28076), column_alias='listing__user') -->
-                <!-- from_source = SqlTableNode(node_id=tfc_28005) -->
+                <!-- from_source = SqlTableNode(node_id=tfc_66) -->
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlTableNode>
                     <!-- description = 'Read from ***************************.dim_listings_latest' -->
-                    <!-- node_id = NodeId(id_str='tfc_28005') -->
+                    <!-- node_id = NodeId(id_str='tfc_66') -->
                     <!-- table_id = '***************************.dim_listings_latest' -->
                 </SqlTableNode>
             </SqlSelectStatementNode>
             <SqlSelectStatementNode>
                 <!-- description = "Pass Only Elements: ['home_state_latest', 'user']" -->
-                <!-- node_id = NodeId(id_str='ss_71') -->
+                <!-- node_id = NodeId(id_str='ss_68') -->
                 <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_1), column_alias='user') -->
                 <!-- col1 =                                                                                               -->
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_0), column_alias='home_state_latest') -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_69) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_67) -->
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = "Read Elements From Semantic Model 'users_latest'" -->
-                    <!-- node_id = NodeId(id_str='ss_69') -->
+                    <!-- node_id = NodeId(id_str='ss_67') -->
                     <!-- col0 =                                                                                          -->
                     <!--   SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_28202), column_alias='ds_latest__day') -->
                     <!-- col1 =                                                                                           -->
@@ -542,12 +542,12 @@ docstring:
                     <!--   )                                                      -->
                     <!-- col24 =                                                                                     -->
                     <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28106), column_alias='user') -->
-                    <!-- from_source = SqlTableNode(node_id=tfc_28009) -->
+                    <!-- from_source = SqlTableNode(node_id=tfc_67) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlTableNode>
                         <!-- description = 'Read from ***************************.dim_users_latest' -->
-                        <!-- node_id = NodeId(id_str='tfc_28009') -->
+                        <!-- node_id = NodeId(id_str='tfc_67') -->
                         <!-- table_id = '***************************.dim_users_latest' -->
                     </SqlTableNode>
                 </SqlSelectStatementNode>

--- a/tests_metricflow/snapshots/test_metric_time_dimension_to_sql.py/SqlPlan/test_metric_time_dimension_transform_node_using_non_primary_time__plan0.xml
+++ b/tests_metricflow/snapshots/test_metric_time_dimension_to_sql.py/SqlPlan/test_metric_time_dimension_transform_node_using_non_primary_time__plan0.xml
@@ -6,7 +6,7 @@ docstring:
 <SqlPlan>
     <SqlSelectStatementNode>
         <!-- description = "Metric Time Dimension 'paid_at'" -->
-        <!-- node_id = NodeId(id_str='ss_3') -->
+        <!-- node_id = NodeId(id_str='ss_1') -->
         <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_3), column_alias='ds__day') -->
         <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_4), column_alias='ds__week') -->
         <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_5), column_alias='ds__month') -->
@@ -230,12 +230,12 @@ docstring:
         <!-- col84 =                                                                                                -->
         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_2), column_alias='booking__is_instant') -->
         <!-- col85 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_0), column_alias='booking_payments') -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
         <!-- where = None -->
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = "Read Elements From Semantic Model 'bookings_source'" -->
-            <!-- node_id = NodeId(id_str='ss_1') -->
+            <!-- node_id = NodeId(id_str='ss_0') -->
             <!-- col0 = SqlSelectColumn(expr=SqlStringExpression(node_id=str_28000 sql_expr=1), column_alias='bookings') -->
             <!-- col1 =                                                                                           -->
             <!--   SqlSelectColumn(                                                                               -->
@@ -489,12 +489,12 @@ docstring:
             <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28035), column_alias='booking__guest') -->
             <!-- col87 =                                                                                              -->
             <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28036), column_alias='booking__host') -->
-            <!-- from_source = SqlTableNode(node_id=tfc_28001) -->
+            <!-- from_source = SqlTableNode(node_id=tfc_0) -->
             <!-- where = None -->
             <!-- distinct = False -->
             <SqlTableNode>
                 <!-- description = 'Read from ***************************.fct_bookings' -->
-                <!-- node_id = NodeId(id_str='tfc_28001') -->
+                <!-- node_id = NodeId(id_str='tfc_0') -->
                 <!-- table_id = '***************************.fct_bookings' -->
             </SqlTableNode>
         </SqlSelectStatementNode>

--- a/tests_metricflow/snapshots/test_metric_time_dimension_to_sql.py/SqlPlan/test_metric_time_dimension_transform_node_using_primary_time__plan0.xml
+++ b/tests_metricflow/snapshots/test_metric_time_dimension_to_sql.py/SqlPlan/test_metric_time_dimension_transform_node_using_primary_time__plan0.xml
@@ -6,7 +6,7 @@ docstring:
 <SqlPlan>
     <SqlSelectStatementNode>
         <!-- description = "Metric Time Dimension 'ds'" -->
-        <!-- node_id = NodeId(id_str='ss_3') -->
+        <!-- node_id = NodeId(id_str='ss_1') -->
         <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_15), column_alias='ds__day') -->
         <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_16), column_alias='ds__week') -->
         <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_17), column_alias='ds__month') -->
@@ -257,12 +257,12 @@ docstring:
         <!--     expr=SqlColumnReferenceExpression(node_id=cr_12),      -->
         <!--     column_alias='approximate_discrete_booking_value_p99', -->
         <!--   )                                                        -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
         <!-- where = None -->
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = "Read Elements From Semantic Model 'bookings_source'" -->
-            <!-- node_id = NodeId(id_str='ss_1') -->
+            <!-- node_id = NodeId(id_str='ss_0') -->
             <!-- col0 = SqlSelectColumn(expr=SqlStringExpression(node_id=str_28000 sql_expr=1), column_alias='bookings') -->
             <!-- col1 =                                                                                           -->
             <!--   SqlSelectColumn(                                                                               -->
@@ -516,12 +516,12 @@ docstring:
             <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28035), column_alias='booking__guest') -->
             <!-- col87 =                                                                                              -->
             <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28036), column_alias='booking__host') -->
-            <!-- from_source = SqlTableNode(node_id=tfc_28001) -->
+            <!-- from_source = SqlTableNode(node_id=tfc_0) -->
             <!-- where = None -->
             <!-- distinct = False -->
             <SqlTableNode>
                 <!-- description = 'Read from ***************************.fct_bookings' -->
-                <!-- node_id = NodeId(id_str='tfc_28001') -->
+                <!-- node_id = NodeId(id_str='tfc_0') -->
                 <!-- table_id = '***************************.fct_bookings' -->
             </SqlTableNode>
         </SqlSelectStatementNode>

--- a/tests_metricflow/snapshots/test_metric_time_dimension_to_sql.py/SqlPlan/test_simple_query_with_metric_time_dimension__plan0.xml
+++ b/tests_metricflow/snapshots/test_metric_time_dimension_to_sql.py/SqlPlan/test_simple_query_with_metric_time_dimension__plan0.xml
@@ -6,7 +6,7 @@ docstring:
 <SqlPlan>
     <SqlSelectStatementNode>
         <!-- description = 'Combine Aggregated Outputs' -->
-        <!-- node_id = NodeId(id_str='ss_91') -->
+        <!-- node_id = NodeId(id_str='ss_138') -->
         <!-- col0 =                                                                         -->
         <!--   SqlSelectColumn(                                                             -->
         <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_4, sql_function=COALESCE), -->
@@ -22,10 +22,10 @@ docstring:
         <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_3, sql_function=MAX), -->
         <!--     column_alias='booking_payments',                                      -->
         <!--   )                                                                       -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_79) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_132) -->
         <!-- join_0 =                                                 -->
         <!--   SqlJoinDescription(                                    -->
-        <!--     right_source=SqlSelectStatementNode(node_id=ss_88),  -->
+        <!--     right_source=SqlSelectStatementNode(node_id=ss_137), -->
         <!--     right_source_alias='subq_9',                         -->
         <!--     join_type=FULL_OUTER,                                -->
         <!--     on_condition=SqlComparisonExpression(node_id=cmp_0), -->
@@ -39,16 +39,16 @@ docstring:
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = 'Compute Metrics via Expressions' -->
-            <!-- node_id = NodeId(id_str='ss_79') -->
+            <!-- node_id = NodeId(id_str='ss_132') -->
             <!-- col0 =                                                                                                -->
             <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_102), column_alias='metric_time__day') -->
             <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_103), column_alias='bookings') -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_77) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_131) -->
             <!-- where = None -->
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = 'Aggregate Measures' -->
-                <!-- node_id = NodeId(id_str='ss_77') -->
+                <!-- node_id = NodeId(id_str='ss_131') -->
                 <!-- col0 =                                                                                                -->
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_101), column_alias='metric_time__day') -->
                 <!-- col1 =                                                                    -->
@@ -56,14 +56,14 @@ docstring:
                 <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_0, sql_function=SUM), -->
                 <!--     column_alias='bookings',                                              -->
                 <!--   )                                                                       -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_75) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_130) -->
                 <!-- group_by0 =                                                                                           -->
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_101), column_alias='metric_time__day') -->
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = "Pass Only Elements: ['bookings', 'metric_time__day']" -->
-                    <!-- node_id = NodeId(id_str='ss_75') -->
+                    <!-- node_id = NodeId(id_str='ss_130') -->
                     <!-- col0 =                                                -->
                     <!--   SqlSelectColumn(                                    -->
                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_99), -->
@@ -71,12 +71,12 @@ docstring:
                     <!--   )                                                   -->
                     <!-- col1 =                                                                                       -->
                     <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_98), column_alias='bookings') -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_73) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_129) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = "Metric Time Dimension 'ds'" -->
-                        <!-- node_id = NodeId(id_str='ss_73') -->
+                        <!-- node_id = NodeId(id_str='ss_129') -->
                         <!-- col0 =                                                                                      -->
                         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_15), column_alias='ds__day') -->
                         <!-- col1 =                                                                                       -->
@@ -540,12 +540,12 @@ docstring:
                         <!--     expr=SqlColumnReferenceExpression(node_id=cr_12),      -->
                         <!--     column_alias='approximate_discrete_booking_value_p99', -->
                         <!--   )                                                        -->
-                        <!-- from_source = SqlSelectStatementNode(node_id=ss_71) -->
+                        <!-- from_source = SqlSelectStatementNode(node_id=ss_128) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
                         <SqlSelectStatementNode>
                             <!-- description = "Read Elements From Semantic Model 'bookings_source'" -->
-                            <!-- node_id = NodeId(id_str='ss_71') -->
+                            <!-- node_id = NodeId(id_str='ss_128') -->
                             <!-- col0 =                                                      -->
                             <!--   SqlSelectColumn(                                          -->
                             <!--     expr=SqlStringExpression(node_id=str_28000 sql_expr=1), -->
@@ -977,12 +977,12 @@ docstring:
                             <!--     expr=SqlColumnReferenceExpression(node_id=cr_28036), -->
                             <!--     column_alias='booking__host',                        -->
                             <!--   )                                                      -->
-                            <!-- from_source = SqlTableNode(node_id=tfc_28001) -->
+                            <!-- from_source = SqlTableNode(node_id=tfc_70) -->
                             <!-- where = None -->
                             <!-- distinct = False -->
                             <SqlTableNode>
                                 <!-- description = 'Read from ***************************.fct_bookings' -->
-                                <!-- node_id = NodeId(id_str='tfc_28001') -->
+                                <!-- node_id = NodeId(id_str='tfc_70') -->
                                 <!-- table_id = '***************************.fct_bookings' -->
                             </SqlTableNode>
                         </SqlSelectStatementNode>
@@ -992,17 +992,17 @@ docstring:
         </SqlSelectStatementNode>
         <SqlSelectStatementNode>
             <!-- description = 'Compute Metrics via Expressions' -->
-            <!-- node_id = NodeId(id_str='ss_88') -->
+            <!-- node_id = NodeId(id_str='ss_137') -->
             <!-- col0 =                                                                                                -->
             <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_194), column_alias='metric_time__day') -->
             <!-- col1 =                                                                                                -->
             <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_195), column_alias='booking_payments') -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_86) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_136) -->
             <!-- where = None -->
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = 'Aggregate Measures' -->
-                <!-- node_id = NodeId(id_str='ss_86') -->
+                <!-- node_id = NodeId(id_str='ss_136') -->
                 <!-- col0 =                                                                                                -->
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_193), column_alias='metric_time__day') -->
                 <!-- col1 =                                                                    -->
@@ -1010,14 +1010,14 @@ docstring:
                 <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_1, sql_function=SUM), -->
                 <!--     column_alias='booking_payments',                                      -->
                 <!--   )                                                                       -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_84) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_135) -->
                 <!-- group_by0 =                                                                                           -->
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_193), column_alias='metric_time__day') -->
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = "Pass Only Elements: ['booking_payments', 'metric_time__day']" -->
-                    <!-- node_id = NodeId(id_str='ss_84') -->
+                    <!-- node_id = NodeId(id_str='ss_135') -->
                     <!-- col0 =                                                 -->
                     <!--   SqlSelectColumn(                                     -->
                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_191), -->
@@ -1028,12 +1028,12 @@ docstring:
                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_190), -->
                     <!--     column_alias='booking_payments',                   -->
                     <!--   )                                                    -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_82) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_134) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = "Metric Time Dimension 'paid_at'" -->
-                        <!-- node_id = NodeId(id_str='ss_82') -->
+                        <!-- node_id = NodeId(id_str='ss_134') -->
                         <!-- col0 =                                                                                       -->
                         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_107), column_alias='ds__day') -->
                         <!-- col1 =                                                                                        -->
@@ -1446,12 +1446,12 @@ docstring:
                         <!--     expr=SqlColumnReferenceExpression(node_id=cr_104), -->
                         <!--     column_alias='booking_payments',                   -->
                         <!--   )                                                    -->
-                        <!-- from_source = SqlSelectStatementNode(node_id=ss_80) -->
+                        <!-- from_source = SqlSelectStatementNode(node_id=ss_133) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
                         <SqlSelectStatementNode>
                             <!-- description = "Read Elements From Semantic Model 'bookings_source'" -->
-                            <!-- node_id = NodeId(id_str='ss_80') -->
+                            <!-- node_id = NodeId(id_str='ss_133') -->
                             <!-- col0 =                                                      -->
                             <!--   SqlSelectColumn(                                          -->
                             <!--     expr=SqlStringExpression(node_id=str_28000 sql_expr=1), -->
@@ -1883,12 +1883,12 @@ docstring:
                             <!--     expr=SqlColumnReferenceExpression(node_id=cr_28036), -->
                             <!--     column_alias='booking__host',                        -->
                             <!--   )                                                      -->
-                            <!-- from_source = SqlTableNode(node_id=tfc_28001) -->
+                            <!-- from_source = SqlTableNode(node_id=tfc_71) -->
                             <!-- where = None -->
                             <!-- distinct = False -->
                             <SqlTableNode>
                                 <!-- description = 'Read from ***************************.fct_bookings' -->
-                                <!-- node_id = NodeId(id_str='tfc_28001') -->
+                                <!-- node_id = NodeId(id_str='tfc_71') -->
                                 <!-- table_id = '***************************.fct_bookings' -->
                             </SqlTableNode>
                         </SqlSelectStatementNode>

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/test_dimensions_with_time_constraint__plan0.xml
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/test_dimensions_with_time_constraint__plan0.xml
@@ -5,7 +5,7 @@ test_filename: test_metric_time_without_metrics.py
     <SqlSelectStatementNode>
         <!-- description =                                                                                     -->
         <!--   "Pass Only Elements: ['user__home_state_latest', 'listing__is_lux_latest', 'metric_time__day']" -->
-        <!-- node_id = NodeId(id_str='ss_104') -->
+        <!-- node_id = NodeId(id_str='ss_102') -->
         <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_148), column_alias='metric_time__day') -->
         <!-- col1 =                                                                                                      -->
         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_146), column_alias='listing__is_lux_latest') -->
@@ -211,12 +211,12 @@ test_filename: test_metric_time_without_metrics.py
             <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_89), column_alias='largest_listing') -->
             <!-- col57 =                                                                                              -->
             <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_90), column_alias='smallest_listing') -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_99) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_100) -->
             <!-- where = SqlBetweenExpression(node_id=betw_0) -->
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = 'Join Standard Outputs' -->
-                <!-- node_id = NodeId(id_str='ss_99') -->
+                <!-- node_id = NodeId(id_str='ss_100') -->
                 <!-- col0 =                                                -->
                 <!--   SqlSelectColumn(                                    -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_29), -->
@@ -419,16 +419,16 @@ test_filename: test_metric_time_without_metrics.py
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_31), column_alias='largest_listing') -->
                 <!-- col57 =                                                                                              -->
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_32), column_alias='smallest_listing') -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_87) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_94) -->
                 <!-- join_0 =                                                -->
                 <!--   SqlJoinDescription(                                   -->
-                <!--     right_source=SqlSelectStatementNode(node_id=ss_93), -->
+                <!--     right_source=SqlSelectStatementNode(node_id=ss_97), -->
                 <!--     right_source_alias='subq_3',                        -->
                 <!--     join_type=CROSS_JOIN,                               -->
                 <!--   )                                                     -->
                 <!-- join_1 =                                                 -->
                 <!--   SqlJoinDescription(                                    -->
-                <!--     right_source=SqlSelectStatementNode(node_id=ss_97),  -->
+                <!--     right_source=SqlSelectStatementNode(node_id=ss_99),  -->
                 <!--     right_source_alias='subq_5',                         -->
                 <!--     join_type=FULL_OUTER,                                -->
                 <!--     on_condition=SqlComparisonExpression(node_id=cmp_0), -->
@@ -437,7 +437,7 @@ test_filename: test_metric_time_without_metrics.py
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = "Read Elements From Semantic Model 'listings_latest'" -->
-                    <!-- node_id = NodeId(id_str='ss_87') -->
+                    <!-- node_id = NodeId(id_str='ss_94') -->
                     <!-- col0 =                                                      -->
                     <!--   SqlSelectColumn(                                          -->
                     <!--     expr=SqlStringExpression(node_id=str_28006 sql_expr=1), -->
@@ -666,29 +666,29 @@ test_filename: test_metric_time_without_metrics.py
                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_28076), -->
                     <!--     column_alias='listing__user',                        -->
                     <!--   )                                                      -->
-                    <!-- from_source = SqlTableNode(node_id=tfc_28005) -->
+                    <!-- from_source = SqlTableNode(node_id=tfc_86) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlTableNode>
                         <!-- description = 'Read from ***************************.dim_listings_latest' -->
-                        <!-- node_id = NodeId(id_str='tfc_28005') -->
+                        <!-- node_id = NodeId(id_str='tfc_86') -->
                         <!-- table_id = '***************************.dim_listings_latest' -->
                     </SqlTableNode>
                 </SqlSelectStatementNode>
                 <SqlSelectStatementNode>
                     <!-- description = "Pass Only Elements: ['metric_time__day',]" -->
-                    <!-- node_id = NodeId(id_str='ss_93') -->
+                    <!-- node_id = NodeId(id_str='ss_97') -->
                     <!-- col0 =                                                -->
                     <!--   SqlSelectColumn(                                    -->
                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_24), -->
                     <!--     column_alias='metric_time__day',                  -->
                     <!--   )                                                   -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_91) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_96) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = "Metric Time Dimension 'ds'" -->
-                        <!-- node_id = NodeId(id_str='ss_91') -->
+                        <!-- node_id = NodeId(id_str='ss_96') -->
                         <!-- col0 =                                                                                     -->
                         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_0), column_alias='ds__day') -->
                         <!-- col1 =                                                                                      -->
@@ -797,12 +797,12 @@ test_filename: test_metric_time_without_metrics.py
                         <!--     expr=SqlColumnReferenceExpression(node_id=cr_23), -->
                         <!--     column_alias='metric_time__alien_day',            -->
                         <!--   )                                                   -->
-                        <!-- from_source = SqlSelectStatementNode(node_id=ss_89) -->
+                        <!-- from_source = SqlSelectStatementNode(node_id=ss_95) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
                         <SqlSelectStatementNode>
                             <!-- description = "Read From Time Spine 'mf_time_spine'" -->
-                            <!-- node_id = NodeId(id_str='ss_89') -->
+                            <!-- node_id = NodeId(id_str='ss_95') -->
                             <!-- col0 =                                                   -->
                             <!--   SqlSelectColumn(                                       -->
                             <!--     expr=SqlColumnReferenceExpression(node_id=cr_28130), -->
@@ -857,12 +857,12 @@ test_filename: test_metric_time_without_metrics.py
                             <!--     expr=SqlColumnReferenceExpression(node_id=cr_28131), -->
                             <!--     column_alias='ds__alien_day',                        -->
                             <!--   )                                                      -->
-                            <!-- from_source = SqlTableNode(node_id=tfc_28018) -->
+                            <!-- from_source = SqlTableNode(node_id=tfc_87) -->
                             <!-- where = None -->
                             <!-- distinct = False -->
                             <SqlTableNode>
                                 <!-- description = 'Read from ***************************.mf_time_spine' -->
-                                <!-- node_id = NodeId(id_str='tfc_28018') -->
+                                <!-- node_id = NodeId(id_str='tfc_87') -->
                                 <!-- table_id = '***************************.mf_time_spine' -->
                             </SqlTableNode>
                         </SqlSelectStatementNode>
@@ -870,19 +870,19 @@ test_filename: test_metric_time_without_metrics.py
                 </SqlSelectStatementNode>
                 <SqlSelectStatementNode>
                     <!-- description = "Pass Only Elements: ['home_state_latest', 'user']" -->
-                    <!-- node_id = NodeId(id_str='ss_97') -->
+                    <!-- node_id = NodeId(id_str='ss_99') -->
                     <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_26), column_alias='user') -->
                     <!-- col1 =                                                -->
                     <!--   SqlSelectColumn(                                    -->
                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_25), -->
                     <!--     column_alias='home_state_latest',                 -->
                     <!--   )                                                   -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_95) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_98) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = "Read Elements From Semantic Model 'users_latest'" -->
-                        <!-- node_id = NodeId(id_str='ss_95') -->
+                        <!-- node_id = NodeId(id_str='ss_98') -->
                         <!-- col0 =                                             -->
                         <!--   SqlSelectColumn(                                 -->
                         <!--     expr=SqlDateTruncExpression(node_id=dt_28202), -->
@@ -1005,12 +1005,12 @@ test_filename: test_metric_time_without_metrics.py
                         <!--   )                                                      -->
                         <!-- col24 =                                                                                     -->
                         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28106), column_alias='user') -->
-                        <!-- from_source = SqlTableNode(node_id=tfc_28009) -->
+                        <!-- from_source = SqlTableNode(node_id=tfc_88) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
                         <SqlTableNode>
                             <!-- description = 'Read from ***************************.dim_users_latest' -->
-                            <!-- node_id = NodeId(id_str='tfc_28009') -->
+                            <!-- node_id = NodeId(id_str='tfc_88') -->
                             <!-- table_id = '***************************.dim_users_latest' -->
                         </SqlTableNode>
                     </SqlSelectStatementNode>

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/test_metric_time_only__plan0.xml
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/test_metric_time_only__plan0.xml
@@ -6,16 +6,16 @@ docstring:
 <SqlPlan>
     <SqlSelectStatementNode>
         <!-- description = "Pass Only Elements: ['metric_time__day',]" -->
-        <!-- node_id = NodeId(id_str='ss_36') -->
+        <!-- node_id = NodeId(id_str='ss_38') -->
         <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_24), column_alias='metric_time__day') -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_33) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_37) -->
         <!-- group_by0 =                                                                                          -->
         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_24), column_alias='metric_time__day') -->
         <!-- where = None -->
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = "Metric Time Dimension 'ds'" -->
-            <!-- node_id = NodeId(id_str='ss_33') -->
+            <!-- node_id = NodeId(id_str='ss_37') -->
             <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_0), column_alias='ds__day') -->
             <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_1), column_alias='ds__week') -->
             <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_2), column_alias='ds__month') -->
@@ -77,12 +77,12 @@ docstring:
             <!--     expr=SqlColumnReferenceExpression(node_id=cr_23), -->
             <!--     column_alias='metric_time__alien_day',            -->
             <!--   )                                                   -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_31) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_36) -->
             <!-- where = None -->
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = "Read From Time Spine 'mf_time_spine'" -->
-                <!-- node_id = NodeId(id_str='ss_31') -->
+                <!-- node_id = NodeId(id_str='ss_36') -->
                 <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28130), column_alias='ds__day') -->
                 <!-- col1 = SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_28287), column_alias='ds__week') -->
                 <!-- col2 = SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_28288), column_alias='ds__month') -->
@@ -100,12 +100,12 @@ docstring:
                 <!--   SqlSelectColumn(expr=SqlExtractExpression(node_id=ex_28305), column_alias='ds__extract_doy') -->
                 <!-- col11 =                                                                                              -->
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28131), column_alias='ds__alien_day') -->
-                <!-- from_source = SqlTableNode(node_id=tfc_28018) -->
+                <!-- from_source = SqlTableNode(node_id=tfc_30) -->
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlTableNode>
                     <!-- description = 'Read from ***************************.mf_time_spine' -->
-                    <!-- node_id = NodeId(id_str='tfc_28018') -->
+                    <!-- node_id = NodeId(id_str='tfc_30') -->
                     <!-- table_id = '***************************.mf_time_spine' -->
                 </SqlTableNode>
             </SqlSelectStatementNode>

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/test_metric_time_quarter_alone__plan0.xml
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/test_metric_time_quarter_alone__plan0.xml
@@ -4,17 +4,17 @@ test_filename: test_metric_time_without_metrics.py
 <SqlPlan>
     <SqlSelectStatementNode>
         <!-- description = "Pass Only Elements: ['metric_time__quarter',]" -->
-        <!-- node_id = NodeId(id_str='ss_36') -->
+        <!-- node_id = NodeId(id_str='ss_38') -->
         <!-- col0 =                                                                                                   -->
         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_24), column_alias='metric_time__quarter') -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_33) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_37) -->
         <!-- group_by0 =                                                                                              -->
         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_24), column_alias='metric_time__quarter') -->
         <!-- where = None -->
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = "Metric Time Dimension 'ds'" -->
-            <!-- node_id = NodeId(id_str='ss_33') -->
+            <!-- node_id = NodeId(id_str='ss_37') -->
             <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_0), column_alias='ds__day') -->
             <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_1), column_alias='ds__week') -->
             <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_2), column_alias='ds__month') -->
@@ -76,12 +76,12 @@ test_filename: test_metric_time_without_metrics.py
             <!--     expr=SqlColumnReferenceExpression(node_id=cr_23), -->
             <!--     column_alias='metric_time__alien_day',            -->
             <!--   )                                                   -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_31) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_36) -->
             <!-- where = None -->
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = "Read From Time Spine 'mf_time_spine'" -->
-                <!-- node_id = NodeId(id_str='ss_31') -->
+                <!-- node_id = NodeId(id_str='ss_36') -->
                 <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28130), column_alias='ds__day') -->
                 <!-- col1 = SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_28287), column_alias='ds__week') -->
                 <!-- col2 = SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_28288), column_alias='ds__month') -->
@@ -99,12 +99,12 @@ test_filename: test_metric_time_without_metrics.py
                 <!--   SqlSelectColumn(expr=SqlExtractExpression(node_id=ex_28305), column_alias='ds__extract_doy') -->
                 <!-- col11 =                                                                                              -->
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28131), column_alias='ds__alien_day') -->
-                <!-- from_source = SqlTableNode(node_id=tfc_28018) -->
+                <!-- from_source = SqlTableNode(node_id=tfc_30) -->
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlTableNode>
                     <!-- description = 'Read from ***************************.mf_time_spine' -->
-                    <!-- node_id = NodeId(id_str='tfc_28018') -->
+                    <!-- node_id = NodeId(id_str='tfc_30') -->
                     <!-- table_id = '***************************.mf_time_spine' -->
                 </SqlTableNode>
             </SqlSelectStatementNode>

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/test_metric_time_with_other_dimensions__plan0.xml
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/test_metric_time_with_other_dimensions__plan0.xml
@@ -5,13 +5,13 @@ test_filename: test_metric_time_without_metrics.py
     <SqlSelectStatementNode>
         <!-- description =                                                                                     -->
         <!--   "Pass Only Elements: ['user__home_state_latest', 'listing__is_lux_latest', 'metric_time__day']" -->
-        <!-- node_id = NodeId(id_str='ss_102') -->
+        <!-- node_id = NodeId(id_str='ss_101') -->
         <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_89), column_alias='metric_time__day') -->
         <!-- col1 =                                                                                                     -->
         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_87), column_alias='listing__is_lux_latest') -->
         <!-- col2 =                                                                                                      -->
         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_88), column_alias='user__home_state_latest') -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_99) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_100) -->
         <!-- group_by0 =                                                                                          -->
         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_89), column_alias='metric_time__day') -->
         <!-- group_by1 =                                                                                                -->
@@ -22,7 +22,7 @@ test_filename: test_metric_time_without_metrics.py
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = 'Join Standard Outputs' -->
-            <!-- node_id = NodeId(id_str='ss_99') -->
+            <!-- node_id = NodeId(id_str='ss_100') -->
             <!-- col0 =                                                -->
             <!--   SqlSelectColumn(                                    -->
             <!--     expr=SqlColumnReferenceExpression(node_id=cr_29), -->
@@ -210,16 +210,16 @@ test_filename: test_metric_time_without_metrics.py
             <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_31), column_alias='largest_listing') -->
             <!-- col57 =                                                                                              -->
             <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_32), column_alias='smallest_listing') -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_87) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_94) -->
             <!-- join_0 =                                                -->
             <!--   SqlJoinDescription(                                   -->
-            <!--     right_source=SqlSelectStatementNode(node_id=ss_93), -->
+            <!--     right_source=SqlSelectStatementNode(node_id=ss_97), -->
             <!--     right_source_alias='subq_3',                        -->
             <!--     join_type=CROSS_JOIN,                               -->
             <!--   )                                                     -->
             <!-- join_1 =                                                 -->
             <!--   SqlJoinDescription(                                    -->
-            <!--     right_source=SqlSelectStatementNode(node_id=ss_97),  -->
+            <!--     right_source=SqlSelectStatementNode(node_id=ss_99),  -->
             <!--     right_source_alias='subq_5',                         -->
             <!--     join_type=FULL_OUTER,                                -->
             <!--     on_condition=SqlComparisonExpression(node_id=cmp_0), -->
@@ -228,7 +228,7 @@ test_filename: test_metric_time_without_metrics.py
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = "Read Elements From Semantic Model 'listings_latest'" -->
-                <!-- node_id = NodeId(id_str='ss_87') -->
+                <!-- node_id = NodeId(id_str='ss_94') -->
                 <!-- col0 =                                                                                             -->
                 <!--   SqlSelectColumn(expr=SqlStringExpression(node_id=str_28006 sql_expr=1), column_alias='listings') -->
                 <!-- col1 =                                                   -->
@@ -422,26 +422,26 @@ test_filename: test_metric_time_without_metrics.py
                 <!-- col54 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28075), column_alias='user') -->
                 <!-- col55 =                                                                                              -->
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28076), column_alias='listing__user') -->
-                <!-- from_source = SqlTableNode(node_id=tfc_28005) -->
+                <!-- from_source = SqlTableNode(node_id=tfc_86) -->
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlTableNode>
                     <!-- description = 'Read from ***************************.dim_listings_latest' -->
-                    <!-- node_id = NodeId(id_str='tfc_28005') -->
+                    <!-- node_id = NodeId(id_str='tfc_86') -->
                     <!-- table_id = '***************************.dim_listings_latest' -->
                 </SqlTableNode>
             </SqlSelectStatementNode>
             <SqlSelectStatementNode>
                 <!-- description = "Pass Only Elements: ['metric_time__day',]" -->
-                <!-- node_id = NodeId(id_str='ss_93') -->
+                <!-- node_id = NodeId(id_str='ss_97') -->
                 <!-- col0 =                                                                                               -->
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_24), column_alias='metric_time__day') -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_91) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_96) -->
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = "Metric Time Dimension 'ds'" -->
-                    <!-- node_id = NodeId(id_str='ss_91') -->
+                    <!-- node_id = NodeId(id_str='ss_96') -->
                     <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_0), column_alias='ds__day') -->
                     <!-- col1 =                                                                                      -->
                     <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_1), column_alias='ds__week') -->
@@ -543,12 +543,12 @@ test_filename: test_metric_time_without_metrics.py
                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_23), -->
                     <!--     column_alias='metric_time__alien_day',            -->
                     <!--   )                                                   -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_89) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_95) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = "Read From Time Spine 'mf_time_spine'" -->
-                        <!-- node_id = NodeId(id_str='ss_89') -->
+                        <!-- node_id = NodeId(id_str='ss_95') -->
                         <!-- col0 =                                                   -->
                         <!--   SqlSelectColumn(                                       -->
                         <!--     expr=SqlColumnReferenceExpression(node_id=cr_28130), -->
@@ -597,12 +597,12 @@ test_filename: test_metric_time_without_metrics.py
                         <!--     expr=SqlColumnReferenceExpression(node_id=cr_28131), -->
                         <!--     column_alias='ds__alien_day',                        -->
                         <!--   )                                                      -->
-                        <!-- from_source = SqlTableNode(node_id=tfc_28018) -->
+                        <!-- from_source = SqlTableNode(node_id=tfc_87) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
                         <SqlTableNode>
                             <!-- description = 'Read from ***************************.mf_time_spine' -->
-                            <!-- node_id = NodeId(id_str='tfc_28018') -->
+                            <!-- node_id = NodeId(id_str='tfc_87') -->
                             <!-- table_id = '***************************.mf_time_spine' -->
                         </SqlTableNode>
                     </SqlSelectStatementNode>
@@ -610,16 +610,16 @@ test_filename: test_metric_time_without_metrics.py
             </SqlSelectStatementNode>
             <SqlSelectStatementNode>
                 <!-- description = "Pass Only Elements: ['home_state_latest', 'user']" -->
-                <!-- node_id = NodeId(id_str='ss_97') -->
+                <!-- node_id = NodeId(id_str='ss_99') -->
                 <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_26), column_alias='user') -->
                 <!-- col1 =                                                                                                -->
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_25), column_alias='home_state_latest') -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_95) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_98) -->
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = "Read Elements From Semantic Model 'users_latest'" -->
-                    <!-- node_id = NodeId(id_str='ss_95') -->
+                    <!-- node_id = NodeId(id_str='ss_98') -->
                     <!-- col0 =                                                                                          -->
                     <!--   SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_28202), column_alias='ds_latest__day') -->
                     <!-- col1 =                                                                                           -->
@@ -730,12 +730,12 @@ test_filename: test_metric_time_without_metrics.py
                     <!--   )                                                      -->
                     <!-- col24 =                                                                                     -->
                     <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28106), column_alias='user') -->
-                    <!-- from_source = SqlTableNode(node_id=tfc_28009) -->
+                    <!-- from_source = SqlTableNode(node_id=tfc_88) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlTableNode>
                         <!-- description = 'Read from ***************************.dim_users_latest' -->
-                        <!-- node_id = NodeId(id_str='tfc_28009') -->
+                        <!-- node_id = NodeId(id_str='tfc_88') -->
                         <!-- table_id = '***************************.dim_users_latest' -->
                     </SqlTableNode>
                 </SqlSelectStatementNode>


### PR DESCRIPTION
* For the nodes in a `SqlPlan`, the invariant is that there are no duplicate nodes.
* With the recent caching updates that allow for more reuse, copying all nodes in the hierarchy is simpler to reason for correctness.
* With the update to do additional copying, the node IDs in the snapshots have changed.
* The additional copy overhead should be small as there aren't that many node in a SQL plan for a query (<100), though the overhead can grow ~n^2 with the number of nodes.
* New copies of the fields in the nodes are not created. Since they are much more numerous, creating copies of those could have a more significant impact.