### PR TITLE
Revert "Don't error for lack of time spines"

### DIFF
--- a/metricflow-semantics/metricflow_semantics/time/time_spine_source.py
+++ b/metricflow-semantics/metricflow_semantics/time/time_spine_source.py
@@ -75,6 +75,12 @@ class TimeSpineSource:
                     base_granularity=legacy_time_spine.grain,
                 )
 
+        # Sanity check: this should have been validated during manifest parsing.
+        if not time_spine_sources:
+            raise RuntimeError(
+                "At least one time spine must be configured to use the semantic layer, but none were found."
+            )
+
         return time_spine_sources
 
     @staticmethod


### PR DESCRIPTION
Reverts dbt-labs/metricflow#1428

We removed this error so that the saved query dependency resolver in mantle wouldn't hit it for a manifest that does not have any semantic models. Later, we decided not to treat that as a valid state for any MF classes, and instead to avoid instantiating the dependency resolver in that case. That means we can put this error back.
Plus, [some customer ran into this error scenario](https://dbt-labs.slack.com/archives/C05K4R7KZ5Z/p1739894465024389), and they got a very unclear error instead. This will give them a better error in the future.