### PR TITLE
Use native Python methods to manage the CSV file handle

### DIFF
--- a/.changes/unreleased/Fixes-20250331-171239.yaml
+++ b/.changes/unreleased/Fixes-20250331-171239.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Address intermittently missing CSV output file
+time: 2025-03-31T17:12:39.989392-07:00
+custom:
+  Author: plypaul
+  Issue: "1709"

--- a/tests_metricflow/cli/test_cli_error.py
+++ b/tests_metricflow/cli/test_cli_error.py
@@ -64,3 +64,46 @@ def test_invalid_metric(
         args=["--metrics", "invalid_metric_0,invalid_metric_1"],
         expected_exit_code=1,
     )
+
+
+@pytest.mark.slow
+@pytest.mark.skip("Need to sanitize the snapshot output for temporary paths.")
+def test_csv_non_writeable_file(
+    request: FixtureRequest,
+    mf_test_configuration: MetricFlowTestConfiguration,
+    cli_runner: IsolatedCliCommandRunner,
+) -> None:
+    """Test the error message when a read-only is passed in for the CSV file path."""
+    with tempfile.TemporaryDirectory() as tmp_directory:
+        tmp_directory_path = Path(tmp_directory)
+        read_only_file_path = tmp_directory_path / "read_only_file.csv"
+        read_only_file_path.touch(mode=0o400)
+
+        run_and_check_cli_command(
+            request=request,
+            mf_test_configuration=mf_test_configuration,
+            cli_runner=cli_runner,
+            command_enum=IsolatedCliCommandEnum.MF_QUERY,
+            args=["--metrics", "transactions", "--csv", str(read_only_file_path)],
+            expected_exit_code=2,
+        )
+
+
+@pytest.mark.slow
+@pytest.mark.skip("Need to sanitize the snapshot output for temporary paths.")
+def test_csv_directory(
+    request: FixtureRequest,
+    mf_test_configuration: MetricFlowTestConfiguration,
+    cli_runner: IsolatedCliCommandRunner,
+) -> None:
+    """Test the error message when a directory is passed in for the CSV file path."""
+    with tempfile.TemporaryDirectory() as tmp_directory:
+        tmp_directory_path = Path(tmp_directory)
+        run_and_check_cli_command(
+            request=request,
+            mf_test_configuration=mf_test_configuration,
+            cli_runner=cli_runner,
+            command_enum=IsolatedCliCommandEnum.MF_QUERY,
+            args=["--metrics", "transactions", "--csv", str(tmp_directory_path)],
+            expected_exit_code=2,
+        )

--- a/tests_metricflow/snapshots/test_cli.py/str/test_csv__result.txt
+++ b/tests_metricflow/snapshots/test_cli.py/str/test_csv__result.txt
@@ -1,0 +1,9 @@
+test_name: test_csv
+test_filename: test_cli.py
+docstring:
+  Tests writing the results of a query to a file.
+expectation_description:
+  A CSV file containing the values for 2 metrics.
+---
+transactions,quick_buy_transactions
+50,10


### PR DESCRIPTION
Resolves #1706 

This PR updates the CLI to use the native Python methods to create and close the CSV file to handle a potential issue with `click`'s `File` / `LazyFile` where the written file was not immediately visible.