### PR TITLE
Remove `dbt` project metadata dependency in tutorial project generation

### DIFF
--- a/.changes/unreleased/Under the Hood-20250328-140847.yaml
+++ b/.changes/unreleased/Under the Hood-20250328-140847.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Remove `dbt` project metadata dependency in tutorial project generation
+time: 2025-03-28T14:08:47.035802-07:00
+custom:
+  Author: plypaul
+  Issue: "1694"

--- a/dbt-metricflow/dbt_metricflow/cli/main.py
+++ b/dbt-metricflow/dbt_metricflow/cli/main.py
@@ -105,12 +105,11 @@ def cli(cfg: CLIConfiguration, verbose: bool) -> None:  # noqa: D103
 # @click.option("--skip-dw", is_flag=True, help="Skip the data warehouse health checks") # TODO: re-enable this
 @click.option("--clean", is_flag=True, help="Remove sample model files.")
 @click.option("--yes", is_flag=True, help="Respond yes to all questions (for scripting).")
-@pass_config
 @click.pass_context
 @log_call(module_name=__name__, telemetry_reporter=_telemetry_reporter)
-def tutorial(ctx: click.core.Context, cfg: CLIConfiguration, message: bool, clean: bool, yes: bool) -> None:
+def tutorial(ctx: click.core.Context, message: bool, clean: bool, yes: bool) -> None:
     """Click command to run the tutorial."""
-    dbtMetricFlowTutorialHelper.run_tutorial(cfg=cfg, message=message, clean=clean, yes=yes)
+    dbtMetricFlowTutorialHelper.run_tutorial(message=message, clean=clean, yes=yes)
 
 
 def _click_echo(message: str, quiet: bool) -> None:

--- a/dbt-metricflow/dbt_metricflow/cli/tutorial.py
+++ b/dbt-metricflow/dbt_metricflow/cli/tutorial.py
@@ -17,7 +17,6 @@ from metricflow_semantics.mf_logging.lazy_formattable import LazyFormat
 from packaging.version import Version
 from typing_extensions import Optional
 
-from dbt_metricflow.cli.cli_configuration import CLIConfiguration
 from dbt_metricflow.cli.cli_link import CliLink
 
 logger = logging.getLogger(__name__)
@@ -136,7 +135,7 @@ class dbtMetricFlowTutorialHelper:
         )
 
     @staticmethod
-    def run_tutorial(cfg: CLIConfiguration, message: bool, clean: bool, yes: bool) -> None:
+    def run_tutorial(message: bool, clean: bool, yes: bool) -> None:
         """Run user through a CLI tutorial.
 
         See the associated Click command for details on the arguments.
@@ -211,20 +210,13 @@ class dbtMetricFlowTutorialHelper:
         project_path = sample_dbt_project_path
 
         click.echo(f"Using the project in {str(project_path)!r}\n")
-        cfg.setup()
 
         # TODO: Health checks
 
         # Load the metadata from dbt project
-        try:
-            dbt_project_metadata = cfg.dbt_project_metadata
-            dbt_paths = dbt_project_metadata.dbt_paths
-            model_path = pathlib.Path(dbt_paths.model_paths[0]) / "sample_model"
-            seed_path = pathlib.Path(dbt_paths.seed_paths[0]) / "sample_seed"
-            manifest_path = pathlib.Path(dbt_paths.target_path) / "semantic_manifest.json"
-        except Exception as e:
-            click.echo(f"Unable to parse path metadata from dbt project.\nERROR: {str(e)}")
-            exit(1)
+        model_path = project_path / "models" / "sample_model"
+        seed_path = project_path / "seeds" / "sample_seeds"
+        manifest_path = project_path / "semantic_manifest.json"
 
         # Remove sample files from dbt project
         if clean:
@@ -271,9 +263,7 @@ class dbtMetricFlowTutorialHelper:
 
         spinner = Halo(text="Generating sample files...", spinner="dots")
         spinner.start()
-        dbtMetricFlowTutorialHelper.generate_model_files(
-            model_path=model_path, profile_schema=dbt_project_metadata.schema
-        )
+        dbtMetricFlowTutorialHelper.generate_model_files(model_path=model_path)
         dbtMetricFlowTutorialHelper.generate_seed_files(seed_path=seed_path)
         dbtMetricFlowTutorialHelper.generate_semantic_manifest_file(manifest_path=manifest_path)
 

--- a/dbt-metricflow/dbt_metricflow/cli/tutorial.py
+++ b/dbt-metricflow/dbt_metricflow/cli/tutorial.py
@@ -34,23 +34,11 @@ class dbtMetricFlowTutorialHelper:
     SAMPLE_SOURCES_FILE = "sources.yml"
 
     @staticmethod
-    def generate_model_files(model_path: pathlib.Path, profile_schema: str) -> None:
+    def generate_model_files(model_path: pathlib.Path) -> None:
         """Generates the sample model files to the given dbt model path."""
         sample_model_path = pathlib.Path(__file__).parent / dbtMetricFlowTutorialHelper.SAMPLE_MODELS_DIRECTORY
         logger.debug(LazyFormat("Copying model files", sample_model_path=sample_model_path, model_path=model_path))
         shutil.copytree(src=sample_model_path, dst=model_path)
-
-        # Generate the sources.yml file with the schema given in profiles.yml
-        sample_sources_path = (
-            pathlib.Path(__file__).parent
-            / dbtMetricFlowTutorialHelper.SAMPLE_DBT_MODEL_DIRECTORY
-            / dbtMetricFlowTutorialHelper.SAMPLE_SOURCES_FILE
-        )
-        with open(sample_sources_path) as file:
-            contents = Template(file.read()).substitute({"system_schema": profile_schema})
-        dest_sources_path = pathlib.Path(model_path) / dbtMetricFlowTutorialHelper.SAMPLE_SOURCES_FILE
-        with open(dest_sources_path, "w") as file:
-            file.write(contents)
 
     @staticmethod
     def generate_seed_files(seed_path: pathlib.Path) -> None:


### PR DESCRIPTION
This PR removes the dependency on the `dbt` project metadata when generating the files associated with the tutorial. This enables the tutorial project (and modified versions) to be more easily generated in test cases.