### PR TITLE
Support pretty-formatting of `msgspec.struct` 

### DIFF
--- a/metricflow-semantics/metricflow_semantics/mf_logging/pretty_print.py
+++ b/metricflow-semantics/metricflow_semantics/mf_logging/pretty_print.py
@@ -6,6 +6,8 @@ from dataclasses import fields, is_dataclass
 from enum import Enum
 from typing import Any, Dict, List, Mapping, Optional, Sized, Tuple, Union
 
+import msgspec
+
 from metricflow_semantics.mf_logging.formatting import indent
 from metricflow_semantics.mf_logging.pretty_formattable import MetricFlowPrettyFormattable
 
@@ -332,6 +334,16 @@ class MetricFlowPrettyFormatter:
         if isinstance(obj, MetricFlowPrettyFormattable):
             if obj.pretty_format is not None:
                 return obj.pretty_format
+
+        if isinstance(obj, msgspec.Struct):
+            return self._handle_mapping_like_obj(
+                msgspec.structs.asdict(obj),
+                left_enclose_str=type(obj).__name__ + "(",
+                key_value_seperator="=",
+                right_enclose_str=")",
+                is_dataclass_like_object=True,
+                remaining_line_width=remaining_line_width,
+            )
 
         if is_dataclass(obj):
             # dataclasses.asdict() seems to exclude None fields, so doing this instead.

--- a/metricflow-semantics/tests_metricflow_semantics/mf_logging/test_pformat_msgspec.py
+++ b/metricflow-semantics/tests_metricflow_semantics/mf_logging/test_pformat_msgspec.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+import msgspec
+from metricflow_semantics.formatting.formatting_helpers import mf_dedent
+from metricflow_semantics.mf_logging.pretty_print import mf_pformat
+
+logger = logging.getLogger(__name__)
+
+
+class _ExampleStruct(msgspec.Struct):
+    int_field: int
+    string_field: str
+    recursive_field: Optional[_ExampleStruct]
+
+
+def test_struct() -> None:
+    """Test formatting of a `msgspec.Struct`."""
+    inner_struct = _ExampleStruct(int_field=1, string_field="inner_struct__string_field", recursive_field=None)
+    outer_struct = _ExampleStruct(int_field=0, string_field="outer_struct__string_field", recursive_field=inner_struct)
+    result = mf_pformat(outer_struct, max_line_length=1)
+    assert result == mf_dedent(
+        """
+        _ExampleStruct(
+          int_field=0,
+          string_field='outer_struct__string_field',
+          recursive_field=_ExampleStruct(
+            int_field=1,
+            string_field='inner_struct__string_field',
+          ),
+        )
+        """
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,8 @@ dependencies = [
   "dbt-duckdb>=1.8.0, <1.9.0",
   # Excluding 1.2.1 due to window functions returning incorrect results:
   # https://github.com/duckdb/duckdb/issues/16617
-  "duckdb !=1.2.1"
+  "duckdb !=1.2.1",
+  "msgspec >=0.19.0, <0.20.0"
 ]
 
 


### PR DESCRIPTION
Related to: https://github.com/dbt-labs/metricflow/issues/1683