### PR TITLE
Address display of whitespace-padded strings in the output of `mf query`

### DIFF
--- a/.changes/unreleased/Fixes-20250328-141817.yaml
+++ b/.changes/unreleased/Fixes-20250328-141817.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Address display of whitespace-padded strings in the output of `mf query`
+time: 2025-03-28T14:18:17.834268-07:00
+custom:
+  Author: plypaul
+  Issue: "1701"

--- a/metricflow/data_table/mf_table.py
+++ b/metricflow/data_table/mf_table.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 import datetime
+import importlib.util
 import itertools
 import logging
+import threading
+import typing
 from dataclasses import dataclass
 from decimal import Decimal
 from typing import Iterable, Iterator, List, Optional, Sequence, Tuple, Type
@@ -14,6 +17,10 @@ from typing_extensions import Self
 
 from metricflow.data_table.column_types import CellValue, InputCellValue, row_cell_types
 from metricflow.data_table.mf_column import ColumnDescription
+
+if typing.TYPE_CHECKING:
+    from mypy.moduleinspect import ModuleType
+
 
 logger = logging.getLogger(__name__)
 
@@ -157,16 +164,12 @@ class MetricFlowDataTable:
                 column_alignment.append("decimal")
             else:
                 column_alignment.append("left")
-
         headers = tuple(column_description.column_name for column_description in self.column_descriptions)
 
-        return tabulate.tabulate(
+        return _IsolatedTabulateRunner.tabulate(
             tabular_data=str_rows,
             headers=headers,
-            # `tabulate.tabulate` can detect numeric values and apply special formatting rules. This can
-            # result in unexpected values when coupled with the `--decimals` option, so disabling this feature.
-            disable_numparse=True,
-            colalign=column_alignment,
+            column_alignment=column_alignment,
         )
 
     def with_lower_case_column_names(self) -> MetricFlowDataTable:
@@ -291,3 +294,66 @@ class _MetricFlowDataTableBuilder:
 
     def build(self) -> MetricFlowDataTable:  # noqa: D102
         return self._build_table_from_rows()
+
+
+class _IsolatedTabulateRunner:
+    """Helps run `tabulate` with different module options.
+
+    The `tabulate.tabulate` method uses some options defined in the module instead of being provided as arguments to
+    the function. This runner is used to change those options in isolation by loading a copy of the `tabulate` module.
+    This helps to ensure that other calls to `tabulate.tabulate` don't see unexpected results.
+    """
+
+    _TABULATE_MODULE_COPY: Optional[ModuleType] = None
+    _STATE_LOCK = threading.Lock()
+
+    @classmethod
+    def tabulate(
+        cls,
+        tabular_data: Sequence[Sequence[CellValue]],
+        headers: Sequence[str],
+        column_alignment: Optional[Sequence[str]],
+    ) -> str:
+        """Produce a text table from the given data. Also see class docstring."""
+        with _IsolatedTabulateRunner._STATE_LOCK:
+            try:
+                if _IsolatedTabulateRunner._TABULATE_MODULE_COPY is None:
+                    tabulate_module_spec = importlib.util.find_spec("tabulate")
+                    if tabulate_module_spec is None:
+                        raise RuntimeError("Unable to find spec for `tabulate`.")
+                    tabulate_module_copy = importlib.util.module_from_spec(tabulate_module_spec)
+                    if tabulate_module_copy is None:
+                        raise RuntimeError(f"Unable to load module using {tabulate_module_spec=}")
+                    if tabulate_module_spec.loader is None:
+                        raise RuntimeError(f"Loader missing for {tabulate_module_spec=}")
+                    tabulate_module_spec.loader.exec_module(tabulate_module_copy)
+                    tabulate_module_copy.PRESERVE_WHITESPACE = True  # type: ignore[attr-defined]
+                    _IsolatedTabulateRunner._TABULATE_MODULE_COPY = tabulate_module_copy
+            except Exception:
+                logger.exception(
+                    "Failed to load a copy of the `tabulate` module. This means that some table-formatting options "
+                    "can't be applied. This is a bug and should be investigated."
+                )
+
+        # `tabulate.tabulate` can detect numeric values and apply special formatting rules. This can
+        # result in unexpected values when coupled with the `--decimals` option, so disabling that feature.
+        disable_numparse = True
+
+        if _IsolatedTabulateRunner._TABULATE_MODULE_COPY is None:
+            logger.warning(
+                "Generating text table without required options set as there was an error loading the "
+                "`tabulate` module."
+            )
+            return tabulate.tabulate(
+                tabular_data=tabular_data,
+                headers=headers,
+                disable_numparse=disable_numparse,
+                colalign=column_alignment,
+            )
+
+        return _IsolatedTabulateRunner._TABULATE_MODULE_COPY.tabulate(
+            tabular_data=tabular_data,
+            headers=headers,
+            disable_numparse=disable_numparse,
+            colalign=column_alignment,
+        )

--- a/tests_metricflow/snapshots/test_output_format.py/str/test_print_string__result.txt
+++ b/tests_metricflow/snapshots/test_output_format.py/str/test_print_string__result.txt
@@ -12,4 +12,4 @@ docstring:
    15  null              String literal 'null'                                    1
    16  Line 1            String with a newline.                                   1
        Line 2
-   17  Space Padded      String with leading / trailing space (' ').              1
+   17   Space Padded     String with leading / trailing space (' ').              1


### PR DESCRIPTION
This PR removes the stripping of whitespace around string values in the output of `mf query`.