### PR TITLE
Replace `time.time()` with `time.perf_counter()`

### DIFF
--- a/dbt-metricflow/dbt_metricflow/cli/dbt_connectors/adapter_backed_client.py
+++ b/dbt-metricflow/dbt_metricflow/cli/dbt_connectors/adapter_backed_client.py
@@ -136,7 +136,7 @@ class AdapterBackedSqlClient:
             sql_bind_parameter_set: The parameter replacement mapping for filling in concrete values for SQL query
             parameters.
         """
-        start = time.time()
+        start = time.perf_counter()
         request_id = SqlRequestId(f"mf_rid__{random_id()}")
         if sql_bind_parameter_set.param_dict:
             raise SqlBindParametersNotSupportedError(
@@ -157,7 +157,7 @@ class AdapterBackedSqlClient:
             column_names=agate_data.column_names,
             rows=rows,
         )
-        stop = time.time()
+        stop = time.perf_counter()
 
         logger.info(
             LazyFormat(
@@ -183,7 +183,7 @@ class AdapterBackedSqlClient:
                 f"Invalid execute statement - we do not support execute commands with bind parameters through dbt "
                 f"adapters! Bind params: {SqlBindParameterSet.param_dict}"
             )
-        start = time.time()
+        start = time.perf_counter()
         request_id = SqlRequestId(f"mf_rid__{random_id()}")
         logger.info(
             LazyFormat("Running execute() statement", statement=stmt, param_dict=sql_bind_parameter_set.param_dict)
@@ -193,7 +193,7 @@ class AdapterBackedSqlClient:
             # Calls to execute often involve some amount of DDL so we commit here
             self._adapter.commit_if_has_connection()
             logger.debug(LazyFormat(lambda: f"execute() returned from dbt Adapter with response  {result[0]}"))
-        stop = time.time()
+        stop = time.perf_counter()
         logger.info(LazyFormat("Finished execute()", runtime=f"{stop - start:.2f}s"))
 
         return None
@@ -212,7 +212,7 @@ class AdapterBackedSqlClient:
             sql_bind_parameter_set: The parameter replacement mapping for filling in
                 concrete values for SQL query parameters.
         """
-        start = time.time()
+        start = time.perf_counter()
         logger.info(LazyFormat("Running dry run", statement=stmt, param_dict=sql_bind_parameter_set.param_dict))
         request_id = SqlRequestId(f"mf_rid__{random_id()}")
         connection_name = f"MetricFlow_dry_run_request_{request_id}"
@@ -248,7 +248,7 @@ class AdapterBackedSqlClient:
                 if has_error:
                     raise DbtDatabaseError(f"Encountered error in Databricks dry run. Full output: {plan_output_str}")
 
-        stop = time.time()
+        stop = time.perf_counter()
         logger.info(LazyFormat("Finished running the dry run", runtime=f"{stop - start:.2f}s"))
         return
 

--- a/dbt-metricflow/dbt_metricflow/cli/main.py
+++ b/dbt-metricflow/dbt_metricflow/cli/main.py
@@ -201,7 +201,7 @@ def query(
         click.echo(f"❌ The `decimals` option was set to {decimals!r}, but it should be a non-negative integer.")
         exit(1)
 
-    start = time.time()
+    start = time.perf_counter()
     spinner: Optional[Halo] = None
     if not quiet:
         spinner = Halo(text="Initiating query…", spinner="dots")
@@ -227,7 +227,7 @@ def query(
         query_result = cfg.mf.query(mf_request=mf_request)
 
     if spinner is not None:
-        spinner.succeed(f"Success 🦄 - query completed after {time.time() - start:.2f} seconds")
+        spinner.succeed(f"Success 🦄 - query completed after {time.perf_counter() - start:.2f} seconds")
 
     if explain:
         assert explain_result

--- a/metricflow-semantics/metricflow_semantics/mf_logging/runtime.py
+++ b/metricflow-semantics/metricflow_semantics/mf_logging/runtime.py
@@ -30,13 +30,13 @@ def log_runtime(
         def _inner(*args: ParametersType.args, **kwargs: ParametersType.kwargs) -> ReturnType:
             # __qualname__ includes the path like MyClass.my_function
             function_name = f"{wrapped_function.__qualname__}()"
-            start_time = time.time()
+            start_time = time.perf_counter()
             logger.info(LazyFormat(lambda: f"Starting {function_name}"))
 
             try:
                 result = wrapped_function(*args, **kwargs)
             finally:
-                runtime = time.time() - start_time
+                runtime = time.perf_counter() - start_time
                 logger.info(LazyFormat(lambda: f"Finished {function_name} in {runtime:.1f}s"))
                 if runtime > runtime_warning_threshold:
                     logger.warning(LazyFormat(lambda: f"{function_name} is slow with a runtime of {runtime:.1f}s"))
@@ -51,13 +51,12 @@ def log_runtime(
 @contextmanager
 def log_block_runtime(code_block_name: str, runtime_warning_threshold: float = 5.0) -> Iterator[None]:
     """Logs the runtime of the enclosed code block."""
-    start_time = time.time()
-    description = f"code_block_name={repr(code_block_name)}"
-    logger.info(LazyFormat(lambda: f"Starting {description}"))
+    start_time = time.perf_counter()
+    logger.info(LazyFormat(lambda: f"Starting {code_block_name!r}"))
 
     yield
 
-    runtime = time.time() - start_time
-    logger.info(LazyFormat(lambda: f"Finished {description} in {runtime:.1f}s"))
+    runtime = time.perf_counter() - start_time
+    logger.info(LazyFormat(lambda: f"Finished {code_block_name!r} in {runtime:.1f}s"))
     if runtime > runtime_warning_threshold:
-        logger.warning(LazyFormat(lambda: f"{description} is slow with a runtime of {runtime:.1f}s"))
+        logger.warning(LazyFormat(lambda: f"{code_block_name!r} is slow with a runtime of {runtime:.1f}s"))

--- a/metricflow-semantics/metricflow_semantics/model/semantics/linkable_element_set.py
+++ b/metricflow-semantics/metricflow_semantics/model/semantics/linkable_element_set.py
@@ -386,7 +386,7 @@ class LinkableElementSet(SemanticModelDerivation):
         Returns a new set consisting of the elements in the `LinkableElementSet` that have a corresponding spec that
         match all the given spec patterns.
         """
-        start_time = time.time()
+        start_time = time.perf_counter()
 
         # Spec patterns need all specs to match properly e.g. `MinimumTimeGrainPattern`.
         matching_specs: Sequence[InstanceSpec] = self.specs
@@ -416,7 +416,9 @@ class LinkableElementSet(SemanticModelDerivation):
             path_key_to_linkable_entities=path_key_to_linkable_entities,
             path_key_to_linkable_metrics=path_key_to_linkable_metrics,
         )
-        logger.debug(LazyFormat(lambda: f"Filtering valid linkable elements took: {time.time() - start_time:.2f}s"))
+        logger.debug(
+            LazyFormat(lambda: f"Filtering valid linkable elements took: {time.perf_counter() - start_time:.2f}s")
+        )
         return filtered_elements
 
     def filter_by_left_semantic_model(

--- a/metricflow-semantics/metricflow_semantics/model/semantics/linkable_spec_index_builder.py
+++ b/metricflow-semantics/metricflow_semantics/model/semantics/linkable_spec_index_builder.py
@@ -93,7 +93,7 @@ class LinkableSpecIndexBuilder:
         )
 
     def build_index(self) -> LinkableSpecIndex:  # noqa: D102
-        start_time = time.time()
+        start_time = time.perf_counter()
         for metric in self._semantic_manifest.metrics:
             # self._metric_references_to_metrics[MetricReference(metric.name)] = metric
             linkable_sets_for_measure = []
@@ -128,7 +128,7 @@ class LinkableSpecIndexBuilder:
 
         # Populate storage dicts with linkable metrics. This loop must happen after the one above so that
         # _metric_to_linkable_element_sets is populated with entities and dimensions.
-        linkable_metrics_start_time = time.time()
+        linkable_metrics_start_time = time.perf_counter()
         for metric in self._semantic_manifest.metrics:
             # Cumulative metrics and time offset metrics require grouping by metric_time, which is not yet available for
             # linkable metrics. So skip those.
@@ -178,7 +178,7 @@ class LinkableSpecIndexBuilder:
             )
         logger.debug(
             LazyFormat(
-                lambda: f"Building valid linkable metrics took: {time.time() - linkable_metrics_start_time:.2f}s"
+                lambda: f"Building valid linkable metrics took: {time.perf_counter() - linkable_metrics_start_time:.2f}s"
             )
         )
 
@@ -190,7 +190,9 @@ class LinkableSpecIndexBuilder:
             linkable_element_sets_for_no_metrics_queries + [metric_time_elements_for_no_metrics]
         )
 
-        logger.debug(LazyFormat(lambda: f"Building valid group-by-item indexes took: {time.time() - start_time:.2f}s"))
+        logger.debug(
+            LazyFormat(lambda: f"Building valid group-by-item indexes took: {time.perf_counter() - start_time:.2f}s")
+        )
 
         return self._linkable_spec_index
 

--- a/metricflow-semantics/metricflow_semantics/model/semantics/metric_lookup.py
+++ b/metricflow-semantics/metricflow_semantics/model/semantics/metric_lookup.py
@@ -127,7 +127,7 @@ class MetricLookup:
         element_filter: LinkableElementFilter = LinkableElementFilter(),
     ) -> LinkableElementSet:
         """Return the set of linkable elements reachable from a given measure."""
-        start_time = time.time()
+        start_time = time.perf_counter()
 
         # Cache the result when group-by-metrics are selected in an LRU cache as there can be many of them and may
         # significantly increase memory usage.
@@ -164,7 +164,7 @@ class MetricLookup:
                 "Finished getting linkable elements",
                 measure_reference=measure_reference,
                 element_filter=element_filter,
-                runtime=time.time() - start_time,
+                runtime=time.perf_counter() - start_time,
             )
         )
         return result.filter(element_filter)

--- a/metricflow/dataflow/builder/dataflow_plan_builder.py
+++ b/metricflow/dataflow/builder/dataflow_plan_builder.py
@@ -1048,7 +1048,7 @@ class DataflowPlanBuilder:
                 f"of the join."
             )
         )
-        start_time = time.time()
+        start_time = time.perf_counter()
 
         node_processor = PreJoinNodeProcessor(
             semantic_model_lookup=self._semantic_model_lookup,
@@ -1116,7 +1116,7 @@ class DataflowPlanBuilder:
             for group_by_metric_spec in linkable_specs_to_satisfy.group_by_metric_specs
         ]
 
-        logger.debug(LazyFormat(lambda: f"Processing nodes took: {time.time()-start_time:.2f}s"))
+        logger.debug(LazyFormat(lambda: f"Processing nodes took: {time.perf_counter()-start_time:.2f}s"))
 
         node_evaluator = NodeEvaluatorForLinkableInstances(
             semantic_model_lookup=self._semantic_model_lookup,
@@ -1153,13 +1153,13 @@ class DataflowPlanBuilder:
                 )
             )
 
-            start_time = time.time()
+            start_time = time.perf_counter()
             evaluation = node_evaluator.evaluate_node(
                 left_node=node,
                 required_linkable_specs=list(linkable_specs_to_satisfy_tuple),
                 default_join_type=default_join_type,
             )
-            logger.debug(LazyFormat(lambda: f"Evaluation of {node} took {time.time() - start_time:.2f}s"))
+            logger.debug(LazyFormat(lambda: f"Evaluation of {node} took {time.perf_counter() - start_time:.2f}s"))
 
             logger.debug(
                 LazyFormat(
@@ -1737,7 +1737,7 @@ class DataflowPlanBuilder:
                     predicate_pushdown_state, time_range_constraint=measure_time_constraint
                 )
 
-            find_recipe_start_time = time.time()
+            find_recipe_start_time = time.perf_counter()
             measure_recipe = self._find_source_node_recipe(
                 FindSourceNodeRecipeParameterSet(
                     measure_spec_properties=measure_properties,
@@ -1748,7 +1748,7 @@ class DataflowPlanBuilder:
             logger.debug(
                 LazyFormat(
                     lambda: f"With {len(self._source_node_set.source_nodes_for_metric_queries)} source nodes, finding a recipe "
-                    f"took {time.time() - find_recipe_start_time:.2f}s"
+                    f"took {time.perf_counter() - find_recipe_start_time:.2f}s"
                 )
             )
 

--- a/metricflow/execution/execution_plan.py
+++ b/metricflow/execution/execution_plan.py
@@ -126,7 +126,7 @@ class SelectSqlQueryToDataTableTask(ExecutionPlanTask):
         return tuple(super().displayed_properties) + (DisplayedProperty(key="sql", value=self.sql_statement.sql),)
 
     def execute(self) -> TaskExecutionResult:  # noqa: D102
-        start_time = time.time()
+        start_time = time.perf_counter()
         sql_statement = self.sql_statement
         assert sql_statement is not None, f"{self.sql_statement=} should have been set during creation."
 
@@ -135,7 +135,7 @@ class SelectSqlQueryToDataTableTask(ExecutionPlanTask):
             sql_bind_parameter_set=sql_statement.bind_parameter_set,
         )
 
-        end_time = time.time()
+        end_time = time.perf_counter()
         return TaskExecutionResult(
             start_time=start_time,
             end_time=end_time,
@@ -198,7 +198,7 @@ class SelectSqlQueryToTableTask(ExecutionPlanTask):
     def execute(self) -> TaskExecutionResult:  # noqa: D102
         sql_statement = self.sql_statement
         assert sql_statement is not None, f"{self.sql_statement=} should have been set during creation."
-        start_time = time.time()
+        start_time = time.perf_counter()
         logger.debug(LazyFormat(lambda: f"Dropping table {self.output_table} in case it already exists"))
         self.sql_client.execute(f"DROP TABLE IF EXISTS {self.output_table.sql}")
         logger.debug(LazyFormat(lambda: f"Creating table {self.output_table} using a query"))
@@ -207,7 +207,7 @@ class SelectSqlQueryToTableTask(ExecutionPlanTask):
             sql_bind_parameter_set=sql_statement.bind_parameter_set,
         )
 
-        end_time = time.time()
+        end_time = time.perf_counter()
         return TaskExecutionResult(start_time=start_time, end_time=end_time, sql=sql_statement.sql)
 
     def __repr__(self) -> str:  # noqa: D105

--- a/metricflow/telemetry/reporter.py
+++ b/metricflow/telemetry/reporter.py
@@ -141,7 +141,7 @@ def log_call(telemetry_reporter: TelemetryReporter, module_name: str) -> Callabl
             # Not every Callable has a __name__
             function_name = getattr(func, "__name__", repr(func))
             invocation_id = f"call_{random_id()}"
-            start_time = time.time()
+            start_time = time.perf_counter()
             telemetry_reporter.log_function_start(
                 invocation_id=invocation_id, module_name=module_name, function_name=function_name
             )
@@ -156,7 +156,7 @@ def log_call(telemetry_reporter: TelemetryReporter, module_name: str) -> Callabl
                     invocation_id=invocation_id,
                     module_name=module_name,
                     function_name=function_name,
-                    runtime=time.time() - start_time,
+                    runtime=time.perf_counter() - start_time,
                     exception_trace=exception_trace,
                 )
 

--- a/tests_metricflow/cli/isolated_cli_command_runner.py
+++ b/tests_metricflow/cli/isolated_cli_command_runner.py
@@ -153,7 +153,7 @@ class IsolatedCliCommandRunner:
                 "Executor process is not alive when it is expected to be - check logs to see why it is not."
             )
 
-        start_time = time.time()
+        start_time = time.perf_counter()
 
         delete_temporary_directory = True
         temporary_directory_path: Optional[Path] = None
@@ -181,7 +181,7 @@ class IsolatedCliCommandRunner:
             result = self._running_executor_process_context.send_command_and_get_result(command_parameter_set)
             logger.debug("Got result from output queue")
 
-            runtime = f"{time.time() - start_time:.2f}s"
+            runtime = f"{time.perf_counter() - start_time:.2f}s"
             if result.exit_code == 0:
                 logger.debug(
                     LazyFormat(

--- a/tests_metricflow/execution/noop_task.py
+++ b/tests_metricflow/execution/noop_task.py
@@ -48,9 +48,9 @@ class NoOpExecutionPlanTask(ExecutionPlanTask):
         return StaticIdPrefix.EXEC_NODE_NOOP
 
     def execute(self) -> TaskExecutionResult:  # noqa: D102
-        start_time = time.time()
+        start_time = time.perf_counter()
         time.sleep(0.01)
-        end_time = time.time()
+        end_time = time.perf_counter()
         return TaskExecutionResult(
             start_time=start_time, end_time=end_time, errors=(self.EXAMPLE_ERROR,) if self.should_error else ()
         )

--- a/tests_metricflow/fixtures/sql_clients/adapter_backed_ddl_client.py
+++ b/tests_metricflow/fixtures/sql_clients/adapter_backed_ddl_client.py
@@ -37,7 +37,7 @@ class AdapterBackedDDLSqlClient(AdapterBackedSqlClient):
         logger.debug(
             LazyFormat(lambda: f"Creating table '{sql_table.sql}' from a DataTable with {df.row_count} row(s)")
         )
-        start_time = time.time()
+        start_time = time.perf_counter()
 
         with self._adapter.connection_named("MetricFlow_create_from_dataframe"):
             # Create table
@@ -90,7 +90,7 @@ class AdapterBackedDDLSqlClient(AdapterBackedSqlClient):
 
         logger.debug(
             LazyFormat(
-                lambda: f"Created SQL table '{sql_table.sql}' from an in-memory table in {time.time() - start_time:.2f}s"
+                lambda: f"Created SQL table '{sql_table.sql}' from an in-memory table in {time.perf_counter() - start_time:.2f}s"
             )
         )
 

--- a/tests_metricflow/performance/test_mf_engine.py
+++ b/tests_metricflow/performance/test_mf_engine.py
@@ -89,7 +89,7 @@ def _time_mf_engine_init(
     semantic_manifest: SemanticManifest,
     linkable_spec_index: Optional[LinkableSpecIndex],
 ) -> float:
-    start_time = time.time()
+    start_time = time.perf_counter()
 
     if linkable_spec_index is None:
         semantic_manifest_lookup = SemanticManifestLookup(semantic_manifest)
@@ -105,4 +105,4 @@ def _time_mf_engine_init(
         column_association_resolver=column_association_resolver,
     )
 
-    return time.time() - start_time
+    return time.perf_counter() - start_time


### PR DESCRIPTION
This PR replaces calls to `time.time()` with `time.perf_counter()` when used in performance measurement cases as `time.time()` may have issues when the system time changes (e.g. daylight savings).