### PR TITLE
Add `Singleton` base class

### DIFF
--- a/metricflow-semantics/metricflow_semantics/experimental/singleton.py
+++ b/metricflow-semantics/metricflow_semantics/experimental/singleton.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import threading
+from abc import ABC
+from typing import ClassVar, Optional, Type, TypeVar
+
+from metricflow_semantics.experimental.dataclass_helpers import fast_frozen_dataclass
+
+SingletonT = TypeVar("SingletonT", bound="Singleton")
+
+
+@fast_frozen_dataclass()
+class Singleton(ABC):
+    """Base class for singletons.
+
+    * Provides significantly faster equality checks / hashing as `id()` can be used (as used in Python's default
+      object implementations of `__eq__` and `__hash__`).
+    * Slower to create due to lookup overhead (see tests).
+    * May be useful for ID-like objects.
+    * Clunky to use due to the need to implement `get_instance()` manually, and there doesn't seem to be a good way to
+      define an abstract method.
+    * Pickling not yet supported.
+    * Private initializer is simulated through the `_created_via_singleton` field.
+
+    Implementing classes should define a method like:
+
+        @classmethod
+        def get_instance(cls, ...) -> Self:
+            return cls._get_singleton_by_kwargs(...)
+    """
+
+    # This might be better as a weakref.
+    _instance_dict: ClassVar[dict] = {}
+    _instance_dict_lock: ClassVar[threading.Lock] = threading.Lock()
+
+    # Helps to indicate to uses that they shouldn't call `__init__`, but doesn't actually do anything.
+    _created_via_singleton: bool
+
+    @classmethod
+    def _get_singleton_by_kwargs(  # type: ignore[no-untyped-def]
+        cls: Type[SingletonT],
+        **kwargs,
+    ) -> SingletonT:
+        key = tuple(kwargs.values())
+        matching_singleton: Optional[SingletonT] = cls._instance_dict.get(key)
+        if matching_singleton is not None:
+            return matching_singleton
+
+        with cls._instance_dict_lock:
+            matching_singleton = cls._instance_dict.get(key)
+            if matching_singleton is None:
+                matching_singleton = cls(_created_via_singleton=True, **kwargs)
+                cls._instance_dict[key] = matching_singleton
+            return matching_singleton

--- a/metricflow-semantics/tests_metricflow_semantics/experimental/collection_helpers/singleton_test_classes.py
+++ b/metricflow-semantics/tests_metricflow_semantics/experimental/collection_helpers/singleton_test_classes.py
@@ -1,0 +1,96 @@
+"""Classes used in tests that benchmark `Singleton` performance."""
+from __future__ import annotations
+
+from collections.abc import Set
+from pathlib import Path
+
+from metricflow_semantics.experimental.dataclass_helpers import fast_frozen_dataclass
+from metricflow_semantics.experimental.singleton import Singleton
+from typing_extensions import Self
+
+PATH_TO_SINGLETON_TEST_CLASS_PY_FILE = Path(__file__)
+
+
+@fast_frozen_dataclass()
+class IdElement:  # noqa: D101
+    int_value: int
+
+
+@fast_frozen_dataclass()
+class CompositeId:  # noqa: D101
+    id_0: IdElement
+    id_1: IdElement
+
+
+@fast_frozen_dataclass()
+class SingletonIdElement(Singleton):  # noqa: D101
+    int_value: int
+
+    @classmethod
+    def get_instance(cls, int_value: int) -> Self:  # noqa: D102
+        return cls._get_singleton_by_kwargs(int_value=int_value)
+
+
+@fast_frozen_dataclass()
+class SingletonCompositeId(Singleton):  # noqa: D101
+    id_0: SingletonIdElement
+    id_1: SingletonIdElement
+
+    @classmethod
+    def get_instance(cls, id_0: SingletonIdElement, id_1: SingletonIdElement) -> Self:  # noqa: D102
+        return cls._get_singleton_by_kwargs(
+            id_0=id_0,
+            id_1=id_1,
+        )
+
+
+def create_id_set(size: int) -> Set[CompositeId]:  # noqa: D103
+    return {
+        CompositeId(
+            id_0=IdElement(int_value=i),
+            id_1=IdElement(int_value=i + 1),
+        )
+        for i in range(size)
+    }
+
+
+def create_singleton_id_set(size: int) -> Set[SingletonCompositeId]:  # noqa: D103
+    return {
+        SingletonCompositeId.get_instance(
+            id_0=SingletonIdElement.get_instance(int_value=i),
+            id_1=SingletonIdElement.get_instance(int_value=i + 1),
+        )
+        for i in range(size)
+    }
+
+
+FIRST_ID = CompositeId(
+    id_0=IdElement(int_value=0),
+    id_1=IdElement(int_value=1),
+)
+
+
+FIRST_SINGLETON_ID = SingletonCompositeId.get_instance(
+    id_0=SingletonIdElement.get_instance(0),
+    id_1=SingletonIdElement.get_instance(1),
+)
+
+
+def create_id_tuple(size: int) -> tuple[CompositeId, ...]:  # noqa: D103
+    return tuple(
+        CompositeId(
+            id_0=IdElement(int_value=i),
+            id_1=IdElement(int_value=i + 1),
+        )
+        for i in range(size)
+    )
+
+
+def create_singleton_id_tuple(size: int) -> tuple[SingletonCompositeId, ...]:  # noqa: D103
+    return tuple(
+        SingletonCompositeId.get_instance(
+            id_0=SingletonIdElement.get_instance(int_value=i),
+            id_1=SingletonIdElement.get_instance(int_value=i + 1),
+        )
+        for i in range(size)
+    )

--- a/metricflow-semantics/tests_metricflow_semantics/experimental/collection_helpers/test_singleton.py
+++ b/metricflow-semantics/tests_metricflow_semantics/experimental/collection_helpers/test_singleton.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import logging
+
+import pytest
+from metricflow_semantics.experimental.test_helpers.performance_helpers import assert_performance_factor
+from metricflow_semantics.formatting.formatting_helpers import mf_dedent
+from metricflow_semantics.helpers.string_helpers import mf_newline_join
+
+from tests_metricflow_semantics.experimental.collection_helpers.singleton_test_classes import (
+    PATH_TO_SINGLETON_TEST_CLASS_PY_FILE,
+    SingletonIdElement,
+)
+from tests_metricflow_semantics.experimental.collection_helpers.statement_helpers import read_statement_from_path
+
+logger = logging.getLogger(__name__)
+
+
+def test_is_expression() -> None:
+    """Test comparison using `is`."""
+    left = SingletonIdElement.get_instance(1)
+    right = SingletonIdElement.get_instance(1)
+
+    assert left is right
+
+
+@pytest.fixture(scope="session")
+def setup_statement() -> str:
+    """Statement that sets up the definition for the classes used in tests below."""
+    return read_statement_from_path(PATH_TO_SINGLETON_TEST_CLASS_PY_FILE)
+
+
+def test_set_equals(setup_statement: str) -> None:
+    """Tests performance of set comparison using singletons."""
+    size = 4
+    assert_performance_factor(
+        slow_code_setup=mf_newline_join(
+            setup_statement,
+            mf_dedent(
+                f"""
+                left = create_id_set({size})
+                right = create_id_set({size})
+                """
+            ),
+        ),
+        slow_code_statement="left == right",
+        fast_code_setup=mf_newline_join(
+            setup_statement,
+            mf_dedent(
+                f"""
+                left = create_singleton_id_set({size})
+                right = create_singleton_id_set({size})
+                """
+            ),
+        ),
+        fast_code_statement="left == right",
+        min_performance_factor=25.0,
+    )
+
+
+def test_set_in(setup_statement: str) -> None:
+    """Tests performance of set inclusion checks."""
+    size = 10
+    assert_performance_factor(
+        slow_code_setup=mf_newline_join(
+            setup_statement,
+            f"id_set = create_id_set({size})",
+        ),
+        slow_code_statement="FIRST_ID in id_set",
+        fast_code_setup=mf_newline_join(
+            setup_statement,
+            f"singleton_id_set = create_singleton_id_set({size})",
+        ),
+        fast_code_statement="FIRST_SINGLETON_ID in singleton_id_set",
+        min_performance_factor=5.0,
+    )
+
+
+def test_tuple_equals(setup_statement: str) -> None:
+    """Tests performance of tuple comparisons."""
+    size = 4
+    assert_performance_factor(
+        slow_code_setup=mf_newline_join(
+            setup_statement,
+            mf_dedent(
+                f"""
+                left = create_id_tuple({size})
+                right = create_id_tuple({size})
+                """
+            ),
+        ),
+        slow_code_statement="left == right",
+        fast_code_setup=mf_newline_join(
+            setup_statement,
+            mf_dedent(
+                f"""
+                left = create_singleton_id_tuple({size})
+                right = create_singleton_id_tuple({size})
+                """
+            ),
+        ),
+        fast_code_statement="left == right",
+        min_performance_factor=50.0,
+    )
+
+
+def test_create_new(setup_statement: str) -> None:
+    """Tests the overhead of creating / getting a new singleton instance.
+
+    Uses a random start index to create new instances instead of getting an existing one.
+    """
+    size = 1000
+    setup_statement = mf_newline_join(setup_statement, "import random")
+    assert_performance_factor(
+        slow_code_setup=setup_statement,
+        slow_code_statement=mf_dedent(
+            f"""
+            start_index = random.randint(0, 1_000_000_000_000)
+            for i in range(start_index, start_index + {size}):
+                CompositeId(
+                    id_0=IdElement(int_value=i),
+                    id_1=IdElement(int_value=i + 1),
+                )
+            """
+        ),
+        fast_code_setup=setup_statement,
+        fast_code_statement=mf_dedent(
+            f"""
+            start_index = random.randint(0, 1_000_000_000_000)
+            for i in range(start_index, start_index + {size}):
+                SingletonCompositeId.get_instance(
+                    id_0=SingletonIdElement.get_instance(int_value=i),
+                    id_1=SingletonIdElement.get_instance(int_value=i + 1),
+                )
+            """
+        ),
+        min_performance_factor=0.15,
+    )
+
+
+def test_create_existing(setup_statement: str) -> None:
+    """Tests the overhead of getting a singleton that has already been created."""
+    size = 1000
+    get_singleton_statement = mf_dedent(
+        f"""
+        for _ in range({size}):
+            SingletonCompositeId.get_instance(
+                id_0=SingletonIdElement.get_instance(int_value=0),
+                id_1=SingletonIdElement.get_instance(int_value=1),
+            )
+        """
+    )
+    assert_performance_factor(
+        slow_code_setup=setup_statement,
+        slow_code_statement=mf_dedent(
+            f"""
+            for _ in range({size}):
+                CompositeId(
+                    id_0=IdElement(int_value=0),
+                    id_1=IdElement(int_value=1),
+                )
+            """
+        ),
+        fast_code_setup=mf_newline_join(setup_statement, get_singleton_statement),
+        fast_code_statement=get_singleton_statement,
+        min_performance_factor=0.3,
+    )


### PR DESCRIPTION
This experimental PR adds a `Singleton` base class that could improve performance of ID-like dataclasses (see tests). This might need some additional refinement / performance verification.