### PR TITLE
Add artifact modified time to CLI error messages

### DIFF
--- a/.changes/unreleased/Features-20250331-171100.yaml
+++ b/.changes/unreleased/Features-20250331-171100.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Add semantic manifest artifact context to error messages
+time: 2025-03-31T17:11:00.964937-07:00
+custom:
+  Author: plypaul
+  Issue: "1708"

--- a/.changes/unreleased/Fixes-20250401-110415.yaml
+++ b/.changes/unreleased/Fixes-20250401-110415.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix issue counter when generating error messages.
+time: 2025-04-01T11:04:15.636629-07:00
+custom:
+  Author: plypaul
+  Issue: "1708"

--- a/dbt-metricflow/dbt_metricflow/cli/cli_configuration.py
+++ b/dbt-metricflow/dbt_metricflow/cli/cli_configuration.py
@@ -6,12 +6,12 @@ import pathlib
 from logging.handlers import TimedRotatingFileHandler
 from typing import Dict, Optional
 
-import click
 from dbt_semantic_interfaces.protocols.semantic_manifest import SemanticManifest
 from metricflow_semantics.mf_logging.lazy_formattable import LazyFormat
 from metricflow_semantics.model.semantic_manifest_lookup import SemanticManifestLookup
 
 from dbt_metricflow.cli import PACKAGE_NAME
+from dbt_metricflow.cli.cli_errors import LoadSemanticManifestException
 from dbt_metricflow.cli.dbt_connectors.adapter_backed_client import AdapterBackedSqlClient
 from dbt_metricflow.cli.dbt_connectors.dbt_config_accessor import dbtArtifacts, dbtProjectMetadata
 from metricflow.engine.metricflow_engine import MetricFlowEngine
@@ -77,10 +77,9 @@ class CLIConfiguration:
 
         dbt_profiles_path = dbt_profiles_path or dbt_profiles_dir_from_env or cwd
         dbt_project_path = dbt_project_path or dbt_project_dir_from_env or cwd
-
-        if not (dbt_project_path / "dbt_project.yml").exists():
-            click.echo("\n".join(["❌ Unable to locate 'dbt_project.yml' in:", f"  {dbt_project_path}", ""]))
-            exit(1)
+        dbt_project_yaml_path = dbt_project_path / "dbt_project.yml"
+        if not dbt_project_yaml_path.exists():
+            raise LoadSemanticManifestException(f"Missing: {str(dbt_project_yaml_path)!r}")
 
         try:
             self._dbt_project_metadata = dbtProjectMetadata.load_from_paths(

--- a/dbt-metricflow/dbt_metricflow/cli/cli_errors.py
+++ b/dbt-metricflow/dbt_metricflow/cli/cli_errors.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+import textwrap
+
 
 class LoadSemanticManifestException(Exception):
     """Errors related to loading a semantic manifest."""
 
     def __init__(self, msg: str = "") -> None:  # noqa: D107
-        error_msg = "Unable to load the semantic manifest"
+        error_msg = "Unable to load the semantic manifest."
         if msg:
-            error_msg += f"\n{msg}"
+            error_msg += f"\n{textwrap.indent(msg, prefix='  ')}"
         super().__init__(error_msg)

--- a/dbt-metricflow/dbt_metricflow/cli/cli_errors.py
+++ b/dbt-metricflow/dbt_metricflow/cli/cli_errors.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 
-class ModelCreationException(Exception):
-    """Exception to represent errors related to the building a model."""
+class LoadSemanticManifestException(Exception):
+    """Errors related to loading a semantic manifest."""
 
     def __init__(self, msg: str = "") -> None:  # noqa: D107
-        error_msg = "An error occurred when attempting to build the semantic model"
+        error_msg = "Unable to load the semantic manifest"
         if msg:
             error_msg += f"\n{msg}"
         super().__init__(error_msg)

--- a/dbt-metricflow/dbt_metricflow/cli/cli_errors.py
+++ b/dbt-metricflow/dbt_metricflow/cli/cli_errors.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+
+class ModelCreationException(Exception):
+    """Exception to represent errors related to the building a model."""
+
+    def __init__(self, msg: str = "") -> None:  # noqa: D107
+        error_msg = "An error occurred when attempting to build the semantic model"
+        if msg:
+            error_msg += f"\n{msg}"
+        super().__init__(error_msg)

--- a/dbt-metricflow/dbt_metricflow/cli/cli_string.py
+++ b/dbt-metricflow/dbt_metricflow/cli/cli_string.py
@@ -5,3 +5,5 @@ class CLIString:
     """Contains CLI strings that benefit from centralization."""
 
     LOG_FILE_PREFIX = "Log File:"
+    ARTIFACT_PATH = "Artifact Path:"
+    ARTIFACT_MODIFIED_TIME = "Artifact Modified Time:"

--- a/dbt-metricflow/dbt_metricflow/cli/dbt_connectors/dbt_config_accessor.py
+++ b/dbt-metricflow/dbt_metricflow/cli/dbt_connectors/dbt_config_accessor.py
@@ -13,10 +13,11 @@ from dbt.config.profile import Profile
 from dbt.config.project import Project
 from dbt.config.runtime import load_profile, load_project
 from dbt_semantic_interfaces.protocols.semantic_manifest import SemanticManifest
-from metricflow_semantics.errors.error_classes import ModelCreationException
 from metricflow_semantics.mf_logging.lazy_formattable import LazyFormat
 from metricflow_semantics.model.dbt_manifest_parser import parse_manifest_from_dbt_generated_manifest
 from typing_extensions import Self
+
+from dbt_metricflow.cli.cli_errors import ModelCreationException
 
 logger = logging.getLogger(__name__)
 

--- a/dbt-metricflow/dbt_metricflow/cli/dbt_connectors/dbt_config_accessor.py
+++ b/dbt-metricflow/dbt_metricflow/cli/dbt_connectors/dbt_config_accessor.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import dataclasses
 import logging
+import textwrap
 from pathlib import Path
 from typing import List, Type
 
@@ -132,10 +133,15 @@ class dbtArtifacts:
         full_path_to_manifest = Path(project_root, DEFAULT_TARGET_PATH).resolve()
         if not full_path_to_manifest.exists():
             raise ModelCreationException(
-                f"Unable to find {full_path_to_manifest}\n"
-                "Please ensure that you are running `mf` in the root directory of a dbt project "
-                "and that the semantic_manifest JSON exists. If this is your first time running "
-                "`mf`, run `dbt parse` to generate the semantic_manifest JSON."
+                "\n"
+                + "\n".join(
+                    textwrap.wrap(
+                        "Please ensure that you are running `mf` in the root directory of a dbt project "
+                        "and that the semantic manifest artifact exists. If this is your first time running "
+                        "`mf`, run `dbt parse` or `dbt build` to generate the artifact.",
+                        width=80,
+                    )
+                )
             )
         try:
             with open(full_path_to_manifest, "r") as file:

--- a/dbt-metricflow/dbt_metricflow/cli/dbt_connectors/dbt_config_accessor.py
+++ b/dbt-metricflow/dbt_metricflow/cli/dbt_connectors/dbt_config_accessor.py
@@ -134,8 +134,7 @@ class dbtArtifacts:
         full_path_to_manifest = Path(project_root, DEFAULT_TARGET_PATH).resolve()
         if not full_path_to_manifest.exists():
             raise LoadSemanticManifestException(
-                "\n"
-                + "\n".join(
+                "\n".join(
                     textwrap.wrap(
                         "Please ensure that you are running `mf` in the root directory of a dbt project "
                         "and that the semantic manifest artifact exists. If this is your first time running "

--- a/dbt-metricflow/dbt_metricflow/cli/dbt_connectors/dbt_config_accessor.py
+++ b/dbt-metricflow/dbt_metricflow/cli/dbt_connectors/dbt_config_accessor.py
@@ -17,7 +17,7 @@ from metricflow_semantics.mf_logging.lazy_formattable import LazyFormat
 from metricflow_semantics.model.dbt_manifest_parser import parse_manifest_from_dbt_generated_manifest
 from typing_extensions import Self
 
-from dbt_metricflow.cli.cli_errors import ModelCreationException
+from dbt_metricflow.cli.cli_errors import LoadSemanticManifestException
 
 logger = logging.getLogger(__name__)
 
@@ -133,7 +133,7 @@ class dbtArtifacts:
         DEFAULT_TARGET_PATH = "target/semantic_manifest.json"
         full_path_to_manifest = Path(project_root, DEFAULT_TARGET_PATH).resolve()
         if not full_path_to_manifest.exists():
-            raise ModelCreationException(
+            raise LoadSemanticManifestException(
                 "\n"
                 + "\n".join(
                     textwrap.wrap(
@@ -149,4 +149,4 @@ class dbtArtifacts:
                 raw_contents = file.read()
                 return parse_manifest_from_dbt_generated_manifest(manifest_json_string=raw_contents)
         except Exception as e:
-            raise ModelCreationException from e
+            raise LoadSemanticManifestException from e

--- a/dbt-metricflow/dbt_metricflow/cli/utils.py
+++ b/dbt-metricflow/dbt_metricflow/cli/utils.py
@@ -115,6 +115,9 @@ def echo_semantic_manifest_context(cli_configuration: CLIConfiguration) -> None:
     can re-run `dbt parse` or `dbt build`.
     """
     try:
+        if not cli_configuration.is_setup:
+            logger.debug("Skipping retrieval of semantic manifest context as the configuration has not been set up.")
+            return
         project = cli_configuration.dbt_project_metadata.project
         target_path = pathlib.Path(project.project_root) / pathlib.Path(project.target_path)
         semantic_manifest_json_path = target_path / "semantic_manifest.json"
@@ -137,21 +140,30 @@ def exception_handler(func: Callable[..., Any]) -> Callable[..., Any]:  # type: 
             func(*args, **kwargs)
         except Exception as e:
             # This will log to the file handlers registered in the root.
-            logging.exception("Logging exception")
+            logging.exception("Logging exception handled by the CLI exception handler")
+            click.echo(f"\nERROR: {str(e)}".rstrip())
 
-            if isinstance(args[0], CLIConfiguration):
-                cli_configuration: CLIConfiguration = args[0]
-                click.echo(f"\nERROR: {str(e)}\n\n{CLIString.LOG_FILE_PREFIX}: {cli_configuration.log_file_path}")
-                echo_semantic_manifest_context(cli_configuration)
-            else:
-                if not isinstance(args[0], CLIConfiguration):
-                    logger.error(
-                        LazyFormat(
-                            lambda: f"Missing {CLIConfiguration.__name__} as the first argument to the function "
-                            f"{getattr(func, '__name__', repr(func))}"
-                        )
+            cli_configuration: Optional[CLIConfiguration] = None
+            first_argument = args[0]
+            if isinstance(first_argument, CLIConfiguration):
+                cli_configuration = first_argument
+
+            if cli_configuration is not None:
+                if cli_configuration.is_setup:
+                    click.echo(f"\n{CLIString.LOG_FILE_PREFIX}: {cli_configuration.log_file_path}")
+                    echo_semantic_manifest_context(cli_configuration)
+                else:
+                    logger.debug(
+                        "CLI configuration is not setup, possibly due to an exception during configuration setup."
                     )
-                click.echo(f"\nERROR: {str(e)}")
+            else:
+                logger.error(
+                    LazyFormat(
+                        "Unexpected first argument in the exception handler - it should have been passed a configuration.",
+                        expected_argument_class=CLIConfiguration.__name__,
+                        first_argument=first_argument,
+                    )
+                )
 
             click.echo(
                 "\n"
@@ -164,7 +176,7 @@ def exception_handler(func: Callable[..., Any]) -> Callable[..., Any]:  # type: 
             )
 
             # Checks if CLIContext has verbose flag set
-            if args and hasattr(args[0], "verbose") and args[0].verbose is True:
+            if args and hasattr(first_argument, "verbose") and first_argument.verbose is True:
                 click.echo(traceback.format_exc())
 
             exit(1)

--- a/dbt-metricflow/dbt_metricflow/cli/utils.py
+++ b/dbt-metricflow/dbt_metricflow/cli/utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import datetime
 import datetime as dt
 import logging
 import pathlib
@@ -107,6 +108,25 @@ def validate_limit(limit: Optional[str]) -> Optional[int]:
     return int(limit) if limit else None
 
 
+def echo_semantic_manifest_context(cli_configuration: CLIConfiguration) -> None:
+    """Best-effort attempt to print details about the semantic manifest to the console when an error occurs.
+
+    These messages could help the user figure out if their error is caused by an out-of-date artifact. If so, they
+    can re-run `dbt parse` or `dbt build`.
+    """
+    try:
+        project = cli_configuration.dbt_project_metadata.project
+        target_path = pathlib.Path(project.project_root) / pathlib.Path(project.target_path)
+        semantic_manifest_json_path = target_path / "semantic_manifest.json"
+
+        click.echo(f"{CLIString.ARTIFACT_PATH} {semantic_manifest_json_path}")
+        if semantic_manifest_json_path.exists():
+            modified_time = datetime.datetime.fromtimestamp(semantic_manifest_json_path.stat().st_mtime)
+            click.echo(f"{CLIString.ARTIFACT_MODIFIED_TIME} {modified_time.isoformat()}")
+    except Exception:
+        logger.exception("Got an exception while trying to get the semantic-manifest context")
+
+
 # Misc
 def exception_handler(func: Callable[..., Any]) -> Callable[..., Any]:  # type: ignore[misc]
     """Decorator to handle exceptions."""
@@ -122,6 +142,7 @@ def exception_handler(func: Callable[..., Any]) -> Callable[..., Any]:  # type: 
             if isinstance(args[0], CLIConfiguration):
                 cli_configuration: CLIConfiguration = args[0]
                 click.echo(f"\nERROR: {str(e)}\n\n{CLIString.LOG_FILE_PREFIX}: {cli_configuration.log_file_path}")
+                echo_semantic_manifest_context(cli_configuration)
             else:
                 if not isinstance(args[0], CLIConfiguration):
                     logger.error(

--- a/metricflow-semantics/metricflow_semantics/errors/error_classes.py
+++ b/metricflow-semantics/metricflow_semantics/errors/error_classes.py
@@ -51,16 +51,6 @@ class ExecutionException(Exception):
     pass
 
 
-class ModelCreationException(Exception):
-    """Exception to represent errors related to the building a model."""
-
-    def __init__(self, msg: str = "") -> None:  # noqa: D107
-        error_msg = "An error occurred when attempting to build the semantic model"
-        if msg:
-            error_msg += f"\n{msg}"
-        super().__init__(error_msg)
-
-
 class InferenceError(Exception):
     """Exception to represent errors related to inference."""
 

--- a/metricflow-semantics/metricflow_semantics/query/query_parser.py
+++ b/metricflow-semantics/metricflow_semantics/query/query_parser.py
@@ -262,7 +262,7 @@ class MetricFlowQueryParser:
         input_to_issue_set: InputToIssueSetMapping,
     ) -> Optional[str]:
         """Create an error message that formats the inputs / issues."""
-        lines: List[str] = ["Got errors while resolving the query."]
+        lines: List[str] = ["Got error(s) during query resolution."]
         issue_counter = 0
 
         for item in input_to_issue_set.items:
@@ -272,8 +272,8 @@ class MetricFlowQueryParser:
             if not issue_set.has_errors:
                 continue
 
-            issue_counter += 1
             for error_issue in issue_set.errors:
+                issue_counter += 1
                 lines.append(f"\nError #{issue_counter}:")
                 issue_set_lines: List[str] = [
                     "Message:\n",

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_ambiguous_entity_path.py/str/test_non_resolvable_ambiguous_entity_path_due_to_mismatch__result_0.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_ambiguous_entity_path.py/str/test_non_resolvable_ambiguous_entity_path_due_to_mismatch__result_0.txt
@@ -5,7 +5,7 @@ docstring:
 
       'entity_0__country' matches ['entity_1__entity_0__country', 'entity_0__country']
 ---
-Got errors while resolving the query.
+Got error(s) during query resolution.
 
 Error #1:
   Message:

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_ambiguous_entity_path.py/str/test_non_resolvable_ambiguous_entity_path_due_to_multiple_matches__result_0.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_ambiguous_entity_path.py/str/test_non_resolvable_ambiguous_entity_path_due_to_multiple_matches__result_0.txt
@@ -5,7 +5,7 @@ docstring:
 
       'entity_0__country' matches ['entity_1__entity_0__country', 'entity_2__entity_0__country']
 ---
-Got errors while resolving the query.
+Got error(s) during query resolution.
 
 Error #1:
   Message:

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_suggestions.py/str/test_suggestions_for_defined_filters_in_multi_metric_query__result_0.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_suggestions.py/str/test_suggestions_for_defined_filters_in_multi_metric_query__result_0.txt
@@ -3,7 +3,7 @@ test_filename: test_suggestions.py
 docstring:
   Tests that the suggestions for invalid items in filters are specific to the metric.
 ---
-Got errors while resolving the query.
+Got error(s) during query resolution.
 
 Error #1:
   Message:

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_suggestions.py/str/test_suggestions_for_defined_where_filter__result_0.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_suggestions.py/str/test_suggestions_for_defined_where_filter__result_0.txt
@@ -1,7 +1,7 @@
 test_name: test_suggestions_for_defined_where_filter
 test_filename: test_suggestions.py
 ---
-Got errors while resolving the query.
+Got error(s) during query resolution.
 
 Error #1:
   Message:

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_suggestions.py/str/test_suggestions_for_group_by_item__result_0.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_suggestions.py/str/test_suggestions_for_group_by_item__result_0.txt
@@ -1,7 +1,7 @@
 test_name: test_suggestions_for_group_by_item
 test_filename: test_suggestions.py
 ---
-Got errors while resolving the query.
+Got error(s) during query resolution.
 
 Error #1:
   Message:

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_suggestions.py/str/test_suggestions_for_metric__result_0.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_suggestions.py/str/test_suggestions_for_metric__result_0.txt
@@ -1,7 +1,7 @@
 test_name: test_suggestions_for_metric
 test_filename: test_suggestions.py
 ---
-Got errors while resolving the query.
+Got error(s) during query resolution.
 
 Error #1:
   Message:

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_suggestions.py/str/test_suggestions_for_multiple_metrics__result_0.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_suggestions.py/str/test_suggestions_for_multiple_metrics__result_0.txt
@@ -1,7 +1,7 @@
 test_name: test_suggestions_for_multiple_metrics
 test_filename: test_suggestions.py
 ---
-Got errors while resolving the query.
+Got error(s) during query resolution.
 
 Error #1:
   Message:

--- a/tests_metricflow/cli/cli_test_helpers.py
+++ b/tests_metricflow/cli/cli_test_helpers.py
@@ -49,7 +49,11 @@ def run_and_check_cli_command(
 
     # Replace incomparable values in snapshots with `***`.
     snapshot_str = result.stdout
-    for prefix in (CLIString.LOG_FILE_PREFIX,):
+    for prefix in (
+        CLIString.LOG_FILE_PREFIX,
+        CLIString.ARTIFACT_PATH,
+        CLIString.ARTIFACT_MODIFIED_TIME,
+    ):
         regex_parts = (r"(?P<prefix>", prefix, r").*")
         snapshot_str = re.sub("".join(regex_parts), repl=r"\g<prefix> ***", string=snapshot_str)
 

--- a/tests_metricflow/cli/executor_process_main_function.py
+++ b/tests_metricflow/cli/executor_process_main_function.py
@@ -146,11 +146,17 @@ class ExecutorProcessMainFunction:
     def _dbt_project_path(self) -> Optional[Path]:
         return self._starting_parameter_set.dbt_project_path
 
-    def _get_mf_cli_config(self) -> CLIConfiguration:
+    def _get_mf_cli_config(self) -> Optional[CLIConfiguration]:
         """Cache `CLIConfiguration` since it's slow to create."""
         if self._mf_cli_cfg is None:
-            self._mf_cli_cfg = CLIConfiguration()
-            self._mf_cli_cfg.setup(dbt_profiles_path=self._dbt_profiles_path, dbt_project_path=self._dbt_project_path)
+            try:
+                self._mf_cli_cfg = CLIConfiguration()
+                self._mf_cli_cfg.setup(
+                    dbt_profiles_path=self._dbt_profiles_path, dbt_project_path=self._dbt_project_path
+                )
+            except Exception:
+                logger.exception("Got an exception while creating the CLI configuration.")
+
         return self._mf_cli_cfg
 
     def _run_cli_command(self, parameter_set: CommandParameterSet) -> IsolatedCliCommandResult:

--- a/tests_metricflow/cli/test_cli_error.py
+++ b/tests_metricflow/cli/test_cli_error.py
@@ -1,0 +1,66 @@
+"""Tests MF CLI commands e.g. `mf query ...`.
+
+These tests could be parameterized to reduce boilerplate.
+Tests are marked as slow because each CLI command is run in a new process, and the dbt adapter needs to be
+initialized.
+"""
+from __future__ import annotations
+
+import logging
+import tempfile
+from pathlib import Path
+
+import pytest
+from _pytest.fixtures import FixtureRequest
+from metricflow_semantics.test_helpers.config_helpers import MetricFlowTestConfiguration
+
+from tests_metricflow.cli.cli_test_helpers import (
+    create_tutorial_project_files,
+    run_and_check_cli_command,
+)
+from tests_metricflow.cli.isolated_cli_command_interface import IsolatedCliCommandEnum
+from tests_metricflow.cli.isolated_cli_command_runner import IsolatedCliCommandRunner
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.slow
+def test_missing_semantic_manifest(
+    request: FixtureRequest,
+    mf_test_configuration: MetricFlowTestConfiguration,
+) -> None:
+    """Tests a case where a semantic manifest is not found."""
+    with tempfile.TemporaryDirectory() as tmp_directory:
+        dbt_project_path = create_tutorial_project_files(Path(tmp_directory))
+        # Skip running `dbt build` so that the artifact is not created.
+        cli_runner = IsolatedCliCommandRunner(
+            dbt_profiles_path=dbt_project_path,
+            dbt_project_path=dbt_project_path,
+        )
+
+        with cli_runner.running_context():
+            run_and_check_cli_command(
+                request=request,
+                mf_test_configuration=mf_test_configuration,
+                cli_runner=cli_runner,
+                command_enum=IsolatedCliCommandEnum.MF_QUERY,
+                args=["--metrics", "transactions"],
+                expected_exit_code=1,
+            )
+
+
+@pytest.mark.slow
+def test_invalid_metric(
+    request: FixtureRequest,
+    mf_test_configuration: MetricFlowTestConfiguration,
+    cli_runner: IsolatedCliCommandRunner,
+) -> None:
+    """Tests a case where a semantic manifest is not found."""
+    run_and_check_cli_command(
+        request=request,
+        mf_test_configuration=mf_test_configuration,
+        cli_runner=cli_runner,
+        command_enum=IsolatedCliCommandEnum.MF_QUERY,
+        args=["--metrics", "invalid_metric_0,invalid_metric_1"],
+        expected_exit_code=1,
+    )

--- a/tests_metricflow/snapshots/test_cli_error.py/str/test_invalid_metric__result.txt
+++ b/tests_metricflow/snapshots/test_cli_error.py/str/test_invalid_metric__result.txt
@@ -1,0 +1,61 @@
+test_name: test_invalid_metric
+test_filename: test_cli_error.py
+docstring:
+  Tests a case where a semantic manifest is not found.
+---
+
+ERROR: Got error(s) during query resolution.
+
+Error #1:
+  Message:
+
+    The given input does not exactly match any known metrics.
+
+    Suggestions:
+      [
+        'alterations',
+        'transaction_amount',
+        'new_customers',
+        'cancellations_mx',
+        'cumulative_transactions',
+        'cancellation_rate',
+      ]
+
+  Query Input:
+
+    invalid_metric_0
+
+  Issue Location:
+
+    [Resolve Query(['invalid_metric_0', 'invalid_metric_1'])]
+
+Error #2:
+  Message:
+
+    The given input does not exactly match any known metrics.
+
+    Suggestions:
+      [
+        'alterations',
+        'transaction_amount',
+        'new_customers',
+        'cancellations_mx',
+        'cumulative_transactions',
+        'cancellation_rate',
+      ]
+
+  Query Input:
+
+    invalid_metric_1
+
+  Issue Location:
+
+    [Resolve Query(['invalid_metric_0', 'invalid_metric_1'])]
+
+Log File: ***
+Artifact Path: ***
+Artifact Modified Time: ***
+
+If you think you found a bug, please report it here:
+    https://github.com/dbt-labs/metricflow/issues
+

--- a/tests_metricflow/snapshots/test_cli_error.py/str/test_missing_semantic_manifest__result.txt
+++ b/tests_metricflow/snapshots/test_cli_error.py/str/test_missing_semantic_manifest__result.txt
@@ -1,0 +1,17 @@
+test_name: test_missing_semantic_manifest
+test_filename: test_cli_error.py
+docstring:
+  Tests a case where a semantic manifest is not found.
+---
+
+ERROR: Unable to load the semantic manifest.
+  Please ensure that you are running `mf` in the root directory of a dbt project
+  and that the semantic manifest artifact exists. If this is your first time
+  running `mf`, run `dbt parse` or `dbt build` to generate the artifact.
+
+Log File: ***
+Artifact Path: ***
+
+If you think you found a bug, please report it here:
+    https://github.com/dbt-labs/metricflow/issues
+


### PR DESCRIPTION
This PR updates error handling so that the modification time of the semantic-manifest artifact is shown when an error message is shown to the user. This may help users realize if they are querying using an old semantic manifest artifact because they forgot to run `dbt build` after updates.