### PR TITLE
Allow no-metric queries without group by

### DIFF
--- a/.changes/unreleased/Features-20250409-152709.yaml
+++ b/.changes/unreleased/Features-20250409-152709.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Allow bypassing the group by when making queries without metrics.
+time: 2025-04-09T15:27:09.079342-07:00
+custom:
+  Author: courtneyholcomb
+  Issue: "1720"

--- a/metricflow-semantics/metricflow_semantics/query/issues/parsing/invalid_apply_group_by.py
+++ b/metricflow-semantics/metricflow_semantics/query/issues/parsing/invalid_apply_group_by.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Tuple
+
+from typing_extensions import override
+
+from metricflow_semantics.query.group_by_item.resolution_path import MetricFlowQueryResolutionPath
+from metricflow_semantics.query.issues.issues_base import (
+    MetricFlowQueryIssueType,
+    MetricFlowQueryResolutionIssue,
+)
+from metricflow_semantics.query.resolver_inputs.base_resolver_inputs import MetricFlowQueryResolverInput
+from metricflow_semantics.query.resolver_inputs.query_resolver_inputs import (
+    ResolverInputForMetric,
+)
+
+
+@dataclass(frozen=True)
+class InvalidApplyGroupByIssue(MetricFlowQueryResolutionIssue):
+    """Describes an issue with the query where the apply group by param is invalid."""
+
+    apply_group_by: bool
+    metric_inputs: Tuple[ResolverInputForMetric, ...]
+
+    @staticmethod
+    def from_parameters(  # noqa: D102
+        apply_group_by: bool,
+        metric_inputs: Tuple[ResolverInputForMetric, ...],
+        query_resolution_path: MetricFlowQueryResolutionPath,
+    ) -> InvalidApplyGroupByIssue:
+        return InvalidApplyGroupByIssue(
+            issue_type=MetricFlowQueryIssueType.ERROR,
+            parent_issues=(),
+            query_resolution_path=query_resolution_path,
+            apply_group_by=apply_group_by,
+            metric_inputs=metric_inputs,
+        )
+
+    @override
+    def ui_description(self, associated_input: MetricFlowQueryResolverInput) -> str:
+        return "`apply_group_by` cannot be False for a query with metrics."
+
+    @override
+    def with_path_prefix(self, path_prefix_node: MetricFlowQueryResolutionPath) -> InvalidApplyGroupByIssue:
+        return InvalidApplyGroupByIssue(
+            issue_type=self.issue_type,
+            parent_issues=tuple(issue.with_path_prefix(path_prefix_node) for issue in self.parent_issues),
+            query_resolution_path=self.query_resolution_path.with_path_prefix(path_prefix_node),
+            apply_group_by=self.apply_group_by,
+            metric_inputs=self.metric_inputs,
+        )

--- a/metricflow-semantics/metricflow_semantics/query/query_parser.py
+++ b/metricflow-semantics/metricflow_semantics/query/query_parser.py
@@ -44,7 +44,7 @@ from metricflow_semantics.query.query_resolver import MetricFlowQueryResolver
 from metricflow_semantics.query.resolver_inputs.base_resolver_inputs import MetricFlowQueryResolverInput
 from metricflow_semantics.query.resolver_inputs.query_resolver_inputs import (
     InvalidStringInput,
-    ResolverInputForDedupe,
+    ResolverInputForApplyGroupBy,
     ResolverInputForGroupByItem,
     ResolverInputForLimit,
     ResolverInputForMetric,
@@ -99,7 +99,7 @@ class MetricFlowQueryParser:
         time_constraint_end: Optional[datetime.datetime] = None,
         order_by_names: Optional[Sequence[str]] = None,
         order_by_parameters: Optional[Sequence[OrderByQueryParameter]] = None,
-        dedupe: bool = True,
+        apply_group_by: bool = True,
     ) -> ParseQueryResult:
         """Parse and validate a query using parameters from a pre-defined / saved query.
 
@@ -127,7 +127,7 @@ class MetricFlowQueryParser:
             order_by_names=order_by_names,
             order_by=order_by_parameters,
             min_max_only=False,
-            dedupe=dedupe,
+            apply_group_by=apply_group_by,
         )
 
     def _get_saved_query(self, saved_query_parameter: SavedQueryParameter) -> SavedQuery:
@@ -320,7 +320,7 @@ class MetricFlowQueryParser:
         order_by_names: Optional[Sequence[str]] = None,
         order_by: Optional[Sequence[OrderByQueryParameter]] = None,
         min_max_only: bool = False,
-        dedupe: bool = True,
+        apply_group_by: bool = True,
     ) -> ParseQueryResult:
         """Parse the query into spec objects, validating them in the process.
 
@@ -341,7 +341,7 @@ class MetricFlowQueryParser:
             order_by_names=order_by_names,
             order_by=order_by,
             min_max_only=min_max_only,
-            dedupe=dedupe,
+            apply_group_by=apply_group_by,
         )
 
     @log_runtime()
@@ -359,7 +359,7 @@ class MetricFlowQueryParser:
         order_by_names: Optional[Sequence[str]],
         order_by: Optional[Sequence[OrderByQueryParameter]],
         min_max_only: bool,
-        dedupe: bool,
+        apply_group_by: bool,
     ) -> ParseQueryResult:
         if min_max_only and (metric_names or metrics):
             raise InvalidQueryException("Cannot use min_max_only param for queries with metrics.")
@@ -501,7 +501,7 @@ class MetricFlowQueryParser:
 
         resolver_input_for_limit = ResolverInputForLimit(limit=limit)
         resolver_input_for_min_max_only = ResolverInputForMinMaxOnly(min_max_only=min_max_only)
-        resolver_input_for_dedupe = ResolverInputForDedupe(dedupe=dedupe)
+        resolver_input_for_apply_group_by = ResolverInputForApplyGroupBy(apply_group_by=apply_group_by)
 
         resolver_input_for_query = ResolverInputForQuery(
             metric_inputs=tuple(resolver_inputs_for_metrics),
@@ -510,7 +510,7 @@ class MetricFlowQueryParser:
             limit_input=resolver_input_for_limit,
             filter_input=resolver_input_for_filter,
             min_max_only=resolver_input_for_min_max_only,
-            dedupe=resolver_input_for_dedupe,
+            apply_group_by=resolver_input_for_apply_group_by,
         )
 
         logger.debug(

--- a/metricflow-semantics/metricflow_semantics/query/query_parser.py
+++ b/metricflow-semantics/metricflow_semantics/query/query_parser.py
@@ -93,12 +93,12 @@ class MetricFlowQueryParser:
     def parse_and_validate_saved_query(
         self,
         saved_query_parameter: SavedQueryParameter,
-        where_filters: Optional[Sequence[WhereFilter]],
-        limit: Optional[int],
-        time_constraint_start: Optional[datetime.datetime],
-        time_constraint_end: Optional[datetime.datetime],
-        order_by_names: Optional[Sequence[str]],
-        order_by_parameters: Optional[Sequence[OrderByQueryParameter]],
+        where_filters: Optional[Sequence[WhereFilter]] = None,
+        limit: Optional[int] = None,
+        time_constraint_start: Optional[datetime.datetime] = None,
+        time_constraint_end: Optional[datetime.datetime] = None,
+        order_by_names: Optional[Sequence[str]] = None,
+        order_by_parameters: Optional[Sequence[OrderByQueryParameter]] = None,
         dedupe: bool = True,
     ) -> ParseQueryResult:
         """Parse and validate a query using parameters from a pre-defined / saved query.

--- a/metricflow-semantics/metricflow_semantics/query/query_parser.py
+++ b/metricflow-semantics/metricflow_semantics/query/query_parser.py
@@ -44,6 +44,7 @@ from metricflow_semantics.query.query_resolver import MetricFlowQueryResolver
 from metricflow_semantics.query.resolver_inputs.base_resolver_inputs import MetricFlowQueryResolverInput
 from metricflow_semantics.query.resolver_inputs.query_resolver_inputs import (
     InvalidStringInput,
+    ResolverInputForDedupe,
     ResolverInputForGroupByItem,
     ResolverInputForLimit,
     ResolverInputForMetric,
@@ -98,6 +99,7 @@ class MetricFlowQueryParser:
         time_constraint_end: Optional[datetime.datetime],
         order_by_names: Optional[Sequence[str]],
         order_by_parameters: Optional[Sequence[OrderByQueryParameter]],
+        dedupe: bool = True,
     ) -> ParseQueryResult:
         """Parse and validate a query using parameters from a pre-defined / saved query.
 
@@ -125,6 +127,7 @@ class MetricFlowQueryParser:
             order_by_names=order_by_names,
             order_by=order_by_parameters,
             min_max_only=False,
+            dedupe=dedupe,
         )
 
     def _get_saved_query(self, saved_query_parameter: SavedQueryParameter) -> SavedQuery:
@@ -317,6 +320,7 @@ class MetricFlowQueryParser:
         order_by_names: Optional[Sequence[str]] = None,
         order_by: Optional[Sequence[OrderByQueryParameter]] = None,
         min_max_only: bool = False,
+        dedupe: bool = True,
     ) -> ParseQueryResult:
         """Parse the query into spec objects, validating them in the process.
 
@@ -337,6 +341,7 @@ class MetricFlowQueryParser:
             order_by_names=order_by_names,
             order_by=order_by,
             min_max_only=min_max_only,
+            dedupe=dedupe,
         )
 
     @log_runtime()
@@ -354,6 +359,7 @@ class MetricFlowQueryParser:
         order_by_names: Optional[Sequence[str]],
         order_by: Optional[Sequence[OrderByQueryParameter]],
         min_max_only: bool,
+        dedupe: bool,
     ) -> ParseQueryResult:
         if min_max_only and (metric_names or metrics):
             raise InvalidQueryException("Cannot use min_max_only param for queries with metrics.")
@@ -495,6 +501,7 @@ class MetricFlowQueryParser:
 
         resolver_input_for_limit = ResolverInputForLimit(limit=limit)
         resolver_input_for_min_max_only = ResolverInputForMinMaxOnly(min_max_only=min_max_only)
+        resolver_input_for_dedupe = ResolverInputForDedupe(dedupe=dedupe)
 
         resolver_input_for_query = ResolverInputForQuery(
             metric_inputs=tuple(resolver_inputs_for_metrics),
@@ -503,6 +510,7 @@ class MetricFlowQueryParser:
             limit_input=resolver_input_for_limit,
             filter_input=resolver_input_for_filter,
             min_max_only=resolver_input_for_min_max_only,
+            dedupe=resolver_input_for_dedupe,
         )
 
         logger.debug(

--- a/metricflow-semantics/metricflow_semantics/query/resolver_inputs/query_resolver_inputs.py
+++ b/metricflow-semantics/metricflow_semantics/query/resolver_inputs/query_resolver_inputs.py
@@ -136,15 +136,15 @@ class ResolverInputForMinMaxOnly(MetricFlowQueryResolverInput):
 
 
 @dataclass(frozen=True)
-class ResolverInputForDedupe(MetricFlowQueryResolverInput):
-    """An input that describes if the query will dedupe group by items (only applicable to no-metric queries)."""
+class ResolverInputForApplyGroupBy(MetricFlowQueryResolverInput):
+    """An input that describes if the query will apply a group by. Can only be false for no-metric queries."""
 
-    dedupe: bool = True
+    apply_group_by: bool = True
 
     @property
     @override
     def ui_description(self) -> str:
-        return str(self.dedupe)
+        return str(self.apply_group_by)
 
 
 @dataclass(frozen=True)
@@ -210,7 +210,7 @@ class ResolverInputForQuery(MetricFlowQueryResolverInput):
     order_by_item_inputs: Tuple[ResolverInputForOrderByItem, ...]
     limit_input: ResolverInputForLimit
     min_max_only: ResolverInputForMinMaxOnly
-    dedupe: ResolverInputForDedupe
+    apply_group_by: ResolverInputForApplyGroupBy
 
     @property
     @override

--- a/metricflow-semantics/metricflow_semantics/query/resolver_inputs/query_resolver_inputs.py
+++ b/metricflow-semantics/metricflow_semantics/query/resolver_inputs/query_resolver_inputs.py
@@ -136,6 +136,18 @@ class ResolverInputForMinMaxOnly(MetricFlowQueryResolverInput):
 
 
 @dataclass(frozen=True)
+class ResolverInputForDedupe(MetricFlowQueryResolverInput):
+    """An input that describes if the query will dedupe group by items (only applicable to no-metric queries)."""
+
+    dedupe: bool = True
+
+    @property
+    @override
+    def ui_description(self) -> str:
+        return str(self.dedupe)
+
+
+@dataclass(frozen=True)
 class ResolverInputForQueryLevelWhereFilterIntersection(MetricFlowQueryResolverInput):
     """An input that describes the where filter for the query."""
 
@@ -198,6 +210,7 @@ class ResolverInputForQuery(MetricFlowQueryResolverInput):
     order_by_item_inputs: Tuple[ResolverInputForOrderByItem, ...]
     limit_input: ResolverInputForLimit
     min_max_only: ResolverInputForMinMaxOnly
+    dedupe: ResolverInputForDedupe
 
     @property
     @override

--- a/metricflow-semantics/metricflow_semantics/specs/query_spec.py
+++ b/metricflow-semantics/metricflow_semantics/specs/query_spec.py
@@ -34,7 +34,7 @@ class MetricFlowQuerySpec(SerializableDataclass):
     filter_intersection: Optional[WhereFilterIntersection] = None
     filter_spec_resolution_lookup: FilterSpecResolutionLookUp = FilterSpecResolutionLookUp.empty_instance()
     min_max_only: bool = False
-    dedupe: bool = True
+    apply_group_by: bool = True
 
     @property
     def linkable_specs(self) -> LinkableSpecSet:  # noqa: D102

--- a/metricflow-semantics/metricflow_semantics/specs/query_spec.py
+++ b/metricflow-semantics/metricflow_semantics/specs/query_spec.py
@@ -34,6 +34,7 @@ class MetricFlowQuerySpec(SerializableDataclass):
     filter_intersection: Optional[WhereFilterIntersection] = None
     filter_spec_resolution_lookup: FilterSpecResolutionLookUp = FilterSpecResolutionLookUp.empty_instance()
     min_max_only: bool = False
+    dedupe: bool = True
 
     @property
     def linkable_specs(self) -> LinkableSpecSet:  # noqa: D102

--- a/metricflow-semantics/metricflow_semantics/test_helpers/semantic_manifest_yamls/simple_manifest/saved_queries.yaml
+++ b/metricflow-semantics/metricflow_semantics/test_helpers/semantic_manifest_yamls/simple_manifest/saved_queries.yaml
@@ -40,3 +40,12 @@ saved_query:
     where:
       - "{{ Dimension('listing__is_lux_latest') }}"
       - "{{ TimeDimension('metric_time', 'day') }} >= '2020-01-02'"
+---
+saved_query:
+  name: dimensions_only
+  description: Query without metrics
+  query_params:
+    group_by:
+      - Dimension('listing__capacity_latest')
+      - TimeDimension('metric_time', 'month')
+    metrics: []

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_ambiguous_entity_path.py/MetricFlowQuerySpec/test_ambiguous_entity_path_resolves_to_shortest_entity_path_item__result_0.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_ambiguous_entity_path.py/MetricFlowQuerySpec/test_ambiguous_entity_path_resolves_to_shortest_entity_path_item__result_0.txt
@@ -9,4 +9,5 @@ MetricFlowQuerySpec(
   filter_intersection=PydanticWhereFilterIntersection(),
   filter_spec_resolution_lookup=FilterSpecResolutionLookUp(),
   min_max_only=False,
+  dedupe=True,
 )

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_ambiguous_entity_path.py/MetricFlowQuerySpec/test_ambiguous_entity_path_resolves_to_shortest_entity_path_item__result_0.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_ambiguous_entity_path.py/MetricFlowQuerySpec/test_ambiguous_entity_path_resolves_to_shortest_entity_path_item__result_0.txt
@@ -9,5 +9,5 @@ MetricFlowQuerySpec(
   filter_intersection=PydanticWhereFilterIntersection(),
   filter_spec_resolution_lookup=FilterSpecResolutionLookUp(),
   min_max_only=False,
-  dedupe=True,
+  apply_group_by=True,
 )

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_ambiguous_entity_path.py/MetricFlowQuerySpec/test_resolvable_ambiguous_entity_path__result_0.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_ambiguous_entity_path.py/MetricFlowQuerySpec/test_resolvable_ambiguous_entity_path__result_0.txt
@@ -12,5 +12,5 @@ MetricFlowQuerySpec(
   filter_intersection=PydanticWhereFilterIntersection(),
   filter_spec_resolution_lookup=FilterSpecResolutionLookUp(),
   min_max_only=False,
-  dedupe=True,
+  apply_group_by=True,
 )

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_ambiguous_entity_path.py/MetricFlowQuerySpec/test_resolvable_ambiguous_entity_path__result_0.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_ambiguous_entity_path.py/MetricFlowQuerySpec/test_resolvable_ambiguous_entity_path__result_0.txt
@@ -12,4 +12,5 @@ MetricFlowQuerySpec(
   filter_intersection=PydanticWhereFilterIntersection(),
   filter_spec_resolution_lookup=FilterSpecResolutionLookUp(),
   min_max_only=False,
+  dedupe=True,
 )

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_conversion_metrics.py/ParseQueryResult/test_conversion_rate_with_constant_properties__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_conversion_metrics.py/ParseQueryResult/test_conversion_rate_with_constant_properties__result.txt
@@ -28,7 +28,7 @@ ParseQueryResult(
     filter_intersection=PydanticWhereFilterIntersection(),
     filter_spec_resolution_lookup=FilterSpecResolutionLookUp(),
     min_max_only=False,
-    dedupe=True,
+    apply_group_by=True,
   ),
   queried_semantic_models=(
     SemanticModelReference(semantic_model_name='buys_source'),

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_conversion_metrics.py/ParseQueryResult/test_conversion_rate_with_constant_properties__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_conversion_metrics.py/ParseQueryResult/test_conversion_rate_with_constant_properties__result.txt
@@ -28,6 +28,7 @@ ParseQueryResult(
     filter_intersection=PydanticWhereFilterIntersection(),
     filter_spec_resolution_lookup=FilterSpecResolutionLookUp(),
     min_max_only=False,
+    dedupe=True,
   ),
   queried_semantic_models=(
     SemanticModelReference(semantic_model_name='buys_source'),

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_metric_time_granularity.py/MetricFlowQuerySpec/test_derived_metric_with_defined_metric_time_filter__result_0.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_metric_time_granularity.py/MetricFlowQuerySpec/test_derived_metric_with_defined_metric_time_filter__result_0.txt
@@ -90,5 +90,5 @@ MetricFlowQuerySpec(
     ),
   ),
   min_max_only=False,
-  dedupe=True,
+  apply_group_by=True,
 )

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_metric_time_granularity.py/MetricFlowQuerySpec/test_derived_metric_with_defined_metric_time_filter__result_0.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_metric_time_granularity.py/MetricFlowQuerySpec/test_derived_metric_with_defined_metric_time_filter__result_0.txt
@@ -90,4 +90,5 @@ MetricFlowQuerySpec(
     ),
   ),
   min_max_only=False,
+  dedupe=True,
 )

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_metric_time_granularity.py/MetricFlowQuerySpec/test_derived_metric_with_defined_metric_time_filter_on_input_metric__result_0.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_metric_time_granularity.py/MetricFlowQuerySpec/test_derived_metric_with_defined_metric_time_filter_on_input_metric__result_0.txt
@@ -169,4 +169,5 @@ MetricFlowQuerySpec(
     ),
   ),
   min_max_only=False,
+  dedupe=True,
 )

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_metric_time_granularity.py/MetricFlowQuerySpec/test_derived_metric_with_defined_metric_time_filter_on_input_metric__result_0.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_metric_time_granularity.py/MetricFlowQuerySpec/test_derived_metric_with_defined_metric_time_filter_on_input_metric__result_0.txt
@@ -169,5 +169,5 @@ MetricFlowQuerySpec(
     ),
   ),
   min_max_only=False,
-  dedupe=True,
+  apply_group_by=True,
 )

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_metric_time_granularity.py/MetricFlowQuerySpec/test_derived_metric_with_explicit_time_granularity__result_0.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_metric_time_granularity.py/MetricFlowQuerySpec/test_derived_metric_with_explicit_time_granularity__result_0.txt
@@ -14,4 +14,5 @@ MetricFlowQuerySpec(
   filter_intersection=PydanticWhereFilterIntersection(),
   filter_spec_resolution_lookup=FilterSpecResolutionLookUp(),
   min_max_only=False,
+  dedupe=True,
 )

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_metric_time_granularity.py/MetricFlowQuerySpec/test_derived_metric_with_explicit_time_granularity__result_0.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_metric_time_granularity.py/MetricFlowQuerySpec/test_derived_metric_with_explicit_time_granularity__result_0.txt
@@ -14,5 +14,5 @@ MetricFlowQuerySpec(
   filter_intersection=PydanticWhereFilterIntersection(),
   filter_spec_resolution_lookup=FilterSpecResolutionLookUp(),
   min_max_only=False,
-  dedupe=True,
+  apply_group_by=True,
 )

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_metric_time_granularity.py/MetricFlowQuerySpec/test_derived_metric_without_explicit_time_granularity__result_0.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_metric_time_granularity.py/MetricFlowQuerySpec/test_derived_metric_without_explicit_time_granularity__result_0.txt
@@ -21,5 +21,5 @@ MetricFlowQuerySpec(
   filter_intersection=PydanticWhereFilterIntersection(),
   filter_spec_resolution_lookup=FilterSpecResolutionLookUp(),
   min_max_only=False,
-  dedupe=True,
+  apply_group_by=True,
 )

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_metric_time_granularity.py/MetricFlowQuerySpec/test_derived_metric_without_explicit_time_granularity__result_0.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_metric_time_granularity.py/MetricFlowQuerySpec/test_derived_metric_without_explicit_time_granularity__result_0.txt
@@ -21,4 +21,5 @@ MetricFlowQuerySpec(
   filter_intersection=PydanticWhereFilterIntersection(),
   filter_spec_resolution_lookup=FilterSpecResolutionLookUp(),
   min_max_only=False,
+  dedupe=True,
 )

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_metric_time_granularity.py/MetricFlowQuerySpec/test_non_metric_time_ignores_default_granularity__result_0.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_metric_time_granularity.py/MetricFlowQuerySpec/test_non_metric_time_ignores_default_granularity__result_0.txt
@@ -13,5 +13,5 @@ MetricFlowQuerySpec(
   filter_intersection=PydanticWhereFilterIntersection(),
   filter_spec_resolution_lookup=FilterSpecResolutionLookUp(),
   min_max_only=False,
-  dedupe=True,
+  apply_group_by=True,
 )

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_metric_time_granularity.py/MetricFlowQuerySpec/test_non_metric_time_ignores_default_granularity__result_0.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_metric_time_granularity.py/MetricFlowQuerySpec/test_non_metric_time_ignores_default_granularity__result_0.txt
@@ -13,4 +13,5 @@ MetricFlowQuerySpec(
   filter_intersection=PydanticWhereFilterIntersection(),
   filter_spec_resolution_lookup=FilterSpecResolutionLookUp(),
   min_max_only=False,
+  dedupe=True,
 )

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_metric_time_granularity.py/MetricFlowQuerySpec/test_simple_metric_with_defined_metric_time_filter__result_0.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_metric_time_granularity.py/MetricFlowQuerySpec/test_simple_metric_with_defined_metric_time_filter__result_0.txt
@@ -90,5 +90,5 @@ MetricFlowQuerySpec(
     ),
   ),
   min_max_only=False,
-  dedupe=True,
+  apply_group_by=True,
 )

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_metric_time_granularity.py/MetricFlowQuerySpec/test_simple_metric_with_defined_metric_time_filter__result_0.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_metric_time_granularity.py/MetricFlowQuerySpec/test_simple_metric_with_defined_metric_time_filter__result_0.txt
@@ -90,4 +90,5 @@ MetricFlowQuerySpec(
     ),
   ),
   min_max_only=False,
+  dedupe=True,
 )

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_metric_time_granularity.py/MetricFlowQuerySpec/test_simple_metric_with_explicit_time_granularity__result_0.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_metric_time_granularity.py/MetricFlowQuerySpec/test_simple_metric_with_explicit_time_granularity__result_0.txt
@@ -12,5 +12,5 @@ MetricFlowQuerySpec(
   filter_intersection=PydanticWhereFilterIntersection(),
   filter_spec_resolution_lookup=FilterSpecResolutionLookUp(),
   min_max_only=False,
-  dedupe=True,
+  apply_group_by=True,
 )

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_metric_time_granularity.py/MetricFlowQuerySpec/test_simple_metric_with_explicit_time_granularity__result_0.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_metric_time_granularity.py/MetricFlowQuerySpec/test_simple_metric_with_explicit_time_granularity__result_0.txt
@@ -12,4 +12,5 @@ MetricFlowQuerySpec(
   filter_intersection=PydanticWhereFilterIntersection(),
   filter_spec_resolution_lookup=FilterSpecResolutionLookUp(),
   min_max_only=False,
+  dedupe=True,
 )

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_metric_time_granularity.py/MetricFlowQuerySpec/test_simple_metric_without_explicit_time_granularity__result_0.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_metric_time_granularity.py/MetricFlowQuerySpec/test_simple_metric_without_explicit_time_granularity__result_0.txt
@@ -14,4 +14,5 @@ MetricFlowQuerySpec(
   filter_intersection=PydanticWhereFilterIntersection(),
   filter_spec_resolution_lookup=FilterSpecResolutionLookUp(),
   min_max_only=False,
+  dedupe=True,
 )

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_metric_time_granularity.py/MetricFlowQuerySpec/test_simple_metric_without_explicit_time_granularity__result_0.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_metric_time_granularity.py/MetricFlowQuerySpec/test_simple_metric_without_explicit_time_granularity__result_0.txt
@@ -14,5 +14,5 @@ MetricFlowQuerySpec(
   filter_intersection=PydanticWhereFilterIntersection(),
   filter_spec_resolution_lookup=FilterSpecResolutionLookUp(),
   min_max_only=False,
-  dedupe=True,
+  apply_group_by=True,
 )

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_cumulative_metric_agg_time_dimension_name_validation__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_cumulative_metric_agg_time_dimension_name_validation__result.txt
@@ -16,7 +16,7 @@ ParseQueryResult(
     filter_intersection=PydanticWhereFilterIntersection(),
     filter_spec_resolution_lookup=FilterSpecResolutionLookUp(),
     min_max_only=False,
-    dedupe=True,
+    apply_group_by=True,
   ),
   queried_semantic_models=(SemanticModelReference(semantic_model_name='revenue_source'),),
 )

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_cumulative_metric_agg_time_dimension_name_validation__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_cumulative_metric_agg_time_dimension_name_validation__result.txt
@@ -16,6 +16,7 @@ ParseQueryResult(
     filter_intersection=PydanticWhereFilterIntersection(),
     filter_spec_resolution_lookup=FilterSpecResolutionLookUp(),
     min_max_only=False,
+    dedupe=True,
   ),
   queried_semantic_models=(SemanticModelReference(semantic_model_name='revenue_source'),),
 )

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_derived_metric_with_offset_parsing__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_derived_metric_with_offset_parsing__result.txt
@@ -15,6 +15,7 @@ ParseQueryResult(
     filter_intersection=PydanticWhereFilterIntersection(),
     filter_spec_resolution_lookup=FilterSpecResolutionLookUp(),
     min_max_only=False,
+    dedupe=True,
   ),
   queried_semantic_models=(SemanticModelReference(semantic_model_name='revenue_source'),),
 )

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_derived_metric_with_offset_parsing__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_derived_metric_with_offset_parsing__result.txt
@@ -15,7 +15,7 @@ ParseQueryResult(
     filter_intersection=PydanticWhereFilterIntersection(),
     filter_spec_resolution_lookup=FilterSpecResolutionLookUp(),
     min_max_only=False,
-    dedupe=True,
+    apply_group_by=True,
   ),
   queried_semantic_models=(SemanticModelReference(semantic_model_name='revenue_source'),),
 )

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_order_by_granularity_conversion__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_order_by_granularity_conversion__result.txt
@@ -33,7 +33,7 @@ ParseQueryResult(
     filter_intersection=PydanticWhereFilterIntersection(),
     filter_spec_resolution_lookup=FilterSpecResolutionLookUp(),
     min_max_only=False,
-    dedupe=True,
+    apply_group_by=True,
   ),
   queried_semantic_models=(
     SemanticModelReference(semantic_model_name='bookings_source'),

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_order_by_granularity_conversion__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_order_by_granularity_conversion__result.txt
@@ -33,6 +33,7 @@ ParseQueryResult(
     filter_intersection=PydanticWhereFilterIntersection(),
     filter_spec_resolution_lookup=FilterSpecResolutionLookUp(),
     min_max_only=False,
+    dedupe=True,
   ),
   queried_semantic_models=(
     SemanticModelReference(semantic_model_name='bookings_source'),

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_order_by_granularity_no_conversion__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_order_by_granularity_no_conversion__result.txt
@@ -25,7 +25,7 @@ ParseQueryResult(
     filter_intersection=PydanticWhereFilterIntersection(),
     filter_spec_resolution_lookup=FilterSpecResolutionLookUp(),
     min_max_only=False,
-    dedupe=True,
+    apply_group_by=True,
   ),
   queried_semantic_models=(SemanticModelReference(semantic_model_name='bookings_source'),),
 )

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_order_by_granularity_no_conversion__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_order_by_granularity_no_conversion__result.txt
@@ -25,6 +25,7 @@ ParseQueryResult(
     filter_intersection=PydanticWhereFilterIntersection(),
     filter_spec_resolution_lookup=FilterSpecResolutionLookUp(),
     min_max_only=False,
+    dedupe=True,
   ),
   queried_semantic_models=(SemanticModelReference(semantic_model_name='bookings_source'),),
 )

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_parse_and_validate_where_constraint_dims__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_parse_and_validate_where_constraint_dims__result.txt
@@ -111,6 +111,7 @@ ParseQueryResult(
       ),
     ),
     min_max_only=False,
+    dedupe=True,
   ),
   queried_semantic_models=(SemanticModelReference(semantic_model_name='bookings_source'),),
 )

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_parse_and_validate_where_constraint_dims__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_parse_and_validate_where_constraint_dims__result.txt
@@ -111,7 +111,7 @@ ParseQueryResult(
       ),
     ),
     min_max_only=False,
-    dedupe=True,
+    apply_group_by=True,
   ),
   queried_semantic_models=(SemanticModelReference(semantic_model_name='bookings_source'),),
 )

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_query_parser__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_query_parser__result.txt
@@ -39,7 +39,7 @@ ParseQueryResult(
     filter_intersection=PydanticWhereFilterIntersection(),
     filter_spec_resolution_lookup=FilterSpecResolutionLookUp(),
     min_max_only=False,
-    dedupe=True,
+    apply_group_by=True,
   ),
   queried_semantic_models=(SemanticModelReference(semantic_model_name='bookings_source'),),
 )

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_query_parser__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_query_parser__result.txt
@@ -39,6 +39,7 @@ ParseQueryResult(
     filter_intersection=PydanticWhereFilterIntersection(),
     filter_spec_resolution_lookup=FilterSpecResolutionLookUp(),
     min_max_only=False,
+    dedupe=True,
   ),
   queried_semantic_models=(SemanticModelReference(semantic_model_name='bookings_source'),),
 )

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_query_parser_case_insensitivity_with_names__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_query_parser_case_insensitivity_with_names__result.txt
@@ -39,7 +39,7 @@ ParseQueryResult(
     filter_intersection=PydanticWhereFilterIntersection(),
     filter_spec_resolution_lookup=FilterSpecResolutionLookUp(),
     min_max_only=False,
-    dedupe=True,
+    apply_group_by=True,
   ),
   queried_semantic_models=(SemanticModelReference(semantic_model_name='bookings_source'),),
 )

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_query_parser_case_insensitivity_with_names__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_query_parser_case_insensitivity_with_names__result.txt
@@ -39,6 +39,7 @@ ParseQueryResult(
     filter_intersection=PydanticWhereFilterIntersection(),
     filter_spec_resolution_lookup=FilterSpecResolutionLookUp(),
     min_max_only=False,
+    dedupe=True,
   ),
   queried_semantic_models=(SemanticModelReference(semantic_model_name='bookings_source'),),
 )

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_query_parser_case_insensitivity_with_parameter_objects__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_query_parser_case_insensitivity_with_parameter_objects__result.txt
@@ -39,7 +39,7 @@ ParseQueryResult(
     filter_intersection=PydanticWhereFilterIntersection(),
     filter_spec_resolution_lookup=FilterSpecResolutionLookUp(),
     min_max_only=False,
-    dedupe=True,
+    apply_group_by=True,
   ),
   queried_semantic_models=(SemanticModelReference(semantic_model_name='bookings_source'),),
 )

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_query_parser_case_insensitivity_with_parameter_objects__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_query_parser_case_insensitivity_with_parameter_objects__result.txt
@@ -39,6 +39,7 @@ ParseQueryResult(
     filter_intersection=PydanticWhereFilterIntersection(),
     filter_spec_resolution_lookup=FilterSpecResolutionLookUp(),
     min_max_only=False,
+    dedupe=True,
   ),
   queried_semantic_models=(SemanticModelReference(semantic_model_name='bookings_source'),),
 )

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_query_parser_with_object_params__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_query_parser_with_object_params__result.txt
@@ -39,7 +39,7 @@ ParseQueryResult(
     filter_intersection=PydanticWhereFilterIntersection(),
     filter_spec_resolution_lookup=FilterSpecResolutionLookUp(),
     min_max_only=False,
-    dedupe=True,
+    apply_group_by=True,
   ),
   queried_semantic_models=(SemanticModelReference(semantic_model_name='bookings_source'),),
 )

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_query_parser_with_object_params__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_query_parser_with_object_params__result.txt
@@ -39,6 +39,7 @@ ParseQueryResult(
     filter_intersection=PydanticWhereFilterIntersection(),
     filter_spec_resolution_lookup=FilterSpecResolutionLookUp(),
     min_max_only=False,
+    dedupe=True,
   ),
   queried_semantic_models=(SemanticModelReference(semantic_model_name='bookings_source'),),
 )

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_time_range_constraint_conversion__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_time_range_constraint_conversion__result.txt
@@ -22,6 +22,7 @@ ParseQueryResult(
     filter_intersection=PydanticWhereFilterIntersection(),
     filter_spec_resolution_lookup=FilterSpecResolutionLookUp(),
     min_max_only=False,
+    dedupe=True,
   ),
   queried_semantic_models=(
     SemanticModelReference(semantic_model_name='bookings_source'),

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_time_range_constraint_conversion__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_time_range_constraint_conversion__result.txt
@@ -22,7 +22,7 @@ ParseQueryResult(
     filter_intersection=PydanticWhereFilterIntersection(),
     filter_spec_resolution_lookup=FilterSpecResolutionLookUp(),
     min_max_only=False,
-    dedupe=True,
+    apply_group_by=True,
   ),
   queried_semantic_models=(
     SemanticModelReference(semantic_model_name='bookings_source'),

--- a/metricflow/dataflow/builder/dataflow_plan_builder.py
+++ b/metricflow/dataflow/builder/dataflow_plan_builder.py
@@ -782,10 +782,10 @@ class DataflowPlanBuilder:
         """
         # Workaround for a Pycharm type inspection issue with decorators.
         # noinspection PyArgumentList
-        return self._build_plan_for_distinct_values(query_spec, optimizations=optimizations)
+        return self._build_plan_for_no_metrics_query(query_spec, optimizations=optimizations)
 
     @log_runtime()
-    def _build_plan_for_distinct_values(
+    def _build_plan_for_no_metrics_query(
         self, query_spec: MetricFlowQuerySpec, optimizations: FrozenSet[DataflowPlanOptimization]
     ) -> DataflowPlan:
         assert not query_spec.metric_specs, "Can't build distinct values plan with metrics."

--- a/metricflow/dataflow/builder/dataflow_plan_builder.py
+++ b/metricflow/dataflow/builder/dataflow_plan_builder.py
@@ -826,7 +826,7 @@ class DataflowPlanBuilder:
             custom_granularity_specs=required_linkable_specs.time_dimension_specs_with_custom_grain,
             where_filter_specs=query_level_filter_specs,
             time_range_constraint=query_spec.time_range_constraint,
-            distinct=True,
+            distinct=query_spec.dedupe,
         )
 
         if query_spec.min_max_only:

--- a/metricflow/dataflow/builder/dataflow_plan_builder.py
+++ b/metricflow/dataflow/builder/dataflow_plan_builder.py
@@ -826,7 +826,7 @@ class DataflowPlanBuilder:
             custom_granularity_specs=required_linkable_specs.time_dimension_specs_with_custom_grain,
             where_filter_specs=query_level_filter_specs,
             time_range_constraint=query_spec.time_range_constraint,
-            distinct=query_spec.dedupe,
+            distinct=query_spec.apply_group_by,
         )
 
         if query_spec.min_max_only:

--- a/metricflow/dataflow/nodes/filter_elements.py
+++ b/metricflow/dataflow/nodes/filter_elements.py
@@ -21,7 +21,7 @@ class FilterElementsNode(DataflowPlanNode):
     Attributes:
         include_specs: The specs for the elements that it should pass.
         replace_description: Replace the default description with this.
-        distinct: If you only want the distinct values for the selected specs..
+        distinct: If you only want the distinct values for the selected specs.
     """
 
     include_specs: InstanceSpecSet

--- a/metricflow/engine/metricflow_engine.py
+++ b/metricflow/engine/metricflow_engine.py
@@ -112,6 +112,7 @@ class MetricFlowQueryRequest:
     order_by_names: Optional[Sequence[str]]
     order_by: Optional[Sequence[OrderByQueryParameter]]
     min_max_only: bool
+    dedupe: bool
     sql_optimization_level: SqlOptimizationLevel
     dataflow_plan_optimizations: FrozenSet[DataflowPlanOptimization]
     query_type: MetricFlowQueryType
@@ -135,6 +136,7 @@ class MetricFlowQueryRequest:
         ] = DataflowPlanOptimization.enabled_optimizations(),
         query_type: MetricFlowQueryType = MetricFlowQueryType.METRIC,
         min_max_only: bool = False,
+        dedupe: bool = True,
     ) -> MetricFlowQueryRequest:
         return MetricFlowQueryRequest(
             request_id=MetricFlowRequestId(mf_rid=f"{random_id()}"),
@@ -153,6 +155,7 @@ class MetricFlowQueryRequest:
             dataflow_plan_optimizations=dataflow_plan_optimizations,
             query_type=query_type,
             min_max_only=min_max_only,
+            dedupe=dedupe,
         )
 
 
@@ -474,6 +477,7 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
                 time_constraint_end=mf_query_request.time_constraint_end,
                 order_by_names=mf_query_request.order_by_names,
                 order_by_parameters=mf_query_request.order_by,
+                dedupe=mf_query_request.dedupe,
             ).query_spec
         else:
             query_spec = self._query_parser.parse_and_validate_query(
@@ -488,6 +492,7 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
                 order_by_names=mf_query_request.order_by_names,
                 order_by=mf_query_request.order_by,
                 min_max_only=mf_query_request.min_max_only,
+                dedupe=mf_query_request.dedupe,
             ).query_spec
         logger.debug(LazyFormat("Parsed query", query_spec=query_spec))
 

--- a/metricflow/engine/metricflow_engine.py
+++ b/metricflow/engine/metricflow_engine.py
@@ -112,7 +112,7 @@ class MetricFlowQueryRequest:
     order_by_names: Optional[Sequence[str]]
     order_by: Optional[Sequence[OrderByQueryParameter]]
     min_max_only: bool
-    dedupe: bool
+    apply_group_by: bool
     sql_optimization_level: SqlOptimizationLevel
     dataflow_plan_optimizations: FrozenSet[DataflowPlanOptimization]
     query_type: MetricFlowQueryType
@@ -136,7 +136,7 @@ class MetricFlowQueryRequest:
         ] = DataflowPlanOptimization.enabled_optimizations(),
         query_type: MetricFlowQueryType = MetricFlowQueryType.METRIC,
         min_max_only: bool = False,
-        dedupe: bool = True,
+        apply_group_by: bool = True,
     ) -> MetricFlowQueryRequest:
         return MetricFlowQueryRequest(
             request_id=MetricFlowRequestId(mf_rid=f"{random_id()}"),
@@ -155,7 +155,7 @@ class MetricFlowQueryRequest:
             dataflow_plan_optimizations=dataflow_plan_optimizations,
             query_type=query_type,
             min_max_only=min_max_only,
-            dedupe=dedupe,
+            apply_group_by=apply_group_by,
         )
 
 
@@ -477,7 +477,7 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
                 time_constraint_end=mf_query_request.time_constraint_end,
                 order_by_names=mf_query_request.order_by_names,
                 order_by_parameters=mf_query_request.order_by,
-                dedupe=mf_query_request.dedupe,
+                apply_group_by=mf_query_request.apply_group_by,
             ).query_spec
         else:
             query_spec = self._query_parser.parse_and_validate_query(
@@ -492,7 +492,7 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
                 order_by_names=mf_query_request.order_by_names,
                 order_by=mf_query_request.order_by,
                 min_max_only=mf_query_request.min_max_only,
-                dedupe=mf_query_request.dedupe,
+                apply_group_by=mf_query_request.apply_group_by,
             ).query_spec
         logger.debug(LazyFormat("Parsed query", query_spec=query_spec))
 

--- a/tests_metricflow/integration/configured_test_case.py
+++ b/tests_metricflow/integration/configured_test_case.py
@@ -54,6 +54,7 @@ class ConfiguredIntegrationTestCase(FrozenBaseModel):
     metrics: Tuple[str, ...] = ()
     group_bys: Tuple[str, ...] = ()
     group_by_objs: Tuple[Dict, ...] = ()
+    saved_query_name: Optional[str] = None
     order_bys: Tuple[str, ...] = ()
     # The required features in the DW engine for the test to complete.
     required_features: Tuple[RequiredDwEngineFeature, ...] = ()
@@ -65,6 +66,7 @@ class ConfiguredIntegrationTestCase(FrozenBaseModel):
     limit: Optional[int] = None
     description: Optional[str] = None
     min_max_only: bool = False
+    dedupe: bool = True
 
 
 class TestCaseParseException(Exception):

--- a/tests_metricflow/integration/configured_test_case.py
+++ b/tests_metricflow/integration/configured_test_case.py
@@ -66,7 +66,7 @@ class ConfiguredIntegrationTestCase(FrozenBaseModel):
     limit: Optional[int] = None
     description: Optional[str] = None
     min_max_only: bool = False
-    dedupe: bool = True
+    apply_group_by: bool = True
 
 
 class TestCaseParseException(Exception):

--- a/tests_metricflow/integration/test_cases/itest_dimensions.yaml
+++ b/tests_metricflow/integration/test_cases/itest_dimensions.yaml
@@ -394,3 +394,34 @@ integration_test:
     FROM {{ source_schema }}.dim_users
     GROUP BY
       {{ render_date_trunc("bio_added_ts", TimeGranularity.SECOND) }}
+---
+integration_test:
+  name: no_dedupe
+  description: Query without dedupe
+  model: SIMPLE_MODEL
+  group_bys: ["user__home_state", "metric_time__month"]
+  dedupe: false
+  where_filter: "{{ render_dimension_template('listing__country_latest') }} = 'us'"
+  check_query: |
+    SELECT
+      u.home_state AS user__home_state
+      , {{ render_date_trunc("ts.ds", TimeGranularity.MONTH) }} AS metric_time__month
+    FROM {{ source_schema }}.dim_listings_latest l
+    CROSS JOIN {{ source_schema }}.mf_time_spine ts
+    FULL OUTER JOIN {{ source_schema }}.dim_users u ON l.user_id = u.user_id
+    WHERE l.country = 'us'
+---
+integration_test:
+  name: saved_query_no_dedupe
+  description: Query without metrics using a saved query and no group by
+  model: SIMPLE_MODEL
+  saved_query_name: dimensions_only
+  dedupe: false
+  where_filter: "{{ render_dimension_template('listing__country_latest') }} = 'us'"
+  check_query: |
+    SELECT
+      {{ render_date_trunc("ds", TimeGranularity.MONTH) }} AS metric_time__month
+      , l.capacity AS listing__capacity_latest
+    FROM {{ source_schema }}.dim_listings_latest l
+    CROSS JOIN {{ source_schema }}.mf_time_spine ts
+    WHERE l.country = 'us'

--- a/tests_metricflow/integration/test_cases/itest_dimensions.yaml
+++ b/tests_metricflow/integration/test_cases/itest_dimensions.yaml
@@ -400,7 +400,7 @@ integration_test:
   description: Query without dedupe
   model: SIMPLE_MODEL
   group_bys: ["user__home_state", "metric_time__month"]
-  dedupe: false
+  apply_group_by: false
   where_filter: "{{ render_dimension_template('listing__country_latest') }} = 'us'"
   check_query: |
     SELECT
@@ -416,7 +416,7 @@ integration_test:
   description: Query without metrics using a saved query and no group by
   model: SIMPLE_MODEL
   saved_query_name: dimensions_only
-  dedupe: false
+  apply_group_by: false
   where_filter: "{{ render_dimension_template('listing__country_latest') }} = 'us'"
   check_query: |
     SELECT

--- a/tests_metricflow/integration/test_configured_cases.py
+++ b/tests_metricflow/integration/test_configured_cases.py
@@ -326,7 +326,7 @@ def test_case(
             ),
             order_by_names=case.order_bys,
             min_max_only=case.min_max_only,
-            dedupe=case.dedupe,
+            apply_group_by=case.apply_group_by,
         )
     )
 

--- a/tests_metricflow/integration/test_configured_cases.py
+++ b/tests_metricflow/integration/test_configured_cases.py
@@ -292,6 +292,7 @@ def test_case(
             metric_names=case.metrics,
             group_by_names=case.group_bys if len(case.group_bys) > 0 else None,
             group_by=tuple(group_by) if len(group_by) > 0 else None,
+            saved_query_name=case.saved_query_name,
             limit=case.limit,
             time_constraint_start=parser.parse(case.time_constraint[0]) if case.time_constraint else None,
             time_constraint_end=parser.parse(case.time_constraint[1]) if case.time_constraint else None,
@@ -325,6 +326,7 @@ def test_case(
             ),
             order_by_names=case.order_bys,
             min_max_only=case.min_max_only,
+            dedupe=case.dedupe,
         )
     )
 

--- a/tests_metricflow/query_rendering/test_query_rendering.py
+++ b/tests_metricflow/query_rendering/test_query_rendering.py
@@ -760,7 +760,7 @@ def test_no_dedupe(  # noqa: D103
 ) -> None:
     query_spec = scd_query_parser.parse_and_validate_query(
         group_by_names=("listing__capacity", "metric_time__month"),
-        dedupe=False,
+        apply_group_by=False,
         where_constraints=[
             PydanticWhereFilter(
                 where_sql_template="{{ Dimension('user__home_state_latest') }} = 'CA'",
@@ -789,7 +789,7 @@ def test_no_dedupe_saved_query(  # noqa: D103
 ) -> None:
     query_spec = query_parser.parse_and_validate_saved_query(
         saved_query_parameter=SavedQueryParameter(name="dimensions_only"),
-        dedupe=False,
+        apply_group_by=False,
         where_filters=[
             PydanticWhereFilter(
                 where_sql_template="{{ Dimension('user__home_state_latest') }} = 'CA'",

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/BigQuery/test_no_dedupe__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/BigQuery/test_no_dedupe__plan0.sql
@@ -1,0 +1,273 @@
+test_name: test_no_dedupe
+test_filename: test_query_rendering.py
+sql_engine: BigQuery
+---
+-- Pass Only Elements: ['listing__capacity', 'metric_time__month']
+SELECT
+  subq_7.metric_time__month
+  , subq_7.listing__capacity
+FROM (
+  -- Constrain Output with WHERE
+  SELECT
+    subq_6.window_start__day
+    , subq_6.window_start__week
+    , subq_6.window_start__month
+    , subq_6.window_start__quarter
+    , subq_6.window_start__year
+    , subq_6.window_start__extract_year
+    , subq_6.window_start__extract_quarter
+    , subq_6.window_start__extract_month
+    , subq_6.window_start__extract_day
+    , subq_6.window_start__extract_dow
+    , subq_6.window_start__extract_doy
+    , subq_6.window_end__day
+    , subq_6.window_end__week
+    , subq_6.window_end__month
+    , subq_6.window_end__quarter
+    , subq_6.window_end__year
+    , subq_6.window_end__extract_year
+    , subq_6.window_end__extract_quarter
+    , subq_6.window_end__extract_month
+    , subq_6.window_end__extract_day
+    , subq_6.window_end__extract_dow
+    , subq_6.window_end__extract_doy
+    , subq_6.listing__window_start__day
+    , subq_6.listing__window_start__week
+    , subq_6.listing__window_start__month
+    , subq_6.listing__window_start__quarter
+    , subq_6.listing__window_start__year
+    , subq_6.listing__window_start__extract_year
+    , subq_6.listing__window_start__extract_quarter
+    , subq_6.listing__window_start__extract_month
+    , subq_6.listing__window_start__extract_day
+    , subq_6.listing__window_start__extract_dow
+    , subq_6.listing__window_start__extract_doy
+    , subq_6.listing__window_end__day
+    , subq_6.listing__window_end__week
+    , subq_6.listing__window_end__month
+    , subq_6.listing__window_end__quarter
+    , subq_6.listing__window_end__year
+    , subq_6.listing__window_end__extract_year
+    , subq_6.listing__window_end__extract_quarter
+    , subq_6.listing__window_end__extract_month
+    , subq_6.listing__window_end__extract_day
+    , subq_6.listing__window_end__extract_dow
+    , subq_6.listing__window_end__extract_doy
+    , subq_6.metric_time__month
+    , subq_6.listing
+    , subq_6.user
+    , subq_6.listing__user
+    , subq_6.country
+    , subq_6.is_lux
+    , subq_6.capacity
+    , subq_6.listing__country
+    , subq_6.listing__is_lux
+    , subq_6.listing__capacity
+    , subq_6.user__home_state_latest
+  FROM (
+    -- Join Standard Outputs
+    SELECT
+      subq_5.home_state_latest AS user__home_state_latest
+      , subq_0.window_start__day AS window_start__day
+      , subq_0.window_start__week AS window_start__week
+      , subq_0.window_start__month AS window_start__month
+      , subq_0.window_start__quarter AS window_start__quarter
+      , subq_0.window_start__year AS window_start__year
+      , subq_0.window_start__extract_year AS window_start__extract_year
+      , subq_0.window_start__extract_quarter AS window_start__extract_quarter
+      , subq_0.window_start__extract_month AS window_start__extract_month
+      , subq_0.window_start__extract_day AS window_start__extract_day
+      , subq_0.window_start__extract_dow AS window_start__extract_dow
+      , subq_0.window_start__extract_doy AS window_start__extract_doy
+      , subq_0.window_end__day AS window_end__day
+      , subq_0.window_end__week AS window_end__week
+      , subq_0.window_end__month AS window_end__month
+      , subq_0.window_end__quarter AS window_end__quarter
+      , subq_0.window_end__year AS window_end__year
+      , subq_0.window_end__extract_year AS window_end__extract_year
+      , subq_0.window_end__extract_quarter AS window_end__extract_quarter
+      , subq_0.window_end__extract_month AS window_end__extract_month
+      , subq_0.window_end__extract_day AS window_end__extract_day
+      , subq_0.window_end__extract_dow AS window_end__extract_dow
+      , subq_0.window_end__extract_doy AS window_end__extract_doy
+      , subq_0.listing__window_start__day AS listing__window_start__day
+      , subq_0.listing__window_start__week AS listing__window_start__week
+      , subq_0.listing__window_start__month AS listing__window_start__month
+      , subq_0.listing__window_start__quarter AS listing__window_start__quarter
+      , subq_0.listing__window_start__year AS listing__window_start__year
+      , subq_0.listing__window_start__extract_year AS listing__window_start__extract_year
+      , subq_0.listing__window_start__extract_quarter AS listing__window_start__extract_quarter
+      , subq_0.listing__window_start__extract_month AS listing__window_start__extract_month
+      , subq_0.listing__window_start__extract_day AS listing__window_start__extract_day
+      , subq_0.listing__window_start__extract_dow AS listing__window_start__extract_dow
+      , subq_0.listing__window_start__extract_doy AS listing__window_start__extract_doy
+      , subq_0.listing__window_end__day AS listing__window_end__day
+      , subq_0.listing__window_end__week AS listing__window_end__week
+      , subq_0.listing__window_end__month AS listing__window_end__month
+      , subq_0.listing__window_end__quarter AS listing__window_end__quarter
+      , subq_0.listing__window_end__year AS listing__window_end__year
+      , subq_0.listing__window_end__extract_year AS listing__window_end__extract_year
+      , subq_0.listing__window_end__extract_quarter AS listing__window_end__extract_quarter
+      , subq_0.listing__window_end__extract_month AS listing__window_end__extract_month
+      , subq_0.listing__window_end__extract_day AS listing__window_end__extract_day
+      , subq_0.listing__window_end__extract_dow AS listing__window_end__extract_dow
+      , subq_0.listing__window_end__extract_doy AS listing__window_end__extract_doy
+      , subq_3.metric_time__month AS metric_time__month
+      , subq_0.listing AS listing
+      , subq_0.user AS user
+      , subq_0.listing__user AS listing__user
+      , subq_0.country AS country
+      , subq_0.is_lux AS is_lux
+      , subq_0.capacity AS capacity
+      , subq_0.listing__country AS listing__country
+      , subq_0.listing__is_lux AS listing__is_lux
+      , subq_0.listing__capacity AS listing__capacity
+    FROM (
+      -- Read Elements From Semantic Model 'listings'
+      SELECT
+        listings_src_26000.active_from AS window_start__day
+        , DATETIME_TRUNC(listings_src_26000.active_from, isoweek) AS window_start__week
+        , DATETIME_TRUNC(listings_src_26000.active_from, month) AS window_start__month
+        , DATETIME_TRUNC(listings_src_26000.active_from, quarter) AS window_start__quarter
+        , DATETIME_TRUNC(listings_src_26000.active_from, year) AS window_start__year
+        , EXTRACT(year FROM listings_src_26000.active_from) AS window_start__extract_year
+        , EXTRACT(quarter FROM listings_src_26000.active_from) AS window_start__extract_quarter
+        , EXTRACT(month FROM listings_src_26000.active_from) AS window_start__extract_month
+        , EXTRACT(day FROM listings_src_26000.active_from) AS window_start__extract_day
+        , IF(EXTRACT(dayofweek FROM listings_src_26000.active_from) = 1, 7, EXTRACT(dayofweek FROM listings_src_26000.active_from) - 1) AS window_start__extract_dow
+        , EXTRACT(dayofyear FROM listings_src_26000.active_from) AS window_start__extract_doy
+        , listings_src_26000.active_to AS window_end__day
+        , DATETIME_TRUNC(listings_src_26000.active_to, isoweek) AS window_end__week
+        , DATETIME_TRUNC(listings_src_26000.active_to, month) AS window_end__month
+        , DATETIME_TRUNC(listings_src_26000.active_to, quarter) AS window_end__quarter
+        , DATETIME_TRUNC(listings_src_26000.active_to, year) AS window_end__year
+        , EXTRACT(year FROM listings_src_26000.active_to) AS window_end__extract_year
+        , EXTRACT(quarter FROM listings_src_26000.active_to) AS window_end__extract_quarter
+        , EXTRACT(month FROM listings_src_26000.active_to) AS window_end__extract_month
+        , EXTRACT(day FROM listings_src_26000.active_to) AS window_end__extract_day
+        , IF(EXTRACT(dayofweek FROM listings_src_26000.active_to) = 1, 7, EXTRACT(dayofweek FROM listings_src_26000.active_to) - 1) AS window_end__extract_dow
+        , EXTRACT(dayofyear FROM listings_src_26000.active_to) AS window_end__extract_doy
+        , listings_src_26000.country
+        , listings_src_26000.is_lux
+        , listings_src_26000.capacity
+        , listings_src_26000.active_from AS listing__window_start__day
+        , DATETIME_TRUNC(listings_src_26000.active_from, isoweek) AS listing__window_start__week
+        , DATETIME_TRUNC(listings_src_26000.active_from, month) AS listing__window_start__month
+        , DATETIME_TRUNC(listings_src_26000.active_from, quarter) AS listing__window_start__quarter
+        , DATETIME_TRUNC(listings_src_26000.active_from, year) AS listing__window_start__year
+        , EXTRACT(year FROM listings_src_26000.active_from) AS listing__window_start__extract_year
+        , EXTRACT(quarter FROM listings_src_26000.active_from) AS listing__window_start__extract_quarter
+        , EXTRACT(month FROM listings_src_26000.active_from) AS listing__window_start__extract_month
+        , EXTRACT(day FROM listings_src_26000.active_from) AS listing__window_start__extract_day
+        , IF(EXTRACT(dayofweek FROM listings_src_26000.active_from) = 1, 7, EXTRACT(dayofweek FROM listings_src_26000.active_from) - 1) AS listing__window_start__extract_dow
+        , EXTRACT(dayofyear FROM listings_src_26000.active_from) AS listing__window_start__extract_doy
+        , listings_src_26000.active_to AS listing__window_end__day
+        , DATETIME_TRUNC(listings_src_26000.active_to, isoweek) AS listing__window_end__week
+        , DATETIME_TRUNC(listings_src_26000.active_to, month) AS listing__window_end__month
+        , DATETIME_TRUNC(listings_src_26000.active_to, quarter) AS listing__window_end__quarter
+        , DATETIME_TRUNC(listings_src_26000.active_to, year) AS listing__window_end__year
+        , EXTRACT(year FROM listings_src_26000.active_to) AS listing__window_end__extract_year
+        , EXTRACT(quarter FROM listings_src_26000.active_to) AS listing__window_end__extract_quarter
+        , EXTRACT(month FROM listings_src_26000.active_to) AS listing__window_end__extract_month
+        , EXTRACT(day FROM listings_src_26000.active_to) AS listing__window_end__extract_day
+        , IF(EXTRACT(dayofweek FROM listings_src_26000.active_to) = 1, 7, EXTRACT(dayofweek FROM listings_src_26000.active_to) - 1) AS listing__window_end__extract_dow
+        , EXTRACT(dayofyear FROM listings_src_26000.active_to) AS listing__window_end__extract_doy
+        , listings_src_26000.country AS listing__country
+        , listings_src_26000.is_lux AS listing__is_lux
+        , listings_src_26000.capacity AS listing__capacity
+        , listings_src_26000.listing_id AS listing
+        , listings_src_26000.user_id AS user
+        , listings_src_26000.user_id AS listing__user
+      FROM ***************************.dim_listings listings_src_26000
+    ) subq_0
+    CROSS JOIN (
+      -- Pass Only Elements: ['metric_time__month',]
+      SELECT
+        subq_2.metric_time__month
+      FROM (
+        -- Metric Time Dimension 'ds'
+        SELECT
+          subq_1.ds__day
+          , subq_1.ds__week
+          , subq_1.ds__month
+          , subq_1.ds__quarter
+          , subq_1.ds__year
+          , subq_1.ds__extract_year
+          , subq_1.ds__extract_quarter
+          , subq_1.ds__extract_month
+          , subq_1.ds__extract_day
+          , subq_1.ds__extract_dow
+          , subq_1.ds__extract_doy
+          , subq_1.ds__alien_day
+          , subq_1.ds__day AS metric_time__day
+          , subq_1.ds__week AS metric_time__week
+          , subq_1.ds__month AS metric_time__month
+          , subq_1.ds__quarter AS metric_time__quarter
+          , subq_1.ds__year AS metric_time__year
+          , subq_1.ds__extract_year AS metric_time__extract_year
+          , subq_1.ds__extract_quarter AS metric_time__extract_quarter
+          , subq_1.ds__extract_month AS metric_time__extract_month
+          , subq_1.ds__extract_day AS metric_time__extract_day
+          , subq_1.ds__extract_dow AS metric_time__extract_dow
+          , subq_1.ds__extract_doy AS metric_time__extract_doy
+          , subq_1.ds__alien_day AS metric_time__alien_day
+        FROM (
+          -- Read From Time Spine 'mf_time_spine'
+          SELECT
+            time_spine_src_26006.ds AS ds__day
+            , DATETIME_TRUNC(time_spine_src_26006.ds, isoweek) AS ds__week
+            , DATETIME_TRUNC(time_spine_src_26006.ds, month) AS ds__month
+            , DATETIME_TRUNC(time_spine_src_26006.ds, quarter) AS ds__quarter
+            , DATETIME_TRUNC(time_spine_src_26006.ds, year) AS ds__year
+            , EXTRACT(year FROM time_spine_src_26006.ds) AS ds__extract_year
+            , EXTRACT(quarter FROM time_spine_src_26006.ds) AS ds__extract_quarter
+            , EXTRACT(month FROM time_spine_src_26006.ds) AS ds__extract_month
+            , EXTRACT(day FROM time_spine_src_26006.ds) AS ds__extract_day
+            , IF(EXTRACT(dayofweek FROM time_spine_src_26006.ds) = 1, 7, EXTRACT(dayofweek FROM time_spine_src_26006.ds) - 1) AS ds__extract_dow
+            , EXTRACT(dayofyear FROM time_spine_src_26006.ds) AS ds__extract_doy
+            , time_spine_src_26006.alien_day AS ds__alien_day
+          FROM ***************************.mf_time_spine time_spine_src_26006
+        ) subq_1
+      ) subq_2
+    ) subq_3
+    FULL OUTER JOIN (
+      -- Pass Only Elements: ['home_state_latest', 'user']
+      SELECT
+        subq_4.user
+        , subq_4.home_state_latest
+      FROM (
+        -- Read Elements From Semantic Model 'users_latest'
+        SELECT
+          DATETIME_TRUNC(users_latest_src_26000.ds, day) AS ds__day
+          , DATETIME_TRUNC(users_latest_src_26000.ds, isoweek) AS ds__week
+          , DATETIME_TRUNC(users_latest_src_26000.ds, month) AS ds__month
+          , DATETIME_TRUNC(users_latest_src_26000.ds, quarter) AS ds__quarter
+          , DATETIME_TRUNC(users_latest_src_26000.ds, year) AS ds__year
+          , EXTRACT(year FROM users_latest_src_26000.ds) AS ds__extract_year
+          , EXTRACT(quarter FROM users_latest_src_26000.ds) AS ds__extract_quarter
+          , EXTRACT(month FROM users_latest_src_26000.ds) AS ds__extract_month
+          , EXTRACT(day FROM users_latest_src_26000.ds) AS ds__extract_day
+          , IF(EXTRACT(dayofweek FROM users_latest_src_26000.ds) = 1, 7, EXTRACT(dayofweek FROM users_latest_src_26000.ds) - 1) AS ds__extract_dow
+          , EXTRACT(dayofyear FROM users_latest_src_26000.ds) AS ds__extract_doy
+          , users_latest_src_26000.home_state_latest
+          , DATETIME_TRUNC(users_latest_src_26000.ds, day) AS user__ds__day
+          , DATETIME_TRUNC(users_latest_src_26000.ds, isoweek) AS user__ds__week
+          , DATETIME_TRUNC(users_latest_src_26000.ds, month) AS user__ds__month
+          , DATETIME_TRUNC(users_latest_src_26000.ds, quarter) AS user__ds__quarter
+          , DATETIME_TRUNC(users_latest_src_26000.ds, year) AS user__ds__year
+          , EXTRACT(year FROM users_latest_src_26000.ds) AS user__ds__extract_year
+          , EXTRACT(quarter FROM users_latest_src_26000.ds) AS user__ds__extract_quarter
+          , EXTRACT(month FROM users_latest_src_26000.ds) AS user__ds__extract_month
+          , EXTRACT(day FROM users_latest_src_26000.ds) AS user__ds__extract_day
+          , IF(EXTRACT(dayofweek FROM users_latest_src_26000.ds) = 1, 7, EXTRACT(dayofweek FROM users_latest_src_26000.ds) - 1) AS user__ds__extract_dow
+          , EXTRACT(dayofyear FROM users_latest_src_26000.ds) AS user__ds__extract_doy
+          , users_latest_src_26000.home_state_latest AS user__home_state_latest
+          , users_latest_src_26000.user_id AS user
+        FROM ***************************.dim_users_latest users_latest_src_26000
+      ) subq_4
+    ) subq_5
+    ON
+      subq_0.user = subq_5.user
+  ) subq_6
+  WHERE user__home_state_latest = 'CA'
+) subq_7

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/BigQuery/test_no_dedupe__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/BigQuery/test_no_dedupe__plan0_optimized.sql
@@ -1,0 +1,24 @@
+test_name: test_no_dedupe
+test_filename: test_query_rendering.py
+sql_engine: BigQuery
+---
+-- Constrain Output with WHERE
+-- Pass Only Elements: ['listing__capacity', 'metric_time__month']
+SELECT
+  metric_time__month
+  , listing__capacity
+FROM (
+  -- Join Standard Outputs
+  SELECT
+    users_latest_src_26000.home_state_latest AS user__home_state_latest
+    , DATETIME_TRUNC(time_spine_src_26006.ds, month) AS metric_time__month
+    , listings_src_26000.capacity AS listing__capacity
+  FROM ***************************.dim_listings listings_src_26000
+  CROSS JOIN
+    ***************************.mf_time_spine time_spine_src_26006
+  FULL OUTER JOIN
+    ***************************.dim_users_latest users_latest_src_26000
+  ON
+    listings_src_26000.user_id = users_latest_src_26000.user_id
+) subq_14
+WHERE user__home_state_latest = 'CA'

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/BigQuery/test_no_dedupe_saved_query__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/BigQuery/test_no_dedupe_saved_query__plan0.sql
@@ -1,0 +1,282 @@
+test_name: test_no_dedupe_saved_query
+test_filename: test_query_rendering.py
+sql_engine: BigQuery
+---
+-- Pass Only Elements: ['listing__capacity_latest', 'metric_time__month']
+SELECT
+  subq_7.metric_time__month
+  , subq_7.listing__capacity_latest
+FROM (
+  -- Constrain Output with WHERE
+  SELECT
+    subq_6.ds__day
+    , subq_6.ds__week
+    , subq_6.ds__month
+    , subq_6.ds__quarter
+    , subq_6.ds__year
+    , subq_6.ds__extract_year
+    , subq_6.ds__extract_quarter
+    , subq_6.ds__extract_month
+    , subq_6.ds__extract_day
+    , subq_6.ds__extract_dow
+    , subq_6.ds__extract_doy
+    , subq_6.created_at__day
+    , subq_6.created_at__week
+    , subq_6.created_at__month
+    , subq_6.created_at__quarter
+    , subq_6.created_at__year
+    , subq_6.created_at__extract_year
+    , subq_6.created_at__extract_quarter
+    , subq_6.created_at__extract_month
+    , subq_6.created_at__extract_day
+    , subq_6.created_at__extract_dow
+    , subq_6.created_at__extract_doy
+    , subq_6.listing__ds__day
+    , subq_6.listing__ds__week
+    , subq_6.listing__ds__month
+    , subq_6.listing__ds__quarter
+    , subq_6.listing__ds__year
+    , subq_6.listing__ds__extract_year
+    , subq_6.listing__ds__extract_quarter
+    , subq_6.listing__ds__extract_month
+    , subq_6.listing__ds__extract_day
+    , subq_6.listing__ds__extract_dow
+    , subq_6.listing__ds__extract_doy
+    , subq_6.listing__created_at__day
+    , subq_6.listing__created_at__week
+    , subq_6.listing__created_at__month
+    , subq_6.listing__created_at__quarter
+    , subq_6.listing__created_at__year
+    , subq_6.listing__created_at__extract_year
+    , subq_6.listing__created_at__extract_quarter
+    , subq_6.listing__created_at__extract_month
+    , subq_6.listing__created_at__extract_day
+    , subq_6.listing__created_at__extract_dow
+    , subq_6.listing__created_at__extract_doy
+    , subq_6.metric_time__month
+    , subq_6.listing
+    , subq_6.user
+    , subq_6.listing__user
+    , subq_6.country_latest
+    , subq_6.is_lux_latest
+    , subq_6.capacity_latest
+    , subq_6.listing__country_latest
+    , subq_6.listing__is_lux_latest
+    , subq_6.listing__capacity_latest
+    , subq_6.user__home_state_latest
+    , subq_6.listings
+    , subq_6.largest_listing
+    , subq_6.smallest_listing
+  FROM (
+    -- Join Standard Outputs
+    SELECT
+      subq_5.home_state_latest AS user__home_state_latest
+      , subq_0.ds__day AS ds__day
+      , subq_0.ds__week AS ds__week
+      , subq_0.ds__month AS ds__month
+      , subq_0.ds__quarter AS ds__quarter
+      , subq_0.ds__year AS ds__year
+      , subq_0.ds__extract_year AS ds__extract_year
+      , subq_0.ds__extract_quarter AS ds__extract_quarter
+      , subq_0.ds__extract_month AS ds__extract_month
+      , subq_0.ds__extract_day AS ds__extract_day
+      , subq_0.ds__extract_dow AS ds__extract_dow
+      , subq_0.ds__extract_doy AS ds__extract_doy
+      , subq_0.created_at__day AS created_at__day
+      , subq_0.created_at__week AS created_at__week
+      , subq_0.created_at__month AS created_at__month
+      , subq_0.created_at__quarter AS created_at__quarter
+      , subq_0.created_at__year AS created_at__year
+      , subq_0.created_at__extract_year AS created_at__extract_year
+      , subq_0.created_at__extract_quarter AS created_at__extract_quarter
+      , subq_0.created_at__extract_month AS created_at__extract_month
+      , subq_0.created_at__extract_day AS created_at__extract_day
+      , subq_0.created_at__extract_dow AS created_at__extract_dow
+      , subq_0.created_at__extract_doy AS created_at__extract_doy
+      , subq_0.listing__ds__day AS listing__ds__day
+      , subq_0.listing__ds__week AS listing__ds__week
+      , subq_0.listing__ds__month AS listing__ds__month
+      , subq_0.listing__ds__quarter AS listing__ds__quarter
+      , subq_0.listing__ds__year AS listing__ds__year
+      , subq_0.listing__ds__extract_year AS listing__ds__extract_year
+      , subq_0.listing__ds__extract_quarter AS listing__ds__extract_quarter
+      , subq_0.listing__ds__extract_month AS listing__ds__extract_month
+      , subq_0.listing__ds__extract_day AS listing__ds__extract_day
+      , subq_0.listing__ds__extract_dow AS listing__ds__extract_dow
+      , subq_0.listing__ds__extract_doy AS listing__ds__extract_doy
+      , subq_0.listing__created_at__day AS listing__created_at__day
+      , subq_0.listing__created_at__week AS listing__created_at__week
+      , subq_0.listing__created_at__month AS listing__created_at__month
+      , subq_0.listing__created_at__quarter AS listing__created_at__quarter
+      , subq_0.listing__created_at__year AS listing__created_at__year
+      , subq_0.listing__created_at__extract_year AS listing__created_at__extract_year
+      , subq_0.listing__created_at__extract_quarter AS listing__created_at__extract_quarter
+      , subq_0.listing__created_at__extract_month AS listing__created_at__extract_month
+      , subq_0.listing__created_at__extract_day AS listing__created_at__extract_day
+      , subq_0.listing__created_at__extract_dow AS listing__created_at__extract_dow
+      , subq_0.listing__created_at__extract_doy AS listing__created_at__extract_doy
+      , subq_3.metric_time__month AS metric_time__month
+      , subq_0.listing AS listing
+      , subq_0.user AS user
+      , subq_0.listing__user AS listing__user
+      , subq_0.country_latest AS country_latest
+      , subq_0.is_lux_latest AS is_lux_latest
+      , subq_0.capacity_latest AS capacity_latest
+      , subq_0.listing__country_latest AS listing__country_latest
+      , subq_0.listing__is_lux_latest AS listing__is_lux_latest
+      , subq_0.listing__capacity_latest AS listing__capacity_latest
+      , subq_0.listings AS listings
+      , subq_0.largest_listing AS largest_listing
+      , subq_0.smallest_listing AS smallest_listing
+    FROM (
+      -- Read Elements From Semantic Model 'listings_latest'
+      SELECT
+        1 AS listings
+        , listings_latest_src_28000.capacity AS largest_listing
+        , listings_latest_src_28000.capacity AS smallest_listing
+        , DATETIME_TRUNC(listings_latest_src_28000.created_at, day) AS ds__day
+        , DATETIME_TRUNC(listings_latest_src_28000.created_at, isoweek) AS ds__week
+        , DATETIME_TRUNC(listings_latest_src_28000.created_at, month) AS ds__month
+        , DATETIME_TRUNC(listings_latest_src_28000.created_at, quarter) AS ds__quarter
+        , DATETIME_TRUNC(listings_latest_src_28000.created_at, year) AS ds__year
+        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS ds__extract_year
+        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS ds__extract_quarter
+        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS ds__extract_month
+        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS ds__extract_day
+        , IF(EXTRACT(dayofweek FROM listings_latest_src_28000.created_at) = 1, 7, EXTRACT(dayofweek FROM listings_latest_src_28000.created_at) - 1) AS ds__extract_dow
+        , EXTRACT(dayofyear FROM listings_latest_src_28000.created_at) AS ds__extract_doy
+        , DATETIME_TRUNC(listings_latest_src_28000.created_at, day) AS created_at__day
+        , DATETIME_TRUNC(listings_latest_src_28000.created_at, isoweek) AS created_at__week
+        , DATETIME_TRUNC(listings_latest_src_28000.created_at, month) AS created_at__month
+        , DATETIME_TRUNC(listings_latest_src_28000.created_at, quarter) AS created_at__quarter
+        , DATETIME_TRUNC(listings_latest_src_28000.created_at, year) AS created_at__year
+        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS created_at__extract_year
+        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS created_at__extract_quarter
+        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS created_at__extract_month
+        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS created_at__extract_day
+        , IF(EXTRACT(dayofweek FROM listings_latest_src_28000.created_at) = 1, 7, EXTRACT(dayofweek FROM listings_latest_src_28000.created_at) - 1) AS created_at__extract_dow
+        , EXTRACT(dayofyear FROM listings_latest_src_28000.created_at) AS created_at__extract_doy
+        , listings_latest_src_28000.country AS country_latest
+        , listings_latest_src_28000.is_lux AS is_lux_latest
+        , listings_latest_src_28000.capacity AS capacity_latest
+        , DATETIME_TRUNC(listings_latest_src_28000.created_at, day) AS listing__ds__day
+        , DATETIME_TRUNC(listings_latest_src_28000.created_at, isoweek) AS listing__ds__week
+        , DATETIME_TRUNC(listings_latest_src_28000.created_at, month) AS listing__ds__month
+        , DATETIME_TRUNC(listings_latest_src_28000.created_at, quarter) AS listing__ds__quarter
+        , DATETIME_TRUNC(listings_latest_src_28000.created_at, year) AS listing__ds__year
+        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__ds__extract_year
+        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__ds__extract_quarter
+        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__ds__extract_month
+        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__ds__extract_day
+        , IF(EXTRACT(dayofweek FROM listings_latest_src_28000.created_at) = 1, 7, EXTRACT(dayofweek FROM listings_latest_src_28000.created_at) - 1) AS listing__ds__extract_dow
+        , EXTRACT(dayofyear FROM listings_latest_src_28000.created_at) AS listing__ds__extract_doy
+        , DATETIME_TRUNC(listings_latest_src_28000.created_at, day) AS listing__created_at__day
+        , DATETIME_TRUNC(listings_latest_src_28000.created_at, isoweek) AS listing__created_at__week
+        , DATETIME_TRUNC(listings_latest_src_28000.created_at, month) AS listing__created_at__month
+        , DATETIME_TRUNC(listings_latest_src_28000.created_at, quarter) AS listing__created_at__quarter
+        , DATETIME_TRUNC(listings_latest_src_28000.created_at, year) AS listing__created_at__year
+        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_year
+        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_quarter
+        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_month
+        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_day
+        , IF(EXTRACT(dayofweek FROM listings_latest_src_28000.created_at) = 1, 7, EXTRACT(dayofweek FROM listings_latest_src_28000.created_at) - 1) AS listing__created_at__extract_dow
+        , EXTRACT(dayofyear FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_doy
+        , listings_latest_src_28000.country AS listing__country_latest
+        , listings_latest_src_28000.is_lux AS listing__is_lux_latest
+        , listings_latest_src_28000.capacity AS listing__capacity_latest
+        , listings_latest_src_28000.listing_id AS listing
+        , listings_latest_src_28000.user_id AS user
+        , listings_latest_src_28000.user_id AS listing__user
+      FROM ***************************.dim_listings_latest listings_latest_src_28000
+    ) subq_0
+    CROSS JOIN (
+      -- Pass Only Elements: ['metric_time__month',]
+      SELECT
+        subq_2.metric_time__month
+      FROM (
+        -- Metric Time Dimension 'ds'
+        SELECT
+          subq_1.ds__day
+          , subq_1.ds__week
+          , subq_1.ds__month
+          , subq_1.ds__quarter
+          , subq_1.ds__year
+          , subq_1.ds__extract_year
+          , subq_1.ds__extract_quarter
+          , subq_1.ds__extract_month
+          , subq_1.ds__extract_day
+          , subq_1.ds__extract_dow
+          , subq_1.ds__extract_doy
+          , subq_1.ds__alien_day
+          , subq_1.ds__day AS metric_time__day
+          , subq_1.ds__week AS metric_time__week
+          , subq_1.ds__month AS metric_time__month
+          , subq_1.ds__quarter AS metric_time__quarter
+          , subq_1.ds__year AS metric_time__year
+          , subq_1.ds__extract_year AS metric_time__extract_year
+          , subq_1.ds__extract_quarter AS metric_time__extract_quarter
+          , subq_1.ds__extract_month AS metric_time__extract_month
+          , subq_1.ds__extract_day AS metric_time__extract_day
+          , subq_1.ds__extract_dow AS metric_time__extract_dow
+          , subq_1.ds__extract_doy AS metric_time__extract_doy
+          , subq_1.ds__alien_day AS metric_time__alien_day
+        FROM (
+          -- Read From Time Spine 'mf_time_spine'
+          SELECT
+            time_spine_src_28006.ds AS ds__day
+            , DATETIME_TRUNC(time_spine_src_28006.ds, isoweek) AS ds__week
+            , DATETIME_TRUNC(time_spine_src_28006.ds, month) AS ds__month
+            , DATETIME_TRUNC(time_spine_src_28006.ds, quarter) AS ds__quarter
+            , DATETIME_TRUNC(time_spine_src_28006.ds, year) AS ds__year
+            , EXTRACT(year FROM time_spine_src_28006.ds) AS ds__extract_year
+            , EXTRACT(quarter FROM time_spine_src_28006.ds) AS ds__extract_quarter
+            , EXTRACT(month FROM time_spine_src_28006.ds) AS ds__extract_month
+            , EXTRACT(day FROM time_spine_src_28006.ds) AS ds__extract_day
+            , IF(EXTRACT(dayofweek FROM time_spine_src_28006.ds) = 1, 7, EXTRACT(dayofweek FROM time_spine_src_28006.ds) - 1) AS ds__extract_dow
+            , EXTRACT(dayofyear FROM time_spine_src_28006.ds) AS ds__extract_doy
+            , time_spine_src_28006.alien_day AS ds__alien_day
+          FROM ***************************.mf_time_spine time_spine_src_28006
+        ) subq_1
+      ) subq_2
+    ) subq_3
+    FULL OUTER JOIN (
+      -- Pass Only Elements: ['home_state_latest', 'user']
+      SELECT
+        subq_4.user
+        , subq_4.home_state_latest
+      FROM (
+        -- Read Elements From Semantic Model 'users_latest'
+        SELECT
+          DATETIME_TRUNC(users_latest_src_28000.ds, day) AS ds_latest__day
+          , DATETIME_TRUNC(users_latest_src_28000.ds, isoweek) AS ds_latest__week
+          , DATETIME_TRUNC(users_latest_src_28000.ds, month) AS ds_latest__month
+          , DATETIME_TRUNC(users_latest_src_28000.ds, quarter) AS ds_latest__quarter
+          , DATETIME_TRUNC(users_latest_src_28000.ds, year) AS ds_latest__year
+          , EXTRACT(year FROM users_latest_src_28000.ds) AS ds_latest__extract_year
+          , EXTRACT(quarter FROM users_latest_src_28000.ds) AS ds_latest__extract_quarter
+          , EXTRACT(month FROM users_latest_src_28000.ds) AS ds_latest__extract_month
+          , EXTRACT(day FROM users_latest_src_28000.ds) AS ds_latest__extract_day
+          , IF(EXTRACT(dayofweek FROM users_latest_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM users_latest_src_28000.ds) - 1) AS ds_latest__extract_dow
+          , EXTRACT(dayofyear FROM users_latest_src_28000.ds) AS ds_latest__extract_doy
+          , users_latest_src_28000.home_state_latest
+          , DATETIME_TRUNC(users_latest_src_28000.ds, day) AS user__ds_latest__day
+          , DATETIME_TRUNC(users_latest_src_28000.ds, isoweek) AS user__ds_latest__week
+          , DATETIME_TRUNC(users_latest_src_28000.ds, month) AS user__ds_latest__month
+          , DATETIME_TRUNC(users_latest_src_28000.ds, quarter) AS user__ds_latest__quarter
+          , DATETIME_TRUNC(users_latest_src_28000.ds, year) AS user__ds_latest__year
+          , EXTRACT(year FROM users_latest_src_28000.ds) AS user__ds_latest__extract_year
+          , EXTRACT(quarter FROM users_latest_src_28000.ds) AS user__ds_latest__extract_quarter
+          , EXTRACT(month FROM users_latest_src_28000.ds) AS user__ds_latest__extract_month
+          , EXTRACT(day FROM users_latest_src_28000.ds) AS user__ds_latest__extract_day
+          , IF(EXTRACT(dayofweek FROM users_latest_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM users_latest_src_28000.ds) - 1) AS user__ds_latest__extract_dow
+          , EXTRACT(dayofyear FROM users_latest_src_28000.ds) AS user__ds_latest__extract_doy
+          , users_latest_src_28000.home_state_latest AS user__home_state_latest
+          , users_latest_src_28000.user_id AS user
+        FROM ***************************.dim_users_latest users_latest_src_28000
+      ) subq_4
+    ) subq_5
+    ON
+      subq_0.user = subq_5.user
+  ) subq_6
+  WHERE user__home_state_latest = 'CA'
+) subq_7

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/BigQuery/test_no_dedupe_saved_query__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/BigQuery/test_no_dedupe_saved_query__plan0_optimized.sql
@@ -1,0 +1,24 @@
+test_name: test_no_dedupe_saved_query
+test_filename: test_query_rendering.py
+sql_engine: BigQuery
+---
+-- Constrain Output with WHERE
+-- Pass Only Elements: ['listing__capacity_latest', 'metric_time__month']
+SELECT
+  metric_time__month
+  , listing__capacity_latest
+FROM (
+  -- Join Standard Outputs
+  SELECT
+    users_latest_src_28000.home_state_latest AS user__home_state_latest
+    , DATETIME_TRUNC(time_spine_src_28006.ds, month) AS metric_time__month
+    , listings_latest_src_28000.capacity AS listing__capacity_latest
+  FROM ***************************.dim_listings_latest listings_latest_src_28000
+  CROSS JOIN
+    ***************************.mf_time_spine time_spine_src_28006
+  FULL OUTER JOIN
+    ***************************.dim_users_latest users_latest_src_28000
+  ON
+    listings_latest_src_28000.user_id = users_latest_src_28000.user_id
+) subq_14
+WHERE user__home_state_latest = 'CA'

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Databricks/test_no_dedupe__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Databricks/test_no_dedupe__plan0.sql
@@ -1,0 +1,273 @@
+test_name: test_no_dedupe
+test_filename: test_query_rendering.py
+sql_engine: Databricks
+---
+-- Pass Only Elements: ['listing__capacity', 'metric_time__month']
+SELECT
+  subq_7.metric_time__month
+  , subq_7.listing__capacity
+FROM (
+  -- Constrain Output with WHERE
+  SELECT
+    subq_6.window_start__day
+    , subq_6.window_start__week
+    , subq_6.window_start__month
+    , subq_6.window_start__quarter
+    , subq_6.window_start__year
+    , subq_6.window_start__extract_year
+    , subq_6.window_start__extract_quarter
+    , subq_6.window_start__extract_month
+    , subq_6.window_start__extract_day
+    , subq_6.window_start__extract_dow
+    , subq_6.window_start__extract_doy
+    , subq_6.window_end__day
+    , subq_6.window_end__week
+    , subq_6.window_end__month
+    , subq_6.window_end__quarter
+    , subq_6.window_end__year
+    , subq_6.window_end__extract_year
+    , subq_6.window_end__extract_quarter
+    , subq_6.window_end__extract_month
+    , subq_6.window_end__extract_day
+    , subq_6.window_end__extract_dow
+    , subq_6.window_end__extract_doy
+    , subq_6.listing__window_start__day
+    , subq_6.listing__window_start__week
+    , subq_6.listing__window_start__month
+    , subq_6.listing__window_start__quarter
+    , subq_6.listing__window_start__year
+    , subq_6.listing__window_start__extract_year
+    , subq_6.listing__window_start__extract_quarter
+    , subq_6.listing__window_start__extract_month
+    , subq_6.listing__window_start__extract_day
+    , subq_6.listing__window_start__extract_dow
+    , subq_6.listing__window_start__extract_doy
+    , subq_6.listing__window_end__day
+    , subq_6.listing__window_end__week
+    , subq_6.listing__window_end__month
+    , subq_6.listing__window_end__quarter
+    , subq_6.listing__window_end__year
+    , subq_6.listing__window_end__extract_year
+    , subq_6.listing__window_end__extract_quarter
+    , subq_6.listing__window_end__extract_month
+    , subq_6.listing__window_end__extract_day
+    , subq_6.listing__window_end__extract_dow
+    , subq_6.listing__window_end__extract_doy
+    , subq_6.metric_time__month
+    , subq_6.listing
+    , subq_6.user
+    , subq_6.listing__user
+    , subq_6.country
+    , subq_6.is_lux
+    , subq_6.capacity
+    , subq_6.listing__country
+    , subq_6.listing__is_lux
+    , subq_6.listing__capacity
+    , subq_6.user__home_state_latest
+  FROM (
+    -- Join Standard Outputs
+    SELECT
+      subq_5.home_state_latest AS user__home_state_latest
+      , subq_0.window_start__day AS window_start__day
+      , subq_0.window_start__week AS window_start__week
+      , subq_0.window_start__month AS window_start__month
+      , subq_0.window_start__quarter AS window_start__quarter
+      , subq_0.window_start__year AS window_start__year
+      , subq_0.window_start__extract_year AS window_start__extract_year
+      , subq_0.window_start__extract_quarter AS window_start__extract_quarter
+      , subq_0.window_start__extract_month AS window_start__extract_month
+      , subq_0.window_start__extract_day AS window_start__extract_day
+      , subq_0.window_start__extract_dow AS window_start__extract_dow
+      , subq_0.window_start__extract_doy AS window_start__extract_doy
+      , subq_0.window_end__day AS window_end__day
+      , subq_0.window_end__week AS window_end__week
+      , subq_0.window_end__month AS window_end__month
+      , subq_0.window_end__quarter AS window_end__quarter
+      , subq_0.window_end__year AS window_end__year
+      , subq_0.window_end__extract_year AS window_end__extract_year
+      , subq_0.window_end__extract_quarter AS window_end__extract_quarter
+      , subq_0.window_end__extract_month AS window_end__extract_month
+      , subq_0.window_end__extract_day AS window_end__extract_day
+      , subq_0.window_end__extract_dow AS window_end__extract_dow
+      , subq_0.window_end__extract_doy AS window_end__extract_doy
+      , subq_0.listing__window_start__day AS listing__window_start__day
+      , subq_0.listing__window_start__week AS listing__window_start__week
+      , subq_0.listing__window_start__month AS listing__window_start__month
+      , subq_0.listing__window_start__quarter AS listing__window_start__quarter
+      , subq_0.listing__window_start__year AS listing__window_start__year
+      , subq_0.listing__window_start__extract_year AS listing__window_start__extract_year
+      , subq_0.listing__window_start__extract_quarter AS listing__window_start__extract_quarter
+      , subq_0.listing__window_start__extract_month AS listing__window_start__extract_month
+      , subq_0.listing__window_start__extract_day AS listing__window_start__extract_day
+      , subq_0.listing__window_start__extract_dow AS listing__window_start__extract_dow
+      , subq_0.listing__window_start__extract_doy AS listing__window_start__extract_doy
+      , subq_0.listing__window_end__day AS listing__window_end__day
+      , subq_0.listing__window_end__week AS listing__window_end__week
+      , subq_0.listing__window_end__month AS listing__window_end__month
+      , subq_0.listing__window_end__quarter AS listing__window_end__quarter
+      , subq_0.listing__window_end__year AS listing__window_end__year
+      , subq_0.listing__window_end__extract_year AS listing__window_end__extract_year
+      , subq_0.listing__window_end__extract_quarter AS listing__window_end__extract_quarter
+      , subq_0.listing__window_end__extract_month AS listing__window_end__extract_month
+      , subq_0.listing__window_end__extract_day AS listing__window_end__extract_day
+      , subq_0.listing__window_end__extract_dow AS listing__window_end__extract_dow
+      , subq_0.listing__window_end__extract_doy AS listing__window_end__extract_doy
+      , subq_3.metric_time__month AS metric_time__month
+      , subq_0.listing AS listing
+      , subq_0.user AS user
+      , subq_0.listing__user AS listing__user
+      , subq_0.country AS country
+      , subq_0.is_lux AS is_lux
+      , subq_0.capacity AS capacity
+      , subq_0.listing__country AS listing__country
+      , subq_0.listing__is_lux AS listing__is_lux
+      , subq_0.listing__capacity AS listing__capacity
+    FROM (
+      -- Read Elements From Semantic Model 'listings'
+      SELECT
+        listings_src_26000.active_from AS window_start__day
+        , DATE_TRUNC('week', listings_src_26000.active_from) AS window_start__week
+        , DATE_TRUNC('month', listings_src_26000.active_from) AS window_start__month
+        , DATE_TRUNC('quarter', listings_src_26000.active_from) AS window_start__quarter
+        , DATE_TRUNC('year', listings_src_26000.active_from) AS window_start__year
+        , EXTRACT(year FROM listings_src_26000.active_from) AS window_start__extract_year
+        , EXTRACT(quarter FROM listings_src_26000.active_from) AS window_start__extract_quarter
+        , EXTRACT(month FROM listings_src_26000.active_from) AS window_start__extract_month
+        , EXTRACT(day FROM listings_src_26000.active_from) AS window_start__extract_day
+        , EXTRACT(DAYOFWEEK_ISO FROM listings_src_26000.active_from) AS window_start__extract_dow
+        , EXTRACT(doy FROM listings_src_26000.active_from) AS window_start__extract_doy
+        , listings_src_26000.active_to AS window_end__day
+        , DATE_TRUNC('week', listings_src_26000.active_to) AS window_end__week
+        , DATE_TRUNC('month', listings_src_26000.active_to) AS window_end__month
+        , DATE_TRUNC('quarter', listings_src_26000.active_to) AS window_end__quarter
+        , DATE_TRUNC('year', listings_src_26000.active_to) AS window_end__year
+        , EXTRACT(year FROM listings_src_26000.active_to) AS window_end__extract_year
+        , EXTRACT(quarter FROM listings_src_26000.active_to) AS window_end__extract_quarter
+        , EXTRACT(month FROM listings_src_26000.active_to) AS window_end__extract_month
+        , EXTRACT(day FROM listings_src_26000.active_to) AS window_end__extract_day
+        , EXTRACT(DAYOFWEEK_ISO FROM listings_src_26000.active_to) AS window_end__extract_dow
+        , EXTRACT(doy FROM listings_src_26000.active_to) AS window_end__extract_doy
+        , listings_src_26000.country
+        , listings_src_26000.is_lux
+        , listings_src_26000.capacity
+        , listings_src_26000.active_from AS listing__window_start__day
+        , DATE_TRUNC('week', listings_src_26000.active_from) AS listing__window_start__week
+        , DATE_TRUNC('month', listings_src_26000.active_from) AS listing__window_start__month
+        , DATE_TRUNC('quarter', listings_src_26000.active_from) AS listing__window_start__quarter
+        , DATE_TRUNC('year', listings_src_26000.active_from) AS listing__window_start__year
+        , EXTRACT(year FROM listings_src_26000.active_from) AS listing__window_start__extract_year
+        , EXTRACT(quarter FROM listings_src_26000.active_from) AS listing__window_start__extract_quarter
+        , EXTRACT(month FROM listings_src_26000.active_from) AS listing__window_start__extract_month
+        , EXTRACT(day FROM listings_src_26000.active_from) AS listing__window_start__extract_day
+        , EXTRACT(DAYOFWEEK_ISO FROM listings_src_26000.active_from) AS listing__window_start__extract_dow
+        , EXTRACT(doy FROM listings_src_26000.active_from) AS listing__window_start__extract_doy
+        , listings_src_26000.active_to AS listing__window_end__day
+        , DATE_TRUNC('week', listings_src_26000.active_to) AS listing__window_end__week
+        , DATE_TRUNC('month', listings_src_26000.active_to) AS listing__window_end__month
+        , DATE_TRUNC('quarter', listings_src_26000.active_to) AS listing__window_end__quarter
+        , DATE_TRUNC('year', listings_src_26000.active_to) AS listing__window_end__year
+        , EXTRACT(year FROM listings_src_26000.active_to) AS listing__window_end__extract_year
+        , EXTRACT(quarter FROM listings_src_26000.active_to) AS listing__window_end__extract_quarter
+        , EXTRACT(month FROM listings_src_26000.active_to) AS listing__window_end__extract_month
+        , EXTRACT(day FROM listings_src_26000.active_to) AS listing__window_end__extract_day
+        , EXTRACT(DAYOFWEEK_ISO FROM listings_src_26000.active_to) AS listing__window_end__extract_dow
+        , EXTRACT(doy FROM listings_src_26000.active_to) AS listing__window_end__extract_doy
+        , listings_src_26000.country AS listing__country
+        , listings_src_26000.is_lux AS listing__is_lux
+        , listings_src_26000.capacity AS listing__capacity
+        , listings_src_26000.listing_id AS listing
+        , listings_src_26000.user_id AS user
+        , listings_src_26000.user_id AS listing__user
+      FROM ***************************.dim_listings listings_src_26000
+    ) subq_0
+    CROSS JOIN (
+      -- Pass Only Elements: ['metric_time__month',]
+      SELECT
+        subq_2.metric_time__month
+      FROM (
+        -- Metric Time Dimension 'ds'
+        SELECT
+          subq_1.ds__day
+          , subq_1.ds__week
+          , subq_1.ds__month
+          , subq_1.ds__quarter
+          , subq_1.ds__year
+          , subq_1.ds__extract_year
+          , subq_1.ds__extract_quarter
+          , subq_1.ds__extract_month
+          , subq_1.ds__extract_day
+          , subq_1.ds__extract_dow
+          , subq_1.ds__extract_doy
+          , subq_1.ds__alien_day
+          , subq_1.ds__day AS metric_time__day
+          , subq_1.ds__week AS metric_time__week
+          , subq_1.ds__month AS metric_time__month
+          , subq_1.ds__quarter AS metric_time__quarter
+          , subq_1.ds__year AS metric_time__year
+          , subq_1.ds__extract_year AS metric_time__extract_year
+          , subq_1.ds__extract_quarter AS metric_time__extract_quarter
+          , subq_1.ds__extract_month AS metric_time__extract_month
+          , subq_1.ds__extract_day AS metric_time__extract_day
+          , subq_1.ds__extract_dow AS metric_time__extract_dow
+          , subq_1.ds__extract_doy AS metric_time__extract_doy
+          , subq_1.ds__alien_day AS metric_time__alien_day
+        FROM (
+          -- Read From Time Spine 'mf_time_spine'
+          SELECT
+            time_spine_src_26006.ds AS ds__day
+            , DATE_TRUNC('week', time_spine_src_26006.ds) AS ds__week
+            , DATE_TRUNC('month', time_spine_src_26006.ds) AS ds__month
+            , DATE_TRUNC('quarter', time_spine_src_26006.ds) AS ds__quarter
+            , DATE_TRUNC('year', time_spine_src_26006.ds) AS ds__year
+            , EXTRACT(year FROM time_spine_src_26006.ds) AS ds__extract_year
+            , EXTRACT(quarter FROM time_spine_src_26006.ds) AS ds__extract_quarter
+            , EXTRACT(month FROM time_spine_src_26006.ds) AS ds__extract_month
+            , EXTRACT(day FROM time_spine_src_26006.ds) AS ds__extract_day
+            , EXTRACT(DAYOFWEEK_ISO FROM time_spine_src_26006.ds) AS ds__extract_dow
+            , EXTRACT(doy FROM time_spine_src_26006.ds) AS ds__extract_doy
+            , time_spine_src_26006.alien_day AS ds__alien_day
+          FROM ***************************.mf_time_spine time_spine_src_26006
+        ) subq_1
+      ) subq_2
+    ) subq_3
+    FULL OUTER JOIN (
+      -- Pass Only Elements: ['home_state_latest', 'user']
+      SELECT
+        subq_4.user
+        , subq_4.home_state_latest
+      FROM (
+        -- Read Elements From Semantic Model 'users_latest'
+        SELECT
+          DATE_TRUNC('day', users_latest_src_26000.ds) AS ds__day
+          , DATE_TRUNC('week', users_latest_src_26000.ds) AS ds__week
+          , DATE_TRUNC('month', users_latest_src_26000.ds) AS ds__month
+          , DATE_TRUNC('quarter', users_latest_src_26000.ds) AS ds__quarter
+          , DATE_TRUNC('year', users_latest_src_26000.ds) AS ds__year
+          , EXTRACT(year FROM users_latest_src_26000.ds) AS ds__extract_year
+          , EXTRACT(quarter FROM users_latest_src_26000.ds) AS ds__extract_quarter
+          , EXTRACT(month FROM users_latest_src_26000.ds) AS ds__extract_month
+          , EXTRACT(day FROM users_latest_src_26000.ds) AS ds__extract_day
+          , EXTRACT(DAYOFWEEK_ISO FROM users_latest_src_26000.ds) AS ds__extract_dow
+          , EXTRACT(doy FROM users_latest_src_26000.ds) AS ds__extract_doy
+          , users_latest_src_26000.home_state_latest
+          , DATE_TRUNC('day', users_latest_src_26000.ds) AS user__ds__day
+          , DATE_TRUNC('week', users_latest_src_26000.ds) AS user__ds__week
+          , DATE_TRUNC('month', users_latest_src_26000.ds) AS user__ds__month
+          , DATE_TRUNC('quarter', users_latest_src_26000.ds) AS user__ds__quarter
+          , DATE_TRUNC('year', users_latest_src_26000.ds) AS user__ds__year
+          , EXTRACT(year FROM users_latest_src_26000.ds) AS user__ds__extract_year
+          , EXTRACT(quarter FROM users_latest_src_26000.ds) AS user__ds__extract_quarter
+          , EXTRACT(month FROM users_latest_src_26000.ds) AS user__ds__extract_month
+          , EXTRACT(day FROM users_latest_src_26000.ds) AS user__ds__extract_day
+          , EXTRACT(DAYOFWEEK_ISO FROM users_latest_src_26000.ds) AS user__ds__extract_dow
+          , EXTRACT(doy FROM users_latest_src_26000.ds) AS user__ds__extract_doy
+          , users_latest_src_26000.home_state_latest AS user__home_state_latest
+          , users_latest_src_26000.user_id AS user
+        FROM ***************************.dim_users_latest users_latest_src_26000
+      ) subq_4
+    ) subq_5
+    ON
+      subq_0.user = subq_5.user
+  ) subq_6
+  WHERE user__home_state_latest = 'CA'
+) subq_7

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Databricks/test_no_dedupe__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Databricks/test_no_dedupe__plan0_optimized.sql
@@ -1,0 +1,24 @@
+test_name: test_no_dedupe
+test_filename: test_query_rendering.py
+sql_engine: Databricks
+---
+-- Constrain Output with WHERE
+-- Pass Only Elements: ['listing__capacity', 'metric_time__month']
+SELECT
+  metric_time__month
+  , listing__capacity
+FROM (
+  -- Join Standard Outputs
+  SELECT
+    users_latest_src_26000.home_state_latest AS user__home_state_latest
+    , DATE_TRUNC('month', time_spine_src_26006.ds) AS metric_time__month
+    , listings_src_26000.capacity AS listing__capacity
+  FROM ***************************.dim_listings listings_src_26000
+  CROSS JOIN
+    ***************************.mf_time_spine time_spine_src_26006
+  FULL OUTER JOIN
+    ***************************.dim_users_latest users_latest_src_26000
+  ON
+    listings_src_26000.user_id = users_latest_src_26000.user_id
+) subq_14
+WHERE user__home_state_latest = 'CA'

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Databricks/test_no_dedupe_saved_query__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Databricks/test_no_dedupe_saved_query__plan0.sql
@@ -1,0 +1,282 @@
+test_name: test_no_dedupe_saved_query
+test_filename: test_query_rendering.py
+sql_engine: Databricks
+---
+-- Pass Only Elements: ['listing__capacity_latest', 'metric_time__month']
+SELECT
+  subq_7.metric_time__month
+  , subq_7.listing__capacity_latest
+FROM (
+  -- Constrain Output with WHERE
+  SELECT
+    subq_6.ds__day
+    , subq_6.ds__week
+    , subq_6.ds__month
+    , subq_6.ds__quarter
+    , subq_6.ds__year
+    , subq_6.ds__extract_year
+    , subq_6.ds__extract_quarter
+    , subq_6.ds__extract_month
+    , subq_6.ds__extract_day
+    , subq_6.ds__extract_dow
+    , subq_6.ds__extract_doy
+    , subq_6.created_at__day
+    , subq_6.created_at__week
+    , subq_6.created_at__month
+    , subq_6.created_at__quarter
+    , subq_6.created_at__year
+    , subq_6.created_at__extract_year
+    , subq_6.created_at__extract_quarter
+    , subq_6.created_at__extract_month
+    , subq_6.created_at__extract_day
+    , subq_6.created_at__extract_dow
+    , subq_6.created_at__extract_doy
+    , subq_6.listing__ds__day
+    , subq_6.listing__ds__week
+    , subq_6.listing__ds__month
+    , subq_6.listing__ds__quarter
+    , subq_6.listing__ds__year
+    , subq_6.listing__ds__extract_year
+    , subq_6.listing__ds__extract_quarter
+    , subq_6.listing__ds__extract_month
+    , subq_6.listing__ds__extract_day
+    , subq_6.listing__ds__extract_dow
+    , subq_6.listing__ds__extract_doy
+    , subq_6.listing__created_at__day
+    , subq_6.listing__created_at__week
+    , subq_6.listing__created_at__month
+    , subq_6.listing__created_at__quarter
+    , subq_6.listing__created_at__year
+    , subq_6.listing__created_at__extract_year
+    , subq_6.listing__created_at__extract_quarter
+    , subq_6.listing__created_at__extract_month
+    , subq_6.listing__created_at__extract_day
+    , subq_6.listing__created_at__extract_dow
+    , subq_6.listing__created_at__extract_doy
+    , subq_6.metric_time__month
+    , subq_6.listing
+    , subq_6.user
+    , subq_6.listing__user
+    , subq_6.country_latest
+    , subq_6.is_lux_latest
+    , subq_6.capacity_latest
+    , subq_6.listing__country_latest
+    , subq_6.listing__is_lux_latest
+    , subq_6.listing__capacity_latest
+    , subq_6.user__home_state_latest
+    , subq_6.listings
+    , subq_6.largest_listing
+    , subq_6.smallest_listing
+  FROM (
+    -- Join Standard Outputs
+    SELECT
+      subq_5.home_state_latest AS user__home_state_latest
+      , subq_0.ds__day AS ds__day
+      , subq_0.ds__week AS ds__week
+      , subq_0.ds__month AS ds__month
+      , subq_0.ds__quarter AS ds__quarter
+      , subq_0.ds__year AS ds__year
+      , subq_0.ds__extract_year AS ds__extract_year
+      , subq_0.ds__extract_quarter AS ds__extract_quarter
+      , subq_0.ds__extract_month AS ds__extract_month
+      , subq_0.ds__extract_day AS ds__extract_day
+      , subq_0.ds__extract_dow AS ds__extract_dow
+      , subq_0.ds__extract_doy AS ds__extract_doy
+      , subq_0.created_at__day AS created_at__day
+      , subq_0.created_at__week AS created_at__week
+      , subq_0.created_at__month AS created_at__month
+      , subq_0.created_at__quarter AS created_at__quarter
+      , subq_0.created_at__year AS created_at__year
+      , subq_0.created_at__extract_year AS created_at__extract_year
+      , subq_0.created_at__extract_quarter AS created_at__extract_quarter
+      , subq_0.created_at__extract_month AS created_at__extract_month
+      , subq_0.created_at__extract_day AS created_at__extract_day
+      , subq_0.created_at__extract_dow AS created_at__extract_dow
+      , subq_0.created_at__extract_doy AS created_at__extract_doy
+      , subq_0.listing__ds__day AS listing__ds__day
+      , subq_0.listing__ds__week AS listing__ds__week
+      , subq_0.listing__ds__month AS listing__ds__month
+      , subq_0.listing__ds__quarter AS listing__ds__quarter
+      , subq_0.listing__ds__year AS listing__ds__year
+      , subq_0.listing__ds__extract_year AS listing__ds__extract_year
+      , subq_0.listing__ds__extract_quarter AS listing__ds__extract_quarter
+      , subq_0.listing__ds__extract_month AS listing__ds__extract_month
+      , subq_0.listing__ds__extract_day AS listing__ds__extract_day
+      , subq_0.listing__ds__extract_dow AS listing__ds__extract_dow
+      , subq_0.listing__ds__extract_doy AS listing__ds__extract_doy
+      , subq_0.listing__created_at__day AS listing__created_at__day
+      , subq_0.listing__created_at__week AS listing__created_at__week
+      , subq_0.listing__created_at__month AS listing__created_at__month
+      , subq_0.listing__created_at__quarter AS listing__created_at__quarter
+      , subq_0.listing__created_at__year AS listing__created_at__year
+      , subq_0.listing__created_at__extract_year AS listing__created_at__extract_year
+      , subq_0.listing__created_at__extract_quarter AS listing__created_at__extract_quarter
+      , subq_0.listing__created_at__extract_month AS listing__created_at__extract_month
+      , subq_0.listing__created_at__extract_day AS listing__created_at__extract_day
+      , subq_0.listing__created_at__extract_dow AS listing__created_at__extract_dow
+      , subq_0.listing__created_at__extract_doy AS listing__created_at__extract_doy
+      , subq_3.metric_time__month AS metric_time__month
+      , subq_0.listing AS listing
+      , subq_0.user AS user
+      , subq_0.listing__user AS listing__user
+      , subq_0.country_latest AS country_latest
+      , subq_0.is_lux_latest AS is_lux_latest
+      , subq_0.capacity_latest AS capacity_latest
+      , subq_0.listing__country_latest AS listing__country_latest
+      , subq_0.listing__is_lux_latest AS listing__is_lux_latest
+      , subq_0.listing__capacity_latest AS listing__capacity_latest
+      , subq_0.listings AS listings
+      , subq_0.largest_listing AS largest_listing
+      , subq_0.smallest_listing AS smallest_listing
+    FROM (
+      -- Read Elements From Semantic Model 'listings_latest'
+      SELECT
+        1 AS listings
+        , listings_latest_src_28000.capacity AS largest_listing
+        , listings_latest_src_28000.capacity AS smallest_listing
+        , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS ds__day
+        , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS ds__week
+        , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS ds__month
+        , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS ds__quarter
+        , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS ds__year
+        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS ds__extract_year
+        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS ds__extract_quarter
+        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS ds__extract_month
+        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS ds__extract_day
+        , EXTRACT(DAYOFWEEK_ISO FROM listings_latest_src_28000.created_at) AS ds__extract_dow
+        , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS ds__extract_doy
+        , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS created_at__day
+        , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS created_at__week
+        , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS created_at__month
+        , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS created_at__quarter
+        , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS created_at__year
+        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS created_at__extract_year
+        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS created_at__extract_quarter
+        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS created_at__extract_month
+        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS created_at__extract_day
+        , EXTRACT(DAYOFWEEK_ISO FROM listings_latest_src_28000.created_at) AS created_at__extract_dow
+        , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS created_at__extract_doy
+        , listings_latest_src_28000.country AS country_latest
+        , listings_latest_src_28000.is_lux AS is_lux_latest
+        , listings_latest_src_28000.capacity AS capacity_latest
+        , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__ds__day
+        , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__ds__week
+        , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__ds__month
+        , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__ds__quarter
+        , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__ds__year
+        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__ds__extract_year
+        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__ds__extract_quarter
+        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__ds__extract_month
+        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__ds__extract_day
+        , EXTRACT(DAYOFWEEK_ISO FROM listings_latest_src_28000.created_at) AS listing__ds__extract_dow
+        , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__ds__extract_doy
+        , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__created_at__day
+        , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__created_at__week
+        , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__created_at__month
+        , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__created_at__quarter
+        , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__created_at__year
+        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_year
+        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_quarter
+        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_month
+        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_day
+        , EXTRACT(DAYOFWEEK_ISO FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_dow
+        , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_doy
+        , listings_latest_src_28000.country AS listing__country_latest
+        , listings_latest_src_28000.is_lux AS listing__is_lux_latest
+        , listings_latest_src_28000.capacity AS listing__capacity_latest
+        , listings_latest_src_28000.listing_id AS listing
+        , listings_latest_src_28000.user_id AS user
+        , listings_latest_src_28000.user_id AS listing__user
+      FROM ***************************.dim_listings_latest listings_latest_src_28000
+    ) subq_0
+    CROSS JOIN (
+      -- Pass Only Elements: ['metric_time__month',]
+      SELECT
+        subq_2.metric_time__month
+      FROM (
+        -- Metric Time Dimension 'ds'
+        SELECT
+          subq_1.ds__day
+          , subq_1.ds__week
+          , subq_1.ds__month
+          , subq_1.ds__quarter
+          , subq_1.ds__year
+          , subq_1.ds__extract_year
+          , subq_1.ds__extract_quarter
+          , subq_1.ds__extract_month
+          , subq_1.ds__extract_day
+          , subq_1.ds__extract_dow
+          , subq_1.ds__extract_doy
+          , subq_1.ds__alien_day
+          , subq_1.ds__day AS metric_time__day
+          , subq_1.ds__week AS metric_time__week
+          , subq_1.ds__month AS metric_time__month
+          , subq_1.ds__quarter AS metric_time__quarter
+          , subq_1.ds__year AS metric_time__year
+          , subq_1.ds__extract_year AS metric_time__extract_year
+          , subq_1.ds__extract_quarter AS metric_time__extract_quarter
+          , subq_1.ds__extract_month AS metric_time__extract_month
+          , subq_1.ds__extract_day AS metric_time__extract_day
+          , subq_1.ds__extract_dow AS metric_time__extract_dow
+          , subq_1.ds__extract_doy AS metric_time__extract_doy
+          , subq_1.ds__alien_day AS metric_time__alien_day
+        FROM (
+          -- Read From Time Spine 'mf_time_spine'
+          SELECT
+            time_spine_src_28006.ds AS ds__day
+            , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week
+            , DATE_TRUNC('month', time_spine_src_28006.ds) AS ds__month
+            , DATE_TRUNC('quarter', time_spine_src_28006.ds) AS ds__quarter
+            , DATE_TRUNC('year', time_spine_src_28006.ds) AS ds__year
+            , EXTRACT(year FROM time_spine_src_28006.ds) AS ds__extract_year
+            , EXTRACT(quarter FROM time_spine_src_28006.ds) AS ds__extract_quarter
+            , EXTRACT(month FROM time_spine_src_28006.ds) AS ds__extract_month
+            , EXTRACT(day FROM time_spine_src_28006.ds) AS ds__extract_day
+            , EXTRACT(DAYOFWEEK_ISO FROM time_spine_src_28006.ds) AS ds__extract_dow
+            , EXTRACT(doy FROM time_spine_src_28006.ds) AS ds__extract_doy
+            , time_spine_src_28006.alien_day AS ds__alien_day
+          FROM ***************************.mf_time_spine time_spine_src_28006
+        ) subq_1
+      ) subq_2
+    ) subq_3
+    FULL OUTER JOIN (
+      -- Pass Only Elements: ['home_state_latest', 'user']
+      SELECT
+        subq_4.user
+        , subq_4.home_state_latest
+      FROM (
+        -- Read Elements From Semantic Model 'users_latest'
+        SELECT
+          DATE_TRUNC('day', users_latest_src_28000.ds) AS ds_latest__day
+          , DATE_TRUNC('week', users_latest_src_28000.ds) AS ds_latest__week
+          , DATE_TRUNC('month', users_latest_src_28000.ds) AS ds_latest__month
+          , DATE_TRUNC('quarter', users_latest_src_28000.ds) AS ds_latest__quarter
+          , DATE_TRUNC('year', users_latest_src_28000.ds) AS ds_latest__year
+          , EXTRACT(year FROM users_latest_src_28000.ds) AS ds_latest__extract_year
+          , EXTRACT(quarter FROM users_latest_src_28000.ds) AS ds_latest__extract_quarter
+          , EXTRACT(month FROM users_latest_src_28000.ds) AS ds_latest__extract_month
+          , EXTRACT(day FROM users_latest_src_28000.ds) AS ds_latest__extract_day
+          , EXTRACT(DAYOFWEEK_ISO FROM users_latest_src_28000.ds) AS ds_latest__extract_dow
+          , EXTRACT(doy FROM users_latest_src_28000.ds) AS ds_latest__extract_doy
+          , users_latest_src_28000.home_state_latest
+          , DATE_TRUNC('day', users_latest_src_28000.ds) AS user__ds_latest__day
+          , DATE_TRUNC('week', users_latest_src_28000.ds) AS user__ds_latest__week
+          , DATE_TRUNC('month', users_latest_src_28000.ds) AS user__ds_latest__month
+          , DATE_TRUNC('quarter', users_latest_src_28000.ds) AS user__ds_latest__quarter
+          , DATE_TRUNC('year', users_latest_src_28000.ds) AS user__ds_latest__year
+          , EXTRACT(year FROM users_latest_src_28000.ds) AS user__ds_latest__extract_year
+          , EXTRACT(quarter FROM users_latest_src_28000.ds) AS user__ds_latest__extract_quarter
+          , EXTRACT(month FROM users_latest_src_28000.ds) AS user__ds_latest__extract_month
+          , EXTRACT(day FROM users_latest_src_28000.ds) AS user__ds_latest__extract_day
+          , EXTRACT(DAYOFWEEK_ISO FROM users_latest_src_28000.ds) AS user__ds_latest__extract_dow
+          , EXTRACT(doy FROM users_latest_src_28000.ds) AS user__ds_latest__extract_doy
+          , users_latest_src_28000.home_state_latest AS user__home_state_latest
+          , users_latest_src_28000.user_id AS user
+        FROM ***************************.dim_users_latest users_latest_src_28000
+      ) subq_4
+    ) subq_5
+    ON
+      subq_0.user = subq_5.user
+  ) subq_6
+  WHERE user__home_state_latest = 'CA'
+) subq_7

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Databricks/test_no_dedupe_saved_query__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Databricks/test_no_dedupe_saved_query__plan0_optimized.sql
@@ -1,0 +1,24 @@
+test_name: test_no_dedupe_saved_query
+test_filename: test_query_rendering.py
+sql_engine: Databricks
+---
+-- Constrain Output with WHERE
+-- Pass Only Elements: ['listing__capacity_latest', 'metric_time__month']
+SELECT
+  metric_time__month
+  , listing__capacity_latest
+FROM (
+  -- Join Standard Outputs
+  SELECT
+    users_latest_src_28000.home_state_latest AS user__home_state_latest
+    , DATE_TRUNC('month', time_spine_src_28006.ds) AS metric_time__month
+    , listings_latest_src_28000.capacity AS listing__capacity_latest
+  FROM ***************************.dim_listings_latest listings_latest_src_28000
+  CROSS JOIN
+    ***************************.mf_time_spine time_spine_src_28006
+  FULL OUTER JOIN
+    ***************************.dim_users_latest users_latest_src_28000
+  ON
+    listings_latest_src_28000.user_id = users_latest_src_28000.user_id
+) subq_14
+WHERE user__home_state_latest = 'CA'

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/DuckDB/test_no_dedupe__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/DuckDB/test_no_dedupe__plan0.sql
@@ -1,0 +1,273 @@
+test_name: test_no_dedupe
+test_filename: test_query_rendering.py
+sql_engine: DuckDB
+---
+-- Pass Only Elements: ['listing__capacity', 'metric_time__month']
+SELECT
+  subq_7.metric_time__month
+  , subq_7.listing__capacity
+FROM (
+  -- Constrain Output with WHERE
+  SELECT
+    subq_6.window_start__day
+    , subq_6.window_start__week
+    , subq_6.window_start__month
+    , subq_6.window_start__quarter
+    , subq_6.window_start__year
+    , subq_6.window_start__extract_year
+    , subq_6.window_start__extract_quarter
+    , subq_6.window_start__extract_month
+    , subq_6.window_start__extract_day
+    , subq_6.window_start__extract_dow
+    , subq_6.window_start__extract_doy
+    , subq_6.window_end__day
+    , subq_6.window_end__week
+    , subq_6.window_end__month
+    , subq_6.window_end__quarter
+    , subq_6.window_end__year
+    , subq_6.window_end__extract_year
+    , subq_6.window_end__extract_quarter
+    , subq_6.window_end__extract_month
+    , subq_6.window_end__extract_day
+    , subq_6.window_end__extract_dow
+    , subq_6.window_end__extract_doy
+    , subq_6.listing__window_start__day
+    , subq_6.listing__window_start__week
+    , subq_6.listing__window_start__month
+    , subq_6.listing__window_start__quarter
+    , subq_6.listing__window_start__year
+    , subq_6.listing__window_start__extract_year
+    , subq_6.listing__window_start__extract_quarter
+    , subq_6.listing__window_start__extract_month
+    , subq_6.listing__window_start__extract_day
+    , subq_6.listing__window_start__extract_dow
+    , subq_6.listing__window_start__extract_doy
+    , subq_6.listing__window_end__day
+    , subq_6.listing__window_end__week
+    , subq_6.listing__window_end__month
+    , subq_6.listing__window_end__quarter
+    , subq_6.listing__window_end__year
+    , subq_6.listing__window_end__extract_year
+    , subq_6.listing__window_end__extract_quarter
+    , subq_6.listing__window_end__extract_month
+    , subq_6.listing__window_end__extract_day
+    , subq_6.listing__window_end__extract_dow
+    , subq_6.listing__window_end__extract_doy
+    , subq_6.metric_time__month
+    , subq_6.listing
+    , subq_6.user
+    , subq_6.listing__user
+    , subq_6.country
+    , subq_6.is_lux
+    , subq_6.capacity
+    , subq_6.listing__country
+    , subq_6.listing__is_lux
+    , subq_6.listing__capacity
+    , subq_6.user__home_state_latest
+  FROM (
+    -- Join Standard Outputs
+    SELECT
+      subq_5.home_state_latest AS user__home_state_latest
+      , subq_0.window_start__day AS window_start__day
+      , subq_0.window_start__week AS window_start__week
+      , subq_0.window_start__month AS window_start__month
+      , subq_0.window_start__quarter AS window_start__quarter
+      , subq_0.window_start__year AS window_start__year
+      , subq_0.window_start__extract_year AS window_start__extract_year
+      , subq_0.window_start__extract_quarter AS window_start__extract_quarter
+      , subq_0.window_start__extract_month AS window_start__extract_month
+      , subq_0.window_start__extract_day AS window_start__extract_day
+      , subq_0.window_start__extract_dow AS window_start__extract_dow
+      , subq_0.window_start__extract_doy AS window_start__extract_doy
+      , subq_0.window_end__day AS window_end__day
+      , subq_0.window_end__week AS window_end__week
+      , subq_0.window_end__month AS window_end__month
+      , subq_0.window_end__quarter AS window_end__quarter
+      , subq_0.window_end__year AS window_end__year
+      , subq_0.window_end__extract_year AS window_end__extract_year
+      , subq_0.window_end__extract_quarter AS window_end__extract_quarter
+      , subq_0.window_end__extract_month AS window_end__extract_month
+      , subq_0.window_end__extract_day AS window_end__extract_day
+      , subq_0.window_end__extract_dow AS window_end__extract_dow
+      , subq_0.window_end__extract_doy AS window_end__extract_doy
+      , subq_0.listing__window_start__day AS listing__window_start__day
+      , subq_0.listing__window_start__week AS listing__window_start__week
+      , subq_0.listing__window_start__month AS listing__window_start__month
+      , subq_0.listing__window_start__quarter AS listing__window_start__quarter
+      , subq_0.listing__window_start__year AS listing__window_start__year
+      , subq_0.listing__window_start__extract_year AS listing__window_start__extract_year
+      , subq_0.listing__window_start__extract_quarter AS listing__window_start__extract_quarter
+      , subq_0.listing__window_start__extract_month AS listing__window_start__extract_month
+      , subq_0.listing__window_start__extract_day AS listing__window_start__extract_day
+      , subq_0.listing__window_start__extract_dow AS listing__window_start__extract_dow
+      , subq_0.listing__window_start__extract_doy AS listing__window_start__extract_doy
+      , subq_0.listing__window_end__day AS listing__window_end__day
+      , subq_0.listing__window_end__week AS listing__window_end__week
+      , subq_0.listing__window_end__month AS listing__window_end__month
+      , subq_0.listing__window_end__quarter AS listing__window_end__quarter
+      , subq_0.listing__window_end__year AS listing__window_end__year
+      , subq_0.listing__window_end__extract_year AS listing__window_end__extract_year
+      , subq_0.listing__window_end__extract_quarter AS listing__window_end__extract_quarter
+      , subq_0.listing__window_end__extract_month AS listing__window_end__extract_month
+      , subq_0.listing__window_end__extract_day AS listing__window_end__extract_day
+      , subq_0.listing__window_end__extract_dow AS listing__window_end__extract_dow
+      , subq_0.listing__window_end__extract_doy AS listing__window_end__extract_doy
+      , subq_3.metric_time__month AS metric_time__month
+      , subq_0.listing AS listing
+      , subq_0.user AS user
+      , subq_0.listing__user AS listing__user
+      , subq_0.country AS country
+      , subq_0.is_lux AS is_lux
+      , subq_0.capacity AS capacity
+      , subq_0.listing__country AS listing__country
+      , subq_0.listing__is_lux AS listing__is_lux
+      , subq_0.listing__capacity AS listing__capacity
+    FROM (
+      -- Read Elements From Semantic Model 'listings'
+      SELECT
+        listings_src_26000.active_from AS window_start__day
+        , DATE_TRUNC('week', listings_src_26000.active_from) AS window_start__week
+        , DATE_TRUNC('month', listings_src_26000.active_from) AS window_start__month
+        , DATE_TRUNC('quarter', listings_src_26000.active_from) AS window_start__quarter
+        , DATE_TRUNC('year', listings_src_26000.active_from) AS window_start__year
+        , EXTRACT(year FROM listings_src_26000.active_from) AS window_start__extract_year
+        , EXTRACT(quarter FROM listings_src_26000.active_from) AS window_start__extract_quarter
+        , EXTRACT(month FROM listings_src_26000.active_from) AS window_start__extract_month
+        , EXTRACT(day FROM listings_src_26000.active_from) AS window_start__extract_day
+        , EXTRACT(isodow FROM listings_src_26000.active_from) AS window_start__extract_dow
+        , EXTRACT(doy FROM listings_src_26000.active_from) AS window_start__extract_doy
+        , listings_src_26000.active_to AS window_end__day
+        , DATE_TRUNC('week', listings_src_26000.active_to) AS window_end__week
+        , DATE_TRUNC('month', listings_src_26000.active_to) AS window_end__month
+        , DATE_TRUNC('quarter', listings_src_26000.active_to) AS window_end__quarter
+        , DATE_TRUNC('year', listings_src_26000.active_to) AS window_end__year
+        , EXTRACT(year FROM listings_src_26000.active_to) AS window_end__extract_year
+        , EXTRACT(quarter FROM listings_src_26000.active_to) AS window_end__extract_quarter
+        , EXTRACT(month FROM listings_src_26000.active_to) AS window_end__extract_month
+        , EXTRACT(day FROM listings_src_26000.active_to) AS window_end__extract_day
+        , EXTRACT(isodow FROM listings_src_26000.active_to) AS window_end__extract_dow
+        , EXTRACT(doy FROM listings_src_26000.active_to) AS window_end__extract_doy
+        , listings_src_26000.country
+        , listings_src_26000.is_lux
+        , listings_src_26000.capacity
+        , listings_src_26000.active_from AS listing__window_start__day
+        , DATE_TRUNC('week', listings_src_26000.active_from) AS listing__window_start__week
+        , DATE_TRUNC('month', listings_src_26000.active_from) AS listing__window_start__month
+        , DATE_TRUNC('quarter', listings_src_26000.active_from) AS listing__window_start__quarter
+        , DATE_TRUNC('year', listings_src_26000.active_from) AS listing__window_start__year
+        , EXTRACT(year FROM listings_src_26000.active_from) AS listing__window_start__extract_year
+        , EXTRACT(quarter FROM listings_src_26000.active_from) AS listing__window_start__extract_quarter
+        , EXTRACT(month FROM listings_src_26000.active_from) AS listing__window_start__extract_month
+        , EXTRACT(day FROM listings_src_26000.active_from) AS listing__window_start__extract_day
+        , EXTRACT(isodow FROM listings_src_26000.active_from) AS listing__window_start__extract_dow
+        , EXTRACT(doy FROM listings_src_26000.active_from) AS listing__window_start__extract_doy
+        , listings_src_26000.active_to AS listing__window_end__day
+        , DATE_TRUNC('week', listings_src_26000.active_to) AS listing__window_end__week
+        , DATE_TRUNC('month', listings_src_26000.active_to) AS listing__window_end__month
+        , DATE_TRUNC('quarter', listings_src_26000.active_to) AS listing__window_end__quarter
+        , DATE_TRUNC('year', listings_src_26000.active_to) AS listing__window_end__year
+        , EXTRACT(year FROM listings_src_26000.active_to) AS listing__window_end__extract_year
+        , EXTRACT(quarter FROM listings_src_26000.active_to) AS listing__window_end__extract_quarter
+        , EXTRACT(month FROM listings_src_26000.active_to) AS listing__window_end__extract_month
+        , EXTRACT(day FROM listings_src_26000.active_to) AS listing__window_end__extract_day
+        , EXTRACT(isodow FROM listings_src_26000.active_to) AS listing__window_end__extract_dow
+        , EXTRACT(doy FROM listings_src_26000.active_to) AS listing__window_end__extract_doy
+        , listings_src_26000.country AS listing__country
+        , listings_src_26000.is_lux AS listing__is_lux
+        , listings_src_26000.capacity AS listing__capacity
+        , listings_src_26000.listing_id AS listing
+        , listings_src_26000.user_id AS user
+        , listings_src_26000.user_id AS listing__user
+      FROM ***************************.dim_listings listings_src_26000
+    ) subq_0
+    CROSS JOIN (
+      -- Pass Only Elements: ['metric_time__month',]
+      SELECT
+        subq_2.metric_time__month
+      FROM (
+        -- Metric Time Dimension 'ds'
+        SELECT
+          subq_1.ds__day
+          , subq_1.ds__week
+          , subq_1.ds__month
+          , subq_1.ds__quarter
+          , subq_1.ds__year
+          , subq_1.ds__extract_year
+          , subq_1.ds__extract_quarter
+          , subq_1.ds__extract_month
+          , subq_1.ds__extract_day
+          , subq_1.ds__extract_dow
+          , subq_1.ds__extract_doy
+          , subq_1.ds__alien_day
+          , subq_1.ds__day AS metric_time__day
+          , subq_1.ds__week AS metric_time__week
+          , subq_1.ds__month AS metric_time__month
+          , subq_1.ds__quarter AS metric_time__quarter
+          , subq_1.ds__year AS metric_time__year
+          , subq_1.ds__extract_year AS metric_time__extract_year
+          , subq_1.ds__extract_quarter AS metric_time__extract_quarter
+          , subq_1.ds__extract_month AS metric_time__extract_month
+          , subq_1.ds__extract_day AS metric_time__extract_day
+          , subq_1.ds__extract_dow AS metric_time__extract_dow
+          , subq_1.ds__extract_doy AS metric_time__extract_doy
+          , subq_1.ds__alien_day AS metric_time__alien_day
+        FROM (
+          -- Read From Time Spine 'mf_time_spine'
+          SELECT
+            time_spine_src_26006.ds AS ds__day
+            , DATE_TRUNC('week', time_spine_src_26006.ds) AS ds__week
+            , DATE_TRUNC('month', time_spine_src_26006.ds) AS ds__month
+            , DATE_TRUNC('quarter', time_spine_src_26006.ds) AS ds__quarter
+            , DATE_TRUNC('year', time_spine_src_26006.ds) AS ds__year
+            , EXTRACT(year FROM time_spine_src_26006.ds) AS ds__extract_year
+            , EXTRACT(quarter FROM time_spine_src_26006.ds) AS ds__extract_quarter
+            , EXTRACT(month FROM time_spine_src_26006.ds) AS ds__extract_month
+            , EXTRACT(day FROM time_spine_src_26006.ds) AS ds__extract_day
+            , EXTRACT(isodow FROM time_spine_src_26006.ds) AS ds__extract_dow
+            , EXTRACT(doy FROM time_spine_src_26006.ds) AS ds__extract_doy
+            , time_spine_src_26006.alien_day AS ds__alien_day
+          FROM ***************************.mf_time_spine time_spine_src_26006
+        ) subq_1
+      ) subq_2
+    ) subq_3
+    FULL OUTER JOIN (
+      -- Pass Only Elements: ['home_state_latest', 'user']
+      SELECT
+        subq_4.user
+        , subq_4.home_state_latest
+      FROM (
+        -- Read Elements From Semantic Model 'users_latest'
+        SELECT
+          DATE_TRUNC('day', users_latest_src_26000.ds) AS ds__day
+          , DATE_TRUNC('week', users_latest_src_26000.ds) AS ds__week
+          , DATE_TRUNC('month', users_latest_src_26000.ds) AS ds__month
+          , DATE_TRUNC('quarter', users_latest_src_26000.ds) AS ds__quarter
+          , DATE_TRUNC('year', users_latest_src_26000.ds) AS ds__year
+          , EXTRACT(year FROM users_latest_src_26000.ds) AS ds__extract_year
+          , EXTRACT(quarter FROM users_latest_src_26000.ds) AS ds__extract_quarter
+          , EXTRACT(month FROM users_latest_src_26000.ds) AS ds__extract_month
+          , EXTRACT(day FROM users_latest_src_26000.ds) AS ds__extract_day
+          , EXTRACT(isodow FROM users_latest_src_26000.ds) AS ds__extract_dow
+          , EXTRACT(doy FROM users_latest_src_26000.ds) AS ds__extract_doy
+          , users_latest_src_26000.home_state_latest
+          , DATE_TRUNC('day', users_latest_src_26000.ds) AS user__ds__day
+          , DATE_TRUNC('week', users_latest_src_26000.ds) AS user__ds__week
+          , DATE_TRUNC('month', users_latest_src_26000.ds) AS user__ds__month
+          , DATE_TRUNC('quarter', users_latest_src_26000.ds) AS user__ds__quarter
+          , DATE_TRUNC('year', users_latest_src_26000.ds) AS user__ds__year
+          , EXTRACT(year FROM users_latest_src_26000.ds) AS user__ds__extract_year
+          , EXTRACT(quarter FROM users_latest_src_26000.ds) AS user__ds__extract_quarter
+          , EXTRACT(month FROM users_latest_src_26000.ds) AS user__ds__extract_month
+          , EXTRACT(day FROM users_latest_src_26000.ds) AS user__ds__extract_day
+          , EXTRACT(isodow FROM users_latest_src_26000.ds) AS user__ds__extract_dow
+          , EXTRACT(doy FROM users_latest_src_26000.ds) AS user__ds__extract_doy
+          , users_latest_src_26000.home_state_latest AS user__home_state_latest
+          , users_latest_src_26000.user_id AS user
+        FROM ***************************.dim_users_latest users_latest_src_26000
+      ) subq_4
+    ) subq_5
+    ON
+      subq_0.user = subq_5.user
+  ) subq_6
+  WHERE user__home_state_latest = 'CA'
+) subq_7

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/DuckDB/test_no_dedupe__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/DuckDB/test_no_dedupe__plan0_optimized.sql
@@ -1,0 +1,24 @@
+test_name: test_no_dedupe
+test_filename: test_query_rendering.py
+sql_engine: DuckDB
+---
+-- Constrain Output with WHERE
+-- Pass Only Elements: ['listing__capacity', 'metric_time__month']
+SELECT
+  metric_time__month
+  , listing__capacity
+FROM (
+  -- Join Standard Outputs
+  SELECT
+    users_latest_src_26000.home_state_latest AS user__home_state_latest
+    , DATE_TRUNC('month', time_spine_src_26006.ds) AS metric_time__month
+    , listings_src_26000.capacity AS listing__capacity
+  FROM ***************************.dim_listings listings_src_26000
+  CROSS JOIN
+    ***************************.mf_time_spine time_spine_src_26006
+  FULL OUTER JOIN
+    ***************************.dim_users_latest users_latest_src_26000
+  ON
+    listings_src_26000.user_id = users_latest_src_26000.user_id
+) subq_14
+WHERE user__home_state_latest = 'CA'

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/DuckDB/test_no_dedupe_saved_query__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/DuckDB/test_no_dedupe_saved_query__plan0.sql
@@ -1,0 +1,282 @@
+test_name: test_no_dedupe_saved_query
+test_filename: test_query_rendering.py
+sql_engine: DuckDB
+---
+-- Pass Only Elements: ['listing__capacity_latest', 'metric_time__month']
+SELECT
+  subq_7.metric_time__month
+  , subq_7.listing__capacity_latest
+FROM (
+  -- Constrain Output with WHERE
+  SELECT
+    subq_6.ds__day
+    , subq_6.ds__week
+    , subq_6.ds__month
+    , subq_6.ds__quarter
+    , subq_6.ds__year
+    , subq_6.ds__extract_year
+    , subq_6.ds__extract_quarter
+    , subq_6.ds__extract_month
+    , subq_6.ds__extract_day
+    , subq_6.ds__extract_dow
+    , subq_6.ds__extract_doy
+    , subq_6.created_at__day
+    , subq_6.created_at__week
+    , subq_6.created_at__month
+    , subq_6.created_at__quarter
+    , subq_6.created_at__year
+    , subq_6.created_at__extract_year
+    , subq_6.created_at__extract_quarter
+    , subq_6.created_at__extract_month
+    , subq_6.created_at__extract_day
+    , subq_6.created_at__extract_dow
+    , subq_6.created_at__extract_doy
+    , subq_6.listing__ds__day
+    , subq_6.listing__ds__week
+    , subq_6.listing__ds__month
+    , subq_6.listing__ds__quarter
+    , subq_6.listing__ds__year
+    , subq_6.listing__ds__extract_year
+    , subq_6.listing__ds__extract_quarter
+    , subq_6.listing__ds__extract_month
+    , subq_6.listing__ds__extract_day
+    , subq_6.listing__ds__extract_dow
+    , subq_6.listing__ds__extract_doy
+    , subq_6.listing__created_at__day
+    , subq_6.listing__created_at__week
+    , subq_6.listing__created_at__month
+    , subq_6.listing__created_at__quarter
+    , subq_6.listing__created_at__year
+    , subq_6.listing__created_at__extract_year
+    , subq_6.listing__created_at__extract_quarter
+    , subq_6.listing__created_at__extract_month
+    , subq_6.listing__created_at__extract_day
+    , subq_6.listing__created_at__extract_dow
+    , subq_6.listing__created_at__extract_doy
+    , subq_6.metric_time__month
+    , subq_6.listing
+    , subq_6.user
+    , subq_6.listing__user
+    , subq_6.country_latest
+    , subq_6.is_lux_latest
+    , subq_6.capacity_latest
+    , subq_6.listing__country_latest
+    , subq_6.listing__is_lux_latest
+    , subq_6.listing__capacity_latest
+    , subq_6.user__home_state_latest
+    , subq_6.listings
+    , subq_6.largest_listing
+    , subq_6.smallest_listing
+  FROM (
+    -- Join Standard Outputs
+    SELECT
+      subq_5.home_state_latest AS user__home_state_latest
+      , subq_0.ds__day AS ds__day
+      , subq_0.ds__week AS ds__week
+      , subq_0.ds__month AS ds__month
+      , subq_0.ds__quarter AS ds__quarter
+      , subq_0.ds__year AS ds__year
+      , subq_0.ds__extract_year AS ds__extract_year
+      , subq_0.ds__extract_quarter AS ds__extract_quarter
+      , subq_0.ds__extract_month AS ds__extract_month
+      , subq_0.ds__extract_day AS ds__extract_day
+      , subq_0.ds__extract_dow AS ds__extract_dow
+      , subq_0.ds__extract_doy AS ds__extract_doy
+      , subq_0.created_at__day AS created_at__day
+      , subq_0.created_at__week AS created_at__week
+      , subq_0.created_at__month AS created_at__month
+      , subq_0.created_at__quarter AS created_at__quarter
+      , subq_0.created_at__year AS created_at__year
+      , subq_0.created_at__extract_year AS created_at__extract_year
+      , subq_0.created_at__extract_quarter AS created_at__extract_quarter
+      , subq_0.created_at__extract_month AS created_at__extract_month
+      , subq_0.created_at__extract_day AS created_at__extract_day
+      , subq_0.created_at__extract_dow AS created_at__extract_dow
+      , subq_0.created_at__extract_doy AS created_at__extract_doy
+      , subq_0.listing__ds__day AS listing__ds__day
+      , subq_0.listing__ds__week AS listing__ds__week
+      , subq_0.listing__ds__month AS listing__ds__month
+      , subq_0.listing__ds__quarter AS listing__ds__quarter
+      , subq_0.listing__ds__year AS listing__ds__year
+      , subq_0.listing__ds__extract_year AS listing__ds__extract_year
+      , subq_0.listing__ds__extract_quarter AS listing__ds__extract_quarter
+      , subq_0.listing__ds__extract_month AS listing__ds__extract_month
+      , subq_0.listing__ds__extract_day AS listing__ds__extract_day
+      , subq_0.listing__ds__extract_dow AS listing__ds__extract_dow
+      , subq_0.listing__ds__extract_doy AS listing__ds__extract_doy
+      , subq_0.listing__created_at__day AS listing__created_at__day
+      , subq_0.listing__created_at__week AS listing__created_at__week
+      , subq_0.listing__created_at__month AS listing__created_at__month
+      , subq_0.listing__created_at__quarter AS listing__created_at__quarter
+      , subq_0.listing__created_at__year AS listing__created_at__year
+      , subq_0.listing__created_at__extract_year AS listing__created_at__extract_year
+      , subq_0.listing__created_at__extract_quarter AS listing__created_at__extract_quarter
+      , subq_0.listing__created_at__extract_month AS listing__created_at__extract_month
+      , subq_0.listing__created_at__extract_day AS listing__created_at__extract_day
+      , subq_0.listing__created_at__extract_dow AS listing__created_at__extract_dow
+      , subq_0.listing__created_at__extract_doy AS listing__created_at__extract_doy
+      , subq_3.metric_time__month AS metric_time__month
+      , subq_0.listing AS listing
+      , subq_0.user AS user
+      , subq_0.listing__user AS listing__user
+      , subq_0.country_latest AS country_latest
+      , subq_0.is_lux_latest AS is_lux_latest
+      , subq_0.capacity_latest AS capacity_latest
+      , subq_0.listing__country_latest AS listing__country_latest
+      , subq_0.listing__is_lux_latest AS listing__is_lux_latest
+      , subq_0.listing__capacity_latest AS listing__capacity_latest
+      , subq_0.listings AS listings
+      , subq_0.largest_listing AS largest_listing
+      , subq_0.smallest_listing AS smallest_listing
+    FROM (
+      -- Read Elements From Semantic Model 'listings_latest'
+      SELECT
+        1 AS listings
+        , listings_latest_src_28000.capacity AS largest_listing
+        , listings_latest_src_28000.capacity AS smallest_listing
+        , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS ds__day
+        , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS ds__week
+        , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS ds__month
+        , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS ds__quarter
+        , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS ds__year
+        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS ds__extract_year
+        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS ds__extract_quarter
+        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS ds__extract_month
+        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS ds__extract_day
+        , EXTRACT(isodow FROM listings_latest_src_28000.created_at) AS ds__extract_dow
+        , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS ds__extract_doy
+        , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS created_at__day
+        , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS created_at__week
+        , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS created_at__month
+        , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS created_at__quarter
+        , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS created_at__year
+        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS created_at__extract_year
+        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS created_at__extract_quarter
+        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS created_at__extract_month
+        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS created_at__extract_day
+        , EXTRACT(isodow FROM listings_latest_src_28000.created_at) AS created_at__extract_dow
+        , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS created_at__extract_doy
+        , listings_latest_src_28000.country AS country_latest
+        , listings_latest_src_28000.is_lux AS is_lux_latest
+        , listings_latest_src_28000.capacity AS capacity_latest
+        , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__ds__day
+        , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__ds__week
+        , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__ds__month
+        , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__ds__quarter
+        , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__ds__year
+        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__ds__extract_year
+        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__ds__extract_quarter
+        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__ds__extract_month
+        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__ds__extract_day
+        , EXTRACT(isodow FROM listings_latest_src_28000.created_at) AS listing__ds__extract_dow
+        , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__ds__extract_doy
+        , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__created_at__day
+        , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__created_at__week
+        , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__created_at__month
+        , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__created_at__quarter
+        , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__created_at__year
+        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_year
+        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_quarter
+        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_month
+        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_day
+        , EXTRACT(isodow FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_dow
+        , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_doy
+        , listings_latest_src_28000.country AS listing__country_latest
+        , listings_latest_src_28000.is_lux AS listing__is_lux_latest
+        , listings_latest_src_28000.capacity AS listing__capacity_latest
+        , listings_latest_src_28000.listing_id AS listing
+        , listings_latest_src_28000.user_id AS user
+        , listings_latest_src_28000.user_id AS listing__user
+      FROM ***************************.dim_listings_latest listings_latest_src_28000
+    ) subq_0
+    CROSS JOIN (
+      -- Pass Only Elements: ['metric_time__month',]
+      SELECT
+        subq_2.metric_time__month
+      FROM (
+        -- Metric Time Dimension 'ds'
+        SELECT
+          subq_1.ds__day
+          , subq_1.ds__week
+          , subq_1.ds__month
+          , subq_1.ds__quarter
+          , subq_1.ds__year
+          , subq_1.ds__extract_year
+          , subq_1.ds__extract_quarter
+          , subq_1.ds__extract_month
+          , subq_1.ds__extract_day
+          , subq_1.ds__extract_dow
+          , subq_1.ds__extract_doy
+          , subq_1.ds__alien_day
+          , subq_1.ds__day AS metric_time__day
+          , subq_1.ds__week AS metric_time__week
+          , subq_1.ds__month AS metric_time__month
+          , subq_1.ds__quarter AS metric_time__quarter
+          , subq_1.ds__year AS metric_time__year
+          , subq_1.ds__extract_year AS metric_time__extract_year
+          , subq_1.ds__extract_quarter AS metric_time__extract_quarter
+          , subq_1.ds__extract_month AS metric_time__extract_month
+          , subq_1.ds__extract_day AS metric_time__extract_day
+          , subq_1.ds__extract_dow AS metric_time__extract_dow
+          , subq_1.ds__extract_doy AS metric_time__extract_doy
+          , subq_1.ds__alien_day AS metric_time__alien_day
+        FROM (
+          -- Read From Time Spine 'mf_time_spine'
+          SELECT
+            time_spine_src_28006.ds AS ds__day
+            , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week
+            , DATE_TRUNC('month', time_spine_src_28006.ds) AS ds__month
+            , DATE_TRUNC('quarter', time_spine_src_28006.ds) AS ds__quarter
+            , DATE_TRUNC('year', time_spine_src_28006.ds) AS ds__year
+            , EXTRACT(year FROM time_spine_src_28006.ds) AS ds__extract_year
+            , EXTRACT(quarter FROM time_spine_src_28006.ds) AS ds__extract_quarter
+            , EXTRACT(month FROM time_spine_src_28006.ds) AS ds__extract_month
+            , EXTRACT(day FROM time_spine_src_28006.ds) AS ds__extract_day
+            , EXTRACT(isodow FROM time_spine_src_28006.ds) AS ds__extract_dow
+            , EXTRACT(doy FROM time_spine_src_28006.ds) AS ds__extract_doy
+            , time_spine_src_28006.alien_day AS ds__alien_day
+          FROM ***************************.mf_time_spine time_spine_src_28006
+        ) subq_1
+      ) subq_2
+    ) subq_3
+    FULL OUTER JOIN (
+      -- Pass Only Elements: ['home_state_latest', 'user']
+      SELECT
+        subq_4.user
+        , subq_4.home_state_latest
+      FROM (
+        -- Read Elements From Semantic Model 'users_latest'
+        SELECT
+          DATE_TRUNC('day', users_latest_src_28000.ds) AS ds_latest__day
+          , DATE_TRUNC('week', users_latest_src_28000.ds) AS ds_latest__week
+          , DATE_TRUNC('month', users_latest_src_28000.ds) AS ds_latest__month
+          , DATE_TRUNC('quarter', users_latest_src_28000.ds) AS ds_latest__quarter
+          , DATE_TRUNC('year', users_latest_src_28000.ds) AS ds_latest__year
+          , EXTRACT(year FROM users_latest_src_28000.ds) AS ds_latest__extract_year
+          , EXTRACT(quarter FROM users_latest_src_28000.ds) AS ds_latest__extract_quarter
+          , EXTRACT(month FROM users_latest_src_28000.ds) AS ds_latest__extract_month
+          , EXTRACT(day FROM users_latest_src_28000.ds) AS ds_latest__extract_day
+          , EXTRACT(isodow FROM users_latest_src_28000.ds) AS ds_latest__extract_dow
+          , EXTRACT(doy FROM users_latest_src_28000.ds) AS ds_latest__extract_doy
+          , users_latest_src_28000.home_state_latest
+          , DATE_TRUNC('day', users_latest_src_28000.ds) AS user__ds_latest__day
+          , DATE_TRUNC('week', users_latest_src_28000.ds) AS user__ds_latest__week
+          , DATE_TRUNC('month', users_latest_src_28000.ds) AS user__ds_latest__month
+          , DATE_TRUNC('quarter', users_latest_src_28000.ds) AS user__ds_latest__quarter
+          , DATE_TRUNC('year', users_latest_src_28000.ds) AS user__ds_latest__year
+          , EXTRACT(year FROM users_latest_src_28000.ds) AS user__ds_latest__extract_year
+          , EXTRACT(quarter FROM users_latest_src_28000.ds) AS user__ds_latest__extract_quarter
+          , EXTRACT(month FROM users_latest_src_28000.ds) AS user__ds_latest__extract_month
+          , EXTRACT(day FROM users_latest_src_28000.ds) AS user__ds_latest__extract_day
+          , EXTRACT(isodow FROM users_latest_src_28000.ds) AS user__ds_latest__extract_dow
+          , EXTRACT(doy FROM users_latest_src_28000.ds) AS user__ds_latest__extract_doy
+          , users_latest_src_28000.home_state_latest AS user__home_state_latest
+          , users_latest_src_28000.user_id AS user
+        FROM ***************************.dim_users_latest users_latest_src_28000
+      ) subq_4
+    ) subq_5
+    ON
+      subq_0.user = subq_5.user
+  ) subq_6
+  WHERE user__home_state_latest = 'CA'
+) subq_7

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/DuckDB/test_no_dedupe_saved_query__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/DuckDB/test_no_dedupe_saved_query__plan0_optimized.sql
@@ -1,0 +1,24 @@
+test_name: test_no_dedupe_saved_query
+test_filename: test_query_rendering.py
+sql_engine: DuckDB
+---
+-- Constrain Output with WHERE
+-- Pass Only Elements: ['listing__capacity_latest', 'metric_time__month']
+SELECT
+  metric_time__month
+  , listing__capacity_latest
+FROM (
+  -- Join Standard Outputs
+  SELECT
+    users_latest_src_28000.home_state_latest AS user__home_state_latest
+    , DATE_TRUNC('month', time_spine_src_28006.ds) AS metric_time__month
+    , listings_latest_src_28000.capacity AS listing__capacity_latest
+  FROM ***************************.dim_listings_latest listings_latest_src_28000
+  CROSS JOIN
+    ***************************.mf_time_spine time_spine_src_28006
+  FULL OUTER JOIN
+    ***************************.dim_users_latest users_latest_src_28000
+  ON
+    listings_latest_src_28000.user_id = users_latest_src_28000.user_id
+) subq_14
+WHERE user__home_state_latest = 'CA'

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Postgres/test_no_dedupe__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Postgres/test_no_dedupe__plan0.sql
@@ -1,0 +1,273 @@
+test_name: test_no_dedupe
+test_filename: test_query_rendering.py
+sql_engine: Postgres
+---
+-- Pass Only Elements: ['listing__capacity', 'metric_time__month']
+SELECT
+  subq_7.metric_time__month
+  , subq_7.listing__capacity
+FROM (
+  -- Constrain Output with WHERE
+  SELECT
+    subq_6.window_start__day
+    , subq_6.window_start__week
+    , subq_6.window_start__month
+    , subq_6.window_start__quarter
+    , subq_6.window_start__year
+    , subq_6.window_start__extract_year
+    , subq_6.window_start__extract_quarter
+    , subq_6.window_start__extract_month
+    , subq_6.window_start__extract_day
+    , subq_6.window_start__extract_dow
+    , subq_6.window_start__extract_doy
+    , subq_6.window_end__day
+    , subq_6.window_end__week
+    , subq_6.window_end__month
+    , subq_6.window_end__quarter
+    , subq_6.window_end__year
+    , subq_6.window_end__extract_year
+    , subq_6.window_end__extract_quarter
+    , subq_6.window_end__extract_month
+    , subq_6.window_end__extract_day
+    , subq_6.window_end__extract_dow
+    , subq_6.window_end__extract_doy
+    , subq_6.listing__window_start__day
+    , subq_6.listing__window_start__week
+    , subq_6.listing__window_start__month
+    , subq_6.listing__window_start__quarter
+    , subq_6.listing__window_start__year
+    , subq_6.listing__window_start__extract_year
+    , subq_6.listing__window_start__extract_quarter
+    , subq_6.listing__window_start__extract_month
+    , subq_6.listing__window_start__extract_day
+    , subq_6.listing__window_start__extract_dow
+    , subq_6.listing__window_start__extract_doy
+    , subq_6.listing__window_end__day
+    , subq_6.listing__window_end__week
+    , subq_6.listing__window_end__month
+    , subq_6.listing__window_end__quarter
+    , subq_6.listing__window_end__year
+    , subq_6.listing__window_end__extract_year
+    , subq_6.listing__window_end__extract_quarter
+    , subq_6.listing__window_end__extract_month
+    , subq_6.listing__window_end__extract_day
+    , subq_6.listing__window_end__extract_dow
+    , subq_6.listing__window_end__extract_doy
+    , subq_6.metric_time__month
+    , subq_6.listing
+    , subq_6.user
+    , subq_6.listing__user
+    , subq_6.country
+    , subq_6.is_lux
+    , subq_6.capacity
+    , subq_6.listing__country
+    , subq_6.listing__is_lux
+    , subq_6.listing__capacity
+    , subq_6.user__home_state_latest
+  FROM (
+    -- Join Standard Outputs
+    SELECT
+      subq_5.home_state_latest AS user__home_state_latest
+      , subq_0.window_start__day AS window_start__day
+      , subq_0.window_start__week AS window_start__week
+      , subq_0.window_start__month AS window_start__month
+      , subq_0.window_start__quarter AS window_start__quarter
+      , subq_0.window_start__year AS window_start__year
+      , subq_0.window_start__extract_year AS window_start__extract_year
+      , subq_0.window_start__extract_quarter AS window_start__extract_quarter
+      , subq_0.window_start__extract_month AS window_start__extract_month
+      , subq_0.window_start__extract_day AS window_start__extract_day
+      , subq_0.window_start__extract_dow AS window_start__extract_dow
+      , subq_0.window_start__extract_doy AS window_start__extract_doy
+      , subq_0.window_end__day AS window_end__day
+      , subq_0.window_end__week AS window_end__week
+      , subq_0.window_end__month AS window_end__month
+      , subq_0.window_end__quarter AS window_end__quarter
+      , subq_0.window_end__year AS window_end__year
+      , subq_0.window_end__extract_year AS window_end__extract_year
+      , subq_0.window_end__extract_quarter AS window_end__extract_quarter
+      , subq_0.window_end__extract_month AS window_end__extract_month
+      , subq_0.window_end__extract_day AS window_end__extract_day
+      , subq_0.window_end__extract_dow AS window_end__extract_dow
+      , subq_0.window_end__extract_doy AS window_end__extract_doy
+      , subq_0.listing__window_start__day AS listing__window_start__day
+      , subq_0.listing__window_start__week AS listing__window_start__week
+      , subq_0.listing__window_start__month AS listing__window_start__month
+      , subq_0.listing__window_start__quarter AS listing__window_start__quarter
+      , subq_0.listing__window_start__year AS listing__window_start__year
+      , subq_0.listing__window_start__extract_year AS listing__window_start__extract_year
+      , subq_0.listing__window_start__extract_quarter AS listing__window_start__extract_quarter
+      , subq_0.listing__window_start__extract_month AS listing__window_start__extract_month
+      , subq_0.listing__window_start__extract_day AS listing__window_start__extract_day
+      , subq_0.listing__window_start__extract_dow AS listing__window_start__extract_dow
+      , subq_0.listing__window_start__extract_doy AS listing__window_start__extract_doy
+      , subq_0.listing__window_end__day AS listing__window_end__day
+      , subq_0.listing__window_end__week AS listing__window_end__week
+      , subq_0.listing__window_end__month AS listing__window_end__month
+      , subq_0.listing__window_end__quarter AS listing__window_end__quarter
+      , subq_0.listing__window_end__year AS listing__window_end__year
+      , subq_0.listing__window_end__extract_year AS listing__window_end__extract_year
+      , subq_0.listing__window_end__extract_quarter AS listing__window_end__extract_quarter
+      , subq_0.listing__window_end__extract_month AS listing__window_end__extract_month
+      , subq_0.listing__window_end__extract_day AS listing__window_end__extract_day
+      , subq_0.listing__window_end__extract_dow AS listing__window_end__extract_dow
+      , subq_0.listing__window_end__extract_doy AS listing__window_end__extract_doy
+      , subq_3.metric_time__month AS metric_time__month
+      , subq_0.listing AS listing
+      , subq_0.user AS user
+      , subq_0.listing__user AS listing__user
+      , subq_0.country AS country
+      , subq_0.is_lux AS is_lux
+      , subq_0.capacity AS capacity
+      , subq_0.listing__country AS listing__country
+      , subq_0.listing__is_lux AS listing__is_lux
+      , subq_0.listing__capacity AS listing__capacity
+    FROM (
+      -- Read Elements From Semantic Model 'listings'
+      SELECT
+        listings_src_26000.active_from AS window_start__day
+        , DATE_TRUNC('week', listings_src_26000.active_from) AS window_start__week
+        , DATE_TRUNC('month', listings_src_26000.active_from) AS window_start__month
+        , DATE_TRUNC('quarter', listings_src_26000.active_from) AS window_start__quarter
+        , DATE_TRUNC('year', listings_src_26000.active_from) AS window_start__year
+        , EXTRACT(year FROM listings_src_26000.active_from) AS window_start__extract_year
+        , EXTRACT(quarter FROM listings_src_26000.active_from) AS window_start__extract_quarter
+        , EXTRACT(month FROM listings_src_26000.active_from) AS window_start__extract_month
+        , EXTRACT(day FROM listings_src_26000.active_from) AS window_start__extract_day
+        , EXTRACT(isodow FROM listings_src_26000.active_from) AS window_start__extract_dow
+        , EXTRACT(doy FROM listings_src_26000.active_from) AS window_start__extract_doy
+        , listings_src_26000.active_to AS window_end__day
+        , DATE_TRUNC('week', listings_src_26000.active_to) AS window_end__week
+        , DATE_TRUNC('month', listings_src_26000.active_to) AS window_end__month
+        , DATE_TRUNC('quarter', listings_src_26000.active_to) AS window_end__quarter
+        , DATE_TRUNC('year', listings_src_26000.active_to) AS window_end__year
+        , EXTRACT(year FROM listings_src_26000.active_to) AS window_end__extract_year
+        , EXTRACT(quarter FROM listings_src_26000.active_to) AS window_end__extract_quarter
+        , EXTRACT(month FROM listings_src_26000.active_to) AS window_end__extract_month
+        , EXTRACT(day FROM listings_src_26000.active_to) AS window_end__extract_day
+        , EXTRACT(isodow FROM listings_src_26000.active_to) AS window_end__extract_dow
+        , EXTRACT(doy FROM listings_src_26000.active_to) AS window_end__extract_doy
+        , listings_src_26000.country
+        , listings_src_26000.is_lux
+        , listings_src_26000.capacity
+        , listings_src_26000.active_from AS listing__window_start__day
+        , DATE_TRUNC('week', listings_src_26000.active_from) AS listing__window_start__week
+        , DATE_TRUNC('month', listings_src_26000.active_from) AS listing__window_start__month
+        , DATE_TRUNC('quarter', listings_src_26000.active_from) AS listing__window_start__quarter
+        , DATE_TRUNC('year', listings_src_26000.active_from) AS listing__window_start__year
+        , EXTRACT(year FROM listings_src_26000.active_from) AS listing__window_start__extract_year
+        , EXTRACT(quarter FROM listings_src_26000.active_from) AS listing__window_start__extract_quarter
+        , EXTRACT(month FROM listings_src_26000.active_from) AS listing__window_start__extract_month
+        , EXTRACT(day FROM listings_src_26000.active_from) AS listing__window_start__extract_day
+        , EXTRACT(isodow FROM listings_src_26000.active_from) AS listing__window_start__extract_dow
+        , EXTRACT(doy FROM listings_src_26000.active_from) AS listing__window_start__extract_doy
+        , listings_src_26000.active_to AS listing__window_end__day
+        , DATE_TRUNC('week', listings_src_26000.active_to) AS listing__window_end__week
+        , DATE_TRUNC('month', listings_src_26000.active_to) AS listing__window_end__month
+        , DATE_TRUNC('quarter', listings_src_26000.active_to) AS listing__window_end__quarter
+        , DATE_TRUNC('year', listings_src_26000.active_to) AS listing__window_end__year
+        , EXTRACT(year FROM listings_src_26000.active_to) AS listing__window_end__extract_year
+        , EXTRACT(quarter FROM listings_src_26000.active_to) AS listing__window_end__extract_quarter
+        , EXTRACT(month FROM listings_src_26000.active_to) AS listing__window_end__extract_month
+        , EXTRACT(day FROM listings_src_26000.active_to) AS listing__window_end__extract_day
+        , EXTRACT(isodow FROM listings_src_26000.active_to) AS listing__window_end__extract_dow
+        , EXTRACT(doy FROM listings_src_26000.active_to) AS listing__window_end__extract_doy
+        , listings_src_26000.country AS listing__country
+        , listings_src_26000.is_lux AS listing__is_lux
+        , listings_src_26000.capacity AS listing__capacity
+        , listings_src_26000.listing_id AS listing
+        , listings_src_26000.user_id AS user
+        , listings_src_26000.user_id AS listing__user
+      FROM ***************************.dim_listings listings_src_26000
+    ) subq_0
+    CROSS JOIN (
+      -- Pass Only Elements: ['metric_time__month',]
+      SELECT
+        subq_2.metric_time__month
+      FROM (
+        -- Metric Time Dimension 'ds'
+        SELECT
+          subq_1.ds__day
+          , subq_1.ds__week
+          , subq_1.ds__month
+          , subq_1.ds__quarter
+          , subq_1.ds__year
+          , subq_1.ds__extract_year
+          , subq_1.ds__extract_quarter
+          , subq_1.ds__extract_month
+          , subq_1.ds__extract_day
+          , subq_1.ds__extract_dow
+          , subq_1.ds__extract_doy
+          , subq_1.ds__alien_day
+          , subq_1.ds__day AS metric_time__day
+          , subq_1.ds__week AS metric_time__week
+          , subq_1.ds__month AS metric_time__month
+          , subq_1.ds__quarter AS metric_time__quarter
+          , subq_1.ds__year AS metric_time__year
+          , subq_1.ds__extract_year AS metric_time__extract_year
+          , subq_1.ds__extract_quarter AS metric_time__extract_quarter
+          , subq_1.ds__extract_month AS metric_time__extract_month
+          , subq_1.ds__extract_day AS metric_time__extract_day
+          , subq_1.ds__extract_dow AS metric_time__extract_dow
+          , subq_1.ds__extract_doy AS metric_time__extract_doy
+          , subq_1.ds__alien_day AS metric_time__alien_day
+        FROM (
+          -- Read From Time Spine 'mf_time_spine'
+          SELECT
+            time_spine_src_26006.ds AS ds__day
+            , DATE_TRUNC('week', time_spine_src_26006.ds) AS ds__week
+            , DATE_TRUNC('month', time_spine_src_26006.ds) AS ds__month
+            , DATE_TRUNC('quarter', time_spine_src_26006.ds) AS ds__quarter
+            , DATE_TRUNC('year', time_spine_src_26006.ds) AS ds__year
+            , EXTRACT(year FROM time_spine_src_26006.ds) AS ds__extract_year
+            , EXTRACT(quarter FROM time_spine_src_26006.ds) AS ds__extract_quarter
+            , EXTRACT(month FROM time_spine_src_26006.ds) AS ds__extract_month
+            , EXTRACT(day FROM time_spine_src_26006.ds) AS ds__extract_day
+            , EXTRACT(isodow FROM time_spine_src_26006.ds) AS ds__extract_dow
+            , EXTRACT(doy FROM time_spine_src_26006.ds) AS ds__extract_doy
+            , time_spine_src_26006.alien_day AS ds__alien_day
+          FROM ***************************.mf_time_spine time_spine_src_26006
+        ) subq_1
+      ) subq_2
+    ) subq_3
+    FULL OUTER JOIN (
+      -- Pass Only Elements: ['home_state_latest', 'user']
+      SELECT
+        subq_4.user
+        , subq_4.home_state_latest
+      FROM (
+        -- Read Elements From Semantic Model 'users_latest'
+        SELECT
+          DATE_TRUNC('day', users_latest_src_26000.ds) AS ds__day
+          , DATE_TRUNC('week', users_latest_src_26000.ds) AS ds__week
+          , DATE_TRUNC('month', users_latest_src_26000.ds) AS ds__month
+          , DATE_TRUNC('quarter', users_latest_src_26000.ds) AS ds__quarter
+          , DATE_TRUNC('year', users_latest_src_26000.ds) AS ds__year
+          , EXTRACT(year FROM users_latest_src_26000.ds) AS ds__extract_year
+          , EXTRACT(quarter FROM users_latest_src_26000.ds) AS ds__extract_quarter
+          , EXTRACT(month FROM users_latest_src_26000.ds) AS ds__extract_month
+          , EXTRACT(day FROM users_latest_src_26000.ds) AS ds__extract_day
+          , EXTRACT(isodow FROM users_latest_src_26000.ds) AS ds__extract_dow
+          , EXTRACT(doy FROM users_latest_src_26000.ds) AS ds__extract_doy
+          , users_latest_src_26000.home_state_latest
+          , DATE_TRUNC('day', users_latest_src_26000.ds) AS user__ds__day
+          , DATE_TRUNC('week', users_latest_src_26000.ds) AS user__ds__week
+          , DATE_TRUNC('month', users_latest_src_26000.ds) AS user__ds__month
+          , DATE_TRUNC('quarter', users_latest_src_26000.ds) AS user__ds__quarter
+          , DATE_TRUNC('year', users_latest_src_26000.ds) AS user__ds__year
+          , EXTRACT(year FROM users_latest_src_26000.ds) AS user__ds__extract_year
+          , EXTRACT(quarter FROM users_latest_src_26000.ds) AS user__ds__extract_quarter
+          , EXTRACT(month FROM users_latest_src_26000.ds) AS user__ds__extract_month
+          , EXTRACT(day FROM users_latest_src_26000.ds) AS user__ds__extract_day
+          , EXTRACT(isodow FROM users_latest_src_26000.ds) AS user__ds__extract_dow
+          , EXTRACT(doy FROM users_latest_src_26000.ds) AS user__ds__extract_doy
+          , users_latest_src_26000.home_state_latest AS user__home_state_latest
+          , users_latest_src_26000.user_id AS user
+        FROM ***************************.dim_users_latest users_latest_src_26000
+      ) subq_4
+    ) subq_5
+    ON
+      subq_0.user = subq_5.user
+  ) subq_6
+  WHERE user__home_state_latest = 'CA'
+) subq_7

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Postgres/test_no_dedupe__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Postgres/test_no_dedupe__plan0_optimized.sql
@@ -1,0 +1,24 @@
+test_name: test_no_dedupe
+test_filename: test_query_rendering.py
+sql_engine: Postgres
+---
+-- Constrain Output with WHERE
+-- Pass Only Elements: ['listing__capacity', 'metric_time__month']
+SELECT
+  metric_time__month
+  , listing__capacity
+FROM (
+  -- Join Standard Outputs
+  SELECT
+    users_latest_src_26000.home_state_latest AS user__home_state_latest
+    , DATE_TRUNC('month', time_spine_src_26006.ds) AS metric_time__month
+    , listings_src_26000.capacity AS listing__capacity
+  FROM ***************************.dim_listings listings_src_26000
+  CROSS JOIN
+    ***************************.mf_time_spine time_spine_src_26006
+  FULL OUTER JOIN
+    ***************************.dim_users_latest users_latest_src_26000
+  ON
+    listings_src_26000.user_id = users_latest_src_26000.user_id
+) subq_14
+WHERE user__home_state_latest = 'CA'

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Postgres/test_no_dedupe_saved_query__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Postgres/test_no_dedupe_saved_query__plan0.sql
@@ -1,0 +1,282 @@
+test_name: test_no_dedupe_saved_query
+test_filename: test_query_rendering.py
+sql_engine: Postgres
+---
+-- Pass Only Elements: ['listing__capacity_latest', 'metric_time__month']
+SELECT
+  subq_7.metric_time__month
+  , subq_7.listing__capacity_latest
+FROM (
+  -- Constrain Output with WHERE
+  SELECT
+    subq_6.ds__day
+    , subq_6.ds__week
+    , subq_6.ds__month
+    , subq_6.ds__quarter
+    , subq_6.ds__year
+    , subq_6.ds__extract_year
+    , subq_6.ds__extract_quarter
+    , subq_6.ds__extract_month
+    , subq_6.ds__extract_day
+    , subq_6.ds__extract_dow
+    , subq_6.ds__extract_doy
+    , subq_6.created_at__day
+    , subq_6.created_at__week
+    , subq_6.created_at__month
+    , subq_6.created_at__quarter
+    , subq_6.created_at__year
+    , subq_6.created_at__extract_year
+    , subq_6.created_at__extract_quarter
+    , subq_6.created_at__extract_month
+    , subq_6.created_at__extract_day
+    , subq_6.created_at__extract_dow
+    , subq_6.created_at__extract_doy
+    , subq_6.listing__ds__day
+    , subq_6.listing__ds__week
+    , subq_6.listing__ds__month
+    , subq_6.listing__ds__quarter
+    , subq_6.listing__ds__year
+    , subq_6.listing__ds__extract_year
+    , subq_6.listing__ds__extract_quarter
+    , subq_6.listing__ds__extract_month
+    , subq_6.listing__ds__extract_day
+    , subq_6.listing__ds__extract_dow
+    , subq_6.listing__ds__extract_doy
+    , subq_6.listing__created_at__day
+    , subq_6.listing__created_at__week
+    , subq_6.listing__created_at__month
+    , subq_6.listing__created_at__quarter
+    , subq_6.listing__created_at__year
+    , subq_6.listing__created_at__extract_year
+    , subq_6.listing__created_at__extract_quarter
+    , subq_6.listing__created_at__extract_month
+    , subq_6.listing__created_at__extract_day
+    , subq_6.listing__created_at__extract_dow
+    , subq_6.listing__created_at__extract_doy
+    , subq_6.metric_time__month
+    , subq_6.listing
+    , subq_6.user
+    , subq_6.listing__user
+    , subq_6.country_latest
+    , subq_6.is_lux_latest
+    , subq_6.capacity_latest
+    , subq_6.listing__country_latest
+    , subq_6.listing__is_lux_latest
+    , subq_6.listing__capacity_latest
+    , subq_6.user__home_state_latest
+    , subq_6.listings
+    , subq_6.largest_listing
+    , subq_6.smallest_listing
+  FROM (
+    -- Join Standard Outputs
+    SELECT
+      subq_5.home_state_latest AS user__home_state_latest
+      , subq_0.ds__day AS ds__day
+      , subq_0.ds__week AS ds__week
+      , subq_0.ds__month AS ds__month
+      , subq_0.ds__quarter AS ds__quarter
+      , subq_0.ds__year AS ds__year
+      , subq_0.ds__extract_year AS ds__extract_year
+      , subq_0.ds__extract_quarter AS ds__extract_quarter
+      , subq_0.ds__extract_month AS ds__extract_month
+      , subq_0.ds__extract_day AS ds__extract_day
+      , subq_0.ds__extract_dow AS ds__extract_dow
+      , subq_0.ds__extract_doy AS ds__extract_doy
+      , subq_0.created_at__day AS created_at__day
+      , subq_0.created_at__week AS created_at__week
+      , subq_0.created_at__month AS created_at__month
+      , subq_0.created_at__quarter AS created_at__quarter
+      , subq_0.created_at__year AS created_at__year
+      , subq_0.created_at__extract_year AS created_at__extract_year
+      , subq_0.created_at__extract_quarter AS created_at__extract_quarter
+      , subq_0.created_at__extract_month AS created_at__extract_month
+      , subq_0.created_at__extract_day AS created_at__extract_day
+      , subq_0.created_at__extract_dow AS created_at__extract_dow
+      , subq_0.created_at__extract_doy AS created_at__extract_doy
+      , subq_0.listing__ds__day AS listing__ds__day
+      , subq_0.listing__ds__week AS listing__ds__week
+      , subq_0.listing__ds__month AS listing__ds__month
+      , subq_0.listing__ds__quarter AS listing__ds__quarter
+      , subq_0.listing__ds__year AS listing__ds__year
+      , subq_0.listing__ds__extract_year AS listing__ds__extract_year
+      , subq_0.listing__ds__extract_quarter AS listing__ds__extract_quarter
+      , subq_0.listing__ds__extract_month AS listing__ds__extract_month
+      , subq_0.listing__ds__extract_day AS listing__ds__extract_day
+      , subq_0.listing__ds__extract_dow AS listing__ds__extract_dow
+      , subq_0.listing__ds__extract_doy AS listing__ds__extract_doy
+      , subq_0.listing__created_at__day AS listing__created_at__day
+      , subq_0.listing__created_at__week AS listing__created_at__week
+      , subq_0.listing__created_at__month AS listing__created_at__month
+      , subq_0.listing__created_at__quarter AS listing__created_at__quarter
+      , subq_0.listing__created_at__year AS listing__created_at__year
+      , subq_0.listing__created_at__extract_year AS listing__created_at__extract_year
+      , subq_0.listing__created_at__extract_quarter AS listing__created_at__extract_quarter
+      , subq_0.listing__created_at__extract_month AS listing__created_at__extract_month
+      , subq_0.listing__created_at__extract_day AS listing__created_at__extract_day
+      , subq_0.listing__created_at__extract_dow AS listing__created_at__extract_dow
+      , subq_0.listing__created_at__extract_doy AS listing__created_at__extract_doy
+      , subq_3.metric_time__month AS metric_time__month
+      , subq_0.listing AS listing
+      , subq_0.user AS user
+      , subq_0.listing__user AS listing__user
+      , subq_0.country_latest AS country_latest
+      , subq_0.is_lux_latest AS is_lux_latest
+      , subq_0.capacity_latest AS capacity_latest
+      , subq_0.listing__country_latest AS listing__country_latest
+      , subq_0.listing__is_lux_latest AS listing__is_lux_latest
+      , subq_0.listing__capacity_latest AS listing__capacity_latest
+      , subq_0.listings AS listings
+      , subq_0.largest_listing AS largest_listing
+      , subq_0.smallest_listing AS smallest_listing
+    FROM (
+      -- Read Elements From Semantic Model 'listings_latest'
+      SELECT
+        1 AS listings
+        , listings_latest_src_28000.capacity AS largest_listing
+        , listings_latest_src_28000.capacity AS smallest_listing
+        , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS ds__day
+        , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS ds__week
+        , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS ds__month
+        , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS ds__quarter
+        , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS ds__year
+        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS ds__extract_year
+        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS ds__extract_quarter
+        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS ds__extract_month
+        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS ds__extract_day
+        , EXTRACT(isodow FROM listings_latest_src_28000.created_at) AS ds__extract_dow
+        , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS ds__extract_doy
+        , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS created_at__day
+        , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS created_at__week
+        , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS created_at__month
+        , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS created_at__quarter
+        , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS created_at__year
+        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS created_at__extract_year
+        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS created_at__extract_quarter
+        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS created_at__extract_month
+        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS created_at__extract_day
+        , EXTRACT(isodow FROM listings_latest_src_28000.created_at) AS created_at__extract_dow
+        , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS created_at__extract_doy
+        , listings_latest_src_28000.country AS country_latest
+        , listings_latest_src_28000.is_lux AS is_lux_latest
+        , listings_latest_src_28000.capacity AS capacity_latest
+        , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__ds__day
+        , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__ds__week
+        , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__ds__month
+        , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__ds__quarter
+        , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__ds__year
+        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__ds__extract_year
+        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__ds__extract_quarter
+        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__ds__extract_month
+        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__ds__extract_day
+        , EXTRACT(isodow FROM listings_latest_src_28000.created_at) AS listing__ds__extract_dow
+        , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__ds__extract_doy
+        , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__created_at__day
+        , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__created_at__week
+        , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__created_at__month
+        , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__created_at__quarter
+        , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__created_at__year
+        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_year
+        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_quarter
+        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_month
+        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_day
+        , EXTRACT(isodow FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_dow
+        , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_doy
+        , listings_latest_src_28000.country AS listing__country_latest
+        , listings_latest_src_28000.is_lux AS listing__is_lux_latest
+        , listings_latest_src_28000.capacity AS listing__capacity_latest
+        , listings_latest_src_28000.listing_id AS listing
+        , listings_latest_src_28000.user_id AS user
+        , listings_latest_src_28000.user_id AS listing__user
+      FROM ***************************.dim_listings_latest listings_latest_src_28000
+    ) subq_0
+    CROSS JOIN (
+      -- Pass Only Elements: ['metric_time__month',]
+      SELECT
+        subq_2.metric_time__month
+      FROM (
+        -- Metric Time Dimension 'ds'
+        SELECT
+          subq_1.ds__day
+          , subq_1.ds__week
+          , subq_1.ds__month
+          , subq_1.ds__quarter
+          , subq_1.ds__year
+          , subq_1.ds__extract_year
+          , subq_1.ds__extract_quarter
+          , subq_1.ds__extract_month
+          , subq_1.ds__extract_day
+          , subq_1.ds__extract_dow
+          , subq_1.ds__extract_doy
+          , subq_1.ds__alien_day
+          , subq_1.ds__day AS metric_time__day
+          , subq_1.ds__week AS metric_time__week
+          , subq_1.ds__month AS metric_time__month
+          , subq_1.ds__quarter AS metric_time__quarter
+          , subq_1.ds__year AS metric_time__year
+          , subq_1.ds__extract_year AS metric_time__extract_year
+          , subq_1.ds__extract_quarter AS metric_time__extract_quarter
+          , subq_1.ds__extract_month AS metric_time__extract_month
+          , subq_1.ds__extract_day AS metric_time__extract_day
+          , subq_1.ds__extract_dow AS metric_time__extract_dow
+          , subq_1.ds__extract_doy AS metric_time__extract_doy
+          , subq_1.ds__alien_day AS metric_time__alien_day
+        FROM (
+          -- Read From Time Spine 'mf_time_spine'
+          SELECT
+            time_spine_src_28006.ds AS ds__day
+            , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week
+            , DATE_TRUNC('month', time_spine_src_28006.ds) AS ds__month
+            , DATE_TRUNC('quarter', time_spine_src_28006.ds) AS ds__quarter
+            , DATE_TRUNC('year', time_spine_src_28006.ds) AS ds__year
+            , EXTRACT(year FROM time_spine_src_28006.ds) AS ds__extract_year
+            , EXTRACT(quarter FROM time_spine_src_28006.ds) AS ds__extract_quarter
+            , EXTRACT(month FROM time_spine_src_28006.ds) AS ds__extract_month
+            , EXTRACT(day FROM time_spine_src_28006.ds) AS ds__extract_day
+            , EXTRACT(isodow FROM time_spine_src_28006.ds) AS ds__extract_dow
+            , EXTRACT(doy FROM time_spine_src_28006.ds) AS ds__extract_doy
+            , time_spine_src_28006.alien_day AS ds__alien_day
+          FROM ***************************.mf_time_spine time_spine_src_28006
+        ) subq_1
+      ) subq_2
+    ) subq_3
+    FULL OUTER JOIN (
+      -- Pass Only Elements: ['home_state_latest', 'user']
+      SELECT
+        subq_4.user
+        , subq_4.home_state_latest
+      FROM (
+        -- Read Elements From Semantic Model 'users_latest'
+        SELECT
+          DATE_TRUNC('day', users_latest_src_28000.ds) AS ds_latest__day
+          , DATE_TRUNC('week', users_latest_src_28000.ds) AS ds_latest__week
+          , DATE_TRUNC('month', users_latest_src_28000.ds) AS ds_latest__month
+          , DATE_TRUNC('quarter', users_latest_src_28000.ds) AS ds_latest__quarter
+          , DATE_TRUNC('year', users_latest_src_28000.ds) AS ds_latest__year
+          , EXTRACT(year FROM users_latest_src_28000.ds) AS ds_latest__extract_year
+          , EXTRACT(quarter FROM users_latest_src_28000.ds) AS ds_latest__extract_quarter
+          , EXTRACT(month FROM users_latest_src_28000.ds) AS ds_latest__extract_month
+          , EXTRACT(day FROM users_latest_src_28000.ds) AS ds_latest__extract_day
+          , EXTRACT(isodow FROM users_latest_src_28000.ds) AS ds_latest__extract_dow
+          , EXTRACT(doy FROM users_latest_src_28000.ds) AS ds_latest__extract_doy
+          , users_latest_src_28000.home_state_latest
+          , DATE_TRUNC('day', users_latest_src_28000.ds) AS user__ds_latest__day
+          , DATE_TRUNC('week', users_latest_src_28000.ds) AS user__ds_latest__week
+          , DATE_TRUNC('month', users_latest_src_28000.ds) AS user__ds_latest__month
+          , DATE_TRUNC('quarter', users_latest_src_28000.ds) AS user__ds_latest__quarter
+          , DATE_TRUNC('year', users_latest_src_28000.ds) AS user__ds_latest__year
+          , EXTRACT(year FROM users_latest_src_28000.ds) AS user__ds_latest__extract_year
+          , EXTRACT(quarter FROM users_latest_src_28000.ds) AS user__ds_latest__extract_quarter
+          , EXTRACT(month FROM users_latest_src_28000.ds) AS user__ds_latest__extract_month
+          , EXTRACT(day FROM users_latest_src_28000.ds) AS user__ds_latest__extract_day
+          , EXTRACT(isodow FROM users_latest_src_28000.ds) AS user__ds_latest__extract_dow
+          , EXTRACT(doy FROM users_latest_src_28000.ds) AS user__ds_latest__extract_doy
+          , users_latest_src_28000.home_state_latest AS user__home_state_latest
+          , users_latest_src_28000.user_id AS user
+        FROM ***************************.dim_users_latest users_latest_src_28000
+      ) subq_4
+    ) subq_5
+    ON
+      subq_0.user = subq_5.user
+  ) subq_6
+  WHERE user__home_state_latest = 'CA'
+) subq_7

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Postgres/test_no_dedupe_saved_query__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Postgres/test_no_dedupe_saved_query__plan0_optimized.sql
@@ -1,0 +1,24 @@
+test_name: test_no_dedupe_saved_query
+test_filename: test_query_rendering.py
+sql_engine: Postgres
+---
+-- Constrain Output with WHERE
+-- Pass Only Elements: ['listing__capacity_latest', 'metric_time__month']
+SELECT
+  metric_time__month
+  , listing__capacity_latest
+FROM (
+  -- Join Standard Outputs
+  SELECT
+    users_latest_src_28000.home_state_latest AS user__home_state_latest
+    , DATE_TRUNC('month', time_spine_src_28006.ds) AS metric_time__month
+    , listings_latest_src_28000.capacity AS listing__capacity_latest
+  FROM ***************************.dim_listings_latest listings_latest_src_28000
+  CROSS JOIN
+    ***************************.mf_time_spine time_spine_src_28006
+  FULL OUTER JOIN
+    ***************************.dim_users_latest users_latest_src_28000
+  ON
+    listings_latest_src_28000.user_id = users_latest_src_28000.user_id
+) subq_14
+WHERE user__home_state_latest = 'CA'

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Redshift/test_no_dedupe__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Redshift/test_no_dedupe__plan0.sql
@@ -1,0 +1,273 @@
+test_name: test_no_dedupe
+test_filename: test_query_rendering.py
+sql_engine: Redshift
+---
+-- Pass Only Elements: ['listing__capacity', 'metric_time__month']
+SELECT
+  subq_7.metric_time__month
+  , subq_7.listing__capacity
+FROM (
+  -- Constrain Output with WHERE
+  SELECT
+    subq_6.window_start__day
+    , subq_6.window_start__week
+    , subq_6.window_start__month
+    , subq_6.window_start__quarter
+    , subq_6.window_start__year
+    , subq_6.window_start__extract_year
+    , subq_6.window_start__extract_quarter
+    , subq_6.window_start__extract_month
+    , subq_6.window_start__extract_day
+    , subq_6.window_start__extract_dow
+    , subq_6.window_start__extract_doy
+    , subq_6.window_end__day
+    , subq_6.window_end__week
+    , subq_6.window_end__month
+    , subq_6.window_end__quarter
+    , subq_6.window_end__year
+    , subq_6.window_end__extract_year
+    , subq_6.window_end__extract_quarter
+    , subq_6.window_end__extract_month
+    , subq_6.window_end__extract_day
+    , subq_6.window_end__extract_dow
+    , subq_6.window_end__extract_doy
+    , subq_6.listing__window_start__day
+    , subq_6.listing__window_start__week
+    , subq_6.listing__window_start__month
+    , subq_6.listing__window_start__quarter
+    , subq_6.listing__window_start__year
+    , subq_6.listing__window_start__extract_year
+    , subq_6.listing__window_start__extract_quarter
+    , subq_6.listing__window_start__extract_month
+    , subq_6.listing__window_start__extract_day
+    , subq_6.listing__window_start__extract_dow
+    , subq_6.listing__window_start__extract_doy
+    , subq_6.listing__window_end__day
+    , subq_6.listing__window_end__week
+    , subq_6.listing__window_end__month
+    , subq_6.listing__window_end__quarter
+    , subq_6.listing__window_end__year
+    , subq_6.listing__window_end__extract_year
+    , subq_6.listing__window_end__extract_quarter
+    , subq_6.listing__window_end__extract_month
+    , subq_6.listing__window_end__extract_day
+    , subq_6.listing__window_end__extract_dow
+    , subq_6.listing__window_end__extract_doy
+    , subq_6.metric_time__month
+    , subq_6.listing
+    , subq_6.user
+    , subq_6.listing__user
+    , subq_6.country
+    , subq_6.is_lux
+    , subq_6.capacity
+    , subq_6.listing__country
+    , subq_6.listing__is_lux
+    , subq_6.listing__capacity
+    , subq_6.user__home_state_latest
+  FROM (
+    -- Join Standard Outputs
+    SELECT
+      subq_5.home_state_latest AS user__home_state_latest
+      , subq_0.window_start__day AS window_start__day
+      , subq_0.window_start__week AS window_start__week
+      , subq_0.window_start__month AS window_start__month
+      , subq_0.window_start__quarter AS window_start__quarter
+      , subq_0.window_start__year AS window_start__year
+      , subq_0.window_start__extract_year AS window_start__extract_year
+      , subq_0.window_start__extract_quarter AS window_start__extract_quarter
+      , subq_0.window_start__extract_month AS window_start__extract_month
+      , subq_0.window_start__extract_day AS window_start__extract_day
+      , subq_0.window_start__extract_dow AS window_start__extract_dow
+      , subq_0.window_start__extract_doy AS window_start__extract_doy
+      , subq_0.window_end__day AS window_end__day
+      , subq_0.window_end__week AS window_end__week
+      , subq_0.window_end__month AS window_end__month
+      , subq_0.window_end__quarter AS window_end__quarter
+      , subq_0.window_end__year AS window_end__year
+      , subq_0.window_end__extract_year AS window_end__extract_year
+      , subq_0.window_end__extract_quarter AS window_end__extract_quarter
+      , subq_0.window_end__extract_month AS window_end__extract_month
+      , subq_0.window_end__extract_day AS window_end__extract_day
+      , subq_0.window_end__extract_dow AS window_end__extract_dow
+      , subq_0.window_end__extract_doy AS window_end__extract_doy
+      , subq_0.listing__window_start__day AS listing__window_start__day
+      , subq_0.listing__window_start__week AS listing__window_start__week
+      , subq_0.listing__window_start__month AS listing__window_start__month
+      , subq_0.listing__window_start__quarter AS listing__window_start__quarter
+      , subq_0.listing__window_start__year AS listing__window_start__year
+      , subq_0.listing__window_start__extract_year AS listing__window_start__extract_year
+      , subq_0.listing__window_start__extract_quarter AS listing__window_start__extract_quarter
+      , subq_0.listing__window_start__extract_month AS listing__window_start__extract_month
+      , subq_0.listing__window_start__extract_day AS listing__window_start__extract_day
+      , subq_0.listing__window_start__extract_dow AS listing__window_start__extract_dow
+      , subq_0.listing__window_start__extract_doy AS listing__window_start__extract_doy
+      , subq_0.listing__window_end__day AS listing__window_end__day
+      , subq_0.listing__window_end__week AS listing__window_end__week
+      , subq_0.listing__window_end__month AS listing__window_end__month
+      , subq_0.listing__window_end__quarter AS listing__window_end__quarter
+      , subq_0.listing__window_end__year AS listing__window_end__year
+      , subq_0.listing__window_end__extract_year AS listing__window_end__extract_year
+      , subq_0.listing__window_end__extract_quarter AS listing__window_end__extract_quarter
+      , subq_0.listing__window_end__extract_month AS listing__window_end__extract_month
+      , subq_0.listing__window_end__extract_day AS listing__window_end__extract_day
+      , subq_0.listing__window_end__extract_dow AS listing__window_end__extract_dow
+      , subq_0.listing__window_end__extract_doy AS listing__window_end__extract_doy
+      , subq_3.metric_time__month AS metric_time__month
+      , subq_0.listing AS listing
+      , subq_0.user AS user
+      , subq_0.listing__user AS listing__user
+      , subq_0.country AS country
+      , subq_0.is_lux AS is_lux
+      , subq_0.capacity AS capacity
+      , subq_0.listing__country AS listing__country
+      , subq_0.listing__is_lux AS listing__is_lux
+      , subq_0.listing__capacity AS listing__capacity
+    FROM (
+      -- Read Elements From Semantic Model 'listings'
+      SELECT
+        listings_src_26000.active_from AS window_start__day
+        , DATE_TRUNC('week', listings_src_26000.active_from) AS window_start__week
+        , DATE_TRUNC('month', listings_src_26000.active_from) AS window_start__month
+        , DATE_TRUNC('quarter', listings_src_26000.active_from) AS window_start__quarter
+        , DATE_TRUNC('year', listings_src_26000.active_from) AS window_start__year
+        , EXTRACT(year FROM listings_src_26000.active_from) AS window_start__extract_year
+        , EXTRACT(quarter FROM listings_src_26000.active_from) AS window_start__extract_quarter
+        , EXTRACT(month FROM listings_src_26000.active_from) AS window_start__extract_month
+        , EXTRACT(day FROM listings_src_26000.active_from) AS window_start__extract_day
+        , CASE WHEN EXTRACT(dow FROM listings_src_26000.active_from) = 0 THEN EXTRACT(dow FROM listings_src_26000.active_from) + 7 ELSE EXTRACT(dow FROM listings_src_26000.active_from) END AS window_start__extract_dow
+        , EXTRACT(doy FROM listings_src_26000.active_from) AS window_start__extract_doy
+        , listings_src_26000.active_to AS window_end__day
+        , DATE_TRUNC('week', listings_src_26000.active_to) AS window_end__week
+        , DATE_TRUNC('month', listings_src_26000.active_to) AS window_end__month
+        , DATE_TRUNC('quarter', listings_src_26000.active_to) AS window_end__quarter
+        , DATE_TRUNC('year', listings_src_26000.active_to) AS window_end__year
+        , EXTRACT(year FROM listings_src_26000.active_to) AS window_end__extract_year
+        , EXTRACT(quarter FROM listings_src_26000.active_to) AS window_end__extract_quarter
+        , EXTRACT(month FROM listings_src_26000.active_to) AS window_end__extract_month
+        , EXTRACT(day FROM listings_src_26000.active_to) AS window_end__extract_day
+        , CASE WHEN EXTRACT(dow FROM listings_src_26000.active_to) = 0 THEN EXTRACT(dow FROM listings_src_26000.active_to) + 7 ELSE EXTRACT(dow FROM listings_src_26000.active_to) END AS window_end__extract_dow
+        , EXTRACT(doy FROM listings_src_26000.active_to) AS window_end__extract_doy
+        , listings_src_26000.country
+        , listings_src_26000.is_lux
+        , listings_src_26000.capacity
+        , listings_src_26000.active_from AS listing__window_start__day
+        , DATE_TRUNC('week', listings_src_26000.active_from) AS listing__window_start__week
+        , DATE_TRUNC('month', listings_src_26000.active_from) AS listing__window_start__month
+        , DATE_TRUNC('quarter', listings_src_26000.active_from) AS listing__window_start__quarter
+        , DATE_TRUNC('year', listings_src_26000.active_from) AS listing__window_start__year
+        , EXTRACT(year FROM listings_src_26000.active_from) AS listing__window_start__extract_year
+        , EXTRACT(quarter FROM listings_src_26000.active_from) AS listing__window_start__extract_quarter
+        , EXTRACT(month FROM listings_src_26000.active_from) AS listing__window_start__extract_month
+        , EXTRACT(day FROM listings_src_26000.active_from) AS listing__window_start__extract_day
+        , CASE WHEN EXTRACT(dow FROM listings_src_26000.active_from) = 0 THEN EXTRACT(dow FROM listings_src_26000.active_from) + 7 ELSE EXTRACT(dow FROM listings_src_26000.active_from) END AS listing__window_start__extract_dow
+        , EXTRACT(doy FROM listings_src_26000.active_from) AS listing__window_start__extract_doy
+        , listings_src_26000.active_to AS listing__window_end__day
+        , DATE_TRUNC('week', listings_src_26000.active_to) AS listing__window_end__week
+        , DATE_TRUNC('month', listings_src_26000.active_to) AS listing__window_end__month
+        , DATE_TRUNC('quarter', listings_src_26000.active_to) AS listing__window_end__quarter
+        , DATE_TRUNC('year', listings_src_26000.active_to) AS listing__window_end__year
+        , EXTRACT(year FROM listings_src_26000.active_to) AS listing__window_end__extract_year
+        , EXTRACT(quarter FROM listings_src_26000.active_to) AS listing__window_end__extract_quarter
+        , EXTRACT(month FROM listings_src_26000.active_to) AS listing__window_end__extract_month
+        , EXTRACT(day FROM listings_src_26000.active_to) AS listing__window_end__extract_day
+        , CASE WHEN EXTRACT(dow FROM listings_src_26000.active_to) = 0 THEN EXTRACT(dow FROM listings_src_26000.active_to) + 7 ELSE EXTRACT(dow FROM listings_src_26000.active_to) END AS listing__window_end__extract_dow
+        , EXTRACT(doy FROM listings_src_26000.active_to) AS listing__window_end__extract_doy
+        , listings_src_26000.country AS listing__country
+        , listings_src_26000.is_lux AS listing__is_lux
+        , listings_src_26000.capacity AS listing__capacity
+        , listings_src_26000.listing_id AS listing
+        , listings_src_26000.user_id AS user
+        , listings_src_26000.user_id AS listing__user
+      FROM ***************************.dim_listings listings_src_26000
+    ) subq_0
+    CROSS JOIN (
+      -- Pass Only Elements: ['metric_time__month',]
+      SELECT
+        subq_2.metric_time__month
+      FROM (
+        -- Metric Time Dimension 'ds'
+        SELECT
+          subq_1.ds__day
+          , subq_1.ds__week
+          , subq_1.ds__month
+          , subq_1.ds__quarter
+          , subq_1.ds__year
+          , subq_1.ds__extract_year
+          , subq_1.ds__extract_quarter
+          , subq_1.ds__extract_month
+          , subq_1.ds__extract_day
+          , subq_1.ds__extract_dow
+          , subq_1.ds__extract_doy
+          , subq_1.ds__alien_day
+          , subq_1.ds__day AS metric_time__day
+          , subq_1.ds__week AS metric_time__week
+          , subq_1.ds__month AS metric_time__month
+          , subq_1.ds__quarter AS metric_time__quarter
+          , subq_1.ds__year AS metric_time__year
+          , subq_1.ds__extract_year AS metric_time__extract_year
+          , subq_1.ds__extract_quarter AS metric_time__extract_quarter
+          , subq_1.ds__extract_month AS metric_time__extract_month
+          , subq_1.ds__extract_day AS metric_time__extract_day
+          , subq_1.ds__extract_dow AS metric_time__extract_dow
+          , subq_1.ds__extract_doy AS metric_time__extract_doy
+          , subq_1.ds__alien_day AS metric_time__alien_day
+        FROM (
+          -- Read From Time Spine 'mf_time_spine'
+          SELECT
+            time_spine_src_26006.ds AS ds__day
+            , DATE_TRUNC('week', time_spine_src_26006.ds) AS ds__week
+            , DATE_TRUNC('month', time_spine_src_26006.ds) AS ds__month
+            , DATE_TRUNC('quarter', time_spine_src_26006.ds) AS ds__quarter
+            , DATE_TRUNC('year', time_spine_src_26006.ds) AS ds__year
+            , EXTRACT(year FROM time_spine_src_26006.ds) AS ds__extract_year
+            , EXTRACT(quarter FROM time_spine_src_26006.ds) AS ds__extract_quarter
+            , EXTRACT(month FROM time_spine_src_26006.ds) AS ds__extract_month
+            , EXTRACT(day FROM time_spine_src_26006.ds) AS ds__extract_day
+            , CASE WHEN EXTRACT(dow FROM time_spine_src_26006.ds) = 0 THEN EXTRACT(dow FROM time_spine_src_26006.ds) + 7 ELSE EXTRACT(dow FROM time_spine_src_26006.ds) END AS ds__extract_dow
+            , EXTRACT(doy FROM time_spine_src_26006.ds) AS ds__extract_doy
+            , time_spine_src_26006.alien_day AS ds__alien_day
+          FROM ***************************.mf_time_spine time_spine_src_26006
+        ) subq_1
+      ) subq_2
+    ) subq_3
+    FULL OUTER JOIN (
+      -- Pass Only Elements: ['home_state_latest', 'user']
+      SELECT
+        subq_4.user
+        , subq_4.home_state_latest
+      FROM (
+        -- Read Elements From Semantic Model 'users_latest'
+        SELECT
+          DATE_TRUNC('day', users_latest_src_26000.ds) AS ds__day
+          , DATE_TRUNC('week', users_latest_src_26000.ds) AS ds__week
+          , DATE_TRUNC('month', users_latest_src_26000.ds) AS ds__month
+          , DATE_TRUNC('quarter', users_latest_src_26000.ds) AS ds__quarter
+          , DATE_TRUNC('year', users_latest_src_26000.ds) AS ds__year
+          , EXTRACT(year FROM users_latest_src_26000.ds) AS ds__extract_year
+          , EXTRACT(quarter FROM users_latest_src_26000.ds) AS ds__extract_quarter
+          , EXTRACT(month FROM users_latest_src_26000.ds) AS ds__extract_month
+          , EXTRACT(day FROM users_latest_src_26000.ds) AS ds__extract_day
+          , CASE WHEN EXTRACT(dow FROM users_latest_src_26000.ds) = 0 THEN EXTRACT(dow FROM users_latest_src_26000.ds) + 7 ELSE EXTRACT(dow FROM users_latest_src_26000.ds) END AS ds__extract_dow
+          , EXTRACT(doy FROM users_latest_src_26000.ds) AS ds__extract_doy
+          , users_latest_src_26000.home_state_latest
+          , DATE_TRUNC('day', users_latest_src_26000.ds) AS user__ds__day
+          , DATE_TRUNC('week', users_latest_src_26000.ds) AS user__ds__week
+          , DATE_TRUNC('month', users_latest_src_26000.ds) AS user__ds__month
+          , DATE_TRUNC('quarter', users_latest_src_26000.ds) AS user__ds__quarter
+          , DATE_TRUNC('year', users_latest_src_26000.ds) AS user__ds__year
+          , EXTRACT(year FROM users_latest_src_26000.ds) AS user__ds__extract_year
+          , EXTRACT(quarter FROM users_latest_src_26000.ds) AS user__ds__extract_quarter
+          , EXTRACT(month FROM users_latest_src_26000.ds) AS user__ds__extract_month
+          , EXTRACT(day FROM users_latest_src_26000.ds) AS user__ds__extract_day
+          , CASE WHEN EXTRACT(dow FROM users_latest_src_26000.ds) = 0 THEN EXTRACT(dow FROM users_latest_src_26000.ds) + 7 ELSE EXTRACT(dow FROM users_latest_src_26000.ds) END AS user__ds__extract_dow
+          , EXTRACT(doy FROM users_latest_src_26000.ds) AS user__ds__extract_doy
+          , users_latest_src_26000.home_state_latest AS user__home_state_latest
+          , users_latest_src_26000.user_id AS user
+        FROM ***************************.dim_users_latest users_latest_src_26000
+      ) subq_4
+    ) subq_5
+    ON
+      subq_0.user = subq_5.user
+  ) subq_6
+  WHERE user__home_state_latest = 'CA'
+) subq_7

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Redshift/test_no_dedupe__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Redshift/test_no_dedupe__plan0_optimized.sql
@@ -1,0 +1,24 @@
+test_name: test_no_dedupe
+test_filename: test_query_rendering.py
+sql_engine: Redshift
+---
+-- Constrain Output with WHERE
+-- Pass Only Elements: ['listing__capacity', 'metric_time__month']
+SELECT
+  metric_time__month
+  , listing__capacity
+FROM (
+  -- Join Standard Outputs
+  SELECT
+    users_latest_src_26000.home_state_latest AS user__home_state_latest
+    , DATE_TRUNC('month', time_spine_src_26006.ds) AS metric_time__month
+    , listings_src_26000.capacity AS listing__capacity
+  FROM ***************************.dim_listings listings_src_26000
+  CROSS JOIN
+    ***************************.mf_time_spine time_spine_src_26006
+  FULL OUTER JOIN
+    ***************************.dim_users_latest users_latest_src_26000
+  ON
+    listings_src_26000.user_id = users_latest_src_26000.user_id
+) subq_14
+WHERE user__home_state_latest = 'CA'

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Redshift/test_no_dedupe_saved_query__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Redshift/test_no_dedupe_saved_query__plan0.sql
@@ -1,0 +1,282 @@
+test_name: test_no_dedupe_saved_query
+test_filename: test_query_rendering.py
+sql_engine: Redshift
+---
+-- Pass Only Elements: ['listing__capacity_latest', 'metric_time__month']
+SELECT
+  subq_7.metric_time__month
+  , subq_7.listing__capacity_latest
+FROM (
+  -- Constrain Output with WHERE
+  SELECT
+    subq_6.ds__day
+    , subq_6.ds__week
+    , subq_6.ds__month
+    , subq_6.ds__quarter
+    , subq_6.ds__year
+    , subq_6.ds__extract_year
+    , subq_6.ds__extract_quarter
+    , subq_6.ds__extract_month
+    , subq_6.ds__extract_day
+    , subq_6.ds__extract_dow
+    , subq_6.ds__extract_doy
+    , subq_6.created_at__day
+    , subq_6.created_at__week
+    , subq_6.created_at__month
+    , subq_6.created_at__quarter
+    , subq_6.created_at__year
+    , subq_6.created_at__extract_year
+    , subq_6.created_at__extract_quarter
+    , subq_6.created_at__extract_month
+    , subq_6.created_at__extract_day
+    , subq_6.created_at__extract_dow
+    , subq_6.created_at__extract_doy
+    , subq_6.listing__ds__day
+    , subq_6.listing__ds__week
+    , subq_6.listing__ds__month
+    , subq_6.listing__ds__quarter
+    , subq_6.listing__ds__year
+    , subq_6.listing__ds__extract_year
+    , subq_6.listing__ds__extract_quarter
+    , subq_6.listing__ds__extract_month
+    , subq_6.listing__ds__extract_day
+    , subq_6.listing__ds__extract_dow
+    , subq_6.listing__ds__extract_doy
+    , subq_6.listing__created_at__day
+    , subq_6.listing__created_at__week
+    , subq_6.listing__created_at__month
+    , subq_6.listing__created_at__quarter
+    , subq_6.listing__created_at__year
+    , subq_6.listing__created_at__extract_year
+    , subq_6.listing__created_at__extract_quarter
+    , subq_6.listing__created_at__extract_month
+    , subq_6.listing__created_at__extract_day
+    , subq_6.listing__created_at__extract_dow
+    , subq_6.listing__created_at__extract_doy
+    , subq_6.metric_time__month
+    , subq_6.listing
+    , subq_6.user
+    , subq_6.listing__user
+    , subq_6.country_latest
+    , subq_6.is_lux_latest
+    , subq_6.capacity_latest
+    , subq_6.listing__country_latest
+    , subq_6.listing__is_lux_latest
+    , subq_6.listing__capacity_latest
+    , subq_6.user__home_state_latest
+    , subq_6.listings
+    , subq_6.largest_listing
+    , subq_6.smallest_listing
+  FROM (
+    -- Join Standard Outputs
+    SELECT
+      subq_5.home_state_latest AS user__home_state_latest
+      , subq_0.ds__day AS ds__day
+      , subq_0.ds__week AS ds__week
+      , subq_0.ds__month AS ds__month
+      , subq_0.ds__quarter AS ds__quarter
+      , subq_0.ds__year AS ds__year
+      , subq_0.ds__extract_year AS ds__extract_year
+      , subq_0.ds__extract_quarter AS ds__extract_quarter
+      , subq_0.ds__extract_month AS ds__extract_month
+      , subq_0.ds__extract_day AS ds__extract_day
+      , subq_0.ds__extract_dow AS ds__extract_dow
+      , subq_0.ds__extract_doy AS ds__extract_doy
+      , subq_0.created_at__day AS created_at__day
+      , subq_0.created_at__week AS created_at__week
+      , subq_0.created_at__month AS created_at__month
+      , subq_0.created_at__quarter AS created_at__quarter
+      , subq_0.created_at__year AS created_at__year
+      , subq_0.created_at__extract_year AS created_at__extract_year
+      , subq_0.created_at__extract_quarter AS created_at__extract_quarter
+      , subq_0.created_at__extract_month AS created_at__extract_month
+      , subq_0.created_at__extract_day AS created_at__extract_day
+      , subq_0.created_at__extract_dow AS created_at__extract_dow
+      , subq_0.created_at__extract_doy AS created_at__extract_doy
+      , subq_0.listing__ds__day AS listing__ds__day
+      , subq_0.listing__ds__week AS listing__ds__week
+      , subq_0.listing__ds__month AS listing__ds__month
+      , subq_0.listing__ds__quarter AS listing__ds__quarter
+      , subq_0.listing__ds__year AS listing__ds__year
+      , subq_0.listing__ds__extract_year AS listing__ds__extract_year
+      , subq_0.listing__ds__extract_quarter AS listing__ds__extract_quarter
+      , subq_0.listing__ds__extract_month AS listing__ds__extract_month
+      , subq_0.listing__ds__extract_day AS listing__ds__extract_day
+      , subq_0.listing__ds__extract_dow AS listing__ds__extract_dow
+      , subq_0.listing__ds__extract_doy AS listing__ds__extract_doy
+      , subq_0.listing__created_at__day AS listing__created_at__day
+      , subq_0.listing__created_at__week AS listing__created_at__week
+      , subq_0.listing__created_at__month AS listing__created_at__month
+      , subq_0.listing__created_at__quarter AS listing__created_at__quarter
+      , subq_0.listing__created_at__year AS listing__created_at__year
+      , subq_0.listing__created_at__extract_year AS listing__created_at__extract_year
+      , subq_0.listing__created_at__extract_quarter AS listing__created_at__extract_quarter
+      , subq_0.listing__created_at__extract_month AS listing__created_at__extract_month
+      , subq_0.listing__created_at__extract_day AS listing__created_at__extract_day
+      , subq_0.listing__created_at__extract_dow AS listing__created_at__extract_dow
+      , subq_0.listing__created_at__extract_doy AS listing__created_at__extract_doy
+      , subq_3.metric_time__month AS metric_time__month
+      , subq_0.listing AS listing
+      , subq_0.user AS user
+      , subq_0.listing__user AS listing__user
+      , subq_0.country_latest AS country_latest
+      , subq_0.is_lux_latest AS is_lux_latest
+      , subq_0.capacity_latest AS capacity_latest
+      , subq_0.listing__country_latest AS listing__country_latest
+      , subq_0.listing__is_lux_latest AS listing__is_lux_latest
+      , subq_0.listing__capacity_latest AS listing__capacity_latest
+      , subq_0.listings AS listings
+      , subq_0.largest_listing AS largest_listing
+      , subq_0.smallest_listing AS smallest_listing
+    FROM (
+      -- Read Elements From Semantic Model 'listings_latest'
+      SELECT
+        1 AS listings
+        , listings_latest_src_28000.capacity AS largest_listing
+        , listings_latest_src_28000.capacity AS smallest_listing
+        , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS ds__day
+        , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS ds__week
+        , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS ds__month
+        , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS ds__quarter
+        , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS ds__year
+        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS ds__extract_year
+        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS ds__extract_quarter
+        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS ds__extract_month
+        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS ds__extract_day
+        , CASE WHEN EXTRACT(dow FROM listings_latest_src_28000.created_at) = 0 THEN EXTRACT(dow FROM listings_latest_src_28000.created_at) + 7 ELSE EXTRACT(dow FROM listings_latest_src_28000.created_at) END AS ds__extract_dow
+        , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS ds__extract_doy
+        , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS created_at__day
+        , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS created_at__week
+        , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS created_at__month
+        , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS created_at__quarter
+        , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS created_at__year
+        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS created_at__extract_year
+        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS created_at__extract_quarter
+        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS created_at__extract_month
+        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS created_at__extract_day
+        , CASE WHEN EXTRACT(dow FROM listings_latest_src_28000.created_at) = 0 THEN EXTRACT(dow FROM listings_latest_src_28000.created_at) + 7 ELSE EXTRACT(dow FROM listings_latest_src_28000.created_at) END AS created_at__extract_dow
+        , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS created_at__extract_doy
+        , listings_latest_src_28000.country AS country_latest
+        , listings_latest_src_28000.is_lux AS is_lux_latest
+        , listings_latest_src_28000.capacity AS capacity_latest
+        , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__ds__day
+        , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__ds__week
+        , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__ds__month
+        , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__ds__quarter
+        , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__ds__year
+        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__ds__extract_year
+        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__ds__extract_quarter
+        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__ds__extract_month
+        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__ds__extract_day
+        , CASE WHEN EXTRACT(dow FROM listings_latest_src_28000.created_at) = 0 THEN EXTRACT(dow FROM listings_latest_src_28000.created_at) + 7 ELSE EXTRACT(dow FROM listings_latest_src_28000.created_at) END AS listing__ds__extract_dow
+        , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__ds__extract_doy
+        , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__created_at__day
+        , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__created_at__week
+        , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__created_at__month
+        , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__created_at__quarter
+        , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__created_at__year
+        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_year
+        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_quarter
+        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_month
+        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_day
+        , CASE WHEN EXTRACT(dow FROM listings_latest_src_28000.created_at) = 0 THEN EXTRACT(dow FROM listings_latest_src_28000.created_at) + 7 ELSE EXTRACT(dow FROM listings_latest_src_28000.created_at) END AS listing__created_at__extract_dow
+        , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_doy
+        , listings_latest_src_28000.country AS listing__country_latest
+        , listings_latest_src_28000.is_lux AS listing__is_lux_latest
+        , listings_latest_src_28000.capacity AS listing__capacity_latest
+        , listings_latest_src_28000.listing_id AS listing
+        , listings_latest_src_28000.user_id AS user
+        , listings_latest_src_28000.user_id AS listing__user
+      FROM ***************************.dim_listings_latest listings_latest_src_28000
+    ) subq_0
+    CROSS JOIN (
+      -- Pass Only Elements: ['metric_time__month',]
+      SELECT
+        subq_2.metric_time__month
+      FROM (
+        -- Metric Time Dimension 'ds'
+        SELECT
+          subq_1.ds__day
+          , subq_1.ds__week
+          , subq_1.ds__month
+          , subq_1.ds__quarter
+          , subq_1.ds__year
+          , subq_1.ds__extract_year
+          , subq_1.ds__extract_quarter
+          , subq_1.ds__extract_month
+          , subq_1.ds__extract_day
+          , subq_1.ds__extract_dow
+          , subq_1.ds__extract_doy
+          , subq_1.ds__alien_day
+          , subq_1.ds__day AS metric_time__day
+          , subq_1.ds__week AS metric_time__week
+          , subq_1.ds__month AS metric_time__month
+          , subq_1.ds__quarter AS metric_time__quarter
+          , subq_1.ds__year AS metric_time__year
+          , subq_1.ds__extract_year AS metric_time__extract_year
+          , subq_1.ds__extract_quarter AS metric_time__extract_quarter
+          , subq_1.ds__extract_month AS metric_time__extract_month
+          , subq_1.ds__extract_day AS metric_time__extract_day
+          , subq_1.ds__extract_dow AS metric_time__extract_dow
+          , subq_1.ds__extract_doy AS metric_time__extract_doy
+          , subq_1.ds__alien_day AS metric_time__alien_day
+        FROM (
+          -- Read From Time Spine 'mf_time_spine'
+          SELECT
+            time_spine_src_28006.ds AS ds__day
+            , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week
+            , DATE_TRUNC('month', time_spine_src_28006.ds) AS ds__month
+            , DATE_TRUNC('quarter', time_spine_src_28006.ds) AS ds__quarter
+            , DATE_TRUNC('year', time_spine_src_28006.ds) AS ds__year
+            , EXTRACT(year FROM time_spine_src_28006.ds) AS ds__extract_year
+            , EXTRACT(quarter FROM time_spine_src_28006.ds) AS ds__extract_quarter
+            , EXTRACT(month FROM time_spine_src_28006.ds) AS ds__extract_month
+            , EXTRACT(day FROM time_spine_src_28006.ds) AS ds__extract_day
+            , CASE WHEN EXTRACT(dow FROM time_spine_src_28006.ds) = 0 THEN EXTRACT(dow FROM time_spine_src_28006.ds) + 7 ELSE EXTRACT(dow FROM time_spine_src_28006.ds) END AS ds__extract_dow
+            , EXTRACT(doy FROM time_spine_src_28006.ds) AS ds__extract_doy
+            , time_spine_src_28006.alien_day AS ds__alien_day
+          FROM ***************************.mf_time_spine time_spine_src_28006
+        ) subq_1
+      ) subq_2
+    ) subq_3
+    FULL OUTER JOIN (
+      -- Pass Only Elements: ['home_state_latest', 'user']
+      SELECT
+        subq_4.user
+        , subq_4.home_state_latest
+      FROM (
+        -- Read Elements From Semantic Model 'users_latest'
+        SELECT
+          DATE_TRUNC('day', users_latest_src_28000.ds) AS ds_latest__day
+          , DATE_TRUNC('week', users_latest_src_28000.ds) AS ds_latest__week
+          , DATE_TRUNC('month', users_latest_src_28000.ds) AS ds_latest__month
+          , DATE_TRUNC('quarter', users_latest_src_28000.ds) AS ds_latest__quarter
+          , DATE_TRUNC('year', users_latest_src_28000.ds) AS ds_latest__year
+          , EXTRACT(year FROM users_latest_src_28000.ds) AS ds_latest__extract_year
+          , EXTRACT(quarter FROM users_latest_src_28000.ds) AS ds_latest__extract_quarter
+          , EXTRACT(month FROM users_latest_src_28000.ds) AS ds_latest__extract_month
+          , EXTRACT(day FROM users_latest_src_28000.ds) AS ds_latest__extract_day
+          , CASE WHEN EXTRACT(dow FROM users_latest_src_28000.ds) = 0 THEN EXTRACT(dow FROM users_latest_src_28000.ds) + 7 ELSE EXTRACT(dow FROM users_latest_src_28000.ds) END AS ds_latest__extract_dow
+          , EXTRACT(doy FROM users_latest_src_28000.ds) AS ds_latest__extract_doy
+          , users_latest_src_28000.home_state_latest
+          , DATE_TRUNC('day', users_latest_src_28000.ds) AS user__ds_latest__day
+          , DATE_TRUNC('week', users_latest_src_28000.ds) AS user__ds_latest__week
+          , DATE_TRUNC('month', users_latest_src_28000.ds) AS user__ds_latest__month
+          , DATE_TRUNC('quarter', users_latest_src_28000.ds) AS user__ds_latest__quarter
+          , DATE_TRUNC('year', users_latest_src_28000.ds) AS user__ds_latest__year
+          , EXTRACT(year FROM users_latest_src_28000.ds) AS user__ds_latest__extract_year
+          , EXTRACT(quarter FROM users_latest_src_28000.ds) AS user__ds_latest__extract_quarter
+          , EXTRACT(month FROM users_latest_src_28000.ds) AS user__ds_latest__extract_month
+          , EXTRACT(day FROM users_latest_src_28000.ds) AS user__ds_latest__extract_day
+          , CASE WHEN EXTRACT(dow FROM users_latest_src_28000.ds) = 0 THEN EXTRACT(dow FROM users_latest_src_28000.ds) + 7 ELSE EXTRACT(dow FROM users_latest_src_28000.ds) END AS user__ds_latest__extract_dow
+          , EXTRACT(doy FROM users_latest_src_28000.ds) AS user__ds_latest__extract_doy
+          , users_latest_src_28000.home_state_latest AS user__home_state_latest
+          , users_latest_src_28000.user_id AS user
+        FROM ***************************.dim_users_latest users_latest_src_28000
+      ) subq_4
+    ) subq_5
+    ON
+      subq_0.user = subq_5.user
+  ) subq_6
+  WHERE user__home_state_latest = 'CA'
+) subq_7

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Redshift/test_no_dedupe_saved_query__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Redshift/test_no_dedupe_saved_query__plan0_optimized.sql
@@ -1,0 +1,24 @@
+test_name: test_no_dedupe_saved_query
+test_filename: test_query_rendering.py
+sql_engine: Redshift
+---
+-- Constrain Output with WHERE
+-- Pass Only Elements: ['listing__capacity_latest', 'metric_time__month']
+SELECT
+  metric_time__month
+  , listing__capacity_latest
+FROM (
+  -- Join Standard Outputs
+  SELECT
+    users_latest_src_28000.home_state_latest AS user__home_state_latest
+    , DATE_TRUNC('month', time_spine_src_28006.ds) AS metric_time__month
+    , listings_latest_src_28000.capacity AS listing__capacity_latest
+  FROM ***************************.dim_listings_latest listings_latest_src_28000
+  CROSS JOIN
+    ***************************.mf_time_spine time_spine_src_28006
+  FULL OUTER JOIN
+    ***************************.dim_users_latest users_latest_src_28000
+  ON
+    listings_latest_src_28000.user_id = users_latest_src_28000.user_id
+) subq_14
+WHERE user__home_state_latest = 'CA'

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Snowflake/test_no_dedupe__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Snowflake/test_no_dedupe__plan0.sql
@@ -1,0 +1,273 @@
+test_name: test_no_dedupe
+test_filename: test_query_rendering.py
+sql_engine: Snowflake
+---
+-- Pass Only Elements: ['listing__capacity', 'metric_time__month']
+SELECT
+  subq_7.metric_time__month
+  , subq_7.listing__capacity
+FROM (
+  -- Constrain Output with WHERE
+  SELECT
+    subq_6.window_start__day
+    , subq_6.window_start__week
+    , subq_6.window_start__month
+    , subq_6.window_start__quarter
+    , subq_6.window_start__year
+    , subq_6.window_start__extract_year
+    , subq_6.window_start__extract_quarter
+    , subq_6.window_start__extract_month
+    , subq_6.window_start__extract_day
+    , subq_6.window_start__extract_dow
+    , subq_6.window_start__extract_doy
+    , subq_6.window_end__day
+    , subq_6.window_end__week
+    , subq_6.window_end__month
+    , subq_6.window_end__quarter
+    , subq_6.window_end__year
+    , subq_6.window_end__extract_year
+    , subq_6.window_end__extract_quarter
+    , subq_6.window_end__extract_month
+    , subq_6.window_end__extract_day
+    , subq_6.window_end__extract_dow
+    , subq_6.window_end__extract_doy
+    , subq_6.listing__window_start__day
+    , subq_6.listing__window_start__week
+    , subq_6.listing__window_start__month
+    , subq_6.listing__window_start__quarter
+    , subq_6.listing__window_start__year
+    , subq_6.listing__window_start__extract_year
+    , subq_6.listing__window_start__extract_quarter
+    , subq_6.listing__window_start__extract_month
+    , subq_6.listing__window_start__extract_day
+    , subq_6.listing__window_start__extract_dow
+    , subq_6.listing__window_start__extract_doy
+    , subq_6.listing__window_end__day
+    , subq_6.listing__window_end__week
+    , subq_6.listing__window_end__month
+    , subq_6.listing__window_end__quarter
+    , subq_6.listing__window_end__year
+    , subq_6.listing__window_end__extract_year
+    , subq_6.listing__window_end__extract_quarter
+    , subq_6.listing__window_end__extract_month
+    , subq_6.listing__window_end__extract_day
+    , subq_6.listing__window_end__extract_dow
+    , subq_6.listing__window_end__extract_doy
+    , subq_6.metric_time__month
+    , subq_6.listing
+    , subq_6.user
+    , subq_6.listing__user
+    , subq_6.country
+    , subq_6.is_lux
+    , subq_6.capacity
+    , subq_6.listing__country
+    , subq_6.listing__is_lux
+    , subq_6.listing__capacity
+    , subq_6.user__home_state_latest
+  FROM (
+    -- Join Standard Outputs
+    SELECT
+      subq_5.home_state_latest AS user__home_state_latest
+      , subq_0.window_start__day AS window_start__day
+      , subq_0.window_start__week AS window_start__week
+      , subq_0.window_start__month AS window_start__month
+      , subq_0.window_start__quarter AS window_start__quarter
+      , subq_0.window_start__year AS window_start__year
+      , subq_0.window_start__extract_year AS window_start__extract_year
+      , subq_0.window_start__extract_quarter AS window_start__extract_quarter
+      , subq_0.window_start__extract_month AS window_start__extract_month
+      , subq_0.window_start__extract_day AS window_start__extract_day
+      , subq_0.window_start__extract_dow AS window_start__extract_dow
+      , subq_0.window_start__extract_doy AS window_start__extract_doy
+      , subq_0.window_end__day AS window_end__day
+      , subq_0.window_end__week AS window_end__week
+      , subq_0.window_end__month AS window_end__month
+      , subq_0.window_end__quarter AS window_end__quarter
+      , subq_0.window_end__year AS window_end__year
+      , subq_0.window_end__extract_year AS window_end__extract_year
+      , subq_0.window_end__extract_quarter AS window_end__extract_quarter
+      , subq_0.window_end__extract_month AS window_end__extract_month
+      , subq_0.window_end__extract_day AS window_end__extract_day
+      , subq_0.window_end__extract_dow AS window_end__extract_dow
+      , subq_0.window_end__extract_doy AS window_end__extract_doy
+      , subq_0.listing__window_start__day AS listing__window_start__day
+      , subq_0.listing__window_start__week AS listing__window_start__week
+      , subq_0.listing__window_start__month AS listing__window_start__month
+      , subq_0.listing__window_start__quarter AS listing__window_start__quarter
+      , subq_0.listing__window_start__year AS listing__window_start__year
+      , subq_0.listing__window_start__extract_year AS listing__window_start__extract_year
+      , subq_0.listing__window_start__extract_quarter AS listing__window_start__extract_quarter
+      , subq_0.listing__window_start__extract_month AS listing__window_start__extract_month
+      , subq_0.listing__window_start__extract_day AS listing__window_start__extract_day
+      , subq_0.listing__window_start__extract_dow AS listing__window_start__extract_dow
+      , subq_0.listing__window_start__extract_doy AS listing__window_start__extract_doy
+      , subq_0.listing__window_end__day AS listing__window_end__day
+      , subq_0.listing__window_end__week AS listing__window_end__week
+      , subq_0.listing__window_end__month AS listing__window_end__month
+      , subq_0.listing__window_end__quarter AS listing__window_end__quarter
+      , subq_0.listing__window_end__year AS listing__window_end__year
+      , subq_0.listing__window_end__extract_year AS listing__window_end__extract_year
+      , subq_0.listing__window_end__extract_quarter AS listing__window_end__extract_quarter
+      , subq_0.listing__window_end__extract_month AS listing__window_end__extract_month
+      , subq_0.listing__window_end__extract_day AS listing__window_end__extract_day
+      , subq_0.listing__window_end__extract_dow AS listing__window_end__extract_dow
+      , subq_0.listing__window_end__extract_doy AS listing__window_end__extract_doy
+      , subq_3.metric_time__month AS metric_time__month
+      , subq_0.listing AS listing
+      , subq_0.user AS user
+      , subq_0.listing__user AS listing__user
+      , subq_0.country AS country
+      , subq_0.is_lux AS is_lux
+      , subq_0.capacity AS capacity
+      , subq_0.listing__country AS listing__country
+      , subq_0.listing__is_lux AS listing__is_lux
+      , subq_0.listing__capacity AS listing__capacity
+    FROM (
+      -- Read Elements From Semantic Model 'listings'
+      SELECT
+        listings_src_26000.active_from AS window_start__day
+        , DATE_TRUNC('week', listings_src_26000.active_from) AS window_start__week
+        , DATE_TRUNC('month', listings_src_26000.active_from) AS window_start__month
+        , DATE_TRUNC('quarter', listings_src_26000.active_from) AS window_start__quarter
+        , DATE_TRUNC('year', listings_src_26000.active_from) AS window_start__year
+        , EXTRACT(year FROM listings_src_26000.active_from) AS window_start__extract_year
+        , EXTRACT(quarter FROM listings_src_26000.active_from) AS window_start__extract_quarter
+        , EXTRACT(month FROM listings_src_26000.active_from) AS window_start__extract_month
+        , EXTRACT(day FROM listings_src_26000.active_from) AS window_start__extract_day
+        , EXTRACT(dayofweekiso FROM listings_src_26000.active_from) AS window_start__extract_dow
+        , EXTRACT(doy FROM listings_src_26000.active_from) AS window_start__extract_doy
+        , listings_src_26000.active_to AS window_end__day
+        , DATE_TRUNC('week', listings_src_26000.active_to) AS window_end__week
+        , DATE_TRUNC('month', listings_src_26000.active_to) AS window_end__month
+        , DATE_TRUNC('quarter', listings_src_26000.active_to) AS window_end__quarter
+        , DATE_TRUNC('year', listings_src_26000.active_to) AS window_end__year
+        , EXTRACT(year FROM listings_src_26000.active_to) AS window_end__extract_year
+        , EXTRACT(quarter FROM listings_src_26000.active_to) AS window_end__extract_quarter
+        , EXTRACT(month FROM listings_src_26000.active_to) AS window_end__extract_month
+        , EXTRACT(day FROM listings_src_26000.active_to) AS window_end__extract_day
+        , EXTRACT(dayofweekiso FROM listings_src_26000.active_to) AS window_end__extract_dow
+        , EXTRACT(doy FROM listings_src_26000.active_to) AS window_end__extract_doy
+        , listings_src_26000.country
+        , listings_src_26000.is_lux
+        , listings_src_26000.capacity
+        , listings_src_26000.active_from AS listing__window_start__day
+        , DATE_TRUNC('week', listings_src_26000.active_from) AS listing__window_start__week
+        , DATE_TRUNC('month', listings_src_26000.active_from) AS listing__window_start__month
+        , DATE_TRUNC('quarter', listings_src_26000.active_from) AS listing__window_start__quarter
+        , DATE_TRUNC('year', listings_src_26000.active_from) AS listing__window_start__year
+        , EXTRACT(year FROM listings_src_26000.active_from) AS listing__window_start__extract_year
+        , EXTRACT(quarter FROM listings_src_26000.active_from) AS listing__window_start__extract_quarter
+        , EXTRACT(month FROM listings_src_26000.active_from) AS listing__window_start__extract_month
+        , EXTRACT(day FROM listings_src_26000.active_from) AS listing__window_start__extract_day
+        , EXTRACT(dayofweekiso FROM listings_src_26000.active_from) AS listing__window_start__extract_dow
+        , EXTRACT(doy FROM listings_src_26000.active_from) AS listing__window_start__extract_doy
+        , listings_src_26000.active_to AS listing__window_end__day
+        , DATE_TRUNC('week', listings_src_26000.active_to) AS listing__window_end__week
+        , DATE_TRUNC('month', listings_src_26000.active_to) AS listing__window_end__month
+        , DATE_TRUNC('quarter', listings_src_26000.active_to) AS listing__window_end__quarter
+        , DATE_TRUNC('year', listings_src_26000.active_to) AS listing__window_end__year
+        , EXTRACT(year FROM listings_src_26000.active_to) AS listing__window_end__extract_year
+        , EXTRACT(quarter FROM listings_src_26000.active_to) AS listing__window_end__extract_quarter
+        , EXTRACT(month FROM listings_src_26000.active_to) AS listing__window_end__extract_month
+        , EXTRACT(day FROM listings_src_26000.active_to) AS listing__window_end__extract_day
+        , EXTRACT(dayofweekiso FROM listings_src_26000.active_to) AS listing__window_end__extract_dow
+        , EXTRACT(doy FROM listings_src_26000.active_to) AS listing__window_end__extract_doy
+        , listings_src_26000.country AS listing__country
+        , listings_src_26000.is_lux AS listing__is_lux
+        , listings_src_26000.capacity AS listing__capacity
+        , listings_src_26000.listing_id AS listing
+        , listings_src_26000.user_id AS user
+        , listings_src_26000.user_id AS listing__user
+      FROM ***************************.dim_listings listings_src_26000
+    ) subq_0
+    CROSS JOIN (
+      -- Pass Only Elements: ['metric_time__month',]
+      SELECT
+        subq_2.metric_time__month
+      FROM (
+        -- Metric Time Dimension 'ds'
+        SELECT
+          subq_1.ds__day
+          , subq_1.ds__week
+          , subq_1.ds__month
+          , subq_1.ds__quarter
+          , subq_1.ds__year
+          , subq_1.ds__extract_year
+          , subq_1.ds__extract_quarter
+          , subq_1.ds__extract_month
+          , subq_1.ds__extract_day
+          , subq_1.ds__extract_dow
+          , subq_1.ds__extract_doy
+          , subq_1.ds__alien_day
+          , subq_1.ds__day AS metric_time__day
+          , subq_1.ds__week AS metric_time__week
+          , subq_1.ds__month AS metric_time__month
+          , subq_1.ds__quarter AS metric_time__quarter
+          , subq_1.ds__year AS metric_time__year
+          , subq_1.ds__extract_year AS metric_time__extract_year
+          , subq_1.ds__extract_quarter AS metric_time__extract_quarter
+          , subq_1.ds__extract_month AS metric_time__extract_month
+          , subq_1.ds__extract_day AS metric_time__extract_day
+          , subq_1.ds__extract_dow AS metric_time__extract_dow
+          , subq_1.ds__extract_doy AS metric_time__extract_doy
+          , subq_1.ds__alien_day AS metric_time__alien_day
+        FROM (
+          -- Read From Time Spine 'mf_time_spine'
+          SELECT
+            time_spine_src_26006.ds AS ds__day
+            , DATE_TRUNC('week', time_spine_src_26006.ds) AS ds__week
+            , DATE_TRUNC('month', time_spine_src_26006.ds) AS ds__month
+            , DATE_TRUNC('quarter', time_spine_src_26006.ds) AS ds__quarter
+            , DATE_TRUNC('year', time_spine_src_26006.ds) AS ds__year
+            , EXTRACT(year FROM time_spine_src_26006.ds) AS ds__extract_year
+            , EXTRACT(quarter FROM time_spine_src_26006.ds) AS ds__extract_quarter
+            , EXTRACT(month FROM time_spine_src_26006.ds) AS ds__extract_month
+            , EXTRACT(day FROM time_spine_src_26006.ds) AS ds__extract_day
+            , EXTRACT(dayofweekiso FROM time_spine_src_26006.ds) AS ds__extract_dow
+            , EXTRACT(doy FROM time_spine_src_26006.ds) AS ds__extract_doy
+            , time_spine_src_26006.alien_day AS ds__alien_day
+          FROM ***************************.mf_time_spine time_spine_src_26006
+        ) subq_1
+      ) subq_2
+    ) subq_3
+    FULL OUTER JOIN (
+      -- Pass Only Elements: ['home_state_latest', 'user']
+      SELECT
+        subq_4.user
+        , subq_4.home_state_latest
+      FROM (
+        -- Read Elements From Semantic Model 'users_latest'
+        SELECT
+          DATE_TRUNC('day', users_latest_src_26000.ds) AS ds__day
+          , DATE_TRUNC('week', users_latest_src_26000.ds) AS ds__week
+          , DATE_TRUNC('month', users_latest_src_26000.ds) AS ds__month
+          , DATE_TRUNC('quarter', users_latest_src_26000.ds) AS ds__quarter
+          , DATE_TRUNC('year', users_latest_src_26000.ds) AS ds__year
+          , EXTRACT(year FROM users_latest_src_26000.ds) AS ds__extract_year
+          , EXTRACT(quarter FROM users_latest_src_26000.ds) AS ds__extract_quarter
+          , EXTRACT(month FROM users_latest_src_26000.ds) AS ds__extract_month
+          , EXTRACT(day FROM users_latest_src_26000.ds) AS ds__extract_day
+          , EXTRACT(dayofweekiso FROM users_latest_src_26000.ds) AS ds__extract_dow
+          , EXTRACT(doy FROM users_latest_src_26000.ds) AS ds__extract_doy
+          , users_latest_src_26000.home_state_latest
+          , DATE_TRUNC('day', users_latest_src_26000.ds) AS user__ds__day
+          , DATE_TRUNC('week', users_latest_src_26000.ds) AS user__ds__week
+          , DATE_TRUNC('month', users_latest_src_26000.ds) AS user__ds__month
+          , DATE_TRUNC('quarter', users_latest_src_26000.ds) AS user__ds__quarter
+          , DATE_TRUNC('year', users_latest_src_26000.ds) AS user__ds__year
+          , EXTRACT(year FROM users_latest_src_26000.ds) AS user__ds__extract_year
+          , EXTRACT(quarter FROM users_latest_src_26000.ds) AS user__ds__extract_quarter
+          , EXTRACT(month FROM users_latest_src_26000.ds) AS user__ds__extract_month
+          , EXTRACT(day FROM users_latest_src_26000.ds) AS user__ds__extract_day
+          , EXTRACT(dayofweekiso FROM users_latest_src_26000.ds) AS user__ds__extract_dow
+          , EXTRACT(doy FROM users_latest_src_26000.ds) AS user__ds__extract_doy
+          , users_latest_src_26000.home_state_latest AS user__home_state_latest
+          , users_latest_src_26000.user_id AS user
+        FROM ***************************.dim_users_latest users_latest_src_26000
+      ) subq_4
+    ) subq_5
+    ON
+      subq_0.user = subq_5.user
+  ) subq_6
+  WHERE user__home_state_latest = 'CA'
+) subq_7

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Snowflake/test_no_dedupe__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Snowflake/test_no_dedupe__plan0_optimized.sql
@@ -1,0 +1,24 @@
+test_name: test_no_dedupe
+test_filename: test_query_rendering.py
+sql_engine: Snowflake
+---
+-- Constrain Output with WHERE
+-- Pass Only Elements: ['listing__capacity', 'metric_time__month']
+SELECT
+  metric_time__month
+  , listing__capacity
+FROM (
+  -- Join Standard Outputs
+  SELECT
+    users_latest_src_26000.home_state_latest AS user__home_state_latest
+    , DATE_TRUNC('month', time_spine_src_26006.ds) AS metric_time__month
+    , listings_src_26000.capacity AS listing__capacity
+  FROM ***************************.dim_listings listings_src_26000
+  CROSS JOIN
+    ***************************.mf_time_spine time_spine_src_26006
+  FULL OUTER JOIN
+    ***************************.dim_users_latest users_latest_src_26000
+  ON
+    listings_src_26000.user_id = users_latest_src_26000.user_id
+) subq_14
+WHERE user__home_state_latest = 'CA'

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Snowflake/test_no_dedupe_saved_query__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Snowflake/test_no_dedupe_saved_query__plan0.sql
@@ -1,0 +1,282 @@
+test_name: test_no_dedupe_saved_query
+test_filename: test_query_rendering.py
+sql_engine: Snowflake
+---
+-- Pass Only Elements: ['listing__capacity_latest', 'metric_time__month']
+SELECT
+  subq_7.metric_time__month
+  , subq_7.listing__capacity_latest
+FROM (
+  -- Constrain Output with WHERE
+  SELECT
+    subq_6.ds__day
+    , subq_6.ds__week
+    , subq_6.ds__month
+    , subq_6.ds__quarter
+    , subq_6.ds__year
+    , subq_6.ds__extract_year
+    , subq_6.ds__extract_quarter
+    , subq_6.ds__extract_month
+    , subq_6.ds__extract_day
+    , subq_6.ds__extract_dow
+    , subq_6.ds__extract_doy
+    , subq_6.created_at__day
+    , subq_6.created_at__week
+    , subq_6.created_at__month
+    , subq_6.created_at__quarter
+    , subq_6.created_at__year
+    , subq_6.created_at__extract_year
+    , subq_6.created_at__extract_quarter
+    , subq_6.created_at__extract_month
+    , subq_6.created_at__extract_day
+    , subq_6.created_at__extract_dow
+    , subq_6.created_at__extract_doy
+    , subq_6.listing__ds__day
+    , subq_6.listing__ds__week
+    , subq_6.listing__ds__month
+    , subq_6.listing__ds__quarter
+    , subq_6.listing__ds__year
+    , subq_6.listing__ds__extract_year
+    , subq_6.listing__ds__extract_quarter
+    , subq_6.listing__ds__extract_month
+    , subq_6.listing__ds__extract_day
+    , subq_6.listing__ds__extract_dow
+    , subq_6.listing__ds__extract_doy
+    , subq_6.listing__created_at__day
+    , subq_6.listing__created_at__week
+    , subq_6.listing__created_at__month
+    , subq_6.listing__created_at__quarter
+    , subq_6.listing__created_at__year
+    , subq_6.listing__created_at__extract_year
+    , subq_6.listing__created_at__extract_quarter
+    , subq_6.listing__created_at__extract_month
+    , subq_6.listing__created_at__extract_day
+    , subq_6.listing__created_at__extract_dow
+    , subq_6.listing__created_at__extract_doy
+    , subq_6.metric_time__month
+    , subq_6.listing
+    , subq_6.user
+    , subq_6.listing__user
+    , subq_6.country_latest
+    , subq_6.is_lux_latest
+    , subq_6.capacity_latest
+    , subq_6.listing__country_latest
+    , subq_6.listing__is_lux_latest
+    , subq_6.listing__capacity_latest
+    , subq_6.user__home_state_latest
+    , subq_6.listings
+    , subq_6.largest_listing
+    , subq_6.smallest_listing
+  FROM (
+    -- Join Standard Outputs
+    SELECT
+      subq_5.home_state_latest AS user__home_state_latest
+      , subq_0.ds__day AS ds__day
+      , subq_0.ds__week AS ds__week
+      , subq_0.ds__month AS ds__month
+      , subq_0.ds__quarter AS ds__quarter
+      , subq_0.ds__year AS ds__year
+      , subq_0.ds__extract_year AS ds__extract_year
+      , subq_0.ds__extract_quarter AS ds__extract_quarter
+      , subq_0.ds__extract_month AS ds__extract_month
+      , subq_0.ds__extract_day AS ds__extract_day
+      , subq_0.ds__extract_dow AS ds__extract_dow
+      , subq_0.ds__extract_doy AS ds__extract_doy
+      , subq_0.created_at__day AS created_at__day
+      , subq_0.created_at__week AS created_at__week
+      , subq_0.created_at__month AS created_at__month
+      , subq_0.created_at__quarter AS created_at__quarter
+      , subq_0.created_at__year AS created_at__year
+      , subq_0.created_at__extract_year AS created_at__extract_year
+      , subq_0.created_at__extract_quarter AS created_at__extract_quarter
+      , subq_0.created_at__extract_month AS created_at__extract_month
+      , subq_0.created_at__extract_day AS created_at__extract_day
+      , subq_0.created_at__extract_dow AS created_at__extract_dow
+      , subq_0.created_at__extract_doy AS created_at__extract_doy
+      , subq_0.listing__ds__day AS listing__ds__day
+      , subq_0.listing__ds__week AS listing__ds__week
+      , subq_0.listing__ds__month AS listing__ds__month
+      , subq_0.listing__ds__quarter AS listing__ds__quarter
+      , subq_0.listing__ds__year AS listing__ds__year
+      , subq_0.listing__ds__extract_year AS listing__ds__extract_year
+      , subq_0.listing__ds__extract_quarter AS listing__ds__extract_quarter
+      , subq_0.listing__ds__extract_month AS listing__ds__extract_month
+      , subq_0.listing__ds__extract_day AS listing__ds__extract_day
+      , subq_0.listing__ds__extract_dow AS listing__ds__extract_dow
+      , subq_0.listing__ds__extract_doy AS listing__ds__extract_doy
+      , subq_0.listing__created_at__day AS listing__created_at__day
+      , subq_0.listing__created_at__week AS listing__created_at__week
+      , subq_0.listing__created_at__month AS listing__created_at__month
+      , subq_0.listing__created_at__quarter AS listing__created_at__quarter
+      , subq_0.listing__created_at__year AS listing__created_at__year
+      , subq_0.listing__created_at__extract_year AS listing__created_at__extract_year
+      , subq_0.listing__created_at__extract_quarter AS listing__created_at__extract_quarter
+      , subq_0.listing__created_at__extract_month AS listing__created_at__extract_month
+      , subq_0.listing__created_at__extract_day AS listing__created_at__extract_day
+      , subq_0.listing__created_at__extract_dow AS listing__created_at__extract_dow
+      , subq_0.listing__created_at__extract_doy AS listing__created_at__extract_doy
+      , subq_3.metric_time__month AS metric_time__month
+      , subq_0.listing AS listing
+      , subq_0.user AS user
+      , subq_0.listing__user AS listing__user
+      , subq_0.country_latest AS country_latest
+      , subq_0.is_lux_latest AS is_lux_latest
+      , subq_0.capacity_latest AS capacity_latest
+      , subq_0.listing__country_latest AS listing__country_latest
+      , subq_0.listing__is_lux_latest AS listing__is_lux_latest
+      , subq_0.listing__capacity_latest AS listing__capacity_latest
+      , subq_0.listings AS listings
+      , subq_0.largest_listing AS largest_listing
+      , subq_0.smallest_listing AS smallest_listing
+    FROM (
+      -- Read Elements From Semantic Model 'listings_latest'
+      SELECT
+        1 AS listings
+        , listings_latest_src_28000.capacity AS largest_listing
+        , listings_latest_src_28000.capacity AS smallest_listing
+        , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS ds__day
+        , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS ds__week
+        , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS ds__month
+        , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS ds__quarter
+        , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS ds__year
+        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS ds__extract_year
+        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS ds__extract_quarter
+        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS ds__extract_month
+        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS ds__extract_day
+        , EXTRACT(dayofweekiso FROM listings_latest_src_28000.created_at) AS ds__extract_dow
+        , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS ds__extract_doy
+        , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS created_at__day
+        , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS created_at__week
+        , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS created_at__month
+        , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS created_at__quarter
+        , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS created_at__year
+        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS created_at__extract_year
+        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS created_at__extract_quarter
+        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS created_at__extract_month
+        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS created_at__extract_day
+        , EXTRACT(dayofweekiso FROM listings_latest_src_28000.created_at) AS created_at__extract_dow
+        , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS created_at__extract_doy
+        , listings_latest_src_28000.country AS country_latest
+        , listings_latest_src_28000.is_lux AS is_lux_latest
+        , listings_latest_src_28000.capacity AS capacity_latest
+        , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__ds__day
+        , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__ds__week
+        , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__ds__month
+        , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__ds__quarter
+        , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__ds__year
+        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__ds__extract_year
+        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__ds__extract_quarter
+        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__ds__extract_month
+        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__ds__extract_day
+        , EXTRACT(dayofweekiso FROM listings_latest_src_28000.created_at) AS listing__ds__extract_dow
+        , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__ds__extract_doy
+        , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__created_at__day
+        , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__created_at__week
+        , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__created_at__month
+        , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__created_at__quarter
+        , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__created_at__year
+        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_year
+        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_quarter
+        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_month
+        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_day
+        , EXTRACT(dayofweekiso FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_dow
+        , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_doy
+        , listings_latest_src_28000.country AS listing__country_latest
+        , listings_latest_src_28000.is_lux AS listing__is_lux_latest
+        , listings_latest_src_28000.capacity AS listing__capacity_latest
+        , listings_latest_src_28000.listing_id AS listing
+        , listings_latest_src_28000.user_id AS user
+        , listings_latest_src_28000.user_id AS listing__user
+      FROM ***************************.dim_listings_latest listings_latest_src_28000
+    ) subq_0
+    CROSS JOIN (
+      -- Pass Only Elements: ['metric_time__month',]
+      SELECT
+        subq_2.metric_time__month
+      FROM (
+        -- Metric Time Dimension 'ds'
+        SELECT
+          subq_1.ds__day
+          , subq_1.ds__week
+          , subq_1.ds__month
+          , subq_1.ds__quarter
+          , subq_1.ds__year
+          , subq_1.ds__extract_year
+          , subq_1.ds__extract_quarter
+          , subq_1.ds__extract_month
+          , subq_1.ds__extract_day
+          , subq_1.ds__extract_dow
+          , subq_1.ds__extract_doy
+          , subq_1.ds__alien_day
+          , subq_1.ds__day AS metric_time__day
+          , subq_1.ds__week AS metric_time__week
+          , subq_1.ds__month AS metric_time__month
+          , subq_1.ds__quarter AS metric_time__quarter
+          , subq_1.ds__year AS metric_time__year
+          , subq_1.ds__extract_year AS metric_time__extract_year
+          , subq_1.ds__extract_quarter AS metric_time__extract_quarter
+          , subq_1.ds__extract_month AS metric_time__extract_month
+          , subq_1.ds__extract_day AS metric_time__extract_day
+          , subq_1.ds__extract_dow AS metric_time__extract_dow
+          , subq_1.ds__extract_doy AS metric_time__extract_doy
+          , subq_1.ds__alien_day AS metric_time__alien_day
+        FROM (
+          -- Read From Time Spine 'mf_time_spine'
+          SELECT
+            time_spine_src_28006.ds AS ds__day
+            , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week
+            , DATE_TRUNC('month', time_spine_src_28006.ds) AS ds__month
+            , DATE_TRUNC('quarter', time_spine_src_28006.ds) AS ds__quarter
+            , DATE_TRUNC('year', time_spine_src_28006.ds) AS ds__year
+            , EXTRACT(year FROM time_spine_src_28006.ds) AS ds__extract_year
+            , EXTRACT(quarter FROM time_spine_src_28006.ds) AS ds__extract_quarter
+            , EXTRACT(month FROM time_spine_src_28006.ds) AS ds__extract_month
+            , EXTRACT(day FROM time_spine_src_28006.ds) AS ds__extract_day
+            , EXTRACT(dayofweekiso FROM time_spine_src_28006.ds) AS ds__extract_dow
+            , EXTRACT(doy FROM time_spine_src_28006.ds) AS ds__extract_doy
+            , time_spine_src_28006.alien_day AS ds__alien_day
+          FROM ***************************.mf_time_spine time_spine_src_28006
+        ) subq_1
+      ) subq_2
+    ) subq_3
+    FULL OUTER JOIN (
+      -- Pass Only Elements: ['home_state_latest', 'user']
+      SELECT
+        subq_4.user
+        , subq_4.home_state_latest
+      FROM (
+        -- Read Elements From Semantic Model 'users_latest'
+        SELECT
+          DATE_TRUNC('day', users_latest_src_28000.ds) AS ds_latest__day
+          , DATE_TRUNC('week', users_latest_src_28000.ds) AS ds_latest__week
+          , DATE_TRUNC('month', users_latest_src_28000.ds) AS ds_latest__month
+          , DATE_TRUNC('quarter', users_latest_src_28000.ds) AS ds_latest__quarter
+          , DATE_TRUNC('year', users_latest_src_28000.ds) AS ds_latest__year
+          , EXTRACT(year FROM users_latest_src_28000.ds) AS ds_latest__extract_year
+          , EXTRACT(quarter FROM users_latest_src_28000.ds) AS ds_latest__extract_quarter
+          , EXTRACT(month FROM users_latest_src_28000.ds) AS ds_latest__extract_month
+          , EXTRACT(day FROM users_latest_src_28000.ds) AS ds_latest__extract_day
+          , EXTRACT(dayofweekiso FROM users_latest_src_28000.ds) AS ds_latest__extract_dow
+          , EXTRACT(doy FROM users_latest_src_28000.ds) AS ds_latest__extract_doy
+          , users_latest_src_28000.home_state_latest
+          , DATE_TRUNC('day', users_latest_src_28000.ds) AS user__ds_latest__day
+          , DATE_TRUNC('week', users_latest_src_28000.ds) AS user__ds_latest__week
+          , DATE_TRUNC('month', users_latest_src_28000.ds) AS user__ds_latest__month
+          , DATE_TRUNC('quarter', users_latest_src_28000.ds) AS user__ds_latest__quarter
+          , DATE_TRUNC('year', users_latest_src_28000.ds) AS user__ds_latest__year
+          , EXTRACT(year FROM users_latest_src_28000.ds) AS user__ds_latest__extract_year
+          , EXTRACT(quarter FROM users_latest_src_28000.ds) AS user__ds_latest__extract_quarter
+          , EXTRACT(month FROM users_latest_src_28000.ds) AS user__ds_latest__extract_month
+          , EXTRACT(day FROM users_latest_src_28000.ds) AS user__ds_latest__extract_day
+          , EXTRACT(dayofweekiso FROM users_latest_src_28000.ds) AS user__ds_latest__extract_dow
+          , EXTRACT(doy FROM users_latest_src_28000.ds) AS user__ds_latest__extract_doy
+          , users_latest_src_28000.home_state_latest AS user__home_state_latest
+          , users_latest_src_28000.user_id AS user
+        FROM ***************************.dim_users_latest users_latest_src_28000
+      ) subq_4
+    ) subq_5
+    ON
+      subq_0.user = subq_5.user
+  ) subq_6
+  WHERE user__home_state_latest = 'CA'
+) subq_7

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Snowflake/test_no_dedupe_saved_query__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Snowflake/test_no_dedupe_saved_query__plan0_optimized.sql
@@ -1,0 +1,24 @@
+test_name: test_no_dedupe_saved_query
+test_filename: test_query_rendering.py
+sql_engine: Snowflake
+---
+-- Constrain Output with WHERE
+-- Pass Only Elements: ['listing__capacity_latest', 'metric_time__month']
+SELECT
+  metric_time__month
+  , listing__capacity_latest
+FROM (
+  -- Join Standard Outputs
+  SELECT
+    users_latest_src_28000.home_state_latest AS user__home_state_latest
+    , DATE_TRUNC('month', time_spine_src_28006.ds) AS metric_time__month
+    , listings_latest_src_28000.capacity AS listing__capacity_latest
+  FROM ***************************.dim_listings_latest listings_latest_src_28000
+  CROSS JOIN
+    ***************************.mf_time_spine time_spine_src_28006
+  FULL OUTER JOIN
+    ***************************.dim_users_latest users_latest_src_28000
+  ON
+    listings_latest_src_28000.user_id = users_latest_src_28000.user_id
+) subq_14
+WHERE user__home_state_latest = 'CA'

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Trino/test_no_dedupe__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Trino/test_no_dedupe__plan0.sql
@@ -1,0 +1,273 @@
+test_name: test_no_dedupe
+test_filename: test_query_rendering.py
+sql_engine: Trino
+---
+-- Pass Only Elements: ['listing__capacity', 'metric_time__month']
+SELECT
+  subq_7.metric_time__month
+  , subq_7.listing__capacity
+FROM (
+  -- Constrain Output with WHERE
+  SELECT
+    subq_6.window_start__day
+    , subq_6.window_start__week
+    , subq_6.window_start__month
+    , subq_6.window_start__quarter
+    , subq_6.window_start__year
+    , subq_6.window_start__extract_year
+    , subq_6.window_start__extract_quarter
+    , subq_6.window_start__extract_month
+    , subq_6.window_start__extract_day
+    , subq_6.window_start__extract_dow
+    , subq_6.window_start__extract_doy
+    , subq_6.window_end__day
+    , subq_6.window_end__week
+    , subq_6.window_end__month
+    , subq_6.window_end__quarter
+    , subq_6.window_end__year
+    , subq_6.window_end__extract_year
+    , subq_6.window_end__extract_quarter
+    , subq_6.window_end__extract_month
+    , subq_6.window_end__extract_day
+    , subq_6.window_end__extract_dow
+    , subq_6.window_end__extract_doy
+    , subq_6.listing__window_start__day
+    , subq_6.listing__window_start__week
+    , subq_6.listing__window_start__month
+    , subq_6.listing__window_start__quarter
+    , subq_6.listing__window_start__year
+    , subq_6.listing__window_start__extract_year
+    , subq_6.listing__window_start__extract_quarter
+    , subq_6.listing__window_start__extract_month
+    , subq_6.listing__window_start__extract_day
+    , subq_6.listing__window_start__extract_dow
+    , subq_6.listing__window_start__extract_doy
+    , subq_6.listing__window_end__day
+    , subq_6.listing__window_end__week
+    , subq_6.listing__window_end__month
+    , subq_6.listing__window_end__quarter
+    , subq_6.listing__window_end__year
+    , subq_6.listing__window_end__extract_year
+    , subq_6.listing__window_end__extract_quarter
+    , subq_6.listing__window_end__extract_month
+    , subq_6.listing__window_end__extract_day
+    , subq_6.listing__window_end__extract_dow
+    , subq_6.listing__window_end__extract_doy
+    , subq_6.metric_time__month
+    , subq_6.listing
+    , subq_6.user
+    , subq_6.listing__user
+    , subq_6.country
+    , subq_6.is_lux
+    , subq_6.capacity
+    , subq_6.listing__country
+    , subq_6.listing__is_lux
+    , subq_6.listing__capacity
+    , subq_6.user__home_state_latest
+  FROM (
+    -- Join Standard Outputs
+    SELECT
+      subq_5.home_state_latest AS user__home_state_latest
+      , subq_0.window_start__day AS window_start__day
+      , subq_0.window_start__week AS window_start__week
+      , subq_0.window_start__month AS window_start__month
+      , subq_0.window_start__quarter AS window_start__quarter
+      , subq_0.window_start__year AS window_start__year
+      , subq_0.window_start__extract_year AS window_start__extract_year
+      , subq_0.window_start__extract_quarter AS window_start__extract_quarter
+      , subq_0.window_start__extract_month AS window_start__extract_month
+      , subq_0.window_start__extract_day AS window_start__extract_day
+      , subq_0.window_start__extract_dow AS window_start__extract_dow
+      , subq_0.window_start__extract_doy AS window_start__extract_doy
+      , subq_0.window_end__day AS window_end__day
+      , subq_0.window_end__week AS window_end__week
+      , subq_0.window_end__month AS window_end__month
+      , subq_0.window_end__quarter AS window_end__quarter
+      , subq_0.window_end__year AS window_end__year
+      , subq_0.window_end__extract_year AS window_end__extract_year
+      , subq_0.window_end__extract_quarter AS window_end__extract_quarter
+      , subq_0.window_end__extract_month AS window_end__extract_month
+      , subq_0.window_end__extract_day AS window_end__extract_day
+      , subq_0.window_end__extract_dow AS window_end__extract_dow
+      , subq_0.window_end__extract_doy AS window_end__extract_doy
+      , subq_0.listing__window_start__day AS listing__window_start__day
+      , subq_0.listing__window_start__week AS listing__window_start__week
+      , subq_0.listing__window_start__month AS listing__window_start__month
+      , subq_0.listing__window_start__quarter AS listing__window_start__quarter
+      , subq_0.listing__window_start__year AS listing__window_start__year
+      , subq_0.listing__window_start__extract_year AS listing__window_start__extract_year
+      , subq_0.listing__window_start__extract_quarter AS listing__window_start__extract_quarter
+      , subq_0.listing__window_start__extract_month AS listing__window_start__extract_month
+      , subq_0.listing__window_start__extract_day AS listing__window_start__extract_day
+      , subq_0.listing__window_start__extract_dow AS listing__window_start__extract_dow
+      , subq_0.listing__window_start__extract_doy AS listing__window_start__extract_doy
+      , subq_0.listing__window_end__day AS listing__window_end__day
+      , subq_0.listing__window_end__week AS listing__window_end__week
+      , subq_0.listing__window_end__month AS listing__window_end__month
+      , subq_0.listing__window_end__quarter AS listing__window_end__quarter
+      , subq_0.listing__window_end__year AS listing__window_end__year
+      , subq_0.listing__window_end__extract_year AS listing__window_end__extract_year
+      , subq_0.listing__window_end__extract_quarter AS listing__window_end__extract_quarter
+      , subq_0.listing__window_end__extract_month AS listing__window_end__extract_month
+      , subq_0.listing__window_end__extract_day AS listing__window_end__extract_day
+      , subq_0.listing__window_end__extract_dow AS listing__window_end__extract_dow
+      , subq_0.listing__window_end__extract_doy AS listing__window_end__extract_doy
+      , subq_3.metric_time__month AS metric_time__month
+      , subq_0.listing AS listing
+      , subq_0.user AS user
+      , subq_0.listing__user AS listing__user
+      , subq_0.country AS country
+      , subq_0.is_lux AS is_lux
+      , subq_0.capacity AS capacity
+      , subq_0.listing__country AS listing__country
+      , subq_0.listing__is_lux AS listing__is_lux
+      , subq_0.listing__capacity AS listing__capacity
+    FROM (
+      -- Read Elements From Semantic Model 'listings'
+      SELECT
+        listings_src_26000.active_from AS window_start__day
+        , DATE_TRUNC('week', listings_src_26000.active_from) AS window_start__week
+        , DATE_TRUNC('month', listings_src_26000.active_from) AS window_start__month
+        , DATE_TRUNC('quarter', listings_src_26000.active_from) AS window_start__quarter
+        , DATE_TRUNC('year', listings_src_26000.active_from) AS window_start__year
+        , EXTRACT(year FROM listings_src_26000.active_from) AS window_start__extract_year
+        , EXTRACT(quarter FROM listings_src_26000.active_from) AS window_start__extract_quarter
+        , EXTRACT(month FROM listings_src_26000.active_from) AS window_start__extract_month
+        , EXTRACT(day FROM listings_src_26000.active_from) AS window_start__extract_day
+        , EXTRACT(DAY_OF_WEEK FROM listings_src_26000.active_from) AS window_start__extract_dow
+        , EXTRACT(doy FROM listings_src_26000.active_from) AS window_start__extract_doy
+        , listings_src_26000.active_to AS window_end__day
+        , DATE_TRUNC('week', listings_src_26000.active_to) AS window_end__week
+        , DATE_TRUNC('month', listings_src_26000.active_to) AS window_end__month
+        , DATE_TRUNC('quarter', listings_src_26000.active_to) AS window_end__quarter
+        , DATE_TRUNC('year', listings_src_26000.active_to) AS window_end__year
+        , EXTRACT(year FROM listings_src_26000.active_to) AS window_end__extract_year
+        , EXTRACT(quarter FROM listings_src_26000.active_to) AS window_end__extract_quarter
+        , EXTRACT(month FROM listings_src_26000.active_to) AS window_end__extract_month
+        , EXTRACT(day FROM listings_src_26000.active_to) AS window_end__extract_day
+        , EXTRACT(DAY_OF_WEEK FROM listings_src_26000.active_to) AS window_end__extract_dow
+        , EXTRACT(doy FROM listings_src_26000.active_to) AS window_end__extract_doy
+        , listings_src_26000.country
+        , listings_src_26000.is_lux
+        , listings_src_26000.capacity
+        , listings_src_26000.active_from AS listing__window_start__day
+        , DATE_TRUNC('week', listings_src_26000.active_from) AS listing__window_start__week
+        , DATE_TRUNC('month', listings_src_26000.active_from) AS listing__window_start__month
+        , DATE_TRUNC('quarter', listings_src_26000.active_from) AS listing__window_start__quarter
+        , DATE_TRUNC('year', listings_src_26000.active_from) AS listing__window_start__year
+        , EXTRACT(year FROM listings_src_26000.active_from) AS listing__window_start__extract_year
+        , EXTRACT(quarter FROM listings_src_26000.active_from) AS listing__window_start__extract_quarter
+        , EXTRACT(month FROM listings_src_26000.active_from) AS listing__window_start__extract_month
+        , EXTRACT(day FROM listings_src_26000.active_from) AS listing__window_start__extract_day
+        , EXTRACT(DAY_OF_WEEK FROM listings_src_26000.active_from) AS listing__window_start__extract_dow
+        , EXTRACT(doy FROM listings_src_26000.active_from) AS listing__window_start__extract_doy
+        , listings_src_26000.active_to AS listing__window_end__day
+        , DATE_TRUNC('week', listings_src_26000.active_to) AS listing__window_end__week
+        , DATE_TRUNC('month', listings_src_26000.active_to) AS listing__window_end__month
+        , DATE_TRUNC('quarter', listings_src_26000.active_to) AS listing__window_end__quarter
+        , DATE_TRUNC('year', listings_src_26000.active_to) AS listing__window_end__year
+        , EXTRACT(year FROM listings_src_26000.active_to) AS listing__window_end__extract_year
+        , EXTRACT(quarter FROM listings_src_26000.active_to) AS listing__window_end__extract_quarter
+        , EXTRACT(month FROM listings_src_26000.active_to) AS listing__window_end__extract_month
+        , EXTRACT(day FROM listings_src_26000.active_to) AS listing__window_end__extract_day
+        , EXTRACT(DAY_OF_WEEK FROM listings_src_26000.active_to) AS listing__window_end__extract_dow
+        , EXTRACT(doy FROM listings_src_26000.active_to) AS listing__window_end__extract_doy
+        , listings_src_26000.country AS listing__country
+        , listings_src_26000.is_lux AS listing__is_lux
+        , listings_src_26000.capacity AS listing__capacity
+        , listings_src_26000.listing_id AS listing
+        , listings_src_26000.user_id AS user
+        , listings_src_26000.user_id AS listing__user
+      FROM ***************************.dim_listings listings_src_26000
+    ) subq_0
+    CROSS JOIN (
+      -- Pass Only Elements: ['metric_time__month',]
+      SELECT
+        subq_2.metric_time__month
+      FROM (
+        -- Metric Time Dimension 'ds'
+        SELECT
+          subq_1.ds__day
+          , subq_1.ds__week
+          , subq_1.ds__month
+          , subq_1.ds__quarter
+          , subq_1.ds__year
+          , subq_1.ds__extract_year
+          , subq_1.ds__extract_quarter
+          , subq_1.ds__extract_month
+          , subq_1.ds__extract_day
+          , subq_1.ds__extract_dow
+          , subq_1.ds__extract_doy
+          , subq_1.ds__alien_day
+          , subq_1.ds__day AS metric_time__day
+          , subq_1.ds__week AS metric_time__week
+          , subq_1.ds__month AS metric_time__month
+          , subq_1.ds__quarter AS metric_time__quarter
+          , subq_1.ds__year AS metric_time__year
+          , subq_1.ds__extract_year AS metric_time__extract_year
+          , subq_1.ds__extract_quarter AS metric_time__extract_quarter
+          , subq_1.ds__extract_month AS metric_time__extract_month
+          , subq_1.ds__extract_day AS metric_time__extract_day
+          , subq_1.ds__extract_dow AS metric_time__extract_dow
+          , subq_1.ds__extract_doy AS metric_time__extract_doy
+          , subq_1.ds__alien_day AS metric_time__alien_day
+        FROM (
+          -- Read From Time Spine 'mf_time_spine'
+          SELECT
+            time_spine_src_26006.ds AS ds__day
+            , DATE_TRUNC('week', time_spine_src_26006.ds) AS ds__week
+            , DATE_TRUNC('month', time_spine_src_26006.ds) AS ds__month
+            , DATE_TRUNC('quarter', time_spine_src_26006.ds) AS ds__quarter
+            , DATE_TRUNC('year', time_spine_src_26006.ds) AS ds__year
+            , EXTRACT(year FROM time_spine_src_26006.ds) AS ds__extract_year
+            , EXTRACT(quarter FROM time_spine_src_26006.ds) AS ds__extract_quarter
+            , EXTRACT(month FROM time_spine_src_26006.ds) AS ds__extract_month
+            , EXTRACT(day FROM time_spine_src_26006.ds) AS ds__extract_day
+            , EXTRACT(DAY_OF_WEEK FROM time_spine_src_26006.ds) AS ds__extract_dow
+            , EXTRACT(doy FROM time_spine_src_26006.ds) AS ds__extract_doy
+            , time_spine_src_26006.alien_day AS ds__alien_day
+          FROM ***************************.mf_time_spine time_spine_src_26006
+        ) subq_1
+      ) subq_2
+    ) subq_3
+    FULL OUTER JOIN (
+      -- Pass Only Elements: ['home_state_latest', 'user']
+      SELECT
+        subq_4.user
+        , subq_4.home_state_latest
+      FROM (
+        -- Read Elements From Semantic Model 'users_latest'
+        SELECT
+          DATE_TRUNC('day', users_latest_src_26000.ds) AS ds__day
+          , DATE_TRUNC('week', users_latest_src_26000.ds) AS ds__week
+          , DATE_TRUNC('month', users_latest_src_26000.ds) AS ds__month
+          , DATE_TRUNC('quarter', users_latest_src_26000.ds) AS ds__quarter
+          , DATE_TRUNC('year', users_latest_src_26000.ds) AS ds__year
+          , EXTRACT(year FROM users_latest_src_26000.ds) AS ds__extract_year
+          , EXTRACT(quarter FROM users_latest_src_26000.ds) AS ds__extract_quarter
+          , EXTRACT(month FROM users_latest_src_26000.ds) AS ds__extract_month
+          , EXTRACT(day FROM users_latest_src_26000.ds) AS ds__extract_day
+          , EXTRACT(DAY_OF_WEEK FROM users_latest_src_26000.ds) AS ds__extract_dow
+          , EXTRACT(doy FROM users_latest_src_26000.ds) AS ds__extract_doy
+          , users_latest_src_26000.home_state_latest
+          , DATE_TRUNC('day', users_latest_src_26000.ds) AS user__ds__day
+          , DATE_TRUNC('week', users_latest_src_26000.ds) AS user__ds__week
+          , DATE_TRUNC('month', users_latest_src_26000.ds) AS user__ds__month
+          , DATE_TRUNC('quarter', users_latest_src_26000.ds) AS user__ds__quarter
+          , DATE_TRUNC('year', users_latest_src_26000.ds) AS user__ds__year
+          , EXTRACT(year FROM users_latest_src_26000.ds) AS user__ds__extract_year
+          , EXTRACT(quarter FROM users_latest_src_26000.ds) AS user__ds__extract_quarter
+          , EXTRACT(month FROM users_latest_src_26000.ds) AS user__ds__extract_month
+          , EXTRACT(day FROM users_latest_src_26000.ds) AS user__ds__extract_day
+          , EXTRACT(DAY_OF_WEEK FROM users_latest_src_26000.ds) AS user__ds__extract_dow
+          , EXTRACT(doy FROM users_latest_src_26000.ds) AS user__ds__extract_doy
+          , users_latest_src_26000.home_state_latest AS user__home_state_latest
+          , users_latest_src_26000.user_id AS user
+        FROM ***************************.dim_users_latest users_latest_src_26000
+      ) subq_4
+    ) subq_5
+    ON
+      subq_0.user = subq_5.user
+  ) subq_6
+  WHERE user__home_state_latest = 'CA'
+) subq_7

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Trino/test_no_dedupe__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Trino/test_no_dedupe__plan0_optimized.sql
@@ -1,0 +1,24 @@
+test_name: test_no_dedupe
+test_filename: test_query_rendering.py
+sql_engine: Trino
+---
+-- Constrain Output with WHERE
+-- Pass Only Elements: ['listing__capacity', 'metric_time__month']
+SELECT
+  metric_time__month
+  , listing__capacity
+FROM (
+  -- Join Standard Outputs
+  SELECT
+    users_latest_src_26000.home_state_latest AS user__home_state_latest
+    , DATE_TRUNC('month', time_spine_src_26006.ds) AS metric_time__month
+    , listings_src_26000.capacity AS listing__capacity
+  FROM ***************************.dim_listings listings_src_26000
+  CROSS JOIN
+    ***************************.mf_time_spine time_spine_src_26006
+  FULL OUTER JOIN
+    ***************************.dim_users_latest users_latest_src_26000
+  ON
+    listings_src_26000.user_id = users_latest_src_26000.user_id
+) subq_14
+WHERE user__home_state_latest = 'CA'

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Trino/test_no_dedupe_saved_query__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Trino/test_no_dedupe_saved_query__plan0.sql
@@ -1,0 +1,282 @@
+test_name: test_no_dedupe_saved_query
+test_filename: test_query_rendering.py
+sql_engine: Trino
+---
+-- Pass Only Elements: ['listing__capacity_latest', 'metric_time__month']
+SELECT
+  subq_7.metric_time__month
+  , subq_7.listing__capacity_latest
+FROM (
+  -- Constrain Output with WHERE
+  SELECT
+    subq_6.ds__day
+    , subq_6.ds__week
+    , subq_6.ds__month
+    , subq_6.ds__quarter
+    , subq_6.ds__year
+    , subq_6.ds__extract_year
+    , subq_6.ds__extract_quarter
+    , subq_6.ds__extract_month
+    , subq_6.ds__extract_day
+    , subq_6.ds__extract_dow
+    , subq_6.ds__extract_doy
+    , subq_6.created_at__day
+    , subq_6.created_at__week
+    , subq_6.created_at__month
+    , subq_6.created_at__quarter
+    , subq_6.created_at__year
+    , subq_6.created_at__extract_year
+    , subq_6.created_at__extract_quarter
+    , subq_6.created_at__extract_month
+    , subq_6.created_at__extract_day
+    , subq_6.created_at__extract_dow
+    , subq_6.created_at__extract_doy
+    , subq_6.listing__ds__day
+    , subq_6.listing__ds__week
+    , subq_6.listing__ds__month
+    , subq_6.listing__ds__quarter
+    , subq_6.listing__ds__year
+    , subq_6.listing__ds__extract_year
+    , subq_6.listing__ds__extract_quarter
+    , subq_6.listing__ds__extract_month
+    , subq_6.listing__ds__extract_day
+    , subq_6.listing__ds__extract_dow
+    , subq_6.listing__ds__extract_doy
+    , subq_6.listing__created_at__day
+    , subq_6.listing__created_at__week
+    , subq_6.listing__created_at__month
+    , subq_6.listing__created_at__quarter
+    , subq_6.listing__created_at__year
+    , subq_6.listing__created_at__extract_year
+    , subq_6.listing__created_at__extract_quarter
+    , subq_6.listing__created_at__extract_month
+    , subq_6.listing__created_at__extract_day
+    , subq_6.listing__created_at__extract_dow
+    , subq_6.listing__created_at__extract_doy
+    , subq_6.metric_time__month
+    , subq_6.listing
+    , subq_6.user
+    , subq_6.listing__user
+    , subq_6.country_latest
+    , subq_6.is_lux_latest
+    , subq_6.capacity_latest
+    , subq_6.listing__country_latest
+    , subq_6.listing__is_lux_latest
+    , subq_6.listing__capacity_latest
+    , subq_6.user__home_state_latest
+    , subq_6.listings
+    , subq_6.largest_listing
+    , subq_6.smallest_listing
+  FROM (
+    -- Join Standard Outputs
+    SELECT
+      subq_5.home_state_latest AS user__home_state_latest
+      , subq_0.ds__day AS ds__day
+      , subq_0.ds__week AS ds__week
+      , subq_0.ds__month AS ds__month
+      , subq_0.ds__quarter AS ds__quarter
+      , subq_0.ds__year AS ds__year
+      , subq_0.ds__extract_year AS ds__extract_year
+      , subq_0.ds__extract_quarter AS ds__extract_quarter
+      , subq_0.ds__extract_month AS ds__extract_month
+      , subq_0.ds__extract_day AS ds__extract_day
+      , subq_0.ds__extract_dow AS ds__extract_dow
+      , subq_0.ds__extract_doy AS ds__extract_doy
+      , subq_0.created_at__day AS created_at__day
+      , subq_0.created_at__week AS created_at__week
+      , subq_0.created_at__month AS created_at__month
+      , subq_0.created_at__quarter AS created_at__quarter
+      , subq_0.created_at__year AS created_at__year
+      , subq_0.created_at__extract_year AS created_at__extract_year
+      , subq_0.created_at__extract_quarter AS created_at__extract_quarter
+      , subq_0.created_at__extract_month AS created_at__extract_month
+      , subq_0.created_at__extract_day AS created_at__extract_day
+      , subq_0.created_at__extract_dow AS created_at__extract_dow
+      , subq_0.created_at__extract_doy AS created_at__extract_doy
+      , subq_0.listing__ds__day AS listing__ds__day
+      , subq_0.listing__ds__week AS listing__ds__week
+      , subq_0.listing__ds__month AS listing__ds__month
+      , subq_0.listing__ds__quarter AS listing__ds__quarter
+      , subq_0.listing__ds__year AS listing__ds__year
+      , subq_0.listing__ds__extract_year AS listing__ds__extract_year
+      , subq_0.listing__ds__extract_quarter AS listing__ds__extract_quarter
+      , subq_0.listing__ds__extract_month AS listing__ds__extract_month
+      , subq_0.listing__ds__extract_day AS listing__ds__extract_day
+      , subq_0.listing__ds__extract_dow AS listing__ds__extract_dow
+      , subq_0.listing__ds__extract_doy AS listing__ds__extract_doy
+      , subq_0.listing__created_at__day AS listing__created_at__day
+      , subq_0.listing__created_at__week AS listing__created_at__week
+      , subq_0.listing__created_at__month AS listing__created_at__month
+      , subq_0.listing__created_at__quarter AS listing__created_at__quarter
+      , subq_0.listing__created_at__year AS listing__created_at__year
+      , subq_0.listing__created_at__extract_year AS listing__created_at__extract_year
+      , subq_0.listing__created_at__extract_quarter AS listing__created_at__extract_quarter
+      , subq_0.listing__created_at__extract_month AS listing__created_at__extract_month
+      , subq_0.listing__created_at__extract_day AS listing__created_at__extract_day
+      , subq_0.listing__created_at__extract_dow AS listing__created_at__extract_dow
+      , subq_0.listing__created_at__extract_doy AS listing__created_at__extract_doy
+      , subq_3.metric_time__month AS metric_time__month
+      , subq_0.listing AS listing
+      , subq_0.user AS user
+      , subq_0.listing__user AS listing__user
+      , subq_0.country_latest AS country_latest
+      , subq_0.is_lux_latest AS is_lux_latest
+      , subq_0.capacity_latest AS capacity_latest
+      , subq_0.listing__country_latest AS listing__country_latest
+      , subq_0.listing__is_lux_latest AS listing__is_lux_latest
+      , subq_0.listing__capacity_latest AS listing__capacity_latest
+      , subq_0.listings AS listings
+      , subq_0.largest_listing AS largest_listing
+      , subq_0.smallest_listing AS smallest_listing
+    FROM (
+      -- Read Elements From Semantic Model 'listings_latest'
+      SELECT
+        1 AS listings
+        , listings_latest_src_28000.capacity AS largest_listing
+        , listings_latest_src_28000.capacity AS smallest_listing
+        , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS ds__day
+        , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS ds__week
+        , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS ds__month
+        , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS ds__quarter
+        , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS ds__year
+        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS ds__extract_year
+        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS ds__extract_quarter
+        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS ds__extract_month
+        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS ds__extract_day
+        , EXTRACT(DAY_OF_WEEK FROM listings_latest_src_28000.created_at) AS ds__extract_dow
+        , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS ds__extract_doy
+        , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS created_at__day
+        , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS created_at__week
+        , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS created_at__month
+        , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS created_at__quarter
+        , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS created_at__year
+        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS created_at__extract_year
+        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS created_at__extract_quarter
+        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS created_at__extract_month
+        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS created_at__extract_day
+        , EXTRACT(DAY_OF_WEEK FROM listings_latest_src_28000.created_at) AS created_at__extract_dow
+        , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS created_at__extract_doy
+        , listings_latest_src_28000.country AS country_latest
+        , listings_latest_src_28000.is_lux AS is_lux_latest
+        , listings_latest_src_28000.capacity AS capacity_latest
+        , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__ds__day
+        , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__ds__week
+        , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__ds__month
+        , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__ds__quarter
+        , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__ds__year
+        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__ds__extract_year
+        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__ds__extract_quarter
+        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__ds__extract_month
+        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__ds__extract_day
+        , EXTRACT(DAY_OF_WEEK FROM listings_latest_src_28000.created_at) AS listing__ds__extract_dow
+        , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__ds__extract_doy
+        , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__created_at__day
+        , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__created_at__week
+        , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__created_at__month
+        , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__created_at__quarter
+        , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__created_at__year
+        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_year
+        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_quarter
+        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_month
+        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_day
+        , EXTRACT(DAY_OF_WEEK FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_dow
+        , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_doy
+        , listings_latest_src_28000.country AS listing__country_latest
+        , listings_latest_src_28000.is_lux AS listing__is_lux_latest
+        , listings_latest_src_28000.capacity AS listing__capacity_latest
+        , listings_latest_src_28000.listing_id AS listing
+        , listings_latest_src_28000.user_id AS user
+        , listings_latest_src_28000.user_id AS listing__user
+      FROM ***************************.dim_listings_latest listings_latest_src_28000
+    ) subq_0
+    CROSS JOIN (
+      -- Pass Only Elements: ['metric_time__month',]
+      SELECT
+        subq_2.metric_time__month
+      FROM (
+        -- Metric Time Dimension 'ds'
+        SELECT
+          subq_1.ds__day
+          , subq_1.ds__week
+          , subq_1.ds__month
+          , subq_1.ds__quarter
+          , subq_1.ds__year
+          , subq_1.ds__extract_year
+          , subq_1.ds__extract_quarter
+          , subq_1.ds__extract_month
+          , subq_1.ds__extract_day
+          , subq_1.ds__extract_dow
+          , subq_1.ds__extract_doy
+          , subq_1.ds__alien_day
+          , subq_1.ds__day AS metric_time__day
+          , subq_1.ds__week AS metric_time__week
+          , subq_1.ds__month AS metric_time__month
+          , subq_1.ds__quarter AS metric_time__quarter
+          , subq_1.ds__year AS metric_time__year
+          , subq_1.ds__extract_year AS metric_time__extract_year
+          , subq_1.ds__extract_quarter AS metric_time__extract_quarter
+          , subq_1.ds__extract_month AS metric_time__extract_month
+          , subq_1.ds__extract_day AS metric_time__extract_day
+          , subq_1.ds__extract_dow AS metric_time__extract_dow
+          , subq_1.ds__extract_doy AS metric_time__extract_doy
+          , subq_1.ds__alien_day AS metric_time__alien_day
+        FROM (
+          -- Read From Time Spine 'mf_time_spine'
+          SELECT
+            time_spine_src_28006.ds AS ds__day
+            , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week
+            , DATE_TRUNC('month', time_spine_src_28006.ds) AS ds__month
+            , DATE_TRUNC('quarter', time_spine_src_28006.ds) AS ds__quarter
+            , DATE_TRUNC('year', time_spine_src_28006.ds) AS ds__year
+            , EXTRACT(year FROM time_spine_src_28006.ds) AS ds__extract_year
+            , EXTRACT(quarter FROM time_spine_src_28006.ds) AS ds__extract_quarter
+            , EXTRACT(month FROM time_spine_src_28006.ds) AS ds__extract_month
+            , EXTRACT(day FROM time_spine_src_28006.ds) AS ds__extract_day
+            , EXTRACT(DAY_OF_WEEK FROM time_spine_src_28006.ds) AS ds__extract_dow
+            , EXTRACT(doy FROM time_spine_src_28006.ds) AS ds__extract_doy
+            , time_spine_src_28006.alien_day AS ds__alien_day
+          FROM ***************************.mf_time_spine time_spine_src_28006
+        ) subq_1
+      ) subq_2
+    ) subq_3
+    FULL OUTER JOIN (
+      -- Pass Only Elements: ['home_state_latest', 'user']
+      SELECT
+        subq_4.user
+        , subq_4.home_state_latest
+      FROM (
+        -- Read Elements From Semantic Model 'users_latest'
+        SELECT
+          DATE_TRUNC('day', users_latest_src_28000.ds) AS ds_latest__day
+          , DATE_TRUNC('week', users_latest_src_28000.ds) AS ds_latest__week
+          , DATE_TRUNC('month', users_latest_src_28000.ds) AS ds_latest__month
+          , DATE_TRUNC('quarter', users_latest_src_28000.ds) AS ds_latest__quarter
+          , DATE_TRUNC('year', users_latest_src_28000.ds) AS ds_latest__year
+          , EXTRACT(year FROM users_latest_src_28000.ds) AS ds_latest__extract_year
+          , EXTRACT(quarter FROM users_latest_src_28000.ds) AS ds_latest__extract_quarter
+          , EXTRACT(month FROM users_latest_src_28000.ds) AS ds_latest__extract_month
+          , EXTRACT(day FROM users_latest_src_28000.ds) AS ds_latest__extract_day
+          , EXTRACT(DAY_OF_WEEK FROM users_latest_src_28000.ds) AS ds_latest__extract_dow
+          , EXTRACT(doy FROM users_latest_src_28000.ds) AS ds_latest__extract_doy
+          , users_latest_src_28000.home_state_latest
+          , DATE_TRUNC('day', users_latest_src_28000.ds) AS user__ds_latest__day
+          , DATE_TRUNC('week', users_latest_src_28000.ds) AS user__ds_latest__week
+          , DATE_TRUNC('month', users_latest_src_28000.ds) AS user__ds_latest__month
+          , DATE_TRUNC('quarter', users_latest_src_28000.ds) AS user__ds_latest__quarter
+          , DATE_TRUNC('year', users_latest_src_28000.ds) AS user__ds_latest__year
+          , EXTRACT(year FROM users_latest_src_28000.ds) AS user__ds_latest__extract_year
+          , EXTRACT(quarter FROM users_latest_src_28000.ds) AS user__ds_latest__extract_quarter
+          , EXTRACT(month FROM users_latest_src_28000.ds) AS user__ds_latest__extract_month
+          , EXTRACT(day FROM users_latest_src_28000.ds) AS user__ds_latest__extract_day
+          , EXTRACT(DAY_OF_WEEK FROM users_latest_src_28000.ds) AS user__ds_latest__extract_dow
+          , EXTRACT(doy FROM users_latest_src_28000.ds) AS user__ds_latest__extract_doy
+          , users_latest_src_28000.home_state_latest AS user__home_state_latest
+          , users_latest_src_28000.user_id AS user
+        FROM ***************************.dim_users_latest users_latest_src_28000
+      ) subq_4
+    ) subq_5
+    ON
+      subq_0.user = subq_5.user
+  ) subq_6
+  WHERE user__home_state_latest = 'CA'
+) subq_7

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Trino/test_no_dedupe_saved_query__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Trino/test_no_dedupe_saved_query__plan0_optimized.sql
@@ -1,0 +1,24 @@
+test_name: test_no_dedupe_saved_query
+test_filename: test_query_rendering.py
+sql_engine: Trino
+---
+-- Constrain Output with WHERE
+-- Pass Only Elements: ['listing__capacity_latest', 'metric_time__month']
+SELECT
+  metric_time__month
+  , listing__capacity_latest
+FROM (
+  -- Join Standard Outputs
+  SELECT
+    users_latest_src_28000.home_state_latest AS user__home_state_latest
+    , DATE_TRUNC('month', time_spine_src_28006.ds) AS metric_time__month
+    , listings_latest_src_28000.capacity AS listing__capacity_latest
+  FROM ***************************.dim_listings_latest listings_latest_src_28000
+  CROSS JOIN
+    ***************************.mf_time_spine time_spine_src_28006
+  FULL OUTER JOIN
+    ***************************.dim_users_latest users_latest_src_28000
+  ON
+    listings_latest_src_28000.user_id = users_latest_src_28000.user_id
+) subq_14
+WHERE user__home_state_latest = 'CA'

--- a/tests_metricflow/validation/test_data_warehouse_tasks.py
+++ b/tests_metricflow/validation/test_data_warehouse_tasks.py
@@ -306,7 +306,7 @@ def test_build_saved_query_tasks(  # noqa: D103
         manifest=simple_semantic_manifest,
         sql_client=sql_client,
     )
-    assert len(tasks) == 3
+    assert len(tasks) == 4
 
     tasks = DataWarehouseTaskBuilder.gen_saved_query_tasks(
         manifest=simple_semantic_manifest, sql_client=sql_client, saved_query_filters=["p0_booking"]


### PR DESCRIPTION
Support no-metric queries without a group by. This can be used in specific cases where the user knows that the dimensions / entities in the query are unique, so the group by will only slow down query performance.