### PR TITLE
Remove `str()` for `LazyFormat` passed into `Exception`

### DIFF
--- a/dbt-metricflow/dbt_metricflow/cli/dbt_connectors/dbt_config_accessor.py
+++ b/dbt-metricflow/dbt_metricflow/cli/dbt_connectors/dbt_config_accessor.py
@@ -64,14 +64,13 @@ class dbtProjectMetadata:
 
         logger.debug(LazyFormat("Ran validation", validation_result=validation_result))
         if validation_result.exception is not None:
-            exception_message = str(
+            raise RuntimeError(
                 LazyFormat(
                     "Error validating the dbt project",
                     profiles_path=profiles_path_str,
                     project_path=project_path_str,
                 )
-            )
-            raise RuntimeError(exception_message) from validation_result.exception
+            ) from validation_result.exception
 
         profile = load_profile(project_root=project_path_str, cli_vars={})
         logger.debug(LazyFormat("Loaded profile", profile=profile))

--- a/metricflow-semantics/metricflow_semantics/model/semantics/dimension_lookup.py
+++ b/metricflow-semantics/metricflow_semantics/model/semantics/dimension_lookup.py
@@ -33,16 +33,14 @@ class DimensionLookup:
                 existing_invariant = self._dimension_reference_to_invariant.get(dimension_reference)
                 if existing_invariant is not None and existing_invariant != invariant:
                     raise ValueError(
-                        str(
-                            LazyFormat(
-                                "Dimensions with the same name have been defined with conflicting values that "
-                                "should have been the same in a given semantic manifest. This should have been caught "
-                                "during validation.",
-                                dimension_reference=dimension_reference,
-                                existing_invariant=existing_invariant,
-                                conflicting_invariant=invariant,
-                                semantic_model_reference=semantic_model.reference,
-                            )
+                        LazyFormat(
+                            "Dimensions with the same name have been defined with conflicting values that "
+                            "should have been the same in a given semantic manifest. This should have been caught "
+                            "during validation.",
+                            dimension_reference=dimension_reference,
+                            existing_invariant=existing_invariant,
+                            conflicting_invariant=invariant,
+                            semantic_model_reference=semantic_model.reference,
                         )
                     )
 
@@ -55,12 +53,10 @@ class DimensionLookup:
         invariant = self._dimension_reference_to_invariant[dimension_reference]
         if invariant is None:
             raise ValueError(
-                str(
-                    LazyFormat(
-                        "Unknown dimension reference",
-                        dimension_reference=dimension_reference,
-                        known_dimension_references=list(self._dimension_reference_to_invariant.keys()),
-                    )
+                LazyFormat(
+                    "Unknown dimension reference",
+                    dimension_reference=dimension_reference,
+                    known_dimension_references=list(self._dimension_reference_to_invariant.keys()),
                 )
             )
 

--- a/metricflow-semantics/metricflow_semantics/model/semantics/measure_lookup.py
+++ b/metricflow-semantics/metricflow_semantics/model/semantics/measure_lookup.py
@@ -85,12 +85,10 @@ class MeasureLookup:
         property_set = self._measure_reference_to_property_set.get(measure_reference)
         if property_set is None:
             raise ValueError(
-                str(
-                    LazyFormat(
-                        "Unable to get properties as the given measure reference is unknown",
-                        measure_reference=measure_reference,
-                        known_measures=list(self._measure_reference_to_property_set.keys()),
-                    )
+                LazyFormat(
+                    "Unable to get properties as the given measure reference is unknown",
+                    measure_reference=measure_reference,
+                    known_measures=list(self._measure_reference_to_property_set.keys()),
                 )
             )
 
@@ -101,12 +99,10 @@ class MeasureLookup:
         measure = self._measure_reference_to_measure.get(measure_reference)
         if measure is None:
             raise ValueError(
-                str(
-                    LazyFormat(
-                        "Unable to get the measure as the given reference is unknown",
-                        measure_reference=measure_reference,
-                        known_measures=self._measure_reference_to_property_set.keys(),
-                    )
+                LazyFormat(
+                    "Unable to get the measure as the given reference is unknown",
+                    measure_reference=measure_reference,
+                    known_measures=self._measure_reference_to_property_set.keys(),
                 )
             )
 

--- a/metricflow-semantics/metricflow_semantics/naming/object_builder_str.py
+++ b/metricflow-semantics/metricflow_semantics/naming/object_builder_str.py
@@ -140,7 +140,7 @@ class ObjectBuilderNameConverter:
         if len(names) == 0:
             return None
         elif len(names) > 1:
-            raise RuntimeError(str(LazyFormat("Expected at most one name", instance_spec=instance_spec, names=names)))
+            raise RuntimeError(LazyFormat("Expected at most one name", instance_spec=instance_spec, names=names))
 
         return names[0]
 

--- a/metricflow/dataset/sql_dataset.py
+++ b/metricflow/dataset/sql_dataset.py
@@ -69,11 +69,9 @@ class SqlDataSet(DataSet):
         """
         if self._sql_select_node is None:
             raise RuntimeError(
-                str(
-                    LazyFormat(
-                        f"{self.__class__.__name__} was created with a SQL node that is not a {SqlSelectStatementNode.__name__}",
-                        sql_node=self.sql_node.structure_text(),
-                    )
+                LazyFormat(
+                    f"{self.__class__.__name__} was created with a SQL node that is not a {SqlSelectStatementNode.__name__}",
+                    sql_node=self.sql_node.structure_text(),
                 )
             )
         return self._sql_select_node
@@ -172,7 +170,7 @@ class SqlDataSet(DataSet):
             if instance.spec == spec:
                 return instance
         raise RuntimeError(
-            str(LazyFormat("Did not find instance matching spec in dataset.", spec=spec, instances=instances))
+            LazyFormat("Did not find instance matching spec in dataset.", spec=spec, instances=instances)
         )
 
     def instance_for_column_name(self, column_name: str) -> MdoInstance:
@@ -182,12 +180,10 @@ class SqlDataSet(DataSet):
             if instance.associated_column.column_name == column_name:
                 return instance
         raise RuntimeError(
-            str(
-                LazyFormat(
-                    "Did not find instance matching column name in dataset.",
-                    column_name=column_name,
-                    instances=instances,
-                )
+            LazyFormat(
+                "Did not find instance matching column name in dataset.",
+                column_name=column_name,
+                instances=instances,
             )
         )
 
@@ -204,13 +200,11 @@ class SqlDataSet(DataSet):
                 return time_dimension_instance
 
         raise RuntimeError(
-            str(
-                LazyFormat(
-                    "Did not find a time dimension instance with grain and date part in dataset.",
-                    time_granularity_name=time_granularity_name,
-                    date_part=date_part,
-                    instances_available=self.instance_set.time_dimension_instances,
-                )
+            LazyFormat(
+                "Did not find a time dimension instance with grain and date part in dataset.",
+                time_granularity_name=time_granularity_name,
+                date_part=date_part,
+                instances_available=self.instance_set.time_dimension_instances,
             )
         )
 

--- a/metricflow/engine/metricflow_engine.py
+++ b/metricflow/engine/metricflow_engine.py
@@ -185,22 +185,18 @@ class MetricFlowExplainResult:
         execution_plan = self.execution_plan
         if len(execution_plan.tasks) != 1:
             raise NotImplementedError(
-                str(
-                    LazyFormat(
-                        "Multiple tasks in the execution plan not yet supported.",
-                        tasks=[task.task_id for task in execution_plan.tasks],
-                    )
+                LazyFormat(
+                    "Multiple tasks in the execution plan not yet supported.",
+                    tasks=[task.task_id for task in execution_plan.tasks],
                 )
             )
 
         sql_statement = execution_plan.tasks[0].sql_statement
         if not sql_statement:
             raise NotImplementedError(
-                str(
-                    LazyFormat(
-                        "Execution plan tasks without a SQL statement are not yet supported.",
-                        tasks=[task.task_id for task in execution_plan.tasks],
-                    )
+                LazyFormat(
+                    "Execution plan tasks without a SQL statement are not yet supported.",
+                    tasks=[task.task_id for task in execution_plan.tasks],
                 )
             )
 

--- a/metricflow/plan_conversion/instance_converters.py
+++ b/metricflow/plan_conversion/instance_converters.py
@@ -458,12 +458,10 @@ class FilterElements(InstanceSetTransform[InstanceSet]):
                     include_specs_not_found.append(include_spec)
             if include_specs_not_found:
                 raise RuntimeError(
-                    str(
-                        LazyFormat(
-                            "Include specs are not in the spec set - check if this node was constructed correctly.",
-                            include_specs_not_found=include_specs_not_found,
-                            available_specs=available_specs,
-                        )
+                    LazyFormat(
+                        "Include specs are not in the spec set - check if this node was constructed correctly.",
+                        include_specs_not_found=include_specs_not_found,
+                        available_specs=available_specs,
                     )
                 )
         elif self._exclude_specs:
@@ -474,12 +472,10 @@ class FilterElements(InstanceSetTransform[InstanceSet]):
                     exclude_specs_not_found.append(exclude_spec)
             if exclude_specs_not_found:
                 raise RuntimeError(
-                    str(
-                        LazyFormat(
-                            "Exclude specs are not in the spec set - check if this node was constructed correctly.",
-                            exclude_specs_not_found=exclude_specs_not_found,
-                            available_specs=available_specs,
-                        )
+                    LazyFormat(
+                        "Exclude specs are not in the spec set - check if this node was constructed correctly.",
+                        exclude_specs_not_found=exclude_specs_not_found,
+                        available_specs=available_specs,
                     )
                 )
         else:

--- a/metricflow/plan_conversion/to_sql_plan/dataflow_to_subquery.py
+++ b/metricflow/plan_conversion/to_sql_plan/dataflow_to_subquery.py
@@ -223,11 +223,9 @@ class DataflowNodeToSqlSubqueryVisitor(DataflowPlanNodeVisitor[SqlDataSet]):
         )
         if len(time_spine_sources) != 1:
             raise RuntimeError(
-                str(
-                    LazyFormat(
-                        "Unexpected number of time spine sources required for query - cumulative metrics should require exactly one.",
-                        time_spine_sources=time_spine_sources,
-                    )
+                LazyFormat(
+                    "Unexpected number of time spine sources required for query - cumulative metrics should require exactly one.",
+                    time_spine_sources=time_spine_sources,
                 )
             )
         time_spine_source = time_spine_sources[0]

--- a/metricflow/sql/optimizer/column_pruning/cte_alias_to_cte_node_mapping.py
+++ b/metricflow/sql/optimizer/column_pruning/cte_alias_to_cte_node_mapping.py
@@ -58,13 +58,11 @@ class SqlCteAliasMappingLookup:
         """
         if select_node in self._select_node_to_cte_alias_mapping:
             raise RuntimeError(
-                str(
-                    LazyFormat(
-                        "`select_node` node has already been added,",
-                        # child_select_node=child_select_node,
-                        select_node=select_node,
-                        current_mapping=self._select_node_to_cte_alias_mapping,
-                    )
+                LazyFormat(
+                    "`select_node` node has already been added,",
+                    # child_select_node=child_select_node,
+                    select_node=select_node,
+                    current_mapping=self._select_node_to_cte_alias_mapping,
                 )
             )
 
@@ -78,6 +76,7 @@ class SqlCteAliasMappingLookup:
         cte_alias_mapping = self._select_node_to_cte_alias_mapping.get(select_node)
         if cte_alias_mapping is None:
             raise RuntimeError(
-                str(LazyFormat("CTE alias mapping does not exist for the given `select_node`", select_node=select_node))
+                LazyFormat("CTE alias mapping does not exist for the given `select_node`", select_node=select_node)
             )
+
         return cte_alias_mapping

--- a/tests_metricflow/cli/cli_test_helpers.py
+++ b/tests_metricflow/cli/cli_test_helpers.py
@@ -38,14 +38,12 @@ def run_and_check_cli_command(
     )
 
     if result.exit_code != expected_exit_code:
-        assert False, str(
-            LazyFormat(
-                "Command exit code mismatch",
-                expected_exit_code=expected_exit_code,
-                actual_exit_code=result.exit_code,
-                result=result,
-            )
-        )
+        assert False, LazyFormat(
+            "Command exit code mismatch",
+            expected_exit_code=expected_exit_code,
+            actual_exit_code=result.exit_code,
+            result=result,
+        ).evaluated_value
 
     # Replace incomparable values in snapshots with `***`.
     snapshot_str = result.stdout

--- a/tests_metricflow/performance/test_manifest_generator.py
+++ b/tests_metricflow/performance/test_manifest_generator.py
@@ -44,10 +44,8 @@ def test_manifest_generator(  # noqa: D103
     validation_result = validator.validate_semantic_manifest(manifest)
     logger.debug(LazyFormat("Generated manifest", manifest=manifest))
 
-    assert not validation_result.has_blocking_issues, str(
-        LazyFormat(
-            "Found validation issues with the generated manifest",
-            validation_result=validation_result,
-            manifest=manifest,
-        )
-    )
+    assert not validation_result.has_blocking_issues, LazyFormat(
+        "Found validation issues with the generated manifest",
+        validation_result=validation_result,
+        manifest=manifest,
+    ).evaluated_value


### PR DESCRIPTION
This PR removes calls similar to `str(LazyFormat(...))` when used with exceptions as `str()` is called on the message anyway.