### PR TITLE
Update tutorial project to use `ref()`

### DIFF
--- a/.changes/unreleased/Fixes-20250328-140319.yaml
+++ b/.changes/unreleased/Fixes-20250328-140319.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Update tutorial project to use `ref()`
+time: 2025-03-28T14:03:19.603544-07:00
+custom:
+  Author: plypaul
+  Issue: "1691"

--- a/dbt-metricflow/dbt_metricflow/cli/sample_dbt_models/sample_models/countries.sql
+++ b/dbt-metricflow/dbt_metricflow/cli/sample_dbt_models/sample_models/countries.sql
@@ -1,3 +1,3 @@
 select
     *
-from {{source('tutorial', 'countries_seed')}}
+from {{ref('countries_seed')}}

--- a/dbt-metricflow/dbt_metricflow/cli/sample_dbt_models/sample_models/customers.sql
+++ b/dbt-metricflow/dbt_metricflow/cli/sample_dbt_models/sample_models/customers.sql
@@ -1,3 +1,3 @@
 select
     *
-from {{source('tutorial', 'customers_seed')}}
+from {{ref('customers_seed')}}

--- a/dbt-metricflow/dbt_metricflow/cli/sample_dbt_models/sample_models/transactions.sql
+++ b/dbt-metricflow/dbt_metricflow/cli/sample_dbt_models/sample_models/transactions.sql
@@ -1,3 +1,3 @@
 select
     *
-from {{source('tutorial', 'transactions_seed')}}
+from {{ref('transactions_seed')}}

--- a/dbt-metricflow/dbt_metricflow/cli/tutorial.py
+++ b/dbt-metricflow/dbt_metricflow/cli/tutorial.py
@@ -108,27 +108,24 @@ class dbtMetricFlowTutorialHelper:
             🤓 {click.style("Please run the following steps:", bold=True)}
 
             1.  Switch to the root directory of the generated sample project (e.g. {click.style(f"`cd {tutorial_directory.name}`", bold=True)}).
-            2.  Run {click.style("`dbt seed`", bold=True)} and check that the steps related to countries, transactions, customers are passing.
-            3.  Run {click.style("`dbt build`", bold=True)} to produce the model tables.
-            4.  Try validating your data model: {click.style("`mf validate-configs`", bold=True)}
-            5.  Check out your metrics: {click.style("`mf list metrics`", bold=True)}
-            6.  Check out dimensions for your metric {click.style("`mf list dimensions --metrics transactions`", bold=True)}
-            7.  Query your first metric:
+                This enables use of the tutorial project and associated connection profile in later steps.
+            2.  Run {click.style("`dbt build`", bold=True)} to seed tables and produce artifacts.
+            3.  Try validating your data model: {click.style("`mf validate-configs`", bold=True)}
+            4.  Check out your metrics: {click.style("`mf list metrics`", bold=True)}
+            5.  Check out dimensions for your metric {click.style("`mf list dimensions --metrics transactions`", bold=True)}
+            6.  Query your first metric:
                     {click.style("mf query --metrics transactions --group-by metric_time --order metric_time", bold=True)}
-            8.  Show the SQL MetricFlow generates:
+            7.  Show the SQL MetricFlow generates:
                     {click.style("mf query --metrics transactions --group-by metric_time --order metric_time --explain", bold=True)}
-            8.  Visualize the plan:
+            8.  Visualize the plan (if you have graphviz installed - see README):
                     {click.style("mf query --metrics transactions --group-by metric_time --order metric_time --explain --display-plans", bold=True)}
-                * This only works if you have graphviz installed - see README.
             9.  Add another dimension:
                     {click.style("mf query --metrics transactions --group-by metric_time,customer__customer_country --order metric_time", bold=True)}
             10. Add a coarser time granularity:
                     {click.style("mf query --metrics transactions --group-by metric_time__week --order metric_time__week", bold=True)}
             11. Try a more complicated query:
                     {click.style(complex_query, bold=True)}
-            12. When you're done with the tutorial, run mf tutorial --clean to delete sample models and seeds.
-                * If a sample project was created, it wil remain.
-            13. Before integrating metrics into your project, read up on adding a time spine.
+            12. Before integrating metrics into your project, read up on adding a time spine.
                 (<Control>+<Left Click> may work in your terminal to follow the link)
                    {CliLink.get_time_spine_docs_link(dbt_core_version)}
 

--- a/tests_metricflow/snapshots/test_cli.py/str/test_tutorial_message__result.txt
+++ b/tests_metricflow/snapshots/test_cli.py/str/test_tutorial_message__result.txt
@@ -14,18 +14,17 @@ docstring:
 🤓 Please run the following steps:
 
 1.  Switch to the root directory of the generated sample project (e.g. `cd mf_tutorial_project`).
-2.  Run `dbt seed` and check that the steps related to countries, transactions, customers are passing.
-3.  Run `dbt build` to produce the model tables.
-4.  Try validating your data model: `mf validate-configs`
-5.  Check out your metrics: `mf list metrics`
-6.  Check out dimensions for your metric `mf list dimensions --metrics transactions`
-7.  Query your first metric:
+    This enables use of the tutorial project and associated connection profile in later steps.
+2.  Run `dbt build` to seed tables and produce artifacts.
+3.  Try validating your data model: `mf validate-configs`
+4.  Check out your metrics: `mf list metrics`
+5.  Check out dimensions for your metric `mf list dimensions --metrics transactions`
+6.  Query your first metric:
         mf query --metrics transactions --group-by metric_time --order metric_time
-8.  Show the SQL MetricFlow generates:
+7.  Show the SQL MetricFlow generates:
         mf query --metrics transactions --group-by metric_time --order metric_time --explain
-8.  Visualize the plan:
+8.  Visualize the plan (if you have graphviz installed - see README):
         mf query --metrics transactions --group-by metric_time --order metric_time --explain --display-plans
-    * This only works if you have graphviz installed - see README.
 9.  Add another dimension:
         mf query --metrics transactions --group-by metric_time,customer__customer_country --order metric_time
 10. Add a coarser time granularity:
@@ -36,9 +35,7 @@ docstring:
         --group-by metric_time,transaction__is_large \
         --order metric_time \
         --start-time 2022-03-20 --end-time 2022-04-01
-12. When you're done with the tutorial, run mf tutorial --clean to delete sample models and seeds.
-    * If a sample project was created, it wil remain.
-13. Before integrating metrics into your project, read up on adding a time spine.
+12. Before integrating metrics into your project, read up on adding a time spine.
     (<Control>+<Left Click> may work in your terminal to follow the link)
        https://docs.getdbt.com/docs/build/metricflow-time-spine?version=1.10
 


### PR DESCRIPTION
This PR updates the tutorial project to use `ref()` instead of `source()` in the models. By using `ref()`, `dbt build` will be able to seed appropriately by determining dependencies, allowing the removal of the `dbt seed` step.

For context, updates to the tutorial project are helpful for later changes to the CLI tests / CLI test framework.