### PR TITLE
Configure `pytest` to skip scanning snapshots directory

### DIFF
--- a/.changes/unreleased/Fixes-20250331-171345.yaml
+++ b/.changes/unreleased/Fixes-20250331-171345.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Configure `pytest` to skip scanning snapshots directory
+time: 2025-03-31T17:13:45.236488-07:00
+custom:
+  Author: plypaul
+  Issue: "1710"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,6 @@
+[pytest]
+# Don't scan for tests in the snapshot directory as they don't contain tests.
+# Speeds up initialization a little bit and also prevent parsing errors.
+norecursedirs =
+    tests_metricflow/snapshots
+    metricflow-semantics/tests_metricflow_semantics/snapshots


### PR DESCRIPTION
This PR updates `pytest.ini` so that `pytest` does not scan the `snapshots` directories for tests. There are many files in that location, and parsing them may result in errors.