### PR TITLE
Use `{}` for pretty-formatting `Set`

### DIFF
--- a/.changes/unreleased/Under the Hood-20250425-173249.yaml
+++ b/.changes/unreleased/Under the Hood-20250425-173249.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Use `{}` for pretty-formatting `Set`
+time: 2025-04-25T17:32:49.025039-07:00
+custom:
+  Author: plypaul
+  Issue: "1734"

--- a/metricflow-semantics/tests_metricflow_semantics/mf_logging/test_pretty_print.py
+++ b/metricflow-semantics/tests_metricflow_semantics/mf_logging/test_pretty_print.py
@@ -28,6 +28,8 @@ def test_containers() -> None:  # noqa: D103
     assert mf_pformat(((1, 2), 3)) == "((1, 2), 3)"
     assert mf_pformat([[1, 2], 3]) == "[[1, 2], 3]"
     assert mf_pformat({"a": ((1, 2), 3), (1, 2): 3}) == "{'a': ((1, 2), 3), (1, 2): 3}"
+    assert mf_pformat({1, 2, 3}) == "{1, 2, 3}"
+    assert mf_pformat(frozenset({1, 2, 3})) == "{1, 2, 3}"
 
 
 def test_classes() -> None:  # noqa: D103


### PR DESCRIPTION
This PR updates pretty-formatting of sets to use `{...}` instead of `set(...)`. `_handle_sequence_obj` was renamed to `_handle_sequence_like_obj`.