### PR TITLE
Backport updated error message for missing time spine

### DIFF
--- a/metricflow-semantics/metricflow_semantics/time/time_spine_source.py
+++ b/metricflow-semantics/metricflow_semantics/time/time_spine_source.py
@@ -75,6 +75,12 @@ class TimeSpineSource:
                     base_granularity=legacy_time_spine.grain,
                 )
 
+        # Sanity check: this should have been validated during manifest parsing.
+        if not time_spine_sources:
+            raise RuntimeError(
+                "At least one time spine must be configured to use the semantic layer, but none were found."
+            )
+
         return time_spine_sources
 
     @staticmethod

--- a/tests_metricflow/snapshots/test_cli.py/str/test_missing_time_spine_error__result.txt
+++ b/tests_metricflow/snapshots/test_cli.py/str/test_missing_time_spine_error__result.txt
@@ -1,0 +1,15 @@
+test_name: test_missing_time_spine_error
+test_filename: test_cli.py
+docstring:
+  Test the error message that a user gets when a time spine is not configured in the project.
+---
+
+ERROR: min() iterable argument is empty
+
+Log File: ***
+Artifact Path: ***
+Artifact Modified Time: ***
+
+If you think you found a bug, please report it here:
+    https://github.com/dbt-labs/metricflow/issues
+

--- a/tests_metricflow/snapshots/test_cli.py/str/test_missing_time_spine_error__result.txt
+++ b/tests_metricflow/snapshots/test_cli.py/str/test_missing_time_spine_error__result.txt
@@ -4,7 +4,7 @@ docstring:
   Test the error message that a user gets when a time spine is not configured in the project.
 ---
 
-ERROR: min() iterable argument is empty
+ERROR: At least one time spine must be configured to use the semantic layer, but none were found.
 
 Log File: ***
 Artifact Path: ***


### PR DESCRIPTION
This PR back ports an improved error message (65e211580) + adds a test for the case where the user did not configure a time spine. Previously, the user would get a cryptic error message (also see associated commit in this PR): 

```
min() iterable argument is empty
```