### PR TITLE
Allow `CliConfiguration` to be loaded from specified paths

### DIFF
--- a/.changes/unreleased/Under the Hood-20250328-140613.yaml
+++ b/.changes/unreleased/Under the Hood-20250328-140613.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Allow `CliConfiguration` to be loaded from specified paths
+time: 2025-03-28T14:06:13.836158-07:00
+custom:
+  Author: plypaul
+  Issue: "1693"

--- a/dbt-metricflow/dbt_metricflow/cli/dbt_connectors/adapter_backed_client.py
+++ b/dbt-metricflow/dbt_metricflow/cli/dbt_connectors/adapter_backed_client.py
@@ -87,7 +87,7 @@ class SupportedAdapterTypes(enum.Enum):
 class AdapterBackedSqlClient:
     """SqlClient implementation which delegates database operations to a dbt BaseAdapter instance.
 
-    This is a generic wrpaper class meant to cover all of our logging, querying, and internal configuration
+    This is a generic wrapper class meant to cover all of our logging, querying, and internal configuration
     needs while delegating all connection state management and warehouse communication work to an underlying
     dbt adapter instance. This relies on BaseAdapter, rather than SQLAdapter, because BigQuery is an instance
     of the more generic BaseAdapter class.

--- a/tests_metricflow/fixtures/cli_fixtures.py
+++ b/tests_metricflow/fixtures/cli_fixtures.py
@@ -39,7 +39,12 @@ class FakeCLIConfiguration(CLIConfiguration):
         self._log_file_path: Optional[pathlib.Path] = None
 
     @override
-    def setup(self) -> None:
+    def setup(
+        self,
+        dbt_profiles_path: Optional[pathlib.Path] = None,
+        dbt_project_path: Optional[pathlib.Path] = None,
+        configure_file_logging: bool = True,
+    ) -> None:
         # For tests, a dbt project is not needed, so don't try to configure it.
         return
 


### PR DESCRIPTION
This PR allows `CliConfiguration` to be loaded from project / profile paths other than the current working directory. This later will enable easier testing of different dbt projects since changing the current working directory can have other side effects.