### PR TITLE
Add support for `DBT_PROFILES_DIR` / `DBT_PROJECT_DIR` in the CLI

### DIFF
--- a/.changes/unreleased/Features-20250328-142032.yaml
+++ b/.changes/unreleased/Features-20250328-142032.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Add support for `DBT_PROFILES_DIR` / `DBT_PROJECT_DIR` in the CLI
+time: 2025-03-28T14:20:32.008585-07:00
+custom:
+  Author: plypaul
+  Issue: 1702,1591

--- a/dbt-metricflow/dbt_metricflow/cli/cli_configuration.py
+++ b/dbt-metricflow/dbt_metricflow/cli/cli_configuration.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import os
 import pathlib
 from logging.handlers import TimedRotatingFileHandler
 from typing import Dict, Optional
@@ -21,6 +22,9 @@ logger = logging.getLogger(__name__)
 
 class CLIConfiguration:
     """Configuration object used for the MetricFlow CLI."""
+
+    DBT_PROFILES_DIR_ENV_VAR_NAME = "DBT_PROFILES_DIR"
+    DBT_PROJECT_DIR_ENV_VAR_NAME = "DBT_PROJECT_DIR"
 
     def __init__(self) -> None:  # noqa: D107
         self.verbose = False
@@ -61,10 +65,18 @@ class CLIConfiguration:
         """
         cwd = pathlib.Path.cwd()
 
-        if dbt_profiles_path is None:
-            dbt_profiles_path = cwd
-        if dbt_project_path is None:
-            dbt_project_path = cwd
+        dbt_profiles_dir_env_var = os.environ.get(CLIConfiguration.DBT_PROFILES_DIR_ENV_VAR_NAME)
+        dbt_profiles_dir_from_env = (
+            pathlib.Path(dbt_profiles_dir_env_var) if dbt_profiles_dir_env_var is not None else None
+        )
+
+        dbt_project_dir_env_var = os.environ.get(CLIConfiguration.DBT_PROJECT_DIR_ENV_VAR_NAME)
+        dbt_project_dir_from_env = (
+            pathlib.Path(dbt_project_dir_env_var) if dbt_project_dir_env_var is not None else None
+        )
+
+        dbt_profiles_path = dbt_profiles_path or dbt_profiles_dir_from_env or cwd
+        dbt_project_path = dbt_project_path or dbt_project_dir_from_env or cwd
 
         if not (dbt_project_path / "dbt_project.yml").exists():
             click.echo("\n".join(["❌ Unable to locate 'dbt_project.yml' in:", f"  {dbt_project_path}", ""]))

--- a/tests_metricflow/cli/executor_process_main_function.py
+++ b/tests_metricflow/cli/executor_process_main_function.py
@@ -64,6 +64,9 @@ class ExecutorProcessMainFunction:
         input_queue = self._starting_parameter_set.input_queue
         output_queue = self._starting_parameter_set.output_queue
 
+        for key, value in self._starting_parameter_set.environment_variables or ():
+            os.environ[key] = value
+
         root_logger = logging.getLogger()
         root_logger.setLevel(self._log_level)
 

--- a/tests_metricflow/cli/isolated_cli_command_interface.py
+++ b/tests_metricflow/cli/isolated_cli_command_interface.py
@@ -75,6 +75,7 @@ class ExecutorProcessStartingParameterSet:
     output_queue: Queue[IsolatedCliCommandResult]
     dbt_profiles_path: Optional[Path]
     dbt_project_path: Optional[Path]
+    environment_variables: Tuple[Tuple[str, str], ...]
 
 
 @dataclass(frozen=True)
@@ -84,3 +85,4 @@ class CommandParameterSet:
     working_directory_path: Path
     command_enum: IsolatedCliCommandEnum
     command_args: Tuple[str, ...]
+    environment_variables: Tuple[Tuple[str, str], ...]

--- a/tests_metricflow/cli/test_isolated_command_runner.py
+++ b/tests_metricflow/cli/test_isolated_command_runner.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import logging
+import os
+import shutil
 import tempfile
 from pathlib import Path
 from typing import Dict
@@ -10,6 +12,7 @@ from _pytest.fixtures import FixtureRequest
 from metricflow_semantics.mf_logging.pretty_print import mf_pformat_dict
 from metricflow_semantics.test_helpers.config_helpers import MetricFlowTestConfiguration
 
+from dbt_metricflow.cli.cli_configuration import CLIConfiguration
 from tests_metricflow.cli.cli_test_helpers import (
     create_tutorial_project_files,
     run_dbt_build,
@@ -100,4 +103,54 @@ def test_multiple_queries(
             snapshot_id="result",
             snapshot_str=mf_pformat_dict(obj_dict=result_dict, preserve_raw_strings=True),
             expectation_description="2 results showing the`transactions` and `quick_buy_transactions` metrics.",
+        )
+
+
+@pytest.mark.slow
+def test_environment_variables(
+    request: FixtureRequest,
+    mf_test_configuration: MetricFlowTestConfiguration,
+) -> None:
+    """Tests running an MF CLI command that configures the profile / project location using environment variables."""
+    with tempfile.TemporaryDirectory() as tmp_directory:
+        tmp_directory_path = Path(tmp_directory)
+        dbt_project_path = create_tutorial_project_files(tmp_directory_path / "dbt_projects")
+
+        # Move the `profiles.yml` to a different directory to isolate the two variables.
+        dbt_profiles_path = tmp_directory_path / "dbt_profiles"
+        os.mkdir(dbt_profiles_path)
+        shutil.move(
+            src=dbt_project_path / "profiles.yml",
+            dst=dbt_profiles_path / "profiles.yml",
+        )
+
+        cli_runner = IsolatedCliCommandRunner(
+            dbt_profiles_path=dbt_profiles_path,
+            dbt_project_path=dbt_project_path,
+        )
+        with cli_runner.running_context():
+            run_dbt_build(cli_runner)
+
+        cli_runner_using_environment_variables = IsolatedCliCommandRunner(
+            environment_variable_mapping={
+                CLIConfiguration.DBT_PROFILES_DIR_ENV_VAR_NAME: str(dbt_profiles_path),
+                CLIConfiguration.DBT_PROJECT_DIR_ENV_VAR_NAME: str(dbt_project_path),
+            }
+        )
+
+        with cli_runner_using_environment_variables.running_context():
+            result = cli_runner_using_environment_variables.run_command(
+                command_enum=IsolatedCliCommandEnum.MF_QUERY,
+                command_args=[
+                    "--metrics",
+                    "transactions",
+                ],
+            )
+        result.raise_exception_on_failure()
+        assert_str_snapshot_equal(
+            request=request,
+            mf_test_configuration=mf_test_configuration,
+            snapshot_id="result",
+            snapshot_str=result.stdout,
+            expectation_description="A table showing the `transactions` metric.",
         )

--- a/tests_metricflow/snapshots/test_isolated_command_runner.py/str/test_environment_variables__result.txt
+++ b/tests_metricflow/snapshots/test_isolated_command_runner.py/str/test_environment_variables__result.txt
@@ -1,0 +1,10 @@
+test_name: test_environment_variables
+test_filename: test_isolated_command_runner.py
+docstring:
+  Tests running an MF CLI command that configures the profile / project location using environment variables.
+expectation_description:
+  A table showing the `transactions` metric.
+---
+  transactions
+--------------
+            50


### PR DESCRIPTION
Resolves #1591

This PR adds support for using the environment variables `DBT_PROFILES_DIR` / `DBT_PROJECT_DIR` to configure how the `mf` command loads the connection / project.