### PR TITLE
Remove `NonAdditiveDimensionSpec.__eq__`

### DIFF
--- a/metricflow-semantics/metricflow_semantics/specs/non_additive_dimension_spec.py
+++ b/metricflow-semantics/metricflow_semantics/specs/non_additive_dimension_spec.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from hashlib import sha1
-from typing import Any, Sequence, Tuple
+from typing import Sequence, Tuple
 
 from dbt_semantic_interfaces.dataclass_serialization import SerializableDataclass
 from dbt_semantic_interfaces.type_enums import AggregationType, TimeGranularity
@@ -71,8 +71,3 @@ class NonAdditiveDimensionSpec(SerializableDataclass):
                 time_granularity=ExpandedTimeGranularity.from_time_granularity(non_additive_dimension_grain),
             ),
         ) + tuple(LinklessEntitySpec.from_element_name(entity_name) for entity_name in self.window_groupings)
-
-    def __eq__(self, other: Any) -> bool:  # type: ignore[misc]  # noqa: D105
-        if not isinstance(other, NonAdditiveDimensionSpec):
-            return False
-        return self.bucket_hash == other.bucket_hash


### PR DESCRIPTION
This PR removes the custom `NonAdditiveDimensionSpec.__eq__` as it can cause odd behavior - two instances that are considered equal can have a different hash.