### PR TITLE
Provide context in `MetricFlowPrettyFormattable.pretty_format()`

### DIFF
--- a/.changes/unreleased/Under the Hood-20250425-173202.yaml
+++ b/.changes/unreleased/Under the Hood-20250425-173202.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Provide context in `MetricFlowPrettyFormattable.pretty_format()`
+time: 2025-04-25T17:32:02.857627-07:00
+custom:
+  Author: plypaul
+  Issue: "1733"

--- a/metricflow-semantics/metricflow_semantics/dag/mf_dag.py
+++ b/metricflow-semantics/metricflow_semantics/dag/mf_dag.py
@@ -16,6 +16,7 @@ from metricflow_semantics.dag.dag_to_text import MetricFlowDagTextFormatter
 from metricflow_semantics.dag.id_prefix import IdPrefix
 from metricflow_semantics.dag.sequential_id import SequentialIdGenerator
 from metricflow_semantics.mf_logging.pretty_formattable import MetricFlowPrettyFormattable
+from metricflow_semantics.mf_logging.pretty_formatter import PrettyFormatContext
 from metricflow_semantics.visitor import VisitorOutputT
 
 logger = logging.getLogger(__name__)
@@ -128,9 +129,8 @@ class DagNode(MetricFlowPrettyFormattable, Generic[DagNodeT], ABC):
         """Return a text representation that shows the structure of the DAG component starting from this node."""
         return formatter.dag_component_to_text(self)
 
-    @property
     @override
-    def pretty_format(self) -> Optional[str]:
+    def pretty_format(self, format_context: PrettyFormatContext) -> Optional[str]:
         return f"{self.__class__.__name__}(node_id={self.node_id.id_str})"
 
 

--- a/metricflow-semantics/metricflow_semantics/mf_logging/pretty_formattable.py
+++ b/metricflow-semantics/metricflow_semantics/mf_logging/pretty_formattable.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
+import typing
 from abc import ABC, abstractmethod
 from typing import Optional
+
+if typing.TYPE_CHECKING:
+    from metricflow_semantics.mf_logging.pretty_formatter import PrettyFormatContext
 
 
 class MetricFlowPrettyFormattable(ABC):
@@ -10,8 +14,7 @@ class MetricFlowPrettyFormattable(ABC):
     This interface is pending updates to allow for additional configuration and structured return types.
     """
 
-    @property
     @abstractmethod
-    def pretty_format(self) -> Optional[str]:
-        """Return the pretty-formatted version of this object, or None if the default approach should be used."""
+    def pretty_format(self, format_context: PrettyFormatContext) -> Optional[str]:
+        """Return the pretty-formatted version of this object, or `None` if the default approach should be used."""
         raise NotImplementedError

--- a/metricflow-semantics/metricflow_semantics/mf_logging/pretty_formatter.py
+++ b/metricflow-semantics/metricflow_semantics/mf_logging/pretty_formatter.py
@@ -328,8 +328,15 @@ class MetricFlowPrettyFormatter:
             )
 
         if isinstance(obj, MetricFlowPrettyFormattable):
-            if obj.pretty_format is not None:
-                return obj.pretty_format
+            result = obj.pretty_format(
+                PrettyFormatContext(
+                    formatter=MetricFlowPrettyFormatter(
+                        format_option=self._format_option.with_max_line_length(remaining_line_width)
+                    )
+                )
+            )
+            if result is not None:
+                return result
 
         if is_dataclass(obj):
             # dataclasses.asdict() seems to exclude None fields, so doing this instead.
@@ -403,3 +410,10 @@ class PrettyFormatOption:
             include_none_object_fields=self.include_none_object_fields,
             include_empty_object_fields=self.include_empty_object_fields,
         )
+
+
+@fast_frozen_dataclass()
+class PrettyFormatContext:
+    """The context to use for pretty-formatting an object."""
+
+    formatter: MetricFlowPrettyFormatter

--- a/metricflow-semantics/metricflow_semantics/sql/sql_exprs.py
+++ b/metricflow-semantics/metricflow_semantics/sql/sql_exprs.py
@@ -19,6 +19,7 @@ from typing_extensions import override
 from metricflow_semantics.collection_helpers.merger import Mergeable
 from metricflow_semantics.dag.id_prefix import IdPrefix, StaticIdPrefix
 from metricflow_semantics.dag.mf_dag import DagNode, DisplayedProperty
+from metricflow_semantics.mf_logging.pretty_formatter import PrettyFormatContext
 from metricflow_semantics.sql.sql_bind_parameters import SqlBindParameterSet
 from metricflow_semantics.visitor import Visitable, VisitorOutputT
 
@@ -316,8 +317,7 @@ class SqlStringExpression(SqlExpressionNode):
         return tuple(super().displayed_properties) + (DisplayedProperty("sql_expr", self.sql_expr),)
 
     @override
-    @property
-    def pretty_format(self) -> str:
+    def pretty_format(self, format_context: PrettyFormatContext) -> Optional[str]:
         return f"{self.__class__.__name__}(node_id={self.node_id} sql_expr={self.sql_expr})"
 
     def rewrite(  # noqa: D102
@@ -873,9 +873,8 @@ class SqlAggregateFunctionExpression(SqlFunctionExpression):
             + tuple(DisplayedProperty("argument", x) for x in self.sql_function_args)
         )
 
-    @property
     @override
-    def pretty_format(self) -> str:  # noqa: D105
+    def pretty_format(self, format_context: PrettyFormatContext) -> Optional[str]:
         return f"{self.__class__.__name__}(node_id={self.node_id}, sql_function={self.sql_function.name})"
 
     def rewrite(  # noqa: D102
@@ -1168,9 +1167,8 @@ class SqlWindowFunctionExpression(SqlFunctionExpression):
     def is_aggregate_function(self) -> bool:  # noqa: D102
         return False
 
-    @property
     @override
-    def pretty_format(self) -> str:  # noqa: D105
+    def pretty_format(self, format_context: PrettyFormatContext) -> Optional[str]:
         return f"{self.__class__.__name__}(node_id={self.node_id}, sql_function={self.sql_function.name})"
 
     def rewrite(  # noqa: D102

--- a/metricflow-semantics/tests_metricflow_semantics/mf_logging/test_pretty_print.py
+++ b/metricflow-semantics/tests_metricflow_semantics/mf_logging/test_pretty_print.py
@@ -9,6 +9,7 @@ from dbt_semantic_interfaces.implementations.elements.dimension import PydanticD
 from dbt_semantic_interfaces.type_enums import DimensionType
 from metricflow_semantics.helpers.string_helpers import mf_indent
 from metricflow_semantics.mf_logging.pretty_formattable import MetricFlowPrettyFormattable
+from metricflow_semantics.mf_logging.pretty_formatter import PrettyFormatContext
 from metricflow_semantics.mf_logging.pretty_print import PrettyFormatDictOption, mf_pformat
 from metricflow_semantics.test_helpers.metric_time_dimension import MTD_SPEC_DAY
 from typing_extensions import override
@@ -158,10 +159,9 @@ def test_custom_pretty_print() -> None:
     class _ExampleDataclass(MetricFlowPrettyFormattable):
         field_0: float
 
-        @property
         @override
-        def pretty_format(self) -> Optional[str]:
-            """Only show 2 decimal points when pretty printing."""
-            return f"{self.__class__.__name__}({self.field_0:.2f})"
+        def pretty_format(self, format_context: PrettyFormatContext) -> Optional[str]:
+            """Print this like a dictionary instead field as a string to 2 decimal places."""
+            return format_context.formatter.pretty_format({"field_0": f"{self.field_0:.2f}"})
 
-    assert mf_pformat(_ExampleDataclass(1.2345)) == f"{_ExampleDataclass.__name__}(1.23)"
+    assert mf_pformat(_ExampleDataclass(1.2345)) == "{'field_0': '1.23'}"


### PR DESCRIPTION
This PR updates the signature of `MetricFlowPrettyFormattable.pretty_format()` to include a format context object. This allows implementing classes to format itself with more flexibility and with more adherence to the format options. One issue with the previous approach was that custom implementations couldn't properly respect the overall line length limit when formatted as a part of a nested object.