### PR TITLE
Add test case to capture display of various data types for `mf query`

### DIFF
--- a/tests_metricflow/cli/demo_data_types_project_add_on/__init__.py
+++ b/tests_metricflow/cli/demo_data_types_project_add_on/__init__.py
@@ -1,0 +1,6 @@
+"""Directory containing files that can be added to a dbt project to query dimension of various data types."""
+from __future__ import annotations
+
+from metricflow_semantics.test_helpers.config_helpers import DirectoryPathAnchor
+
+DEMO_DATA_TYPES_ADD_ON_PATH_ANCHOR = DirectoryPathAnchor()

--- a/tests_metricflow/cli/demo_data_types_project_add_on/models/demo_data_types.sql
+++ b/tests_metricflow/cli/demo_data_types_project_add_on/models/demo_data_types.sql
@@ -1,0 +1,3 @@
+select
+    *
+from {{ref('demo_data_types_seed')}}

--- a/tests_metricflow/cli/demo_data_types_project_add_on/models/demo_data_types.yml
+++ b/tests_metricflow/cli/demo_data_types_project_add_on/models/demo_data_types.yml
@@ -1,0 +1,31 @@
+semantic_models:
+  - name: demo_data_types
+    description: Demonstrates different data types.
+    defaults:
+      agg_time_dimension: ds
+    model: ref('demo_data_types')
+
+    measures:
+      - name: demo_measure
+        expr: 1
+        agg: MAX
+    entities:
+      - name: row
+        type: primary
+    dimensions:
+      - name: ds
+        type: time
+        type_params:
+          time_granularity: day
+      - name: str_value
+        type: categorical
+      - name: int_value
+        type: categorical
+      - name: float_value
+        type: categorical
+      - name: decimal_value
+        type: categorical
+      - name: test_group
+        type: categorical
+      - name: description
+        type: categorical

--- a/tests_metricflow/cli/demo_data_types_project_add_on/models/metrics.yml
+++ b/tests_metricflow/cli/demo_data_types_project_add_on/models/metrics.yml
@@ -1,0 +1,7 @@
+---
+metrics:
+  - name: demo_metric
+    type: SIMPLE
+    type_params:
+      measure: demo_measure
+    label: "Demo Metric"

--- a/tests_metricflow/cli/demo_data_types_project_add_on/seeds/demo_data_types_seed.csv
+++ b/tests_metricflow/cli/demo_data_types_project_add_on/seeds/demo_data_types_seed.csv
@@ -1,0 +1,20 @@
+ds,row,str_value,int_value,float_value,decimal_value,test_group,description
+,,,,,,null,Each type as NULL.
+2020-01-01,1,-1234000000,-1234000000,-1.234e9,-1234000000,numeric,
+2020-01-02,2,-1234,-1234,-1234,-1234,numeric,
+2020-01-03,3,-1.234,-1,-1.234,-1.234,numeric,
+2020-01-04,4,-0.000000001234,0,-1.234e-9,-0.000000001234,numeric,
+2020-01-05,5,0,0,0,0,numeric,
+2020-01-06,6,0.000000001234,0,1.234e-9,0.000000001234,numeric,
+2020-01-07,7,1.234,1,1.234,1.234,numeric,
+2020-01-08,8,1234,1234,1234,1234,numeric,
+2020-01-09,9,1234000000,1234000000,1.234e9,1234000000,numeric,
+2020-01-10,11, ,,,,string,Single space (' ').
+2020-01-11,12,None,,,,string,String literal 'None'
+2020-01-12,13,none,,,,string,String literal 'none'
+2020-01-13,14,NULL,,,,string,String literal 'NULL'
+2020-01-14,15,null,,,,string,String literal 'null'
+2020-01-15,16,"Line 1
+Line 2",,,,string,String with a newline.
+2020-01-16,17, Space Padded ,,,,string,String with leading / trailing space (' ').
+2020-01-17,18,1234000000,1234000000,1.234e9,1234000000,large_numbers_in_one_row,

--- a/tests_metricflow/cli/demo_data_types_project_add_on/seeds/properties.yml
+++ b/tests_metricflow/cli/demo_data_types_project_add_on/seeds/properties.yml
@@ -1,0 +1,8 @@
+seeds:
+  - name: demo_data_types_seed
+    config:
+      column_types:
+        str_value: VARCHAR
+        int_value: BIGINT
+        float_value: FLOAT
+        decimal_value: DECIMAL(38,19)

--- a/tests_metricflow/cli/test_output_format.py
+++ b/tests_metricflow/cli/test_output_format.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+import logging
+import shutil
+import tempfile
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+from _pytest.fixtures import FixtureRequest
+from metricflow_semantics.mf_logging.lazy_formattable import LazyFormat
+from metricflow_semantics.test_helpers.config_helpers import MetricFlowTestConfiguration
+
+from dbt_metricflow.cli.tutorial import dbtMetricFlowTutorialHelper
+from tests_metricflow.cli.cli_test_helpers import (
+    run_and_check_cli_command,
+    run_dbt_build,
+)
+from tests_metricflow.cli.demo_data_types_project_add_on import DEMO_DATA_TYPES_ADD_ON_PATH_ANCHOR
+from tests_metricflow.cli.isolated_cli_command_interface import IsolatedCliCommandEnum
+from tests_metricflow.cli.isolated_cli_command_runner import IsolatedCliCommandRunner
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="session")
+def cli_runner() -> Iterator[IsolatedCliCommandRunner]:
+    """CLI runner using the dbt project for testing CLI output format."""
+    with tempfile.TemporaryDirectory() as tmp_directory:
+        tmp_directory_path = Path(tmp_directory)
+        dbt_project_path = tmp_directory_path / DEMO_DATA_TYPES_ADD_ON_PATH_ANCHOR.directory.name
+        copytree_src = DEMO_DATA_TYPES_ADD_ON_PATH_ANCHOR.directory
+        copytree_dest = dbt_project_path
+        logger.debug(
+            LazyFormat(
+                "Creating data-types project",
+                dbt_project_path=dbt_project_path,
+                copytree_src=copytree_src,
+                copytree_dest=copytree_dest,
+            )
+        )
+        dbtMetricFlowTutorialHelper.generate_dbt_project(dbt_project_path)
+        shutil.copytree(
+            src=copytree_src,
+            dst=copytree_dest,
+            dirs_exist_ok=True,
+        )
+        cli_runner = IsolatedCliCommandRunner(
+            dbt_profiles_path=dbt_project_path,
+            dbt_project_path=dbt_project_path,
+        )
+
+        with cli_runner.running_context():
+            run_dbt_build(cli_runner)
+
+            yield cli_runner
+
+
+@pytest.mark.slow
+def test_print_numeric_types(
+    request: FixtureRequest,
+    mf_test_configuration: MetricFlowTestConfiguration,
+    cli_runner: IsolatedCliCommandRunner,
+) -> None:
+    """Tests the default display of numeric types in the output of `mf query`."""
+    run_and_check_cli_command(
+        request=request,
+        mf_test_configuration=mf_test_configuration,
+        cli_runner=cli_runner,
+        command_enum=IsolatedCliCommandEnum.MF_QUERY,
+        args=[
+            "--metrics",
+            "demo_metric",
+            "--group-by",
+            "row,row__str_value,row__int_value,row__float_value,row__decimal_value",
+            "--where",
+            "{{ Dimension('row__test_group') }} = 'numeric'",
+            "--order",
+            "row",
+        ],
+    )
+
+
+@pytest.mark.slow
+def test_print_string(
+    request: FixtureRequest,
+    mf_test_configuration: MetricFlowTestConfiguration,
+    cli_runner: IsolatedCliCommandRunner,
+) -> None:
+    """Tests the default display of strings in the output of `mf query`."""
+    run_and_check_cli_command(
+        request=request,
+        mf_test_configuration=mf_test_configuration,
+        cli_runner=cli_runner,
+        command_enum=IsolatedCliCommandEnum.MF_QUERY,
+        args=[
+            "--metrics",
+            "demo_metric",
+            "--group-by",
+            "row,row__str_value,row__description",
+            "--where",
+            "{{ Dimension('row__test_group') }} = 'string'",
+            "--order",
+            "row",
+        ],
+    )
+
+
+@pytest.mark.slow
+def test_print_null(
+    request: FixtureRequest,
+    mf_test_configuration: MetricFlowTestConfiguration,
+    cli_runner: IsolatedCliCommandRunner,
+) -> None:
+    """Tests the default display of `NULL` in the output of `mf query`."""
+    run_and_check_cli_command(
+        request=request,
+        mf_test_configuration=mf_test_configuration,
+        cli_runner=cli_runner,
+        command_enum=IsolatedCliCommandEnum.MF_QUERY,
+        args=[
+            "--metrics",
+            "demo_metric",
+            "--group-by",
+            "row,row__str_value,row__int_value,row__float_value,row__decimal_value,row__description",
+            "--where",
+            "{{ Dimension('row__test_group') }} = 'null'",
+            "--order",
+            "row",
+        ],
+    )
+
+
+@pytest.mark.slow
+def test_decimals_option(
+    request: FixtureRequest,
+    mf_test_configuration: MetricFlowTestConfiguration,
+    cli_runner: IsolatedCliCommandRunner,
+) -> None:
+    """Tests the output of `mf query --decimals 1 ...`."""
+    run_and_check_cli_command(
+        request=request,
+        mf_test_configuration=mf_test_configuration,
+        cli_runner=cli_runner,
+        command_enum=IsolatedCliCommandEnum.MF_QUERY,
+        args=[
+            "--metrics",
+            "demo_metric",
+            "--group-by",
+            "row,row__str_value,row__int_value,row__float_value,row__decimal_value",
+            "--where",
+            "{{ Dimension('row__test_group') }} = 'numeric'",
+            "--order",
+            "row",
+            "--decimals",
+            "1",
+        ],
+        expectation_description="Non-integer numeric types should be displayed with 1 digit after the decimal point.",
+    )
+
+
+@pytest.mark.slow
+def test_single_large_number_with_decimals_option(
+    request: FixtureRequest,
+    mf_test_configuration: MetricFlowTestConfiguration,
+    cli_runner: IsolatedCliCommandRunner,
+) -> None:
+    """Tests how a large number in a single row is displayed as the result of `mf query`.
+
+    Originally added to reproduce a bug with how large numbers were displayed due to use of `tabulate`.
+    """
+    run_and_check_cli_command(
+        request=request,
+        mf_test_configuration=mf_test_configuration,
+        cli_runner=cli_runner,
+        command_enum=IsolatedCliCommandEnum.MF_QUERY,
+        args=[
+            "--metrics",
+            "demo_metric",
+            "--group-by",
+            "row,row__str_value,row__int_value,row__float_value,row__decimal_value",
+            "--where",
+            "{{ Dimension('row__test_group') }} = 'large_numbers_in_one_row'",
+            "--order",
+            "row",
+            "--decimals",
+            "2",
+        ],
+        expectation_description=(
+            "Numeric values should not be displayed in exponent notation and should have 2 decimals."
+        ),
+    )

--- a/tests_metricflow/snapshots/test_output_format.py/str/test_decimals_option__result.txt
+++ b/tests_metricflow/snapshots/test_output_format.py/str/test_decimals_option__result.txt
@@ -1,0 +1,18 @@
+test_name: test_decimals_option
+test_filename: test_output_format.py
+docstring:
+  Tests the output of `mf query --decimals 1 ...`.
+expectation_description:
+  Non-integer numeric types should be displayed with 1 digit after the decimal point.
+---
+  row    row__str_value    row__int_value    row__float_value    row__decimal_value    demo_metric
+-----  ----------------  ----------------  ------------------  --------------------  -------------
+    1        -1.234e+09       -1234000000          -1.234e+09            -1.234e+09              1
+    2     -1234                     -1234       -1234                 -1234                      1
+    3        -1.234                    -1          -1.2                  -1.2                    1
+    4        -1.234e-09                 0          -0                    -0                      1
+    5         0                         0           0                     0                      1
+    6         1.234e-09                 0           0                     0                      1
+    7         1.234                     1           1.2                   1.2                    1
+    8      1234                      1234        1234                  1234                      1
+    9         1.234e+09        1234000000           1.234e+09             1.234e+09              1

--- a/tests_metricflow/snapshots/test_output_format.py/str/test_print_null__result.txt
+++ b/tests_metricflow/snapshots/test_output_format.py/str/test_print_null__result.txt
@@ -1,0 +1,8 @@
+test_name: test_print_null
+test_filename: test_output_format.py
+docstring:
+  Tests the default display of `NULL` in the output of `mf query`.
+---
+row    row__str_value    row__int_value    row__float_value    row__decimal_value    row__description      demo_metric
+-----  ----------------  ----------------  ------------------  --------------------  ------------------  -------------
+None   None              None              None                None                  Each type as NULL.              1

--- a/tests_metricflow/snapshots/test_output_format.py/str/test_print_numeric_types__result.txt
+++ b/tests_metricflow/snapshots/test_output_format.py/str/test_print_numeric_types__result.txt
@@ -1,0 +1,16 @@
+test_name: test_print_numeric_types
+test_filename: test_output_format.py
+docstring:
+  Tests the default display of numeric types in the output of `mf query`.
+---
+  row    row__str_value    row__int_value    row__float_value    row__decimal_value    demo_metric
+-----  ----------------  ----------------  ------------------  --------------------  -------------
+    1        -1.234e+09       -1234000000          -1.234e+09            -1.234e+09              1
+    2     -1234                     -1234       -1234                 -1234                      1
+    3        -1.234                    -1          -1.23                 -1.23                   1
+    4        -1.234e-09                 0          -0                    -0                      1
+    5         0                         0           0                     0                      1
+    6         1.234e-09                 0           0                     0                      1
+    7         1.234                     1           1.23                  1.23                   1
+    8      1234                      1234        1234                  1234                      1
+    9         1.234e+09        1234000000           1.234e+09             1.234e+09              1

--- a/tests_metricflow/snapshots/test_output_format.py/str/test_print_string__result.txt
+++ b/tests_metricflow/snapshots/test_output_format.py/str/test_print_string__result.txt
@@ -1,0 +1,15 @@
+test_name: test_print_string
+test_filename: test_output_format.py
+docstring:
+  Tests the default display of strings in the output of `mf query`.
+---
+  row  row__str_value    row__description                               demo_metric
+-----  ----------------  -------------------------------------------  -------------
+   11                    Single space (' ').                                      1
+   12  None              String literal 'None'                                    1
+   13  none              String literal 'none'                                    1
+   14  NULL              String literal 'NULL'                                    1
+   15  null              String literal 'null'                                    1
+   16  Line 1            String with a newline.                                   1
+       Line 2
+   17  Space Padded      String with leading / trailing space (' ').              1

--- a/tests_metricflow/snapshots/test_output_format.py/str/test_single_large_number_with_decimals_option__result.txt
+++ b/tests_metricflow/snapshots/test_output_format.py/str/test_single_large_number_with_decimals_option__result.txt
@@ -1,0 +1,12 @@
+test_name: test_single_large_number_with_decimals_option
+test_filename: test_output_format.py
+docstring:
+  Tests how a large number in a single row is displayed as the result of `mf query`.
+
+      Originally added to reproduce a bug with how large numbers were displayed due to use of `tabulate`.
+expectation_description:
+  Numeric values should not be displayed in exponent notation and should have 2 decimals.
+---
+  row    row__str_value    row__int_value    row__float_value    row__decimal_value    demo_metric
+-----  ----------------  ----------------  ------------------  --------------------  -------------
+   18        1234000000        1234000000           1.234e+09             1.234e+09              1


### PR DESCRIPTION
This PR adds a test case that includes snapshots of the CLI output when running `mf query ...` with results that contain a variety of data types. There are a few issues that are demonstrated in the snapshots:

* `--decimals` option not taking effect.
* `NULL` values showing up as `None`.
* Alignment changes depending on query output.
* String values that are shown with stripped whitespace.
* Unexpected / inconsistent use of exponential format.

These are resolved in later PRs.