### PR TITLE
Specify DB file path in tutorial-project profile

### DIFF
--- a/.changes/unreleased/Features-20250328-140506.yaml
+++ b/.changes/unreleased/Features-20250328-140506.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Specify DB file path in tutorial-project profile
+time: 2025-03-28T14:05:06.062055-07:00
+custom:
+  Author: plypaul
+  Issue: "1692"

--- a/dbt-metricflow/dbt_metricflow/cli/mf_tutorial_project/profiles.yml
+++ b/dbt-metricflow/dbt_metricflow/cli/mf_tutorial_project/profiles.yml
@@ -3,4 +3,4 @@ mf_tutorial:
   outputs:
     dev:
       type: duckdb
-      path: 'mf_tutorial.duckdb'
+      path: $db_file_path


### PR DESCRIPTION
This PR updates the `profiles.yml` file in the tutorial project so that the `DuckDB` database file is stored within the project directory instead of the current working directory. This helps to allow for later test cases that run the CLI from directories outside of the project directory.