### PR TITLE
Add process-isolated CLI runner for tests

### DIFF
--- a/.changes/unreleased/Under the Hood-20250328-141234.yaml
+++ b/.changes/unreleased/Under the Hood-20250328-141234.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Add process-isolated CLI runner for tests
+time: 2025-03-28T14:12:34.120975-07:00
+custom:
+  Author: plypaul
+  Issue: "1695"

--- a/tests_metricflow/cli/cli_test_helpers.py
+++ b/tests_metricflow/cli/cli_test_helpers.py
@@ -1,15 +1,24 @@
 from __future__ import annotations
 
+import logging
+from pathlib import Path
 from typing import Optional, Sequence
 
 import click
 from _pytest.capture import CaptureFixture
 from _pytest.fixtures import FixtureRequest
+from metricflow_semantics.mf_logging.lazy_formattable import LazyFormat
 from metricflow_semantics.test_helpers.config_helpers import MetricFlowTestConfiguration
 
+from dbt_metricflow.cli.cli_configuration import CLIConfiguration
+from dbt_metricflow.cli.tutorial import dbtMetricFlowTutorialHelper
 from metricflow.protocols.sql_client import SqlClient
+from tests_metricflow.cli.isolated_cli_command_interface import IsolatedCliCommandEnum
+from tests_metricflow.cli.isolated_cli_command_runner import IsolatedCliCommandRunner
 from tests_metricflow.fixtures.cli_fixtures import MetricFlowCliRunner
 from tests_metricflow.snapshot_utils import assert_str_snapshot_equal
+
+logger = logging.getLogger(__name__)
 
 
 def run_and_check_cli_command(
@@ -37,3 +46,43 @@ def run_and_check_cli_command(
         expectation_description=expectation_description,
     )
     assert result.exit_code == expected_exit_code
+
+
+def create_tutorial_project_files(tmp_directory: Path) -> Path:
+    """Create files for the tutorial project in a subdirectory of the given path.
+
+    Returns the path to the tutorial project.
+    """
+    dbt_project_path = tmp_directory / "mf_tutorial_project"
+    logger.debug(LazyFormat("Creating all tutorial files", dbt_project_path=dbt_project_path))
+    dbtMetricFlowTutorialHelper.generate_dbt_project(dbt_project_path)
+
+    model_path = dbt_project_path / "models" / "sample_model"
+    seed_path = dbt_project_path / "seeds" / "sample_seed"
+
+    dbtMetricFlowTutorialHelper.generate_model_files(model_path=model_path)
+    dbtMetricFlowTutorialHelper.generate_seed_files(seed_path=seed_path)
+    logger.debug(LazyFormat("Created dbt project", dbt_project_path=dbt_project_path))
+    return dbt_project_path
+
+
+def run_dbt_build(cli_command_runner: IsolatedCliCommandRunner) -> None:
+    """Runs `dbt build` using the given runner.
+
+    If there is an error with the build, an exception is raised.
+    """
+    dbt_build_result = cli_command_runner.run_command(
+        command_enum=IsolatedCliCommandEnum.DBT_BUILD,
+        command_args=(),
+    )
+    dbt_build_result.raise_exception_on_failure()
+    logger.debug(LazyFormat("`dbt build` successful"))
+
+
+def create_cli_runner(dbt_project_path: Path) -> MetricFlowCliRunner:
+    """Return a CLI runner that is based on the dbt project at the given path."""
+    cli_configuration = CLIConfiguration()
+    cli_configuration.setup(
+        dbt_profiles_path=dbt_project_path, dbt_project_path=dbt_project_path, configure_file_logging=False
+    )
+    return MetricFlowCliRunner(cli_configuration, str(dbt_project_path))

--- a/tests_metricflow/cli/executor_process_main_function.py
+++ b/tests_metricflow/cli/executor_process_main_function.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+import logging
+import os
+import sys
+import traceback
+from contextlib import contextmanager, redirect_stderr, redirect_stdout
+from pathlib import Path
+from typing import Iterator, Optional
+
+import click.testing
+from dbt.cli.main import dbtRunner
+from dbt_semantic_interfaces.enum_extension import assert_values_exhausted
+from metricflow_semantics.mf_logging.lazy_formattable import LazyFormat
+from typing_extensions import TextIO
+
+from dbt_metricflow.cli.cli_configuration import CLIConfiguration
+from dbt_metricflow.cli.main import metrics, query
+from tests_metricflow.cli.isolated_cli_command_interface import (
+    CommandParameterSet,
+    ExecutorProcessStartingParameterSet,
+    IsolatedCliCommandEnum,
+    IsolatedCliCommandResult,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class ExecutorProcessMainFunction:
+    """Encapsulates code that runs in the executor process."""
+
+    def __init__(self, starting_parameter_set: ExecutorProcessStartingParameterSet) -> None:
+        """Initializer.
+
+        Args:
+            starting_parameter_set: The parameters to use to start the executor process.
+        """
+        self._starting_parameter_set = starting_parameter_set
+        self._mf_cli_runner = click.testing.CliRunner()
+        # The `CliConfiguration` object is slow to create since it invokes the `dbt` command runner. Create it once
+        # and store it between CLI calls for faster tests.
+        self._mf_cli_cfg: Optional[CLIConfiguration] = None
+        self._log_level = logging.DEBUG
+        # For debugging stdout / stderr / logging library. Set to true to print some example lines.
+        self._output_logging_check_lines = False
+
+    def main_loop(self) -> None:
+        """The main method that runs in the executor process.
+
+        Runs a loop that gets CLI commands to run from the input queue, then puts the result into the output queue.
+        If `None` is passed in the input queue, this loop (and consequently the executor process) will exit.
+        """
+        log_file_path = self._starting_parameter_set.log_file_path
+        input_queue = self._starting_parameter_set.input_queue
+        output_queue = self._starting_parameter_set.output_queue
+
+        root_logger = logging.getLogger()
+        root_logger.setLevel(self._log_level)
+
+        try:
+            # Put the contents of stdout / stderr / logger in a separate file for easier debugging.
+            with self._redirect_output_to_file(log_file_path) as output_file:
+                while True:
+                    input_work = input_queue.get()
+                    logger.debug(LazyFormat("Got item from input queue", input_work=input_work))
+                    if input_work is None:
+                        logger.debug("Exiting loop due to `None` input.")
+                        break
+                    os.chdir(input_work.working_directory_path)
+                    result = self._run_cli_command(input_work)
+                    output_file.flush()
+                    output_queue.put(result)
+        except BaseException as exception:
+            formatted_exception = (
+                "".join(traceback.format_exception(type(exception), exception, exception.__traceback__))
+                if exception is not None
+                else None
+            )
+
+            with open(log_file_path, "r") as log_file:
+                log_file_contents = (
+                    "Exception caught in executor process - this is unexpected as each command should capture them."
+                    "\n\nLog contents:\n\n"
+                ) + log_file.read()
+            # After the parent process puts an item into the input queue, it waits to get an item from the output queue.
+            # Consequently, a result always needs to be put in to the queue before exiting if an item from the input
+            # queue was read to avoid a deadlock in the parent process.
+            output_queue.put(
+                IsolatedCliCommandResult(
+                    exit_code=1,
+                    stdout=log_file_contents,
+                    formatted_exception=formatted_exception,
+                    executor_process_log_path=self._starting_parameter_set.log_file_path,
+                )
+            )
+
+    @contextmanager
+    def _redirect_output_to_file(self, log_file_path: Path) -> Iterator[TextIO]:
+        """Provides a context manager the redirects stdout, stderr, and logging output to the given file.
+
+        Useful for debugging as without the log file, the output is invisible. This method is not thread safe due to
+        mutation of global state (i.e. logging configuration, `redirect_*`).
+        """
+        with (
+            open(log_file_path, "w") as log_file,
+            redirect_stdout(log_file),
+            redirect_stderr(log_file),
+        ):
+            # Setup logging. Note: a new process does not inherit the logging configuration of the parent process.
+            logging_handler = logging.StreamHandler(log_file)
+            logging_handler.setFormatter(
+                logging.Formatter("%(asctime)s %(levelname)s %(filename)s:%(lineno)d [%(threadName)s] - %(message)s")
+            )
+            root_logger = logging.getLogger()
+            try:
+                root_logger.addHandler(logging_handler)
+                if self._output_logging_check_lines:
+                    print("Capturing `stdout` into this file.")
+                    print("Capturing `stderr` into this file.", file=sys.stderr)
+                    logger.log(
+                        level=self._log_level,
+                        msg=LazyFormat("Capturing logging into this file.", log_level=self._log_level),
+                    )
+                yield log_file
+            finally:
+                root_logger.removeHandler(logging_handler)
+
+    @property
+    def _dbt_profiles_path(self) -> Optional[Path]:
+        return self._starting_parameter_set.dbt_profiles_path
+
+    @property
+    def _dbt_project_path(self) -> Optional[Path]:
+        return self._starting_parameter_set.dbt_project_path
+
+    def _get_mf_cli_config(self) -> CLIConfiguration:
+        """Cache `CLIConfiguration` since it's slow to create."""
+        if self._mf_cli_cfg is None:
+            self._mf_cli_cfg = CLIConfiguration()
+            self._mf_cli_cfg.setup(dbt_profiles_path=self._dbt_profiles_path, dbt_project_path=self._dbt_project_path)
+        return self._mf_cli_cfg
+
+    def _run_cli_command(self, parameter_set: CommandParameterSet) -> IsolatedCliCommandResult:
+        """Run either a `dbt` or `mf` CLI command."""
+        if parameter_set.command_enum is IsolatedCliCommandEnum.DBT_BUILD:
+            dbt_cli_runner = dbtRunner()
+
+            args = ["build"]
+            if self._dbt_profiles_path is not None:
+                args.append("--profiles-dir")
+                args.append(str(self._dbt_profiles_path))
+            if self._dbt_project_path is not None:
+                args.append("--project-dir")
+                args.append(str(self._dbt_project_path))
+
+            args.extend(parameter_set.command_args)
+            dbt_build_result = dbt_cli_runner.invoke(args=args)
+
+            exception = dbt_build_result.exception
+            formatted_exception = (
+                "".join(traceback.format_exception(type(exception), exception, exception.__traceback__))
+                if exception is not None
+                else None
+            )
+            return IsolatedCliCommandResult(
+                exit_code=0 if dbt_build_result.success else 1,
+                stdout="",
+                formatted_exception=formatted_exception,
+                executor_process_log_path=self._starting_parameter_set.log_file_path,
+            )
+        elif parameter_set.command_enum is IsolatedCliCommandEnum.MF_METRICS:
+            return self._run_mf_cli_command(
+                parameter_set=parameter_set,
+                click_command=metrics,
+            )
+        elif parameter_set.command_enum is IsolatedCliCommandEnum.MF_QUERY:
+            return self._run_mf_cli_command(
+                parameter_set=parameter_set,
+                click_command=query,
+            )
+        else:
+            assert_values_exhausted(parameter_set.command_enum)
+
+    def _run_mf_cli_command(
+        self,
+        parameter_set: CommandParameterSet,
+        click_command: click.BaseCommand,
+    ) -> IsolatedCliCommandResult:
+        """Runs a MF CLI command."""
+        click_result = self._mf_cli_runner.invoke(
+            click_command, obj=self._get_mf_cli_config(), args=parameter_set.command_args
+        )
+        exception = click_result.exception
+        formatted_exception = (
+            "".join(traceback.format_exception(type(exception), exception, exception.__traceback__))
+            if exception is not None
+            else None
+        )
+        return IsolatedCliCommandResult(
+            exit_code=click_result.exit_code,
+            stdout=click_result.stdout,
+            formatted_exception=formatted_exception,
+            executor_process_log_path=self._starting_parameter_set.log_file_path,
+        )

--- a/tests_metricflow/cli/isolated_cli_command_interface.py
+++ b/tests_metricflow/cli/isolated_cli_command_interface.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from enum import Enum
+from multiprocessing import Queue
+from pathlib import Path
+from typing import Optional, Tuple
+
+from metricflow_semantics.mf_logging.lazy_formattable import LazyFormat
+
+logger = logging.getLogger(__name__)
+
+
+class IsolatedCliCommandEnum(Enum):
+    """Enumerates the types of CLI commands supported in `IsolatedCliCommandRunner`."""
+
+    # `dbt ...` commands
+    DBT_BUILD = "dbt_build"
+    # `mf ...` commands
+    MF_QUERY = "mf_query"
+    MF_METRICS = "mf_metrics"
+
+
+class IsolatedCliCommandException(Exception):
+    """Raised when there is an error running the command."""
+
+    pass
+
+
+@dataclass(frozen=True)
+class IsolatedCliCommandResult:
+    """Contains the result of running a CLI command.
+
+    This class is used instead of `click.testing.Result` as it needs to be pickled for use with `multiprocessing`, and
+    there can be issues if the result object contains complex types.
+    """
+
+    exit_code: int
+    stdout: str
+    # Pass as the formatted version as it's unclear if there would be problems pickling some exception types.
+    formatted_exception: Optional[str]
+    executor_process_log_path: Path
+
+    def raise_exception_on_failure(self) -> None:
+        """Check the exit code and raise an exception with the appropriate context."""
+        exception_message = str(
+            LazyFormat(
+                "Isolated CLI command failed",
+                exit_code=self.exit_code,
+                stdout=self.stdout,
+                formatted_exception=self.formatted_exception,
+                executor_process_log_path=str(self.executor_process_log_path),
+            )
+        )
+        if self.exit_code == 0:
+            return
+
+        raise IsolatedCliCommandException(exception_message)
+
+
+@dataclass(frozen=True)
+class ExecutorProcessStartingParameterSet:
+    """When a child process is started, this contains all variables related to how it was set up."""
+
+    log_file_path: Path
+    input_queue: Queue[Optional[CommandParameterSet]]
+    output_queue: Queue[IsolatedCliCommandResult]
+    dbt_profiles_path: Optional[Path]
+    dbt_project_path: Optional[Path]
+
+
+@dataclass(frozen=True)
+class CommandParameterSet:
+    """Encapsulates parameters required to run a specific CLI command."""
+
+    working_directory_path: Path
+    command_enum: IsolatedCliCommandEnum
+    command_args: Tuple[str, ...]

--- a/tests_metricflow/cli/isolated_cli_command_runner.py
+++ b/tests_metricflow/cli/isolated_cli_command_runner.py
@@ -1,0 +1,256 @@
+from __future__ import annotations
+
+import logging
+import multiprocessing
+import os
+import shutil
+import tempfile
+import time
+from contextlib import contextmanager
+from dataclasses import dataclass
+from multiprocessing.context import SpawnProcess
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+from typing import Iterator, Optional, Sequence
+
+from metricflow_semantics.mf_logging.lazy_formattable import LazyFormat
+
+from tests_metricflow.cli.executor_process_main_function import ExecutorProcessMainFunction
+from tests_metricflow.cli.isolated_cli_command_interface import (
+    CommandParameterSet,
+    ExecutorProcessStartingParameterSet,
+    IsolatedCliCommandEnum,
+    IsolatedCliCommandResult,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class IsolatedCliCommandRunner:
+    """Helps to run a CLI command in a separate process for better isolation.
+
+    A separate process is used because methods in the `dbt*` packages mutate global state e.g. state of the SQL engine
+    adapters. `mf` CLI commands call methods in `dbt` packages, so this is useful for testing the `mf` CLI with
+    different `dbt` projects.
+
+    In the separate process, the command is run and the results are returned to the main process through a shared queue.
+
+    `ProcessPoolExecutor` could be used here, but this uses separate queue and process instances for easier debugging.
+    """
+
+    def __init__(
+        self,
+        dbt_profiles_path: Optional[Path] = None,
+        dbt_project_path: Optional[Path] = None,
+    ) -> None:
+        """Initializer.
+
+        Args:
+            dbt_profiles_path: The path to the directory containing dbt profiles.
+            dbt_project_path: The path to the directory containing the dbt project.
+        """
+        self._dbt_profiles_path = dbt_profiles_path
+        self._dbt_project_path = dbt_project_path
+
+        # Use this context to use the `spawn` method to create new processes.
+        # `spawn` helps avoid seg faults vs. `fork`.
+        self._multiprocessing_context = multiprocessing.get_context("spawn")
+        self._parent_pid = os.getpid()
+        self._running_executor_process_context: Optional[_RunningExecutorProcessContext] = None
+        self._delete_temporary_items = logger.getEffectiveLevel() == logging.DEBUG
+
+    @contextmanager
+    def running_context(self) -> Iterator[None]:
+        """A context manager to help call `start()` / `shutdown()`.
+
+        The context encapsulates the state where the executor is running.
+        """
+        self.start()
+        try:
+            yield None
+        finally:
+            self.shutdown()
+
+    def start(self) -> None:
+        """Start the executor process."""
+        if self._running_executor_process_context is not None:
+            logger.warning(
+                f"`start()` was called already on the same {self.__class__.__name__} instance - it should only be "
+                f"once. Handling as a no-op."
+            )
+            return
+
+        temporary_file = NamedTemporaryFile(
+            prefix="executor_process_",
+            suffix=".log",
+            mode="w",
+            delete=False,
+        )
+
+        log_file_path = Path(temporary_file.name)
+        input_queue = self._multiprocessing_context.Queue()
+        output_queue = self._multiprocessing_context.Queue()
+
+        executor_process_starting_parameter_set = ExecutorProcessStartingParameterSet(
+            log_file_path=log_file_path,
+            input_queue=input_queue,
+            output_queue=output_queue,
+            dbt_profiles_path=self._dbt_profiles_path,
+            dbt_project_path=self._dbt_project_path,
+        )
+
+        executor_process: multiprocessing.context.SpawnProcess = self._multiprocessing_context.Process(
+            target=IsolatedCliCommandRunner._process_target,
+            args=(executor_process_starting_parameter_set,),
+        )
+        executor_process.start()
+        executor_pid = executor_process.pid
+
+        if executor_pid is None:
+            raise RuntimeError(f"Got unexpected {executor_pid=} after starting the executor process")
+
+        self._running_executor_process_context = _RunningExecutorProcessContext(
+            process=executor_process,
+            executor_process_starting_parameter_set=executor_process_starting_parameter_set,
+            executor_pid=executor_pid,
+        )
+        logger.debug(
+            LazyFormat(
+                "Started the executor process to execute CLI commands",
+                running_executor_process_context=self._running_executor_process_context,
+            )
+        )
+
+    def run_command(
+        self,
+        command_enum: IsolatedCliCommandEnum,
+        command_args: Sequence[str],
+        working_directory_path: Optional[Path] = None,
+    ) -> IsolatedCliCommandResult:
+        """Run a CLI command by sending it to the executor process.
+
+        Args:
+            command_enum: The command to run.
+            command_args: The arguments to pass to the command.
+            working_directory_path: If supplied, use this as the working directory. Otherwise, a temporary directory
+            will be created.
+
+        Returns: The result of the command.
+        """
+        if self._running_executor_process_context is None:
+            raise RuntimeError("Executor process not started - `start()` should have been called first.")
+        if not self._running_executor_process_context.is_alive:
+            raise RuntimeError(
+                "Executor process is not alive when it is expected to be - check logs to see why it is not."
+            )
+
+        start_time = time.time()
+
+        delete_temporary_directory = True
+        temporary_directory_path: Optional[Path] = None
+        if working_directory_path is None:
+            temporary_directory_path = Path(tempfile.mkdtemp())
+            working_directory_path = temporary_directory_path
+            delete_temporary_directory = True
+
+        if logger.isEnabledFor(logging.DEBUG):
+            delete_temporary_directory = False
+        try:
+            command_parameter_set = CommandParameterSet(
+                working_directory_path=working_directory_path,
+                command_enum=command_enum,
+                command_args=tuple(command_args),
+            )
+            logger.debug(LazyFormat("Put command in input queue", command_parameter_set=command_parameter_set))
+            result = self._running_executor_process_context.send_command_and_get_result(command_parameter_set)
+            logger.debug("Got result from output queue")
+
+            runtime = f"{time.time() - start_time:.2f}s"
+            if result.exit_code == 0:
+                logger.debug(
+                    LazyFormat(
+                        "Successfully ran CLI command", command_parameter_set=command_parameter_set, runtime=runtime
+                    )
+                )
+            else:
+                logger.error(
+                    LazyFormat(
+                        "CLI command failed",
+                        executor_process_log_file=str(
+                            self._running_executor_process_context.executor_process_starting_parameter_set.log_file_path
+                        ),
+                        command_parameter_set=command_parameter_set,
+                        result=result,
+                        runtime=runtime,
+                    )
+                )
+        finally:
+            if delete_temporary_directory and temporary_directory_path is not None:
+                logger.debug(
+                    LazyFormat("Deleting temporary directory", temporary_directory=str(temporary_directory_path))
+                )
+                shutil.rmtree(temporary_directory_path)
+            else:
+                logger.debug(
+                    LazyFormat(
+                        "Leaving temporary directory untouched due to logging setting",
+                        logger_effective_level=logging.getLevelName(logger.getEffectiveLevel()),
+                        delete_temporary_directory=delete_temporary_directory,
+                        temporary_directory_path=str(temporary_directory_path),
+                    )
+                )
+        return result
+
+    def shutdown(self) -> None:
+        """When finished, call this method to stop the executor process if one was started."""
+        if self._running_executor_process_context is None:
+            logger.warning("Shutdown called, but the executor process was not set. Handling as a no-op")
+            return
+
+        logger.debug("Shutdown called, so sending stop message to the executor process")
+        # `None` signals to the executor process to stop.
+        self._running_executor_process_context.executor_process_starting_parameter_set.input_queue.put(None)
+        logger.debug(
+            LazyFormat(
+                "Waiting for executor process to exit",
+                parent_pid=self._parent_pid,
+                executor_pid=self._running_executor_process_context.executor_pid,
+            )
+        )
+        self._running_executor_process_context.join()
+        logger.debug("Executor process finished")
+
+    @staticmethod
+    def _process_target(
+        executor_process_starting: ExecutorProcessStartingParameterSet,
+    ) -> None:
+        """Target method that is run in a new process.
+
+        * All arguments / work / results should be pickleable.
+        * Work should be read from the input queue.
+        * Results should be written to the output queue.
+        """
+        runner = ExecutorProcessMainFunction(executor_process_starting)
+        runner.main_loop()
+
+
+@dataclass(frozen=True)
+class _RunningExecutorProcessContext:
+    """Contains all variables related to how the executor process was set up / should be used."""
+
+    process: SpawnProcess
+    executor_process_starting_parameter_set: ExecutorProcessStartingParameterSet
+    executor_pid: int
+
+    @property
+    def is_alive(self) -> bool:
+        """Shortcut to see if the process is running."""
+        return self.process.is_alive()
+
+    def send_command_and_get_result(self, command_parameter_set: CommandParameterSet) -> IsolatedCliCommandResult:
+        self.executor_process_starting_parameter_set.input_queue.put(command_parameter_set)
+        result = self.executor_process_starting_parameter_set.output_queue.get()
+        return result
+
+    def join(self) -> None:
+        self.process.join()

--- a/tests_metricflow/cli/test_isolated_command_runner.py
+++ b/tests_metricflow/cli/test_isolated_command_runner.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import logging
+import tempfile
+from pathlib import Path
+from typing import Dict
+
+import pytest
+from _pytest.fixtures import FixtureRequest
+from metricflow_semantics.mf_logging.pretty_print import mf_pformat_dict
+from metricflow_semantics.test_helpers.config_helpers import MetricFlowTestConfiguration
+
+from tests_metricflow.cli.cli_test_helpers import (
+    create_tutorial_project_files,
+    run_dbt_build,
+)
+from tests_metricflow.cli.isolated_cli_command_interface import IsolatedCliCommandEnum
+from tests_metricflow.cli.isolated_cli_command_runner import IsolatedCliCommandRunner
+from tests_metricflow.snapshot_utils import assert_str_snapshot_equal
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.slow
+def test_isolated_query(
+    request: FixtureRequest,
+    mf_test_configuration: MetricFlowTestConfiguration,
+) -> None:
+    """Tests running an MF query using the isolated runner."""
+    with tempfile.TemporaryDirectory() as tmp_directory:
+        dbt_project_path = create_tutorial_project_files(Path(tmp_directory))
+
+        cli_runner = IsolatedCliCommandRunner(
+            dbt_profiles_path=dbt_project_path,
+            dbt_project_path=dbt_project_path,
+        )
+        with cli_runner.running_context():
+            run_dbt_build(cli_runner)
+            command_enum = IsolatedCliCommandEnum.MF_QUERY
+            logger.debug(f"{command_enum=}")
+            result = cli_runner.run_command(
+                command_enum=command_enum,
+                command_args=[
+                    "--metrics",
+                    "transactions",
+                ],
+            )
+
+        result.raise_exception_on_failure()
+        assert_str_snapshot_equal(
+            request=request,
+            mf_test_configuration=mf_test_configuration,
+            snapshot_id="result",
+            snapshot_str=result.stdout,
+            expectation_description="A table showing the `transactions` metric.",
+        )
+
+
+@pytest.mark.slow
+def test_multiple_queries(
+    request: FixtureRequest,
+    mf_test_configuration: MetricFlowTestConfiguration,
+) -> None:
+    """Tests running multiple sequential MF queries using a single runner."""
+    with tempfile.TemporaryDirectory() as tmp_directory:
+        dbt_project_path = create_tutorial_project_files(Path(tmp_directory))
+
+        cli_runner = IsolatedCliCommandRunner(
+            dbt_profiles_path=dbt_project_path,
+            dbt_project_path=dbt_project_path,
+        )
+
+        result_dict: Dict[str, str] = {}
+        with cli_runner.running_context():
+            run_dbt_build(cli_runner)
+            command_enum = IsolatedCliCommandEnum.MF_QUERY
+            logger.debug(f"{command_enum=}")
+            result = cli_runner.run_command(
+                command_enum=command_enum,
+                command_args=[
+                    "--metrics",
+                    "transactions",
+                ],
+            )
+            result.raise_exception_on_failure()
+            result_dict["transactions_query"] = result.stdout
+            result = cli_runner.run_command(
+                command_enum=command_enum,
+                command_args=[
+                    "--metrics",
+                    "quick_buy_transactions",
+                ],
+            )
+            result.raise_exception_on_failure()
+            result_dict["quick_buy_transactions_query"] = result.stdout
+
+        assert_str_snapshot_equal(
+            request=request,
+            mf_test_configuration=mf_test_configuration,
+            snapshot_id="result",
+            snapshot_str=mf_pformat_dict(obj_dict=result_dict, preserve_raw_strings=True),
+            expectation_description="2 results showing the`transactions` and `quick_buy_transactions` metrics.",
+        )

--- a/tests_metricflow/snapshots/test_isolated_command_runner.py/str/test_isolated_query__result.txt
+++ b/tests_metricflow/snapshots/test_isolated_command_runner.py/str/test_isolated_query__result.txt
@@ -1,0 +1,10 @@
+test_name: test_isolated_query
+test_filename: test_isolated_command_runner.py
+docstring:
+  Tests running an MF query using the isolated runner.
+expectation_description:
+  A table showing the `transactions` metric.
+---
+  transactions
+--------------
+            50

--- a/tests_metricflow/snapshots/test_isolated_command_runner.py/str/test_multiple_queries__result.txt
+++ b/tests_metricflow/snapshots/test_isolated_command_runner.py/str/test_multiple_queries__result.txt
@@ -1,0 +1,16 @@
+test_name: test_multiple_queries
+test_filename: test_isolated_command_runner.py
+docstring:
+  Tests running multiple sequential MF queries using a single runner.
+expectation_description:
+  2 results showing the`transactions` and `quick_buy_transactions` metrics.
+---
+transactions_query:
+    transactions
+  --------------
+              50
+
+quick_buy_transactions_query:
+    quick_buy_transactions
+  ------------------------
+                        10


### PR DESCRIPTION
* The `mf` CLI depends on `dbt` libraries to load the profile for the SQL-engine connection and to load the project manifest.
* However, the `dbt` libraries mutate global / module state, and the contractural guarantees regarding these mutations are not clear.
* In tests, there is a need to test different CLI commands that require different project configurations, so the best way to provide this isolation is to use a separate process to run each CLI command.
* A separate process also enables isolated testing for global-like settings (e.g. settings passed via environment variables).
* Process-level isolation mitigates issues with test execution order / concurrency when different tests load different project configurations.
* This PR adds a CLI runner that uses the `multiprocessing` module to use a separate process for each CLI command invocation.