### PR TITLE
Remove trailing comma when pretty-formatting `list`

### DIFF
--- a/.changes/unreleased/Fixes-20250425-182810.yaml
+++ b/.changes/unreleased/Fixes-20250425-182810.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Remove trailing comma when pretty-formatting `list`
+time: 2025-04-25T18:28:10.828256-07:00
+custom:
+  Author: plypaul
+  Issue: "1735"

--- a/metricflow-semantics/metricflow_semantics/mf_logging/pretty_formatter.py
+++ b/metricflow-semantics/metricflow_semantics/mf_logging/pretty_formatter.py
@@ -38,9 +38,11 @@ class MetricFlowPrettyFormatter:
         Returns:
             A string representation of the sequence. e.g. `(1, 2), [1, 2], {1, 2}`
         """
+        include_trailing_comma_for_single_item_in_one_line = False
         if isinstance(sequence_like_obj, tuple):
             left_enclose_str = "("
             right_enclose_str = ")"
+            include_trailing_comma_for_single_item_in_one_line = True
         elif isinstance(sequence_like_obj, Sequence):
             left_enclose_str = "["
             right_enclose_str = "]"
@@ -60,7 +62,7 @@ class MetricFlowPrettyFormatter:
         line_items = [left_enclose_str]
         if len(items_as_str) > 0:
             line_items.extend([", ".join(items_as_str)])
-            if len(items_as_str) == 1:
+            if include_trailing_comma_for_single_item_in_one_line and len(items_as_str) == 1:
                 line_items.append(",")
         line_items.append(right_enclose_str)
         result_without_width_limit = "".join(line_items)

--- a/metricflow-semantics/tests_metricflow_semantics/mf_logging/test_pretty_print.py
+++ b/metricflow-semantics/tests_metricflow_semantics/mf_logging/test_pretty_print.py
@@ -7,9 +7,9 @@ from typing import Optional
 
 from dbt_semantic_interfaces.implementations.elements.dimension import PydanticDimension
 from dbt_semantic_interfaces.type_enums import DimensionType
-from metricflow_semantics.helpers.string_helpers import mf_indent
+from metricflow_semantics.helpers.string_helpers import mf_dedent, mf_indent
 from metricflow_semantics.mf_logging.pretty_formattable import MetricFlowPrettyFormattable
-from metricflow_semantics.mf_logging.pretty_formatter import PrettyFormatContext
+from metricflow_semantics.mf_logging.pretty_formatter import PrettyFormatContext, PrettyFormatOption
 from metricflow_semantics.mf_logging.pretty_print import PrettyFormatDictOption, mf_pformat
 from metricflow_semantics.test_helpers.metric_time_dimension import MTD_SPEC_DAY
 from typing_extensions import override
@@ -25,6 +25,14 @@ def test_literals() -> None:  # noqa: D103
 
 def test_containers() -> None:  # noqa: D103
     assert mf_pformat((1,)) == "(1,)"
+    assert mf_pformat([1]) == "[1]"
+    assert mf_pformat([1], format_option=PrettyFormatOption(max_line_length=1)) == mf_dedent(
+        """
+        [
+          1,
+        ]
+        """
+    )
     assert mf_pformat(((1, 2), 3)) == "((1, 2), 3)"
     assert mf_pformat([[1, 2], 3]) == "[[1, 2], 3]"
     assert mf_pformat({"a": ((1, 2), 3), (1, 2): 3}) == "{'a': ((1, 2), 3), (1, 2): 3}"

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_ambiguous_entity_path.py/str/test_non_resolvable_ambiguous_entity_path_due_to_mismatch__result_0.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_ambiguous_entity_path.py/str/test_non_resolvable_ambiguous_entity_path_due_to_mismatch__result_0.txt
@@ -16,7 +16,7 @@ Error #1:
     However, the given input does not match to a common item that is available to those parents:
 
       {
-        "Matching items for: Metric('entity_0_metric')": ['entity_0__country',],
+        "Matching items for: Metric('entity_0_metric')": ['entity_0__country'],
         "Matching items for: Metric('entity_1_metric')": [
           'entity_1__entity_0__country',
         ],

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_resolution_dags.py/GroupByItemResolutionDag/test_snapshot__accumulate_last_2_months_metric__gbir_6.xml
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_resolution_dags.py/GroupByItemResolutionDag/test_snapshot__accumulate_last_2_months_metric__gbir_6.xml
@@ -7,8 +7,8 @@ docstring:
     <QueryGroupByItemResolutionNode>
         <!-- description = 'Output the group-by items for query.' -->
         <!-- node_id = NodeId(id_str='qr_6') -->
-        <!-- metrics_in_query = ['accumulate_last_2_months_metric',] -->
-        <!-- where_filter = ["{{ TimeDimension('metric_time') }} > '2020-01-01'",] -->
+        <!-- metrics_in_query = ['accumulate_last_2_months_metric'] -->
+        <!-- where_filter = ["{{ TimeDimension('metric_time') }} > '2020-01-01'"] -->
         <MetricGroupByItemResolutionNode>
             <!-- description = 'Output group-by-items available for this metric.' -->
             <!-- node_id = NodeId(id_str='mtr_11') -->

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_resolution_dags.py/GroupByItemResolutionDag/test_snapshot__derived_metric_with_different_parent_time_grains__gbir_5.xml
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_resolution_dags.py/GroupByItemResolutionDag/test_snapshot__derived_metric_with_different_parent_time_grains__gbir_5.xml
@@ -7,8 +7,8 @@ docstring:
     <QueryGroupByItemResolutionNode>
         <!-- description = 'Output the group-by items for query.' -->
         <!-- node_id = NodeId(id_str='qr_5') -->
-        <!-- metrics_in_query = ['derived_metric_with_different_parent_time_grains',] -->
-        <!-- where_filter = ["{{ TimeDimension('metric_time') }} > '2020-01-01'",] -->
+        <!-- metrics_in_query = ['derived_metric_with_different_parent_time_grains'] -->
+        <!-- where_filter = ["{{ TimeDimension('metric_time') }} > '2020-01-01'"] -->
         <MetricGroupByItemResolutionNode>
             <!-- description = 'Output group-by-items available for this metric.' -->
             <!-- node_id = NodeId(id_str='mtr_10') -->

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_resolution_dags.py/GroupByItemResolutionDag/test_snapshot__derived_metric_with_same_parent_time_grains__gbir_4.xml
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_resolution_dags.py/GroupByItemResolutionDag/test_snapshot__derived_metric_with_same_parent_time_grains__gbir_4.xml
@@ -7,8 +7,8 @@ docstring:
     <QueryGroupByItemResolutionNode>
         <!-- description = 'Output the group-by items for query.' -->
         <!-- node_id = NodeId(id_str='qr_4') -->
-        <!-- metrics_in_query = ['derived_metric_with_same_parent_time_grains',] -->
-        <!-- where_filter = ["{{ TimeDimension('metric_time') }} > '2020-01-01'",] -->
+        <!-- metrics_in_query = ['derived_metric_with_same_parent_time_grains'] -->
+        <!-- where_filter = ["{{ TimeDimension('metric_time') }} > '2020-01-01'"] -->
         <MetricGroupByItemResolutionNode>
             <!-- description = 'Output group-by-items available for this metric.' -->
             <!-- node_id = NodeId(id_str='mtr_7') -->

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_resolution_dags.py/GroupByItemResolutionDag/test_snapshot__metrics_with_different_time_grains__gbir_3.xml
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_resolution_dags.py/GroupByItemResolutionDag/test_snapshot__metrics_with_different_time_grains__gbir_3.xml
@@ -8,7 +8,7 @@ docstring:
         <!-- description = 'Output the group-by items for query.' -->
         <!-- node_id = NodeId(id_str='qr_3') -->
         <!-- metrics_in_query = ['monthly_metric_0', 'yearly_metric_0'] -->
-        <!-- where_filter = ["{{ TimeDimension('metric_time') }} > '2020-01-01'",] -->
+        <!-- where_filter = ["{{ TimeDimension('metric_time') }} > '2020-01-01'"] -->
         <MetricGroupByItemResolutionNode>
             <!-- description = 'Output group-by-items available for this metric.' -->
             <!-- node_id = NodeId(id_str='mtr_3') -->

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_resolution_dags.py/GroupByItemResolutionDag/test_snapshot__metrics_with_same_time_grains__gbir_2.xml
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_resolution_dags.py/GroupByItemResolutionDag/test_snapshot__metrics_with_same_time_grains__gbir_2.xml
@@ -8,7 +8,7 @@ docstring:
         <!-- description = 'Output the group-by items for query.' -->
         <!-- node_id = NodeId(id_str='qr_2') -->
         <!-- metrics_in_query = ['monthly_metric_0', 'monthly_metric_1'] -->
-        <!-- where_filter = ["{{ TimeDimension('metric_time') }} > '2020-01-01'",] -->
+        <!-- where_filter = ["{{ TimeDimension('metric_time') }} > '2020-01-01'"] -->
         <MetricGroupByItemResolutionNode>
             <!-- description = 'Output group-by-items available for this metric.' -->
             <!-- node_id = NodeId(id_str='mtr_1') -->

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_resolution_dags.py/GroupByItemResolutionDag/test_snapshot__simple_metric__gbir_1.xml
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_resolution_dags.py/GroupByItemResolutionDag/test_snapshot__simple_metric__gbir_1.xml
@@ -7,8 +7,8 @@ docstring:
     <QueryGroupByItemResolutionNode>
         <!-- description = 'Output the group-by items for query.' -->
         <!-- node_id = NodeId(id_str='qr_1') -->
-        <!-- metrics_in_query = ['monthly_metric_0',] -->
-        <!-- where_filter = ["{{ TimeDimension('metric_time') }} > '2020-01-01'",] -->
+        <!-- metrics_in_query = ['monthly_metric_0'] -->
+        <!-- where_filter = ["{{ TimeDimension('metric_time') }} > '2020-01-01'"] -->
         <MetricGroupByItemResolutionNode>
             <!-- description = 'Output group-by-items available for this metric.' -->
             <!-- node_id = NodeId(id_str='mtr_0') -->

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_suggestions.py/str/test_suggestions_for_defined_filters_in_multi_metric_query__result_0.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_suggestions.py/str/test_suggestions_for_defined_filters_in_multi_metric_query__result_0.txt
@@ -30,7 +30,7 @@ Error #1:
   Query Input:
 
     WhereFilter(
-      ["{{ TimeDimension('booking__paid_at') }} > '2020-01-01'",]
+      ["{{ TimeDimension('booking__paid_at') }} > '2020-01-01'"]
     )
     Filter Path:
       [Resolve Query(['bookings', 'listings'])]

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_suggestions.py/str/test_suggestions_for_defined_where_filter__result_0.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_suggestions.py/str/test_suggestions_for_defined_where_filter__result_0.txt
@@ -28,7 +28,7 @@ Error #1:
   Query Input:
 
     WhereFilter(
-      ["{{ TimeDimension('listing__paid_at') }} > '2020-01-01'",]
+      ["{{ TimeDimension('listing__paid_at') }} > '2020-01-01'"]
     )
     Filter Path:
       [Resolve Query(['listings'])]

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlPlan/BigQuery/test_conversion_metric_with_different_time_dimension_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlPlan/BigQuery/test_conversion_metric_with_different_time_dimension_grains__plan0.sql
@@ -17,7 +17,7 @@ FROM (
     SELECT
       SUM(subq_2.visits) AS visits
     FROM (
-      -- Pass Only Elements: ['visits',]
+      -- Pass Only Elements: ['visits']
       SELECT
         subq_1.visits
       FROM (
@@ -107,7 +107,7 @@ FROM (
     SELECT
       SUM(subq_11.buys_month) AS buys_month
     FROM (
-      -- Pass Only Elements: ['buys_month',]
+      -- Pass Only Elements: ['buys_month']
       SELECT
         subq_10.buys_month
       FROM (

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlPlan/BigQuery/test_conversion_metric_with_different_time_dimension_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlPlan/BigQuery/test_conversion_metric_with_different_time_dimension_grains__plan0_optimized.sql
@@ -20,7 +20,7 @@ SELECT
   CAST(MAX(subq_26.buys_month) AS FLOAT64) / CAST(NULLIF(MAX(subq_17.visits), 0) AS FLOAT64) AS visit_buy_conversion_rate_with_monthly_conversion
 FROM (
   -- Read From CTE For node_id=sma_28019
-  -- Pass Only Elements: ['visits',]
+  -- Pass Only Elements: ['visits']
   -- Aggregate Measures
   SELECT
     SUM(visits) AS visits
@@ -28,7 +28,7 @@ FROM (
 ) subq_17
 CROSS JOIN (
   -- Find conversions for user within the range of 1 month
-  -- Pass Only Elements: ['buys_month',]
+  -- Pass Only Elements: ['buys_month']
   -- Aggregate Measures
   SELECT
     SUM(buys_month) AS buys_month

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlPlan/BigQuery/test_conversion_metric_with_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlPlan/BigQuery/test_conversion_metric_with_filter__plan0.sql
@@ -17,7 +17,7 @@ FROM (
     SELECT
       SUM(subq_3.visits) AS visits
     FROM (
-      -- Pass Only Elements: ['visits',]
+      -- Pass Only Elements: ['visits']
       SELECT
         subq_2.visits
       FROM (
@@ -153,7 +153,7 @@ FROM (
     SELECT
       SUM(subq_13.buys) AS buys
     FROM (
-      -- Pass Only Elements: ['buys',]
+      -- Pass Only Elements: ['buys']
       SELECT
         subq_12.buys
       FROM (

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlPlan/BigQuery/test_conversion_metric_with_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlPlan/BigQuery/test_conversion_metric_with_filter__plan0_optimized.sql
@@ -20,7 +20,7 @@ SELECT
   CAST(MAX(subq_30.buys) AS FLOAT64) / CAST(NULLIF(MAX(subq_20.visits), 0) AS FLOAT64) AS visit_buy_conversion_rate
 FROM (
   -- Constrain Output with WHERE
-  -- Pass Only Elements: ['visits',]
+  -- Pass Only Elements: ['visits']
   -- Aggregate Measures
   SELECT
     SUM(visits) AS visits
@@ -35,7 +35,7 @@ FROM (
 ) subq_20
 CROSS JOIN (
   -- Find conversions for user within the range of INF
-  -- Pass Only Elements: ['buys',]
+  -- Pass Only Elements: ['buys']
   -- Aggregate Measures
   SELECT
     SUM(buys) AS buys

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlPlan/BigQuery/test_conversion_metric_with_filter_not_in_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlPlan/BigQuery/test_conversion_metric_with_filter_not_in_group_by__plan0.sql
@@ -17,7 +17,7 @@ FROM (
     SELECT
       SUM(subq_3.visits) AS visits
     FROM (
-      -- Pass Only Elements: ['visits',]
+      -- Pass Only Elements: ['visits']
       SELECT
         subq_2.visits
       FROM (
@@ -153,7 +153,7 @@ FROM (
     SELECT
       SUM(subq_13.buys) AS buys
     FROM (
-      -- Pass Only Elements: ['buys',]
+      -- Pass Only Elements: ['buys']
       SELECT
         subq_12.buys
       FROM (

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlPlan/BigQuery/test_conversion_metric_with_filter_not_in_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlPlan/BigQuery/test_conversion_metric_with_filter_not_in_group_by__plan0_optimized.sql
@@ -21,7 +21,7 @@ SELECT
   COALESCE(MAX(subq_30.buys), 0) AS visit_buy_conversions
 FROM (
   -- Constrain Output with WHERE
-  -- Pass Only Elements: ['visits',]
+  -- Pass Only Elements: ['visits']
   -- Aggregate Measures
   SELECT
     SUM(visits) AS visits
@@ -36,7 +36,7 @@ FROM (
 ) subq_20
 CROSS JOIN (
   -- Find conversions for user within the range of 7 day
-  -- Pass Only Elements: ['buys',]
+  -- Pass Only Elements: ['buys']
   -- Aggregate Measures
   SELECT
     SUM(buys) AS buys

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlPlan/Databricks/test_conversion_metric_with_different_time_dimension_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlPlan/Databricks/test_conversion_metric_with_different_time_dimension_grains__plan0.sql
@@ -17,7 +17,7 @@ FROM (
     SELECT
       SUM(subq_2.visits) AS visits
     FROM (
-      -- Pass Only Elements: ['visits',]
+      -- Pass Only Elements: ['visits']
       SELECT
         subq_1.visits
       FROM (
@@ -107,7 +107,7 @@ FROM (
     SELECT
       SUM(subq_11.buys_month) AS buys_month
     FROM (
-      -- Pass Only Elements: ['buys_month',]
+      -- Pass Only Elements: ['buys_month']
       SELECT
         subq_10.buys_month
       FROM (

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlPlan/Databricks/test_conversion_metric_with_different_time_dimension_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlPlan/Databricks/test_conversion_metric_with_different_time_dimension_grains__plan0_optimized.sql
@@ -20,7 +20,7 @@ SELECT
   CAST(MAX(subq_26.buys_month) AS DOUBLE) / CAST(NULLIF(MAX(subq_17.visits), 0) AS DOUBLE) AS visit_buy_conversion_rate_with_monthly_conversion
 FROM (
   -- Read From CTE For node_id=sma_28019
-  -- Pass Only Elements: ['visits',]
+  -- Pass Only Elements: ['visits']
   -- Aggregate Measures
   SELECT
     SUM(visits) AS visits
@@ -28,7 +28,7 @@ FROM (
 ) subq_17
 CROSS JOIN (
   -- Find conversions for user within the range of 1 month
-  -- Pass Only Elements: ['buys_month',]
+  -- Pass Only Elements: ['buys_month']
   -- Aggregate Measures
   SELECT
     SUM(buys_month) AS buys_month

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlPlan/Databricks/test_conversion_metric_with_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlPlan/Databricks/test_conversion_metric_with_filter__plan0.sql
@@ -17,7 +17,7 @@ FROM (
     SELECT
       SUM(subq_3.visits) AS visits
     FROM (
-      -- Pass Only Elements: ['visits',]
+      -- Pass Only Elements: ['visits']
       SELECT
         subq_2.visits
       FROM (
@@ -153,7 +153,7 @@ FROM (
     SELECT
       SUM(subq_13.buys) AS buys
     FROM (
-      -- Pass Only Elements: ['buys',]
+      -- Pass Only Elements: ['buys']
       SELECT
         subq_12.buys
       FROM (

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlPlan/Databricks/test_conversion_metric_with_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlPlan/Databricks/test_conversion_metric_with_filter__plan0_optimized.sql
@@ -20,7 +20,7 @@ SELECT
   CAST(MAX(subq_30.buys) AS DOUBLE) / CAST(NULLIF(MAX(subq_20.visits), 0) AS DOUBLE) AS visit_buy_conversion_rate
 FROM (
   -- Constrain Output with WHERE
-  -- Pass Only Elements: ['visits',]
+  -- Pass Only Elements: ['visits']
   -- Aggregate Measures
   SELECT
     SUM(visits) AS visits
@@ -35,7 +35,7 @@ FROM (
 ) subq_20
 CROSS JOIN (
   -- Find conversions for user within the range of INF
-  -- Pass Only Elements: ['buys',]
+  -- Pass Only Elements: ['buys']
   -- Aggregate Measures
   SELECT
     SUM(buys) AS buys

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlPlan/Databricks/test_conversion_metric_with_filter_not_in_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlPlan/Databricks/test_conversion_metric_with_filter_not_in_group_by__plan0.sql
@@ -17,7 +17,7 @@ FROM (
     SELECT
       SUM(subq_3.visits) AS visits
     FROM (
-      -- Pass Only Elements: ['visits',]
+      -- Pass Only Elements: ['visits']
       SELECT
         subq_2.visits
       FROM (
@@ -153,7 +153,7 @@ FROM (
     SELECT
       SUM(subq_13.buys) AS buys
     FROM (
-      -- Pass Only Elements: ['buys',]
+      -- Pass Only Elements: ['buys']
       SELECT
         subq_12.buys
       FROM (

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlPlan/Databricks/test_conversion_metric_with_filter_not_in_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlPlan/Databricks/test_conversion_metric_with_filter_not_in_group_by__plan0_optimized.sql
@@ -21,7 +21,7 @@ SELECT
   COALESCE(MAX(subq_30.buys), 0) AS visit_buy_conversions
 FROM (
   -- Constrain Output with WHERE
-  -- Pass Only Elements: ['visits',]
+  -- Pass Only Elements: ['visits']
   -- Aggregate Measures
   SELECT
     SUM(visits) AS visits
@@ -36,7 +36,7 @@ FROM (
 ) subq_20
 CROSS JOIN (
   -- Find conversions for user within the range of 7 day
-  -- Pass Only Elements: ['buys',]
+  -- Pass Only Elements: ['buys']
   -- Aggregate Measures
   SELECT
     SUM(buys) AS buys

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlPlan/DuckDB/test_conversion_metric_with_different_time_dimension_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlPlan/DuckDB/test_conversion_metric_with_different_time_dimension_grains__plan0.sql
@@ -17,7 +17,7 @@ FROM (
     SELECT
       SUM(subq_2.visits) AS visits
     FROM (
-      -- Pass Only Elements: ['visits',]
+      -- Pass Only Elements: ['visits']
       SELECT
         subq_1.visits
       FROM (
@@ -107,7 +107,7 @@ FROM (
     SELECT
       SUM(subq_11.buys_month) AS buys_month
     FROM (
-      -- Pass Only Elements: ['buys_month',]
+      -- Pass Only Elements: ['buys_month']
       SELECT
         subq_10.buys_month
       FROM (

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlPlan/DuckDB/test_conversion_metric_with_different_time_dimension_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlPlan/DuckDB/test_conversion_metric_with_different_time_dimension_grains__plan0_optimized.sql
@@ -20,7 +20,7 @@ SELECT
   CAST(MAX(subq_26.buys_month) AS DOUBLE) / CAST(NULLIF(MAX(subq_17.visits), 0) AS DOUBLE) AS visit_buy_conversion_rate_with_monthly_conversion
 FROM (
   -- Read From CTE For node_id=sma_28019
-  -- Pass Only Elements: ['visits',]
+  -- Pass Only Elements: ['visits']
   -- Aggregate Measures
   SELECT
     SUM(visits) AS visits
@@ -28,7 +28,7 @@ FROM (
 ) subq_17
 CROSS JOIN (
   -- Find conversions for user within the range of 1 month
-  -- Pass Only Elements: ['buys_month',]
+  -- Pass Only Elements: ['buys_month']
   -- Aggregate Measures
   SELECT
     SUM(buys_month) AS buys_month

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlPlan/DuckDB/test_conversion_metric_with_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlPlan/DuckDB/test_conversion_metric_with_filter__plan0.sql
@@ -17,7 +17,7 @@ FROM (
     SELECT
       SUM(subq_3.visits) AS visits
     FROM (
-      -- Pass Only Elements: ['visits',]
+      -- Pass Only Elements: ['visits']
       SELECT
         subq_2.visits
       FROM (
@@ -153,7 +153,7 @@ FROM (
     SELECT
       SUM(subq_13.buys) AS buys
     FROM (
-      -- Pass Only Elements: ['buys',]
+      -- Pass Only Elements: ['buys']
       SELECT
         subq_12.buys
       FROM (

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlPlan/DuckDB/test_conversion_metric_with_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlPlan/DuckDB/test_conversion_metric_with_filter__plan0_optimized.sql
@@ -20,7 +20,7 @@ SELECT
   CAST(MAX(subq_30.buys) AS DOUBLE) / CAST(NULLIF(MAX(subq_20.visits), 0) AS DOUBLE) AS visit_buy_conversion_rate
 FROM (
   -- Constrain Output with WHERE
-  -- Pass Only Elements: ['visits',]
+  -- Pass Only Elements: ['visits']
   -- Aggregate Measures
   SELECT
     SUM(visits) AS visits
@@ -35,7 +35,7 @@ FROM (
 ) subq_20
 CROSS JOIN (
   -- Find conversions for user within the range of INF
-  -- Pass Only Elements: ['buys',]
+  -- Pass Only Elements: ['buys']
   -- Aggregate Measures
   SELECT
     SUM(buys) AS buys

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlPlan/DuckDB/test_conversion_metric_with_filter_not_in_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlPlan/DuckDB/test_conversion_metric_with_filter_not_in_group_by__plan0.sql
@@ -17,7 +17,7 @@ FROM (
     SELECT
       SUM(subq_3.visits) AS visits
     FROM (
-      -- Pass Only Elements: ['visits',]
+      -- Pass Only Elements: ['visits']
       SELECT
         subq_2.visits
       FROM (
@@ -153,7 +153,7 @@ FROM (
     SELECT
       SUM(subq_13.buys) AS buys
     FROM (
-      -- Pass Only Elements: ['buys',]
+      -- Pass Only Elements: ['buys']
       SELECT
         subq_12.buys
       FROM (

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlPlan/DuckDB/test_conversion_metric_with_filter_not_in_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlPlan/DuckDB/test_conversion_metric_with_filter_not_in_group_by__plan0_optimized.sql
@@ -21,7 +21,7 @@ SELECT
   COALESCE(MAX(subq_30.buys), 0) AS visit_buy_conversions
 FROM (
   -- Constrain Output with WHERE
-  -- Pass Only Elements: ['visits',]
+  -- Pass Only Elements: ['visits']
   -- Aggregate Measures
   SELECT
     SUM(visits) AS visits
@@ -36,7 +36,7 @@ FROM (
 ) subq_20
 CROSS JOIN (
   -- Find conversions for user within the range of 7 day
-  -- Pass Only Elements: ['buys',]
+  -- Pass Only Elements: ['buys']
   -- Aggregate Measures
   SELECT
     SUM(buys) AS buys

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlPlan/Postgres/test_conversion_metric_with_different_time_dimension_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlPlan/Postgres/test_conversion_metric_with_different_time_dimension_grains__plan0.sql
@@ -17,7 +17,7 @@ FROM (
     SELECT
       SUM(subq_2.visits) AS visits
     FROM (
-      -- Pass Only Elements: ['visits',]
+      -- Pass Only Elements: ['visits']
       SELECT
         subq_1.visits
       FROM (
@@ -107,7 +107,7 @@ FROM (
     SELECT
       SUM(subq_11.buys_month) AS buys_month
     FROM (
-      -- Pass Only Elements: ['buys_month',]
+      -- Pass Only Elements: ['buys_month']
       SELECT
         subq_10.buys_month
       FROM (

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlPlan/Postgres/test_conversion_metric_with_different_time_dimension_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlPlan/Postgres/test_conversion_metric_with_different_time_dimension_grains__plan0_optimized.sql
@@ -20,7 +20,7 @@ SELECT
   CAST(MAX(subq_26.buys_month) AS DOUBLE PRECISION) / CAST(NULLIF(MAX(subq_17.visits), 0) AS DOUBLE PRECISION) AS visit_buy_conversion_rate_with_monthly_conversion
 FROM (
   -- Read From CTE For node_id=sma_28019
-  -- Pass Only Elements: ['visits',]
+  -- Pass Only Elements: ['visits']
   -- Aggregate Measures
   SELECT
     SUM(visits) AS visits
@@ -28,7 +28,7 @@ FROM (
 ) subq_17
 CROSS JOIN (
   -- Find conversions for user within the range of 1 month
-  -- Pass Only Elements: ['buys_month',]
+  -- Pass Only Elements: ['buys_month']
   -- Aggregate Measures
   SELECT
     SUM(buys_month) AS buys_month

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlPlan/Postgres/test_conversion_metric_with_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlPlan/Postgres/test_conversion_metric_with_filter__plan0.sql
@@ -17,7 +17,7 @@ FROM (
     SELECT
       SUM(subq_3.visits) AS visits
     FROM (
-      -- Pass Only Elements: ['visits',]
+      -- Pass Only Elements: ['visits']
       SELECT
         subq_2.visits
       FROM (
@@ -153,7 +153,7 @@ FROM (
     SELECT
       SUM(subq_13.buys) AS buys
     FROM (
-      -- Pass Only Elements: ['buys',]
+      -- Pass Only Elements: ['buys']
       SELECT
         subq_12.buys
       FROM (

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlPlan/Postgres/test_conversion_metric_with_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlPlan/Postgres/test_conversion_metric_with_filter__plan0_optimized.sql
@@ -20,7 +20,7 @@ SELECT
   CAST(MAX(subq_30.buys) AS DOUBLE PRECISION) / CAST(NULLIF(MAX(subq_20.visits), 0) AS DOUBLE PRECISION) AS visit_buy_conversion_rate
 FROM (
   -- Constrain Output with WHERE
-  -- Pass Only Elements: ['visits',]
+  -- Pass Only Elements: ['visits']
   -- Aggregate Measures
   SELECT
     SUM(visits) AS visits
@@ -35,7 +35,7 @@ FROM (
 ) subq_20
 CROSS JOIN (
   -- Find conversions for user within the range of INF
-  -- Pass Only Elements: ['buys',]
+  -- Pass Only Elements: ['buys']
   -- Aggregate Measures
   SELECT
     SUM(buys) AS buys

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlPlan/Postgres/test_conversion_metric_with_filter_not_in_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlPlan/Postgres/test_conversion_metric_with_filter_not_in_group_by__plan0.sql
@@ -17,7 +17,7 @@ FROM (
     SELECT
       SUM(subq_3.visits) AS visits
     FROM (
-      -- Pass Only Elements: ['visits',]
+      -- Pass Only Elements: ['visits']
       SELECT
         subq_2.visits
       FROM (
@@ -153,7 +153,7 @@ FROM (
     SELECT
       SUM(subq_13.buys) AS buys
     FROM (
-      -- Pass Only Elements: ['buys',]
+      -- Pass Only Elements: ['buys']
       SELECT
         subq_12.buys
       FROM (

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlPlan/Postgres/test_conversion_metric_with_filter_not_in_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlPlan/Postgres/test_conversion_metric_with_filter_not_in_group_by__plan0_optimized.sql
@@ -21,7 +21,7 @@ SELECT
   COALESCE(MAX(subq_30.buys), 0) AS visit_buy_conversions
 FROM (
   -- Constrain Output with WHERE
-  -- Pass Only Elements: ['visits',]
+  -- Pass Only Elements: ['visits']
   -- Aggregate Measures
   SELECT
     SUM(visits) AS visits
@@ -36,7 +36,7 @@ FROM (
 ) subq_20
 CROSS JOIN (
   -- Find conversions for user within the range of 7 day
-  -- Pass Only Elements: ['buys',]
+  -- Pass Only Elements: ['buys']
   -- Aggregate Measures
   SELECT
     SUM(buys) AS buys

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlPlan/Redshift/test_conversion_metric_with_different_time_dimension_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlPlan/Redshift/test_conversion_metric_with_different_time_dimension_grains__plan0.sql
@@ -17,7 +17,7 @@ FROM (
     SELECT
       SUM(subq_2.visits) AS visits
     FROM (
-      -- Pass Only Elements: ['visits',]
+      -- Pass Only Elements: ['visits']
       SELECT
         subq_1.visits
       FROM (
@@ -107,7 +107,7 @@ FROM (
     SELECT
       SUM(subq_11.buys_month) AS buys_month
     FROM (
-      -- Pass Only Elements: ['buys_month',]
+      -- Pass Only Elements: ['buys_month']
       SELECT
         subq_10.buys_month
       FROM (

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlPlan/Redshift/test_conversion_metric_with_different_time_dimension_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlPlan/Redshift/test_conversion_metric_with_different_time_dimension_grains__plan0_optimized.sql
@@ -20,7 +20,7 @@ SELECT
   CAST(MAX(subq_26.buys_month) AS DOUBLE PRECISION) / CAST(NULLIF(MAX(subq_17.visits), 0) AS DOUBLE PRECISION) AS visit_buy_conversion_rate_with_monthly_conversion
 FROM (
   -- Read From CTE For node_id=sma_28019
-  -- Pass Only Elements: ['visits',]
+  -- Pass Only Elements: ['visits']
   -- Aggregate Measures
   SELECT
     SUM(visits) AS visits
@@ -28,7 +28,7 @@ FROM (
 ) subq_17
 CROSS JOIN (
   -- Find conversions for user within the range of 1 month
-  -- Pass Only Elements: ['buys_month',]
+  -- Pass Only Elements: ['buys_month']
   -- Aggregate Measures
   SELECT
     SUM(buys_month) AS buys_month

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlPlan/Redshift/test_conversion_metric_with_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlPlan/Redshift/test_conversion_metric_with_filter__plan0.sql
@@ -17,7 +17,7 @@ FROM (
     SELECT
       SUM(subq_3.visits) AS visits
     FROM (
-      -- Pass Only Elements: ['visits',]
+      -- Pass Only Elements: ['visits']
       SELECT
         subq_2.visits
       FROM (
@@ -153,7 +153,7 @@ FROM (
     SELECT
       SUM(subq_13.buys) AS buys
     FROM (
-      -- Pass Only Elements: ['buys',]
+      -- Pass Only Elements: ['buys']
       SELECT
         subq_12.buys
       FROM (

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlPlan/Redshift/test_conversion_metric_with_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlPlan/Redshift/test_conversion_metric_with_filter__plan0_optimized.sql
@@ -20,7 +20,7 @@ SELECT
   CAST(MAX(subq_30.buys) AS DOUBLE PRECISION) / CAST(NULLIF(MAX(subq_20.visits), 0) AS DOUBLE PRECISION) AS visit_buy_conversion_rate
 FROM (
   -- Constrain Output with WHERE
-  -- Pass Only Elements: ['visits',]
+  -- Pass Only Elements: ['visits']
   -- Aggregate Measures
   SELECT
     SUM(visits) AS visits
@@ -35,7 +35,7 @@ FROM (
 ) subq_20
 CROSS JOIN (
   -- Find conversions for user within the range of INF
-  -- Pass Only Elements: ['buys',]
+  -- Pass Only Elements: ['buys']
   -- Aggregate Measures
   SELECT
     SUM(buys) AS buys

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlPlan/Redshift/test_conversion_metric_with_filter_not_in_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlPlan/Redshift/test_conversion_metric_with_filter_not_in_group_by__plan0.sql
@@ -17,7 +17,7 @@ FROM (
     SELECT
       SUM(subq_3.visits) AS visits
     FROM (
-      -- Pass Only Elements: ['visits',]
+      -- Pass Only Elements: ['visits']
       SELECT
         subq_2.visits
       FROM (
@@ -153,7 +153,7 @@ FROM (
     SELECT
       SUM(subq_13.buys) AS buys
     FROM (
-      -- Pass Only Elements: ['buys',]
+      -- Pass Only Elements: ['buys']
       SELECT
         subq_12.buys
       FROM (

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlPlan/Redshift/test_conversion_metric_with_filter_not_in_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlPlan/Redshift/test_conversion_metric_with_filter_not_in_group_by__plan0_optimized.sql
@@ -21,7 +21,7 @@ SELECT
   COALESCE(MAX(subq_30.buys), 0) AS visit_buy_conversions
 FROM (
   -- Constrain Output with WHERE
-  -- Pass Only Elements: ['visits',]
+  -- Pass Only Elements: ['visits']
   -- Aggregate Measures
   SELECT
     SUM(visits) AS visits
@@ -36,7 +36,7 @@ FROM (
 ) subq_20
 CROSS JOIN (
   -- Find conversions for user within the range of 7 day
-  -- Pass Only Elements: ['buys',]
+  -- Pass Only Elements: ['buys']
   -- Aggregate Measures
   SELECT
     SUM(buys) AS buys

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlPlan/Snowflake/test_conversion_metric_with_different_time_dimension_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlPlan/Snowflake/test_conversion_metric_with_different_time_dimension_grains__plan0.sql
@@ -17,7 +17,7 @@ FROM (
     SELECT
       SUM(subq_2.visits) AS visits
     FROM (
-      -- Pass Only Elements: ['visits',]
+      -- Pass Only Elements: ['visits']
       SELECT
         subq_1.visits
       FROM (
@@ -107,7 +107,7 @@ FROM (
     SELECT
       SUM(subq_11.buys_month) AS buys_month
     FROM (
-      -- Pass Only Elements: ['buys_month',]
+      -- Pass Only Elements: ['buys_month']
       SELECT
         subq_10.buys_month
       FROM (

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlPlan/Snowflake/test_conversion_metric_with_different_time_dimension_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlPlan/Snowflake/test_conversion_metric_with_different_time_dimension_grains__plan0_optimized.sql
@@ -20,7 +20,7 @@ SELECT
   CAST(MAX(subq_26.buys_month) AS DOUBLE) / CAST(NULLIF(MAX(subq_17.visits), 0) AS DOUBLE) AS visit_buy_conversion_rate_with_monthly_conversion
 FROM (
   -- Read From CTE For node_id=sma_28019
-  -- Pass Only Elements: ['visits',]
+  -- Pass Only Elements: ['visits']
   -- Aggregate Measures
   SELECT
     SUM(visits) AS visits
@@ -28,7 +28,7 @@ FROM (
 ) subq_17
 CROSS JOIN (
   -- Find conversions for user within the range of 1 month
-  -- Pass Only Elements: ['buys_month',]
+  -- Pass Only Elements: ['buys_month']
   -- Aggregate Measures
   SELECT
     SUM(buys_month) AS buys_month

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlPlan/Snowflake/test_conversion_metric_with_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlPlan/Snowflake/test_conversion_metric_with_filter__plan0.sql
@@ -17,7 +17,7 @@ FROM (
     SELECT
       SUM(subq_3.visits) AS visits
     FROM (
-      -- Pass Only Elements: ['visits',]
+      -- Pass Only Elements: ['visits']
       SELECT
         subq_2.visits
       FROM (
@@ -153,7 +153,7 @@ FROM (
     SELECT
       SUM(subq_13.buys) AS buys
     FROM (
-      -- Pass Only Elements: ['buys',]
+      -- Pass Only Elements: ['buys']
       SELECT
         subq_12.buys
       FROM (

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlPlan/Snowflake/test_conversion_metric_with_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlPlan/Snowflake/test_conversion_metric_with_filter__plan0_optimized.sql
@@ -20,7 +20,7 @@ SELECT
   CAST(MAX(subq_30.buys) AS DOUBLE) / CAST(NULLIF(MAX(subq_20.visits), 0) AS DOUBLE) AS visit_buy_conversion_rate
 FROM (
   -- Constrain Output with WHERE
-  -- Pass Only Elements: ['visits',]
+  -- Pass Only Elements: ['visits']
   -- Aggregate Measures
   SELECT
     SUM(visits) AS visits
@@ -35,7 +35,7 @@ FROM (
 ) subq_20
 CROSS JOIN (
   -- Find conversions for user within the range of INF
-  -- Pass Only Elements: ['buys',]
+  -- Pass Only Elements: ['buys']
   -- Aggregate Measures
   SELECT
     SUM(buys) AS buys

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlPlan/Snowflake/test_conversion_metric_with_filter_not_in_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlPlan/Snowflake/test_conversion_metric_with_filter_not_in_group_by__plan0.sql
@@ -17,7 +17,7 @@ FROM (
     SELECT
       SUM(subq_3.visits) AS visits
     FROM (
-      -- Pass Only Elements: ['visits',]
+      -- Pass Only Elements: ['visits']
       SELECT
         subq_2.visits
       FROM (
@@ -153,7 +153,7 @@ FROM (
     SELECT
       SUM(subq_13.buys) AS buys
     FROM (
-      -- Pass Only Elements: ['buys',]
+      -- Pass Only Elements: ['buys']
       SELECT
         subq_12.buys
       FROM (

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlPlan/Snowflake/test_conversion_metric_with_filter_not_in_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlPlan/Snowflake/test_conversion_metric_with_filter_not_in_group_by__plan0_optimized.sql
@@ -21,7 +21,7 @@ SELECT
   COALESCE(MAX(subq_30.buys), 0) AS visit_buy_conversions
 FROM (
   -- Constrain Output with WHERE
-  -- Pass Only Elements: ['visits',]
+  -- Pass Only Elements: ['visits']
   -- Aggregate Measures
   SELECT
     SUM(visits) AS visits
@@ -36,7 +36,7 @@ FROM (
 ) subq_20
 CROSS JOIN (
   -- Find conversions for user within the range of 7 day
-  -- Pass Only Elements: ['buys',]
+  -- Pass Only Elements: ['buys']
   -- Aggregate Measures
   SELECT
     SUM(buys) AS buys

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlPlan/Trino/test_conversion_metric_with_different_time_dimension_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlPlan/Trino/test_conversion_metric_with_different_time_dimension_grains__plan0.sql
@@ -17,7 +17,7 @@ FROM (
     SELECT
       SUM(subq_2.visits) AS visits
     FROM (
-      -- Pass Only Elements: ['visits',]
+      -- Pass Only Elements: ['visits']
       SELECT
         subq_1.visits
       FROM (
@@ -107,7 +107,7 @@ FROM (
     SELECT
       SUM(subq_11.buys_month) AS buys_month
     FROM (
-      -- Pass Only Elements: ['buys_month',]
+      -- Pass Only Elements: ['buys_month']
       SELECT
         subq_10.buys_month
       FROM (

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlPlan/Trino/test_conversion_metric_with_different_time_dimension_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlPlan/Trino/test_conversion_metric_with_different_time_dimension_grains__plan0_optimized.sql
@@ -20,7 +20,7 @@ SELECT
   CAST(MAX(subq_26.buys_month) AS DOUBLE) / CAST(NULLIF(MAX(subq_17.visits), 0) AS DOUBLE) AS visit_buy_conversion_rate_with_monthly_conversion
 FROM (
   -- Read From CTE For node_id=sma_28019
-  -- Pass Only Elements: ['visits',]
+  -- Pass Only Elements: ['visits']
   -- Aggregate Measures
   SELECT
     SUM(visits) AS visits
@@ -28,7 +28,7 @@ FROM (
 ) subq_17
 CROSS JOIN (
   -- Find conversions for user within the range of 1 month
-  -- Pass Only Elements: ['buys_month',]
+  -- Pass Only Elements: ['buys_month']
   -- Aggregate Measures
   SELECT
     SUM(buys_month) AS buys_month

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlPlan/Trino/test_conversion_metric_with_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlPlan/Trino/test_conversion_metric_with_filter__plan0.sql
@@ -17,7 +17,7 @@ FROM (
     SELECT
       SUM(subq_3.visits) AS visits
     FROM (
-      -- Pass Only Elements: ['visits',]
+      -- Pass Only Elements: ['visits']
       SELECT
         subq_2.visits
       FROM (
@@ -153,7 +153,7 @@ FROM (
     SELECT
       SUM(subq_13.buys) AS buys
     FROM (
-      -- Pass Only Elements: ['buys',]
+      -- Pass Only Elements: ['buys']
       SELECT
         subq_12.buys
       FROM (

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlPlan/Trino/test_conversion_metric_with_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlPlan/Trino/test_conversion_metric_with_filter__plan0_optimized.sql
@@ -20,7 +20,7 @@ SELECT
   CAST(MAX(subq_30.buys) AS DOUBLE) / CAST(NULLIF(MAX(subq_20.visits), 0) AS DOUBLE) AS visit_buy_conversion_rate
 FROM (
   -- Constrain Output with WHERE
-  -- Pass Only Elements: ['visits',]
+  -- Pass Only Elements: ['visits']
   -- Aggregate Measures
   SELECT
     SUM(visits) AS visits
@@ -35,7 +35,7 @@ FROM (
 ) subq_20
 CROSS JOIN (
   -- Find conversions for user within the range of INF
-  -- Pass Only Elements: ['buys',]
+  -- Pass Only Elements: ['buys']
   -- Aggregate Measures
   SELECT
     SUM(buys) AS buys

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlPlan/Trino/test_conversion_metric_with_filter_not_in_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlPlan/Trino/test_conversion_metric_with_filter_not_in_group_by__plan0.sql
@@ -17,7 +17,7 @@ FROM (
     SELECT
       SUM(subq_3.visits) AS visits
     FROM (
-      -- Pass Only Elements: ['visits',]
+      -- Pass Only Elements: ['visits']
       SELECT
         subq_2.visits
       FROM (
@@ -153,7 +153,7 @@ FROM (
     SELECT
       SUM(subq_13.buys) AS buys
     FROM (
-      -- Pass Only Elements: ['buys',]
+      -- Pass Only Elements: ['buys']
       SELECT
         subq_12.buys
       FROM (

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlPlan/Trino/test_conversion_metric_with_filter_not_in_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlPlan/Trino/test_conversion_metric_with_filter_not_in_group_by__plan0_optimized.sql
@@ -21,7 +21,7 @@ SELECT
   COALESCE(MAX(subq_30.buys), 0) AS visit_buy_conversions
 FROM (
   -- Constrain Output with WHERE
-  -- Pass Only Elements: ['visits',]
+  -- Pass Only Elements: ['visits']
   -- Aggregate Measures
   SELECT
     SUM(visits) AS visits
@@ -36,7 +36,7 @@ FROM (
 ) subq_20
 CROSS JOIN (
   -- Find conversions for user within the range of 7 day
-  -- Pass Only Elements: ['buys',]
+  -- Pass Only Elements: ['buys']
   -- Aggregate Measures
   SELECT
     SUM(buys) AS buys

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/BigQuery/test_conversion_count_with_no_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/BigQuery/test_conversion_count_with_no_group_by__plan0.sql
@@ -17,7 +17,7 @@ FROM (
     SELECT
       SUM(subq_2.visits) AS visits
     FROM (
-      -- Pass Only Elements: ['visits',]
+      -- Pass Only Elements: ['visits']
       SELECT
         subq_1.visits
       FROM (
@@ -107,7 +107,7 @@ FROM (
     SELECT
       SUM(subq_11.buys) AS buys
     FROM (
-      -- Pass Only Elements: ['buys',]
+      -- Pass Only Elements: ['buys']
       SELECT
         subq_10.buys
       FROM (

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/BigQuery/test_conversion_count_with_no_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/BigQuery/test_conversion_count_with_no_group_by__plan0_optimized.sql
@@ -20,7 +20,7 @@ SELECT
   COALESCE(MAX(subq_26.buys), 0) AS visit_buy_conversions
 FROM (
   -- Read From CTE For node_id=sma_28019
-  -- Pass Only Elements: ['visits',]
+  -- Pass Only Elements: ['visits']
   -- Aggregate Measures
   SELECT
     SUM(visits) AS visits
@@ -28,7 +28,7 @@ FROM (
 ) subq_17
 CROSS JOIN (
   -- Find conversions for user within the range of 7 day
-  -- Pass Only Elements: ['buys',]
+  -- Pass Only Elements: ['buys']
   -- Aggregate Measures
   SELECT
     SUM(buys) AS buys

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/BigQuery/test_conversion_metric_join_to_timespine_and_fill_nulls_with_0__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/BigQuery/test_conversion_metric_join_to_timespine_and_fill_nulls_with_0__plan0.sql
@@ -20,7 +20,7 @@ FROM (
       subq_6.metric_time__day AS metric_time__day
       , subq_3.visits AS visits
     FROM (
-      -- Pass Only Elements: ['metric_time__day',]
+      -- Pass Only Elements: ['metric_time__day']
       SELECT
         subq_5.metric_time__day
       FROM (
@@ -160,7 +160,7 @@ FROM (
       subq_19.metric_time__day AS metric_time__day
       , subq_16.buys AS buys
     FROM (
-      -- Pass Only Elements: ['metric_time__day',]
+      -- Pass Only Elements: ['metric_time__day']
       SELECT
         subq_18.metric_time__day
       FROM (

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/BigQuery/test_conversion_rate_with_no_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/BigQuery/test_conversion_rate_with_no_group_by__plan0.sql
@@ -17,7 +17,7 @@ FROM (
     SELECT
       SUM(subq_2.visits) AS visits
     FROM (
-      -- Pass Only Elements: ['visits',]
+      -- Pass Only Elements: ['visits']
       SELECT
         subq_1.visits
       FROM (
@@ -107,7 +107,7 @@ FROM (
     SELECT
       SUM(subq_11.buys) AS buys
     FROM (
-      -- Pass Only Elements: ['buys',]
+      -- Pass Only Elements: ['buys']
       SELECT
         subq_10.buys
       FROM (

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/BigQuery/test_conversion_rate_with_no_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/BigQuery/test_conversion_rate_with_no_group_by__plan0_optimized.sql
@@ -20,7 +20,7 @@ SELECT
   CAST(MAX(subq_26.buys) AS FLOAT64) / CAST(NULLIF(MAX(subq_17.visits), 0) AS FLOAT64) AS visit_buy_conversion_rate_7days
 FROM (
   -- Read From CTE For node_id=sma_28019
-  -- Pass Only Elements: ['visits',]
+  -- Pass Only Elements: ['visits']
   -- Aggregate Measures
   SELECT
     SUM(visits) AS visits
@@ -28,7 +28,7 @@ FROM (
 ) subq_17
 CROSS JOIN (
   -- Find conversions for user within the range of 7 day
-  -- Pass Only Elements: ['buys',]
+  -- Pass Only Elements: ['buys']
   -- Aggregate Measures
   SELECT
     SUM(buys) AS buys

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/Databricks/test_conversion_count_with_no_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/Databricks/test_conversion_count_with_no_group_by__plan0.sql
@@ -17,7 +17,7 @@ FROM (
     SELECT
       SUM(subq_2.visits) AS visits
     FROM (
-      -- Pass Only Elements: ['visits',]
+      -- Pass Only Elements: ['visits']
       SELECT
         subq_1.visits
       FROM (
@@ -107,7 +107,7 @@ FROM (
     SELECT
       SUM(subq_11.buys) AS buys
     FROM (
-      -- Pass Only Elements: ['buys',]
+      -- Pass Only Elements: ['buys']
       SELECT
         subq_10.buys
       FROM (

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/Databricks/test_conversion_count_with_no_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/Databricks/test_conversion_count_with_no_group_by__plan0_optimized.sql
@@ -20,7 +20,7 @@ SELECT
   COALESCE(MAX(subq_26.buys), 0) AS visit_buy_conversions
 FROM (
   -- Read From CTE For node_id=sma_28019
-  -- Pass Only Elements: ['visits',]
+  -- Pass Only Elements: ['visits']
   -- Aggregate Measures
   SELECT
     SUM(visits) AS visits
@@ -28,7 +28,7 @@ FROM (
 ) subq_17
 CROSS JOIN (
   -- Find conversions for user within the range of 7 day
-  -- Pass Only Elements: ['buys',]
+  -- Pass Only Elements: ['buys']
   -- Aggregate Measures
   SELECT
     SUM(buys) AS buys

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/Databricks/test_conversion_metric_join_to_timespine_and_fill_nulls_with_0__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/Databricks/test_conversion_metric_join_to_timespine_and_fill_nulls_with_0__plan0.sql
@@ -20,7 +20,7 @@ FROM (
       subq_6.metric_time__day AS metric_time__day
       , subq_3.visits AS visits
     FROM (
-      -- Pass Only Elements: ['metric_time__day',]
+      -- Pass Only Elements: ['metric_time__day']
       SELECT
         subq_5.metric_time__day
       FROM (
@@ -160,7 +160,7 @@ FROM (
       subq_19.metric_time__day AS metric_time__day
       , subq_16.buys AS buys
     FROM (
-      -- Pass Only Elements: ['metric_time__day',]
+      -- Pass Only Elements: ['metric_time__day']
       SELECT
         subq_18.metric_time__day
       FROM (

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/Databricks/test_conversion_rate_with_no_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/Databricks/test_conversion_rate_with_no_group_by__plan0.sql
@@ -17,7 +17,7 @@ FROM (
     SELECT
       SUM(subq_2.visits) AS visits
     FROM (
-      -- Pass Only Elements: ['visits',]
+      -- Pass Only Elements: ['visits']
       SELECT
         subq_1.visits
       FROM (
@@ -107,7 +107,7 @@ FROM (
     SELECT
       SUM(subq_11.buys) AS buys
     FROM (
-      -- Pass Only Elements: ['buys',]
+      -- Pass Only Elements: ['buys']
       SELECT
         subq_10.buys
       FROM (

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/Databricks/test_conversion_rate_with_no_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/Databricks/test_conversion_rate_with_no_group_by__plan0_optimized.sql
@@ -20,7 +20,7 @@ SELECT
   CAST(MAX(subq_26.buys) AS DOUBLE) / CAST(NULLIF(MAX(subq_17.visits), 0) AS DOUBLE) AS visit_buy_conversion_rate_7days
 FROM (
   -- Read From CTE For node_id=sma_28019
-  -- Pass Only Elements: ['visits',]
+  -- Pass Only Elements: ['visits']
   -- Aggregate Measures
   SELECT
     SUM(visits) AS visits
@@ -28,7 +28,7 @@ FROM (
 ) subq_17
 CROSS JOIN (
   -- Find conversions for user within the range of 7 day
-  -- Pass Only Elements: ['buys',]
+  -- Pass Only Elements: ['buys']
   -- Aggregate Measures
   SELECT
     SUM(buys) AS buys

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/DuckDB/test_conversion_count_with_no_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/DuckDB/test_conversion_count_with_no_group_by__plan0.sql
@@ -17,7 +17,7 @@ FROM (
     SELECT
       SUM(subq_2.visits) AS visits
     FROM (
-      -- Pass Only Elements: ['visits',]
+      -- Pass Only Elements: ['visits']
       SELECT
         subq_1.visits
       FROM (
@@ -107,7 +107,7 @@ FROM (
     SELECT
       SUM(subq_11.buys) AS buys
     FROM (
-      -- Pass Only Elements: ['buys',]
+      -- Pass Only Elements: ['buys']
       SELECT
         subq_10.buys
       FROM (

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/DuckDB/test_conversion_count_with_no_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/DuckDB/test_conversion_count_with_no_group_by__plan0_optimized.sql
@@ -20,7 +20,7 @@ SELECT
   COALESCE(MAX(subq_26.buys), 0) AS visit_buy_conversions
 FROM (
   -- Read From CTE For node_id=sma_28019
-  -- Pass Only Elements: ['visits',]
+  -- Pass Only Elements: ['visits']
   -- Aggregate Measures
   SELECT
     SUM(visits) AS visits
@@ -28,7 +28,7 @@ FROM (
 ) subq_17
 CROSS JOIN (
   -- Find conversions for user within the range of 7 day
-  -- Pass Only Elements: ['buys',]
+  -- Pass Only Elements: ['buys']
   -- Aggregate Measures
   SELECT
     SUM(buys) AS buys

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/DuckDB/test_conversion_metric_join_to_timespine_and_fill_nulls_with_0__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/DuckDB/test_conversion_metric_join_to_timespine_and_fill_nulls_with_0__plan0.sql
@@ -20,7 +20,7 @@ FROM (
       subq_6.metric_time__day AS metric_time__day
       , subq_3.visits AS visits
     FROM (
-      -- Pass Only Elements: ['metric_time__day',]
+      -- Pass Only Elements: ['metric_time__day']
       SELECT
         subq_5.metric_time__day
       FROM (
@@ -160,7 +160,7 @@ FROM (
       subq_19.metric_time__day AS metric_time__day
       , subq_16.buys AS buys
     FROM (
-      -- Pass Only Elements: ['metric_time__day',]
+      -- Pass Only Elements: ['metric_time__day']
       SELECT
         subq_18.metric_time__day
       FROM (

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/DuckDB/test_conversion_rate_with_no_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/DuckDB/test_conversion_rate_with_no_group_by__plan0.sql
@@ -17,7 +17,7 @@ FROM (
     SELECT
       SUM(subq_2.visits) AS visits
     FROM (
-      -- Pass Only Elements: ['visits',]
+      -- Pass Only Elements: ['visits']
       SELECT
         subq_1.visits
       FROM (
@@ -107,7 +107,7 @@ FROM (
     SELECT
       SUM(subq_11.buys) AS buys
     FROM (
-      -- Pass Only Elements: ['buys',]
+      -- Pass Only Elements: ['buys']
       SELECT
         subq_10.buys
       FROM (

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/DuckDB/test_conversion_rate_with_no_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/DuckDB/test_conversion_rate_with_no_group_by__plan0_optimized.sql
@@ -20,7 +20,7 @@ SELECT
   CAST(MAX(subq_26.buys) AS DOUBLE) / CAST(NULLIF(MAX(subq_17.visits), 0) AS DOUBLE) AS visit_buy_conversion_rate_7days
 FROM (
   -- Read From CTE For node_id=sma_28019
-  -- Pass Only Elements: ['visits',]
+  -- Pass Only Elements: ['visits']
   -- Aggregate Measures
   SELECT
     SUM(visits) AS visits
@@ -28,7 +28,7 @@ FROM (
 ) subq_17
 CROSS JOIN (
   -- Find conversions for user within the range of 7 day
-  -- Pass Only Elements: ['buys',]
+  -- Pass Only Elements: ['buys']
   -- Aggregate Measures
   SELECT
     SUM(buys) AS buys

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/Postgres/test_conversion_count_with_no_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/Postgres/test_conversion_count_with_no_group_by__plan0.sql
@@ -17,7 +17,7 @@ FROM (
     SELECT
       SUM(subq_2.visits) AS visits
     FROM (
-      -- Pass Only Elements: ['visits',]
+      -- Pass Only Elements: ['visits']
       SELECT
         subq_1.visits
       FROM (
@@ -107,7 +107,7 @@ FROM (
     SELECT
       SUM(subq_11.buys) AS buys
     FROM (
-      -- Pass Only Elements: ['buys',]
+      -- Pass Only Elements: ['buys']
       SELECT
         subq_10.buys
       FROM (

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/Postgres/test_conversion_count_with_no_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/Postgres/test_conversion_count_with_no_group_by__plan0_optimized.sql
@@ -20,7 +20,7 @@ SELECT
   COALESCE(MAX(subq_26.buys), 0) AS visit_buy_conversions
 FROM (
   -- Read From CTE For node_id=sma_28019
-  -- Pass Only Elements: ['visits',]
+  -- Pass Only Elements: ['visits']
   -- Aggregate Measures
   SELECT
     SUM(visits) AS visits
@@ -28,7 +28,7 @@ FROM (
 ) subq_17
 CROSS JOIN (
   -- Find conversions for user within the range of 7 day
-  -- Pass Only Elements: ['buys',]
+  -- Pass Only Elements: ['buys']
   -- Aggregate Measures
   SELECT
     SUM(buys) AS buys

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/Postgres/test_conversion_metric_join_to_timespine_and_fill_nulls_with_0__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/Postgres/test_conversion_metric_join_to_timespine_and_fill_nulls_with_0__plan0.sql
@@ -20,7 +20,7 @@ FROM (
       subq_6.metric_time__day AS metric_time__day
       , subq_3.visits AS visits
     FROM (
-      -- Pass Only Elements: ['metric_time__day',]
+      -- Pass Only Elements: ['metric_time__day']
       SELECT
         subq_5.metric_time__day
       FROM (
@@ -160,7 +160,7 @@ FROM (
       subq_19.metric_time__day AS metric_time__day
       , subq_16.buys AS buys
     FROM (
-      -- Pass Only Elements: ['metric_time__day',]
+      -- Pass Only Elements: ['metric_time__day']
       SELECT
         subq_18.metric_time__day
       FROM (

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/Postgres/test_conversion_rate_with_no_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/Postgres/test_conversion_rate_with_no_group_by__plan0.sql
@@ -17,7 +17,7 @@ FROM (
     SELECT
       SUM(subq_2.visits) AS visits
     FROM (
-      -- Pass Only Elements: ['visits',]
+      -- Pass Only Elements: ['visits']
       SELECT
         subq_1.visits
       FROM (
@@ -107,7 +107,7 @@ FROM (
     SELECT
       SUM(subq_11.buys) AS buys
     FROM (
-      -- Pass Only Elements: ['buys',]
+      -- Pass Only Elements: ['buys']
       SELECT
         subq_10.buys
       FROM (

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/Postgres/test_conversion_rate_with_no_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/Postgres/test_conversion_rate_with_no_group_by__plan0_optimized.sql
@@ -20,7 +20,7 @@ SELECT
   CAST(MAX(subq_26.buys) AS DOUBLE PRECISION) / CAST(NULLIF(MAX(subq_17.visits), 0) AS DOUBLE PRECISION) AS visit_buy_conversion_rate_7days
 FROM (
   -- Read From CTE For node_id=sma_28019
-  -- Pass Only Elements: ['visits',]
+  -- Pass Only Elements: ['visits']
   -- Aggregate Measures
   SELECT
     SUM(visits) AS visits
@@ -28,7 +28,7 @@ FROM (
 ) subq_17
 CROSS JOIN (
   -- Find conversions for user within the range of 7 day
-  -- Pass Only Elements: ['buys',]
+  -- Pass Only Elements: ['buys']
   -- Aggregate Measures
   SELECT
     SUM(buys) AS buys

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/Redshift/test_conversion_count_with_no_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/Redshift/test_conversion_count_with_no_group_by__plan0.sql
@@ -17,7 +17,7 @@ FROM (
     SELECT
       SUM(subq_2.visits) AS visits
     FROM (
-      -- Pass Only Elements: ['visits',]
+      -- Pass Only Elements: ['visits']
       SELECT
         subq_1.visits
       FROM (
@@ -107,7 +107,7 @@ FROM (
     SELECT
       SUM(subq_11.buys) AS buys
     FROM (
-      -- Pass Only Elements: ['buys',]
+      -- Pass Only Elements: ['buys']
       SELECT
         subq_10.buys
       FROM (

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/Redshift/test_conversion_count_with_no_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/Redshift/test_conversion_count_with_no_group_by__plan0_optimized.sql
@@ -20,7 +20,7 @@ SELECT
   COALESCE(MAX(subq_26.buys), 0) AS visit_buy_conversions
 FROM (
   -- Read From CTE For node_id=sma_28019
-  -- Pass Only Elements: ['visits',]
+  -- Pass Only Elements: ['visits']
   -- Aggregate Measures
   SELECT
     SUM(visits) AS visits
@@ -28,7 +28,7 @@ FROM (
 ) subq_17
 CROSS JOIN (
   -- Find conversions for user within the range of 7 day
-  -- Pass Only Elements: ['buys',]
+  -- Pass Only Elements: ['buys']
   -- Aggregate Measures
   SELECT
     SUM(buys) AS buys

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/Redshift/test_conversion_metric_join_to_timespine_and_fill_nulls_with_0__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/Redshift/test_conversion_metric_join_to_timespine_and_fill_nulls_with_0__plan0.sql
@@ -20,7 +20,7 @@ FROM (
       subq_6.metric_time__day AS metric_time__day
       , subq_3.visits AS visits
     FROM (
-      -- Pass Only Elements: ['metric_time__day',]
+      -- Pass Only Elements: ['metric_time__day']
       SELECT
         subq_5.metric_time__day
       FROM (
@@ -160,7 +160,7 @@ FROM (
       subq_19.metric_time__day AS metric_time__day
       , subq_16.buys AS buys
     FROM (
-      -- Pass Only Elements: ['metric_time__day',]
+      -- Pass Only Elements: ['metric_time__day']
       SELECT
         subq_18.metric_time__day
       FROM (

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/Redshift/test_conversion_rate_with_no_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/Redshift/test_conversion_rate_with_no_group_by__plan0.sql
@@ -17,7 +17,7 @@ FROM (
     SELECT
       SUM(subq_2.visits) AS visits
     FROM (
-      -- Pass Only Elements: ['visits',]
+      -- Pass Only Elements: ['visits']
       SELECT
         subq_1.visits
       FROM (
@@ -107,7 +107,7 @@ FROM (
     SELECT
       SUM(subq_11.buys) AS buys
     FROM (
-      -- Pass Only Elements: ['buys',]
+      -- Pass Only Elements: ['buys']
       SELECT
         subq_10.buys
       FROM (

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/Redshift/test_conversion_rate_with_no_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/Redshift/test_conversion_rate_with_no_group_by__plan0_optimized.sql
@@ -20,7 +20,7 @@ SELECT
   CAST(MAX(subq_26.buys) AS DOUBLE PRECISION) / CAST(NULLIF(MAX(subq_17.visits), 0) AS DOUBLE PRECISION) AS visit_buy_conversion_rate_7days
 FROM (
   -- Read From CTE For node_id=sma_28019
-  -- Pass Only Elements: ['visits',]
+  -- Pass Only Elements: ['visits']
   -- Aggregate Measures
   SELECT
     SUM(visits) AS visits
@@ -28,7 +28,7 @@ FROM (
 ) subq_17
 CROSS JOIN (
   -- Find conversions for user within the range of 7 day
-  -- Pass Only Elements: ['buys',]
+  -- Pass Only Elements: ['buys']
   -- Aggregate Measures
   SELECT
     SUM(buys) AS buys

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/Snowflake/test_conversion_count_with_no_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/Snowflake/test_conversion_count_with_no_group_by__plan0.sql
@@ -17,7 +17,7 @@ FROM (
     SELECT
       SUM(subq_2.visits) AS visits
     FROM (
-      -- Pass Only Elements: ['visits',]
+      -- Pass Only Elements: ['visits']
       SELECT
         subq_1.visits
       FROM (
@@ -107,7 +107,7 @@ FROM (
     SELECT
       SUM(subq_11.buys) AS buys
     FROM (
-      -- Pass Only Elements: ['buys',]
+      -- Pass Only Elements: ['buys']
       SELECT
         subq_10.buys
       FROM (

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/Snowflake/test_conversion_count_with_no_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/Snowflake/test_conversion_count_with_no_group_by__plan0_optimized.sql
@@ -20,7 +20,7 @@ SELECT
   COALESCE(MAX(subq_26.buys), 0) AS visit_buy_conversions
 FROM (
   -- Read From CTE For node_id=sma_28019
-  -- Pass Only Elements: ['visits',]
+  -- Pass Only Elements: ['visits']
   -- Aggregate Measures
   SELECT
     SUM(visits) AS visits
@@ -28,7 +28,7 @@ FROM (
 ) subq_17
 CROSS JOIN (
   -- Find conversions for user within the range of 7 day
-  -- Pass Only Elements: ['buys',]
+  -- Pass Only Elements: ['buys']
   -- Aggregate Measures
   SELECT
     SUM(buys) AS buys

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/Snowflake/test_conversion_metric_join_to_timespine_and_fill_nulls_with_0__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/Snowflake/test_conversion_metric_join_to_timespine_and_fill_nulls_with_0__plan0.sql
@@ -20,7 +20,7 @@ FROM (
       subq_6.metric_time__day AS metric_time__day
       , subq_3.visits AS visits
     FROM (
-      -- Pass Only Elements: ['metric_time__day',]
+      -- Pass Only Elements: ['metric_time__day']
       SELECT
         subq_5.metric_time__day
       FROM (
@@ -160,7 +160,7 @@ FROM (
       subq_19.metric_time__day AS metric_time__day
       , subq_16.buys AS buys
     FROM (
-      -- Pass Only Elements: ['metric_time__day',]
+      -- Pass Only Elements: ['metric_time__day']
       SELECT
         subq_18.metric_time__day
       FROM (

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/Snowflake/test_conversion_rate_with_no_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/Snowflake/test_conversion_rate_with_no_group_by__plan0.sql
@@ -17,7 +17,7 @@ FROM (
     SELECT
       SUM(subq_2.visits) AS visits
     FROM (
-      -- Pass Only Elements: ['visits',]
+      -- Pass Only Elements: ['visits']
       SELECT
         subq_1.visits
       FROM (
@@ -107,7 +107,7 @@ FROM (
     SELECT
       SUM(subq_11.buys) AS buys
     FROM (
-      -- Pass Only Elements: ['buys',]
+      -- Pass Only Elements: ['buys']
       SELECT
         subq_10.buys
       FROM (

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/Snowflake/test_conversion_rate_with_no_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/Snowflake/test_conversion_rate_with_no_group_by__plan0_optimized.sql
@@ -20,7 +20,7 @@ SELECT
   CAST(MAX(subq_26.buys) AS DOUBLE) / CAST(NULLIF(MAX(subq_17.visits), 0) AS DOUBLE) AS visit_buy_conversion_rate_7days
 FROM (
   -- Read From CTE For node_id=sma_28019
-  -- Pass Only Elements: ['visits',]
+  -- Pass Only Elements: ['visits']
   -- Aggregate Measures
   SELECT
     SUM(visits) AS visits
@@ -28,7 +28,7 @@ FROM (
 ) subq_17
 CROSS JOIN (
   -- Find conversions for user within the range of 7 day
-  -- Pass Only Elements: ['buys',]
+  -- Pass Only Elements: ['buys']
   -- Aggregate Measures
   SELECT
     SUM(buys) AS buys

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/Trino/test_conversion_count_with_no_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/Trino/test_conversion_count_with_no_group_by__plan0.sql
@@ -17,7 +17,7 @@ FROM (
     SELECT
       SUM(subq_2.visits) AS visits
     FROM (
-      -- Pass Only Elements: ['visits',]
+      -- Pass Only Elements: ['visits']
       SELECT
         subq_1.visits
       FROM (
@@ -107,7 +107,7 @@ FROM (
     SELECT
       SUM(subq_11.buys) AS buys
     FROM (
-      -- Pass Only Elements: ['buys',]
+      -- Pass Only Elements: ['buys']
       SELECT
         subq_10.buys
       FROM (

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/Trino/test_conversion_count_with_no_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/Trino/test_conversion_count_with_no_group_by__plan0_optimized.sql
@@ -20,7 +20,7 @@ SELECT
   COALESCE(MAX(subq_26.buys), 0) AS visit_buy_conversions
 FROM (
   -- Read From CTE For node_id=sma_28019
-  -- Pass Only Elements: ['visits',]
+  -- Pass Only Elements: ['visits']
   -- Aggregate Measures
   SELECT
     SUM(visits) AS visits
@@ -28,7 +28,7 @@ FROM (
 ) subq_17
 CROSS JOIN (
   -- Find conversions for user within the range of 7 day
-  -- Pass Only Elements: ['buys',]
+  -- Pass Only Elements: ['buys']
   -- Aggregate Measures
   SELECT
     SUM(buys) AS buys

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/Trino/test_conversion_metric_join_to_timespine_and_fill_nulls_with_0__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/Trino/test_conversion_metric_join_to_timespine_and_fill_nulls_with_0__plan0.sql
@@ -20,7 +20,7 @@ FROM (
       subq_6.metric_time__day AS metric_time__day
       , subq_3.visits AS visits
     FROM (
-      -- Pass Only Elements: ['metric_time__day',]
+      -- Pass Only Elements: ['metric_time__day']
       SELECT
         subq_5.metric_time__day
       FROM (
@@ -160,7 +160,7 @@ FROM (
       subq_19.metric_time__day AS metric_time__day
       , subq_16.buys AS buys
     FROM (
-      -- Pass Only Elements: ['metric_time__day',]
+      -- Pass Only Elements: ['metric_time__day']
       SELECT
         subq_18.metric_time__day
       FROM (

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/Trino/test_conversion_rate_with_no_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/Trino/test_conversion_rate_with_no_group_by__plan0.sql
@@ -17,7 +17,7 @@ FROM (
     SELECT
       SUM(subq_2.visits) AS visits
     FROM (
-      -- Pass Only Elements: ['visits',]
+      -- Pass Only Elements: ['visits']
       SELECT
         subq_1.visits
       FROM (
@@ -107,7 +107,7 @@ FROM (
     SELECT
       SUM(subq_11.buys) AS buys
     FROM (
-      -- Pass Only Elements: ['buys',]
+      -- Pass Only Elements: ['buys']
       SELECT
         subq_10.buys
       FROM (

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/Trino/test_conversion_rate_with_no_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/Trino/test_conversion_rate_with_no_group_by__plan0_optimized.sql
@@ -20,7 +20,7 @@ SELECT
   CAST(MAX(subq_26.buys) AS DOUBLE) / CAST(NULLIF(MAX(subq_17.visits), 0) AS DOUBLE) AS visit_buy_conversion_rate_7days
 FROM (
   -- Read From CTE For node_id=sma_28019
-  -- Pass Only Elements: ['visits',]
+  -- Pass Only Elements: ['visits']
   -- Aggregate Measures
   SELECT
     SUM(visits) AS visits
@@ -28,7 +28,7 @@ FROM (
 ) subq_17
 CROSS JOIN (
   -- Find conversions for user within the range of 7 day
-  -- Pass Only Elements: ['buys',]
+  -- Pass Only Elements: ['buys']
   -- Aggregate Measures
   SELECT
     SUM(buys) AS buys

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/test_conversion_count_with_no_group_by__plan0.xml
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/test_conversion_count_with_no_group_by__plan0.xml
@@ -46,7 +46,7 @@ docstring:
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
-                    <!-- description = "Pass Only Elements: ['visits',]" -->
+                    <!-- description = "Pass Only Elements: ['visits']" -->
                     <!-- node_id = NodeId(id_str='ss_194') -->
                     <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_41), column_alias='visits') -->
                     <!-- from_source = SqlSelectStatementNode(node_id=ss_193) -->
@@ -407,7 +407,7 @@ docstring:
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
-                    <!-- description = "Pass Only Elements: ['buys',]" -->
+                    <!-- description = "Pass Only Elements: ['buys']" -->
                     <!-- node_id = NodeId(id_str='ss_204') -->
                     <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_176), column_alias='buys') -->
                     <!-- from_source = SqlSelectStatementNode(node_id=ss_203) -->

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/test_conversion_metric_join_to_timespine_and_fill_nulls_with_0__plan0.xml
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/test_conversion_metric_join_to_timespine_and_fill_nulls_with_0__plan0.xml
@@ -66,7 +66,7 @@ docstring:
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
-                    <!-- description = "Pass Only Elements: ['metric_time__day',]" -->
+                    <!-- description = "Pass Only Elements: ['metric_time__day']" -->
                     <!-- node_id = NodeId(id_str='ss_200') -->
                     <!-- col0 =                                                -->
                     <!--   SqlSelectColumn(                                    -->
@@ -623,7 +623,7 @@ docstring:
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
-                    <!-- description = "Pass Only Elements: ['metric_time__day',]" -->
+                    <!-- description = "Pass Only Elements: ['metric_time__day']" -->
                     <!-- node_id = NodeId(id_str='ss_214') -->
                     <!-- col0 =                                                 -->
                     <!--   SqlSelectColumn(                                     -->

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/test_conversion_rate_with_no_group_by__plan0.xml
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlPlan/test_conversion_rate_with_no_group_by__plan0.xml
@@ -49,7 +49,7 @@ docstring:
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
-                    <!-- description = "Pass Only Elements: ['visits',]" -->
+                    <!-- description = "Pass Only Elements: ['visits']" -->
                     <!-- node_id = NodeId(id_str='ss_194') -->
                     <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_41), column_alias='visits') -->
                     <!-- from_source = SqlSelectStatementNode(node_id=ss_193) -->
@@ -410,7 +410,7 @@ docstring:
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
-                    <!-- description = "Pass Only Elements: ['buys',]" -->
+                    <!-- description = "Pass Only Elements: ['buys']" -->
                     <!-- node_id = NodeId(id_str='ss_204') -->
                     <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_176), column_alias='buys') -->
                     <!-- from_source = SqlSelectStatementNode(node_id=ss_203) -->

--- a/tests_metricflow/snapshots/test_cte_sql.py/str/test_cte_for_simple_dataflow_plan__result.txt
+++ b/tests_metricflow/snapshots/test_cte_sql.py/str/test_cte_for_simple_dataflow_plan__result.txt
@@ -5,7 +5,7 @@ docstring:
 ---
 sql_without_cte:
   -- Read Elements From Semantic Model 'bookings_source'
-  -- Pass Only Elements: ['bookings',]
+  -- Pass Only Elements: ['bookings']
   SELECT
     1 AS bookings
   FROM ***************************.fct_bookings bookings_source_src_28000
@@ -13,7 +13,7 @@ sql_without_cte:
 
 sql_with_cte:
   -- Read From CTE For node_id=rss_28001
-  -- Pass Only Elements: ['bookings',]
+  -- Pass Only Elements: ['bookings']
   WITH rss_28001_cte AS (
     -- Read Elements From Semantic Model 'bookings_source'
     SELECT

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/BigQuery/test_cumulative_metric_no_ds__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/BigQuery/test_cumulative_metric_no_ds__plan0.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     SUM(subq_2.txn_revenue) AS txn_revenue
   FROM (
-    -- Pass Only Elements: ['txn_revenue',]
+    -- Pass Only Elements: ['txn_revenue']
     SELECT
       subq_1.txn_revenue
     FROM (

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/BigQuery/test_cumulative_metric_no_ds__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/BigQuery/test_cumulative_metric_no_ds__plan0_optimized.sql
@@ -6,7 +6,7 @@ sql_engine: BigQuery
 ---
 -- Read Elements From Semantic Model 'revenue'
 -- Metric Time Dimension 'ds'
--- Pass Only Elements: ['txn_revenue',]
+-- Pass Only Elements: ['txn_revenue']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Databricks/test_cumulative_metric_no_ds__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Databricks/test_cumulative_metric_no_ds__plan0.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     SUM(subq_2.txn_revenue) AS txn_revenue
   FROM (
-    -- Pass Only Elements: ['txn_revenue',]
+    -- Pass Only Elements: ['txn_revenue']
     SELECT
       subq_1.txn_revenue
     FROM (

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Databricks/test_cumulative_metric_no_ds__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Databricks/test_cumulative_metric_no_ds__plan0_optimized.sql
@@ -6,7 +6,7 @@ sql_engine: Databricks
 ---
 -- Read Elements From Semantic Model 'revenue'
 -- Metric Time Dimension 'ds'
--- Pass Only Elements: ['txn_revenue',]
+-- Pass Only Elements: ['txn_revenue']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/DuckDB/test_cumulative_metric_no_ds__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/DuckDB/test_cumulative_metric_no_ds__plan0.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     SUM(subq_2.txn_revenue) AS txn_revenue
   FROM (
-    -- Pass Only Elements: ['txn_revenue',]
+    -- Pass Only Elements: ['txn_revenue']
     SELECT
       subq_1.txn_revenue
     FROM (

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/DuckDB/test_cumulative_metric_no_ds__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/DuckDB/test_cumulative_metric_no_ds__plan0_optimized.sql
@@ -6,7 +6,7 @@ sql_engine: DuckDB
 ---
 -- Read Elements From Semantic Model 'revenue'
 -- Metric Time Dimension 'ds'
--- Pass Only Elements: ['txn_revenue',]
+-- Pass Only Elements: ['txn_revenue']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Postgres/test_cumulative_metric_no_ds__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Postgres/test_cumulative_metric_no_ds__plan0.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     SUM(subq_2.txn_revenue) AS txn_revenue
   FROM (
-    -- Pass Only Elements: ['txn_revenue',]
+    -- Pass Only Elements: ['txn_revenue']
     SELECT
       subq_1.txn_revenue
     FROM (

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Postgres/test_cumulative_metric_no_ds__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Postgres/test_cumulative_metric_no_ds__plan0_optimized.sql
@@ -6,7 +6,7 @@ sql_engine: Postgres
 ---
 -- Read Elements From Semantic Model 'revenue'
 -- Metric Time Dimension 'ds'
--- Pass Only Elements: ['txn_revenue',]
+-- Pass Only Elements: ['txn_revenue']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Redshift/test_cumulative_metric_no_ds__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Redshift/test_cumulative_metric_no_ds__plan0.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     SUM(subq_2.txn_revenue) AS txn_revenue
   FROM (
-    -- Pass Only Elements: ['txn_revenue',]
+    -- Pass Only Elements: ['txn_revenue']
     SELECT
       subq_1.txn_revenue
     FROM (

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Redshift/test_cumulative_metric_no_ds__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Redshift/test_cumulative_metric_no_ds__plan0_optimized.sql
@@ -6,7 +6,7 @@ sql_engine: Redshift
 ---
 -- Read Elements From Semantic Model 'revenue'
 -- Metric Time Dimension 'ds'
--- Pass Only Elements: ['txn_revenue',]
+-- Pass Only Elements: ['txn_revenue']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Snowflake/test_cumulative_metric_no_ds__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Snowflake/test_cumulative_metric_no_ds__plan0.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     SUM(subq_2.txn_revenue) AS txn_revenue
   FROM (
-    -- Pass Only Elements: ['txn_revenue',]
+    -- Pass Only Elements: ['txn_revenue']
     SELECT
       subq_1.txn_revenue
     FROM (

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Snowflake/test_cumulative_metric_no_ds__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Snowflake/test_cumulative_metric_no_ds__plan0_optimized.sql
@@ -6,7 +6,7 @@ sql_engine: Snowflake
 ---
 -- Read Elements From Semantic Model 'revenue'
 -- Metric Time Dimension 'ds'
--- Pass Only Elements: ['txn_revenue',]
+-- Pass Only Elements: ['txn_revenue']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Trino/test_cumulative_metric_no_ds__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Trino/test_cumulative_metric_no_ds__plan0.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     SUM(subq_2.txn_revenue) AS txn_revenue
   FROM (
-    -- Pass Only Elements: ['txn_revenue',]
+    -- Pass Only Elements: ['txn_revenue']
     SELECT
       subq_1.txn_revenue
     FROM (

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Trino/test_cumulative_metric_no_ds__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Trino/test_cumulative_metric_no_ds__plan0_optimized.sql
@@ -6,7 +6,7 @@ sql_engine: Trino
 ---
 -- Read Elements From Semantic Model 'revenue'
 -- Metric Time Dimension 'ds'
--- Pass Only Elements: ['txn_revenue',]
+-- Pass Only Elements: ['txn_revenue']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/BigQuery/test_conversion_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/BigQuery/test_conversion_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
@@ -15,7 +15,7 @@ FROM (
     SELECT
       SUM(subq_4.visits) AS visits
     FROM (
-      -- Pass Only Elements: ['visits',]
+      -- Pass Only Elements: ['visits']
       SELECT
         subq_3.visits
       FROM (
@@ -158,7 +158,7 @@ FROM (
     SELECT
       SUM(subq_15.buys) AS buys
     FROM (
-      -- Pass Only Elements: ['buys',]
+      -- Pass Only Elements: ['buys']
       SELECT
         subq_14.buys
       FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/BigQuery/test_conversion_metric_with_custom_granularity_filter_not_in_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/BigQuery/test_conversion_metric_with_custom_granularity_filter_not_in_group_by__plan0_optimized.sql
@@ -18,7 +18,7 @@ SELECT
   CAST(MAX(subq_34.buys) AS FLOAT64) / CAST(NULLIF(MAX(subq_23.visits), 0) AS FLOAT64) AS visit_buy_conversion_rate_7days
 FROM (
   -- Constrain Output with WHERE
-  -- Pass Only Elements: ['visits',]
+  -- Pass Only Elements: ['visits']
   -- Aggregate Measures
   SELECT
     SUM(visits) AS visits
@@ -38,7 +38,7 @@ FROM (
 ) subq_23
 CROSS JOIN (
   -- Find conversions for user within the range of 7 day
-  -- Pass Only Elements: ['buys',]
+  -- Pass Only Elements: ['buys']
   -- Aggregate Measures
   SELECT
     SUM(buys) AS buys

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/BigQuery/test_join_to_time_spine_metric_grouped_by_custom_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/BigQuery/test_join_to_time_spine_metric_grouped_by_custom_grain__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_7.metric_time__alien_day AS metric_time__alien_day
     , subq_4.bookings AS bookings
   FROM (
-    -- Pass Only Elements: ['metric_time__alien_day',]
+    -- Pass Only Elements: ['metric_time__alien_day']
     SELECT
       subq_6.metric_time__alien_day
     FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/BigQuery/test_join_to_time_spine_metric_grouped_by_custom_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/BigQuery/test_join_to_time_spine_metric_grouped_by_custom_grain__plan0_optimized.sql
@@ -10,7 +10,7 @@ SELECT
 FROM (
   -- Read From Time Spine 'mf_time_spine'
   -- Change Column Aliases
-  -- Pass Only Elements: ['metric_time__alien_day',]
+  -- Pass Only Elements: ['metric_time__alien_day']
   SELECT
     alien_day AS metric_time__alien_day
   FROM ***************************.mf_time_spine time_spine_src_28006

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/BigQuery/test_join_to_timespine_metric_with_custom_granularity_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/BigQuery/test_join_to_timespine_metric_with_custom_granularity_filter__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_9.metric_time__alien_day AS metric_time__alien_day
     , subq_5.bookings AS bookings
   FROM (
-    -- Pass Only Elements: ['metric_time__alien_day',]
+    -- Pass Only Elements: ['metric_time__alien_day']
     SELECT
       subq_8.metric_time__alien_day
     FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/BigQuery/test_join_to_timespine_metric_with_custom_granularity_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/BigQuery/test_join_to_timespine_metric_with_custom_granularity_filter__plan0_optimized.sql
@@ -9,7 +9,7 @@ SELECT
   , subq_16.bookings AS bookings_join_to_time_spine
 FROM (
   -- Constrain Output with WHERE
-  -- Pass Only Elements: ['metric_time__alien_day',]
+  -- Pass Only Elements: ['metric_time__alien_day']
   SELECT
     metric_time__alien_day
   FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/BigQuery/test_join_to_timespine_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/BigQuery/test_join_to_timespine_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_9.metric_time__day AS metric_time__day
     , subq_5.bookings AS bookings
   FROM (
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       subq_8.metric_time__day
     FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/BigQuery/test_join_to_timespine_metric_with_custom_granularity_filter_not_in_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/BigQuery/test_join_to_timespine_metric_with_custom_granularity_filter_not_in_group_by__plan0_optimized.sql
@@ -9,7 +9,7 @@ SELECT
   , subq_16.bookings AS bookings_join_to_time_spine
 FROM (
   -- Constrain Output with WHERE
-  -- Pass Only Elements: ['metric_time__day',]
+  -- Pass Only Elements: ['metric_time__day']
   SELECT
     metric_time__day
   FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/BigQuery/test_no_metric_custom_granularity_joined_to_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/BigQuery/test_no_metric_custom_granularity_joined_to_non_default_grain__plan0.sql
@@ -380,7 +380,7 @@ FROM (
     FROM ***************************.dim_users users_ds_source_src_28000
   ) subq_0
   CROSS JOIN (
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       subq_2.metric_time__day
     FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/BigQuery/test_no_metric_custom_granularity_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/BigQuery/test_no_metric_custom_granularity_metric_time__plan0.sql
@@ -2,7 +2,7 @@ test_name: test_no_metric_custom_granularity_metric_time
 test_filename: test_custom_granularity.py
 sql_engine: BigQuery
 ---
--- Pass Only Elements: ['metric_time__alien_day',]
+-- Pass Only Elements: ['metric_time__alien_day']
 SELECT
   subq_2.metric_time__alien_day
 FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/BigQuery/test_no_metric_custom_granularity_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/BigQuery/test_no_metric_custom_granularity_metric_time__plan0_optimized.sql
@@ -4,7 +4,7 @@ sql_engine: BigQuery
 ---
 -- Metric Time Dimension 'ds'
 -- Join to Custom Granularity Dataset
--- Pass Only Elements: ['metric_time__alien_day',]
+-- Pass Only Elements: ['metric_time__alien_day']
 SELECT
   subq_4.alien_day AS metric_time__alien_day
 FROM ***************************.mf_time_spine time_spine_src_28006

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/BigQuery/test_no_metric_custom_granularity_non_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/BigQuery/test_no_metric_custom_granularity_non_metric_time__plan0.sql
@@ -2,7 +2,7 @@ test_name: test_no_metric_custom_granularity_non_metric_time
 test_filename: test_custom_granularity.py
 sql_engine: BigQuery
 ---
--- Pass Only Elements: ['booking__ds__alien_day',]
+-- Pass Only Elements: ['booking__ds__alien_day']
 SELECT
   subq_1.booking__ds__alien_day
 FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/BigQuery/test_no_metric_custom_granularity_non_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/BigQuery/test_no_metric_custom_granularity_non_metric_time__plan0_optimized.sql
@@ -4,7 +4,7 @@ sql_engine: BigQuery
 ---
 -- Read Elements From Semantic Model 'bookings_source'
 -- Join to Custom Granularity Dataset
--- Pass Only Elements: ['booking__ds__alien_day',]
+-- Pass Only Elements: ['booking__ds__alien_day']
 SELECT
   subq_2.alien_day AS booking__ds__alien_day
 FROM ***************************.fct_bookings bookings_source_src_28000

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/BigQuery/test_no_metrics_with_custom_granularity_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/BigQuery/test_no_metrics_with_custom_granularity_filter__plan0.sql
@@ -4,7 +4,7 @@ docstring:
   Group by items only queried with a filter on a custom grain, where that grain is not used in the group by.
 sql_engine: BigQuery
 ---
--- Pass Only Elements: ['listing__ds__day',]
+-- Pass Only Elements: ['listing__ds__day']
 SELECT
   subq_2.listing__ds__day
 FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/BigQuery/test_no_metrics_with_custom_granularity_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/BigQuery/test_no_metrics_with_custom_granularity_filter__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: BigQuery
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['listing__ds__day',]
+-- Pass Only Elements: ['listing__ds__day']
 SELECT
   listing__ds__day
 FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/BigQuery/test_no_metrics_with_custom_granularity_in_filter_and_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/BigQuery/test_no_metrics_with_custom_granularity_in_filter_and_group_by__plan0.sql
@@ -4,7 +4,7 @@ docstring:
   Group by items only queried with a filter on a custom grain, where that grain is also used in the group by.
 sql_engine: BigQuery
 ---
--- Pass Only Elements: ['listing__ds__alien_day',]
+-- Pass Only Elements: ['listing__ds__alien_day']
 SELECT
   subq_2.listing__ds__alien_day
 FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/BigQuery/test_no_metrics_with_custom_granularity_in_filter_and_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/BigQuery/test_no_metrics_with_custom_granularity_in_filter_and_group_by__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: BigQuery
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['listing__ds__alien_day',]
+-- Pass Only Elements: ['listing__ds__alien_day']
 SELECT
   listing__ds__alien_day
 FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/BigQuery/test_offset_metric_with_custom_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/BigQuery/test_offset_metric_with_custom_granularity__plan0.sql
@@ -125,7 +125,7 @@ FROM (
           , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           , subq_5.alien_day AS booking__ds__alien_day
         FROM (
-          -- Pass Only Elements: ['booking__ds__day',]
+          -- Pass Only Elements: ['booking__ds__day']
           SELECT
             subq_3.booking__ds__day
           FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/BigQuery/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/BigQuery/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
@@ -227,7 +227,7 @@ FROM (
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             , subq_5.alien_day AS metric_time__alien_day
           FROM (
-            -- Pass Only Elements: ['metric_time__day',]
+            -- Pass Only Elements: ['metric_time__day']
             SELECT
               subq_3.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/BigQuery/test_simple_metric_with_custom_granularity_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/BigQuery/test_simple_metric_with_custom_granularity_filter__plan0.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     SUM(subq_4.bookings) AS bookings
   FROM (
-    -- Pass Only Elements: ['bookings',]
+    -- Pass Only Elements: ['bookings']
     SELECT
       subq_3.bookings
     FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/BigQuery/test_simple_metric_with_custom_granularity_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/BigQuery/test_simple_metric_with_custom_granularity_filter__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: BigQuery
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['bookings',]
+-- Pass Only Elements: ['bookings']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Databricks/test_conversion_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Databricks/test_conversion_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
@@ -15,7 +15,7 @@ FROM (
     SELECT
       SUM(subq_4.visits) AS visits
     FROM (
-      -- Pass Only Elements: ['visits',]
+      -- Pass Only Elements: ['visits']
       SELECT
         subq_3.visits
       FROM (
@@ -158,7 +158,7 @@ FROM (
     SELECT
       SUM(subq_15.buys) AS buys
     FROM (
-      -- Pass Only Elements: ['buys',]
+      -- Pass Only Elements: ['buys']
       SELECT
         subq_14.buys
       FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Databricks/test_conversion_metric_with_custom_granularity_filter_not_in_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Databricks/test_conversion_metric_with_custom_granularity_filter_not_in_group_by__plan0_optimized.sql
@@ -18,7 +18,7 @@ SELECT
   CAST(MAX(subq_34.buys) AS DOUBLE) / CAST(NULLIF(MAX(subq_23.visits), 0) AS DOUBLE) AS visit_buy_conversion_rate_7days
 FROM (
   -- Constrain Output with WHERE
-  -- Pass Only Elements: ['visits',]
+  -- Pass Only Elements: ['visits']
   -- Aggregate Measures
   SELECT
     SUM(visits) AS visits
@@ -38,7 +38,7 @@ FROM (
 ) subq_23
 CROSS JOIN (
   -- Find conversions for user within the range of 7 day
-  -- Pass Only Elements: ['buys',]
+  -- Pass Only Elements: ['buys']
   -- Aggregate Measures
   SELECT
     SUM(buys) AS buys

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Databricks/test_join_to_time_spine_metric_grouped_by_custom_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Databricks/test_join_to_time_spine_metric_grouped_by_custom_grain__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_7.metric_time__alien_day AS metric_time__alien_day
     , subq_4.bookings AS bookings
   FROM (
-    -- Pass Only Elements: ['metric_time__alien_day',]
+    -- Pass Only Elements: ['metric_time__alien_day']
     SELECT
       subq_6.metric_time__alien_day
     FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Databricks/test_join_to_time_spine_metric_grouped_by_custom_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Databricks/test_join_to_time_spine_metric_grouped_by_custom_grain__plan0_optimized.sql
@@ -10,7 +10,7 @@ SELECT
 FROM (
   -- Read From Time Spine 'mf_time_spine'
   -- Change Column Aliases
-  -- Pass Only Elements: ['metric_time__alien_day',]
+  -- Pass Only Elements: ['metric_time__alien_day']
   SELECT
     alien_day AS metric_time__alien_day
   FROM ***************************.mf_time_spine time_spine_src_28006

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Databricks/test_join_to_timespine_metric_with_custom_granularity_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Databricks/test_join_to_timespine_metric_with_custom_granularity_filter__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_9.metric_time__alien_day AS metric_time__alien_day
     , subq_5.bookings AS bookings
   FROM (
-    -- Pass Only Elements: ['metric_time__alien_day',]
+    -- Pass Only Elements: ['metric_time__alien_day']
     SELECT
       subq_8.metric_time__alien_day
     FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Databricks/test_join_to_timespine_metric_with_custom_granularity_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Databricks/test_join_to_timespine_metric_with_custom_granularity_filter__plan0_optimized.sql
@@ -9,7 +9,7 @@ SELECT
   , subq_16.bookings AS bookings_join_to_time_spine
 FROM (
   -- Constrain Output with WHERE
-  -- Pass Only Elements: ['metric_time__alien_day',]
+  -- Pass Only Elements: ['metric_time__alien_day']
   SELECT
     metric_time__alien_day
   FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Databricks/test_join_to_timespine_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Databricks/test_join_to_timespine_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_9.metric_time__day AS metric_time__day
     , subq_5.bookings AS bookings
   FROM (
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       subq_8.metric_time__day
     FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Databricks/test_join_to_timespine_metric_with_custom_granularity_filter_not_in_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Databricks/test_join_to_timespine_metric_with_custom_granularity_filter_not_in_group_by__plan0_optimized.sql
@@ -9,7 +9,7 @@ SELECT
   , subq_16.bookings AS bookings_join_to_time_spine
 FROM (
   -- Constrain Output with WHERE
-  -- Pass Only Elements: ['metric_time__day',]
+  -- Pass Only Elements: ['metric_time__day']
   SELECT
     metric_time__day
   FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Databricks/test_no_metric_custom_granularity_joined_to_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Databricks/test_no_metric_custom_granularity_joined_to_non_default_grain__plan0.sql
@@ -380,7 +380,7 @@ FROM (
     FROM ***************************.dim_users users_ds_source_src_28000
   ) subq_0
   CROSS JOIN (
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       subq_2.metric_time__day
     FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Databricks/test_no_metric_custom_granularity_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Databricks/test_no_metric_custom_granularity_metric_time__plan0.sql
@@ -2,7 +2,7 @@ test_name: test_no_metric_custom_granularity_metric_time
 test_filename: test_custom_granularity.py
 sql_engine: Databricks
 ---
--- Pass Only Elements: ['metric_time__alien_day',]
+-- Pass Only Elements: ['metric_time__alien_day']
 SELECT
   subq_2.metric_time__alien_day
 FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Databricks/test_no_metric_custom_granularity_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Databricks/test_no_metric_custom_granularity_metric_time__plan0_optimized.sql
@@ -4,7 +4,7 @@ sql_engine: Databricks
 ---
 -- Metric Time Dimension 'ds'
 -- Join to Custom Granularity Dataset
--- Pass Only Elements: ['metric_time__alien_day',]
+-- Pass Only Elements: ['metric_time__alien_day']
 SELECT
   subq_4.alien_day AS metric_time__alien_day
 FROM ***************************.mf_time_spine time_spine_src_28006

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Databricks/test_no_metric_custom_granularity_non_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Databricks/test_no_metric_custom_granularity_non_metric_time__plan0.sql
@@ -2,7 +2,7 @@ test_name: test_no_metric_custom_granularity_non_metric_time
 test_filename: test_custom_granularity.py
 sql_engine: Databricks
 ---
--- Pass Only Elements: ['booking__ds__alien_day',]
+-- Pass Only Elements: ['booking__ds__alien_day']
 SELECT
   subq_1.booking__ds__alien_day
 FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Databricks/test_no_metric_custom_granularity_non_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Databricks/test_no_metric_custom_granularity_non_metric_time__plan0_optimized.sql
@@ -4,7 +4,7 @@ sql_engine: Databricks
 ---
 -- Read Elements From Semantic Model 'bookings_source'
 -- Join to Custom Granularity Dataset
--- Pass Only Elements: ['booking__ds__alien_day',]
+-- Pass Only Elements: ['booking__ds__alien_day']
 SELECT
   subq_2.alien_day AS booking__ds__alien_day
 FROM ***************************.fct_bookings bookings_source_src_28000

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Databricks/test_no_metrics_with_custom_granularity_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Databricks/test_no_metrics_with_custom_granularity_filter__plan0.sql
@@ -4,7 +4,7 @@ docstring:
   Group by items only queried with a filter on a custom grain, where that grain is not used in the group by.
 sql_engine: Databricks
 ---
--- Pass Only Elements: ['listing__ds__day',]
+-- Pass Only Elements: ['listing__ds__day']
 SELECT
   subq_2.listing__ds__day
 FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Databricks/test_no_metrics_with_custom_granularity_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Databricks/test_no_metrics_with_custom_granularity_filter__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: Databricks
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['listing__ds__day',]
+-- Pass Only Elements: ['listing__ds__day']
 SELECT
   listing__ds__day
 FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Databricks/test_no_metrics_with_custom_granularity_in_filter_and_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Databricks/test_no_metrics_with_custom_granularity_in_filter_and_group_by__plan0.sql
@@ -4,7 +4,7 @@ docstring:
   Group by items only queried with a filter on a custom grain, where that grain is also used in the group by.
 sql_engine: Databricks
 ---
--- Pass Only Elements: ['listing__ds__alien_day',]
+-- Pass Only Elements: ['listing__ds__alien_day']
 SELECT
   subq_2.listing__ds__alien_day
 FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Databricks/test_no_metrics_with_custom_granularity_in_filter_and_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Databricks/test_no_metrics_with_custom_granularity_in_filter_and_group_by__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: Databricks
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['listing__ds__alien_day',]
+-- Pass Only Elements: ['listing__ds__alien_day']
 SELECT
   listing__ds__alien_day
 FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Databricks/test_offset_metric_with_custom_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Databricks/test_offset_metric_with_custom_granularity__plan0.sql
@@ -125,7 +125,7 @@ FROM (
           , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           , subq_5.alien_day AS booking__ds__alien_day
         FROM (
-          -- Pass Only Elements: ['booking__ds__day',]
+          -- Pass Only Elements: ['booking__ds__day']
           SELECT
             subq_3.booking__ds__day
           FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Databricks/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Databricks/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
@@ -227,7 +227,7 @@ FROM (
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             , subq_5.alien_day AS metric_time__alien_day
           FROM (
-            -- Pass Only Elements: ['metric_time__day',]
+            -- Pass Only Elements: ['metric_time__day']
             SELECT
               subq_3.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Databricks/test_simple_metric_with_custom_granularity_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Databricks/test_simple_metric_with_custom_granularity_filter__plan0.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     SUM(subq_4.bookings) AS bookings
   FROM (
-    -- Pass Only Elements: ['bookings',]
+    -- Pass Only Elements: ['bookings']
     SELECT
       subq_3.bookings
     FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Databricks/test_simple_metric_with_custom_granularity_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Databricks/test_simple_metric_with_custom_granularity_filter__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: Databricks
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['bookings',]
+-- Pass Only Elements: ['bookings']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/DuckDB/test_conversion_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/DuckDB/test_conversion_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
@@ -15,7 +15,7 @@ FROM (
     SELECT
       SUM(subq_4.visits) AS visits
     FROM (
-      -- Pass Only Elements: ['visits',]
+      -- Pass Only Elements: ['visits']
       SELECT
         subq_3.visits
       FROM (
@@ -158,7 +158,7 @@ FROM (
     SELECT
       SUM(subq_15.buys) AS buys
     FROM (
-      -- Pass Only Elements: ['buys',]
+      -- Pass Only Elements: ['buys']
       SELECT
         subq_14.buys
       FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/DuckDB/test_conversion_metric_with_custom_granularity_filter_not_in_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/DuckDB/test_conversion_metric_with_custom_granularity_filter_not_in_group_by__plan0_optimized.sql
@@ -18,7 +18,7 @@ SELECT
   CAST(MAX(subq_34.buys) AS DOUBLE) / CAST(NULLIF(MAX(subq_23.visits), 0) AS DOUBLE) AS visit_buy_conversion_rate_7days
 FROM (
   -- Constrain Output with WHERE
-  -- Pass Only Elements: ['visits',]
+  -- Pass Only Elements: ['visits']
   -- Aggregate Measures
   SELECT
     SUM(visits) AS visits
@@ -38,7 +38,7 @@ FROM (
 ) subq_23
 CROSS JOIN (
   -- Find conversions for user within the range of 7 day
-  -- Pass Only Elements: ['buys',]
+  -- Pass Only Elements: ['buys']
   -- Aggregate Measures
   SELECT
     SUM(buys) AS buys

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/DuckDB/test_join_to_time_spine_metric_grouped_by_custom_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/DuckDB/test_join_to_time_spine_metric_grouped_by_custom_grain__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_7.metric_time__alien_day AS metric_time__alien_day
     , subq_4.bookings AS bookings
   FROM (
-    -- Pass Only Elements: ['metric_time__alien_day',]
+    -- Pass Only Elements: ['metric_time__alien_day']
     SELECT
       subq_6.metric_time__alien_day
     FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/DuckDB/test_join_to_time_spine_metric_grouped_by_custom_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/DuckDB/test_join_to_time_spine_metric_grouped_by_custom_grain__plan0_optimized.sql
@@ -10,7 +10,7 @@ SELECT
 FROM (
   -- Read From Time Spine 'mf_time_spine'
   -- Change Column Aliases
-  -- Pass Only Elements: ['metric_time__alien_day',]
+  -- Pass Only Elements: ['metric_time__alien_day']
   SELECT
     alien_day AS metric_time__alien_day
   FROM ***************************.mf_time_spine time_spine_src_28006

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/DuckDB/test_join_to_timespine_metric_with_custom_granularity_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/DuckDB/test_join_to_timespine_metric_with_custom_granularity_filter__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_9.metric_time__alien_day AS metric_time__alien_day
     , subq_5.bookings AS bookings
   FROM (
-    -- Pass Only Elements: ['metric_time__alien_day',]
+    -- Pass Only Elements: ['metric_time__alien_day']
     SELECT
       subq_8.metric_time__alien_day
     FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/DuckDB/test_join_to_timespine_metric_with_custom_granularity_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/DuckDB/test_join_to_timespine_metric_with_custom_granularity_filter__plan0_optimized.sql
@@ -9,7 +9,7 @@ SELECT
   , subq_16.bookings AS bookings_join_to_time_spine
 FROM (
   -- Constrain Output with WHERE
-  -- Pass Only Elements: ['metric_time__alien_day',]
+  -- Pass Only Elements: ['metric_time__alien_day']
   SELECT
     metric_time__alien_day
   FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/DuckDB/test_join_to_timespine_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/DuckDB/test_join_to_timespine_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_9.metric_time__day AS metric_time__day
     , subq_5.bookings AS bookings
   FROM (
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       subq_8.metric_time__day
     FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/DuckDB/test_join_to_timespine_metric_with_custom_granularity_filter_not_in_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/DuckDB/test_join_to_timespine_metric_with_custom_granularity_filter_not_in_group_by__plan0_optimized.sql
@@ -9,7 +9,7 @@ SELECT
   , subq_16.bookings AS bookings_join_to_time_spine
 FROM (
   -- Constrain Output with WHERE
-  -- Pass Only Elements: ['metric_time__day',]
+  -- Pass Only Elements: ['metric_time__day']
   SELECT
     metric_time__day
   FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/DuckDB/test_no_metric_custom_granularity_joined_to_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/DuckDB/test_no_metric_custom_granularity_joined_to_non_default_grain__plan0.sql
@@ -380,7 +380,7 @@ FROM (
     FROM ***************************.dim_users users_ds_source_src_28000
   ) subq_0
   CROSS JOIN (
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       subq_2.metric_time__day
     FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/DuckDB/test_no_metric_custom_granularity_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/DuckDB/test_no_metric_custom_granularity_metric_time__plan0.sql
@@ -2,7 +2,7 @@ test_name: test_no_metric_custom_granularity_metric_time
 test_filename: test_custom_granularity.py
 sql_engine: DuckDB
 ---
--- Pass Only Elements: ['metric_time__alien_day',]
+-- Pass Only Elements: ['metric_time__alien_day']
 SELECT
   subq_2.metric_time__alien_day
 FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/DuckDB/test_no_metric_custom_granularity_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/DuckDB/test_no_metric_custom_granularity_metric_time__plan0_optimized.sql
@@ -4,7 +4,7 @@ sql_engine: DuckDB
 ---
 -- Metric Time Dimension 'ds'
 -- Join to Custom Granularity Dataset
--- Pass Only Elements: ['metric_time__alien_day',]
+-- Pass Only Elements: ['metric_time__alien_day']
 SELECT
   subq_4.alien_day AS metric_time__alien_day
 FROM ***************************.mf_time_spine time_spine_src_28006

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/DuckDB/test_no_metric_custom_granularity_non_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/DuckDB/test_no_metric_custom_granularity_non_metric_time__plan0.sql
@@ -2,7 +2,7 @@ test_name: test_no_metric_custom_granularity_non_metric_time
 test_filename: test_custom_granularity.py
 sql_engine: DuckDB
 ---
--- Pass Only Elements: ['booking__ds__alien_day',]
+-- Pass Only Elements: ['booking__ds__alien_day']
 SELECT
   subq_1.booking__ds__alien_day
 FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/DuckDB/test_no_metric_custom_granularity_non_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/DuckDB/test_no_metric_custom_granularity_non_metric_time__plan0_optimized.sql
@@ -4,7 +4,7 @@ sql_engine: DuckDB
 ---
 -- Read Elements From Semantic Model 'bookings_source'
 -- Join to Custom Granularity Dataset
--- Pass Only Elements: ['booking__ds__alien_day',]
+-- Pass Only Elements: ['booking__ds__alien_day']
 SELECT
   subq_2.alien_day AS booking__ds__alien_day
 FROM ***************************.fct_bookings bookings_source_src_28000

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/DuckDB/test_no_metrics_with_custom_granularity_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/DuckDB/test_no_metrics_with_custom_granularity_filter__plan0.sql
@@ -4,7 +4,7 @@ docstring:
   Group by items only queried with a filter on a custom grain, where that grain is not used in the group by.
 sql_engine: DuckDB
 ---
--- Pass Only Elements: ['listing__ds__day',]
+-- Pass Only Elements: ['listing__ds__day']
 SELECT
   subq_2.listing__ds__day
 FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/DuckDB/test_no_metrics_with_custom_granularity_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/DuckDB/test_no_metrics_with_custom_granularity_filter__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: DuckDB
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['listing__ds__day',]
+-- Pass Only Elements: ['listing__ds__day']
 SELECT
   listing__ds__day
 FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/DuckDB/test_no_metrics_with_custom_granularity_in_filter_and_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/DuckDB/test_no_metrics_with_custom_granularity_in_filter_and_group_by__plan0.sql
@@ -4,7 +4,7 @@ docstring:
   Group by items only queried with a filter on a custom grain, where that grain is also used in the group by.
 sql_engine: DuckDB
 ---
--- Pass Only Elements: ['listing__ds__alien_day',]
+-- Pass Only Elements: ['listing__ds__alien_day']
 SELECT
   subq_2.listing__ds__alien_day
 FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/DuckDB/test_no_metrics_with_custom_granularity_in_filter_and_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/DuckDB/test_no_metrics_with_custom_granularity_in_filter_and_group_by__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: DuckDB
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['listing__ds__alien_day',]
+-- Pass Only Elements: ['listing__ds__alien_day']
 SELECT
   listing__ds__alien_day
 FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/DuckDB/test_offset_metric_with_custom_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/DuckDB/test_offset_metric_with_custom_granularity__plan0.sql
@@ -125,7 +125,7 @@ FROM (
           , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           , subq_5.alien_day AS booking__ds__alien_day
         FROM (
-          -- Pass Only Elements: ['booking__ds__day',]
+          -- Pass Only Elements: ['booking__ds__day']
           SELECT
             subq_3.booking__ds__day
           FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/DuckDB/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/DuckDB/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
@@ -227,7 +227,7 @@ FROM (
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             , subq_5.alien_day AS metric_time__alien_day
           FROM (
-            -- Pass Only Elements: ['metric_time__day',]
+            -- Pass Only Elements: ['metric_time__day']
             SELECT
               subq_3.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/DuckDB/test_simple_metric_with_custom_granularity_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/DuckDB/test_simple_metric_with_custom_granularity_filter__plan0.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     SUM(subq_4.bookings) AS bookings
   FROM (
-    -- Pass Only Elements: ['bookings',]
+    -- Pass Only Elements: ['bookings']
     SELECT
       subq_3.bookings
     FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/DuckDB/test_simple_metric_with_custom_granularity_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/DuckDB/test_simple_metric_with_custom_granularity_filter__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: DuckDB
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['bookings',]
+-- Pass Only Elements: ['bookings']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Postgres/test_conversion_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Postgres/test_conversion_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
@@ -15,7 +15,7 @@ FROM (
     SELECT
       SUM(subq_4.visits) AS visits
     FROM (
-      -- Pass Only Elements: ['visits',]
+      -- Pass Only Elements: ['visits']
       SELECT
         subq_3.visits
       FROM (
@@ -158,7 +158,7 @@ FROM (
     SELECT
       SUM(subq_15.buys) AS buys
     FROM (
-      -- Pass Only Elements: ['buys',]
+      -- Pass Only Elements: ['buys']
       SELECT
         subq_14.buys
       FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Postgres/test_conversion_metric_with_custom_granularity_filter_not_in_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Postgres/test_conversion_metric_with_custom_granularity_filter_not_in_group_by__plan0_optimized.sql
@@ -18,7 +18,7 @@ SELECT
   CAST(MAX(subq_34.buys) AS DOUBLE PRECISION) / CAST(NULLIF(MAX(subq_23.visits), 0) AS DOUBLE PRECISION) AS visit_buy_conversion_rate_7days
 FROM (
   -- Constrain Output with WHERE
-  -- Pass Only Elements: ['visits',]
+  -- Pass Only Elements: ['visits']
   -- Aggregate Measures
   SELECT
     SUM(visits) AS visits
@@ -38,7 +38,7 @@ FROM (
 ) subq_23
 CROSS JOIN (
   -- Find conversions for user within the range of 7 day
-  -- Pass Only Elements: ['buys',]
+  -- Pass Only Elements: ['buys']
   -- Aggregate Measures
   SELECT
     SUM(buys) AS buys

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Postgres/test_join_to_time_spine_metric_grouped_by_custom_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Postgres/test_join_to_time_spine_metric_grouped_by_custom_grain__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_7.metric_time__alien_day AS metric_time__alien_day
     , subq_4.bookings AS bookings
   FROM (
-    -- Pass Only Elements: ['metric_time__alien_day',]
+    -- Pass Only Elements: ['metric_time__alien_day']
     SELECT
       subq_6.metric_time__alien_day
     FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Postgres/test_join_to_time_spine_metric_grouped_by_custom_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Postgres/test_join_to_time_spine_metric_grouped_by_custom_grain__plan0_optimized.sql
@@ -10,7 +10,7 @@ SELECT
 FROM (
   -- Read From Time Spine 'mf_time_spine'
   -- Change Column Aliases
-  -- Pass Only Elements: ['metric_time__alien_day',]
+  -- Pass Only Elements: ['metric_time__alien_day']
   SELECT
     alien_day AS metric_time__alien_day
   FROM ***************************.mf_time_spine time_spine_src_28006

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Postgres/test_join_to_timespine_metric_with_custom_granularity_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Postgres/test_join_to_timespine_metric_with_custom_granularity_filter__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_9.metric_time__alien_day AS metric_time__alien_day
     , subq_5.bookings AS bookings
   FROM (
-    -- Pass Only Elements: ['metric_time__alien_day',]
+    -- Pass Only Elements: ['metric_time__alien_day']
     SELECT
       subq_8.metric_time__alien_day
     FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Postgres/test_join_to_timespine_metric_with_custom_granularity_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Postgres/test_join_to_timespine_metric_with_custom_granularity_filter__plan0_optimized.sql
@@ -9,7 +9,7 @@ SELECT
   , subq_16.bookings AS bookings_join_to_time_spine
 FROM (
   -- Constrain Output with WHERE
-  -- Pass Only Elements: ['metric_time__alien_day',]
+  -- Pass Only Elements: ['metric_time__alien_day']
   SELECT
     metric_time__alien_day
   FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Postgres/test_join_to_timespine_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Postgres/test_join_to_timespine_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_9.metric_time__day AS metric_time__day
     , subq_5.bookings AS bookings
   FROM (
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       subq_8.metric_time__day
     FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Postgres/test_join_to_timespine_metric_with_custom_granularity_filter_not_in_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Postgres/test_join_to_timespine_metric_with_custom_granularity_filter_not_in_group_by__plan0_optimized.sql
@@ -9,7 +9,7 @@ SELECT
   , subq_16.bookings AS bookings_join_to_time_spine
 FROM (
   -- Constrain Output with WHERE
-  -- Pass Only Elements: ['metric_time__day',]
+  -- Pass Only Elements: ['metric_time__day']
   SELECT
     metric_time__day
   FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Postgres/test_no_metric_custom_granularity_joined_to_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Postgres/test_no_metric_custom_granularity_joined_to_non_default_grain__plan0.sql
@@ -380,7 +380,7 @@ FROM (
     FROM ***************************.dim_users users_ds_source_src_28000
   ) subq_0
   CROSS JOIN (
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       subq_2.metric_time__day
     FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Postgres/test_no_metric_custom_granularity_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Postgres/test_no_metric_custom_granularity_metric_time__plan0.sql
@@ -2,7 +2,7 @@ test_name: test_no_metric_custom_granularity_metric_time
 test_filename: test_custom_granularity.py
 sql_engine: Postgres
 ---
--- Pass Only Elements: ['metric_time__alien_day',]
+-- Pass Only Elements: ['metric_time__alien_day']
 SELECT
   subq_2.metric_time__alien_day
 FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Postgres/test_no_metric_custom_granularity_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Postgres/test_no_metric_custom_granularity_metric_time__plan0_optimized.sql
@@ -4,7 +4,7 @@ sql_engine: Postgres
 ---
 -- Metric Time Dimension 'ds'
 -- Join to Custom Granularity Dataset
--- Pass Only Elements: ['metric_time__alien_day',]
+-- Pass Only Elements: ['metric_time__alien_day']
 SELECT
   subq_4.alien_day AS metric_time__alien_day
 FROM ***************************.mf_time_spine time_spine_src_28006

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Postgres/test_no_metric_custom_granularity_non_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Postgres/test_no_metric_custom_granularity_non_metric_time__plan0.sql
@@ -2,7 +2,7 @@ test_name: test_no_metric_custom_granularity_non_metric_time
 test_filename: test_custom_granularity.py
 sql_engine: Postgres
 ---
--- Pass Only Elements: ['booking__ds__alien_day',]
+-- Pass Only Elements: ['booking__ds__alien_day']
 SELECT
   subq_1.booking__ds__alien_day
 FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Postgres/test_no_metric_custom_granularity_non_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Postgres/test_no_metric_custom_granularity_non_metric_time__plan0_optimized.sql
@@ -4,7 +4,7 @@ sql_engine: Postgres
 ---
 -- Read Elements From Semantic Model 'bookings_source'
 -- Join to Custom Granularity Dataset
--- Pass Only Elements: ['booking__ds__alien_day',]
+-- Pass Only Elements: ['booking__ds__alien_day']
 SELECT
   subq_2.alien_day AS booking__ds__alien_day
 FROM ***************************.fct_bookings bookings_source_src_28000

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Postgres/test_no_metrics_with_custom_granularity_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Postgres/test_no_metrics_with_custom_granularity_filter__plan0.sql
@@ -4,7 +4,7 @@ docstring:
   Group by items only queried with a filter on a custom grain, where that grain is not used in the group by.
 sql_engine: Postgres
 ---
--- Pass Only Elements: ['listing__ds__day',]
+-- Pass Only Elements: ['listing__ds__day']
 SELECT
   subq_2.listing__ds__day
 FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Postgres/test_no_metrics_with_custom_granularity_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Postgres/test_no_metrics_with_custom_granularity_filter__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: Postgres
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['listing__ds__day',]
+-- Pass Only Elements: ['listing__ds__day']
 SELECT
   listing__ds__day
 FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Postgres/test_no_metrics_with_custom_granularity_in_filter_and_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Postgres/test_no_metrics_with_custom_granularity_in_filter_and_group_by__plan0.sql
@@ -4,7 +4,7 @@ docstring:
   Group by items only queried with a filter on a custom grain, where that grain is also used in the group by.
 sql_engine: Postgres
 ---
--- Pass Only Elements: ['listing__ds__alien_day',]
+-- Pass Only Elements: ['listing__ds__alien_day']
 SELECT
   subq_2.listing__ds__alien_day
 FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Postgres/test_no_metrics_with_custom_granularity_in_filter_and_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Postgres/test_no_metrics_with_custom_granularity_in_filter_and_group_by__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: Postgres
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['listing__ds__alien_day',]
+-- Pass Only Elements: ['listing__ds__alien_day']
 SELECT
   listing__ds__alien_day
 FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Postgres/test_offset_metric_with_custom_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Postgres/test_offset_metric_with_custom_granularity__plan0.sql
@@ -125,7 +125,7 @@ FROM (
           , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           , subq_5.alien_day AS booking__ds__alien_day
         FROM (
-          -- Pass Only Elements: ['booking__ds__day',]
+          -- Pass Only Elements: ['booking__ds__day']
           SELECT
             subq_3.booking__ds__day
           FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Postgres/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Postgres/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
@@ -227,7 +227,7 @@ FROM (
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             , subq_5.alien_day AS metric_time__alien_day
           FROM (
-            -- Pass Only Elements: ['metric_time__day',]
+            -- Pass Only Elements: ['metric_time__day']
             SELECT
               subq_3.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Postgres/test_simple_metric_with_custom_granularity_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Postgres/test_simple_metric_with_custom_granularity_filter__plan0.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     SUM(subq_4.bookings) AS bookings
   FROM (
-    -- Pass Only Elements: ['bookings',]
+    -- Pass Only Elements: ['bookings']
     SELECT
       subq_3.bookings
     FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Postgres/test_simple_metric_with_custom_granularity_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Postgres/test_simple_metric_with_custom_granularity_filter__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: Postgres
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['bookings',]
+-- Pass Only Elements: ['bookings']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Redshift/test_conversion_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Redshift/test_conversion_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
@@ -15,7 +15,7 @@ FROM (
     SELECT
       SUM(subq_4.visits) AS visits
     FROM (
-      -- Pass Only Elements: ['visits',]
+      -- Pass Only Elements: ['visits']
       SELECT
         subq_3.visits
       FROM (
@@ -158,7 +158,7 @@ FROM (
     SELECT
       SUM(subq_15.buys) AS buys
     FROM (
-      -- Pass Only Elements: ['buys',]
+      -- Pass Only Elements: ['buys']
       SELECT
         subq_14.buys
       FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Redshift/test_conversion_metric_with_custom_granularity_filter_not_in_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Redshift/test_conversion_metric_with_custom_granularity_filter_not_in_group_by__plan0_optimized.sql
@@ -18,7 +18,7 @@ SELECT
   CAST(MAX(subq_34.buys) AS DOUBLE PRECISION) / CAST(NULLIF(MAX(subq_23.visits), 0) AS DOUBLE PRECISION) AS visit_buy_conversion_rate_7days
 FROM (
   -- Constrain Output with WHERE
-  -- Pass Only Elements: ['visits',]
+  -- Pass Only Elements: ['visits']
   -- Aggregate Measures
   SELECT
     SUM(visits) AS visits
@@ -38,7 +38,7 @@ FROM (
 ) subq_23
 CROSS JOIN (
   -- Find conversions for user within the range of 7 day
-  -- Pass Only Elements: ['buys',]
+  -- Pass Only Elements: ['buys']
   -- Aggregate Measures
   SELECT
     SUM(buys) AS buys

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Redshift/test_join_to_time_spine_metric_grouped_by_custom_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Redshift/test_join_to_time_spine_metric_grouped_by_custom_grain__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_7.metric_time__alien_day AS metric_time__alien_day
     , subq_4.bookings AS bookings
   FROM (
-    -- Pass Only Elements: ['metric_time__alien_day',]
+    -- Pass Only Elements: ['metric_time__alien_day']
     SELECT
       subq_6.metric_time__alien_day
     FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Redshift/test_join_to_time_spine_metric_grouped_by_custom_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Redshift/test_join_to_time_spine_metric_grouped_by_custom_grain__plan0_optimized.sql
@@ -10,7 +10,7 @@ SELECT
 FROM (
   -- Read From Time Spine 'mf_time_spine'
   -- Change Column Aliases
-  -- Pass Only Elements: ['metric_time__alien_day',]
+  -- Pass Only Elements: ['metric_time__alien_day']
   SELECT
     alien_day AS metric_time__alien_day
   FROM ***************************.mf_time_spine time_spine_src_28006

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Redshift/test_join_to_timespine_metric_with_custom_granularity_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Redshift/test_join_to_timespine_metric_with_custom_granularity_filter__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_9.metric_time__alien_day AS metric_time__alien_day
     , subq_5.bookings AS bookings
   FROM (
-    -- Pass Only Elements: ['metric_time__alien_day',]
+    -- Pass Only Elements: ['metric_time__alien_day']
     SELECT
       subq_8.metric_time__alien_day
     FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Redshift/test_join_to_timespine_metric_with_custom_granularity_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Redshift/test_join_to_timespine_metric_with_custom_granularity_filter__plan0_optimized.sql
@@ -9,7 +9,7 @@ SELECT
   , subq_16.bookings AS bookings_join_to_time_spine
 FROM (
   -- Constrain Output with WHERE
-  -- Pass Only Elements: ['metric_time__alien_day',]
+  -- Pass Only Elements: ['metric_time__alien_day']
   SELECT
     metric_time__alien_day
   FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Redshift/test_join_to_timespine_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Redshift/test_join_to_timespine_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_9.metric_time__day AS metric_time__day
     , subq_5.bookings AS bookings
   FROM (
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       subq_8.metric_time__day
     FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Redshift/test_join_to_timespine_metric_with_custom_granularity_filter_not_in_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Redshift/test_join_to_timespine_metric_with_custom_granularity_filter_not_in_group_by__plan0_optimized.sql
@@ -9,7 +9,7 @@ SELECT
   , subq_16.bookings AS bookings_join_to_time_spine
 FROM (
   -- Constrain Output with WHERE
-  -- Pass Only Elements: ['metric_time__day',]
+  -- Pass Only Elements: ['metric_time__day']
   SELECT
     metric_time__day
   FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Redshift/test_no_metric_custom_granularity_joined_to_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Redshift/test_no_metric_custom_granularity_joined_to_non_default_grain__plan0.sql
@@ -380,7 +380,7 @@ FROM (
     FROM ***************************.dim_users users_ds_source_src_28000
   ) subq_0
   CROSS JOIN (
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       subq_2.metric_time__day
     FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Redshift/test_no_metric_custom_granularity_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Redshift/test_no_metric_custom_granularity_metric_time__plan0.sql
@@ -2,7 +2,7 @@ test_name: test_no_metric_custom_granularity_metric_time
 test_filename: test_custom_granularity.py
 sql_engine: Redshift
 ---
--- Pass Only Elements: ['metric_time__alien_day',]
+-- Pass Only Elements: ['metric_time__alien_day']
 SELECT
   subq_2.metric_time__alien_day
 FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Redshift/test_no_metric_custom_granularity_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Redshift/test_no_metric_custom_granularity_metric_time__plan0_optimized.sql
@@ -4,7 +4,7 @@ sql_engine: Redshift
 ---
 -- Metric Time Dimension 'ds'
 -- Join to Custom Granularity Dataset
--- Pass Only Elements: ['metric_time__alien_day',]
+-- Pass Only Elements: ['metric_time__alien_day']
 SELECT
   subq_4.alien_day AS metric_time__alien_day
 FROM ***************************.mf_time_spine time_spine_src_28006

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Redshift/test_no_metric_custom_granularity_non_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Redshift/test_no_metric_custom_granularity_non_metric_time__plan0.sql
@@ -2,7 +2,7 @@ test_name: test_no_metric_custom_granularity_non_metric_time
 test_filename: test_custom_granularity.py
 sql_engine: Redshift
 ---
--- Pass Only Elements: ['booking__ds__alien_day',]
+-- Pass Only Elements: ['booking__ds__alien_day']
 SELECT
   subq_1.booking__ds__alien_day
 FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Redshift/test_no_metric_custom_granularity_non_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Redshift/test_no_metric_custom_granularity_non_metric_time__plan0_optimized.sql
@@ -4,7 +4,7 @@ sql_engine: Redshift
 ---
 -- Read Elements From Semantic Model 'bookings_source'
 -- Join to Custom Granularity Dataset
--- Pass Only Elements: ['booking__ds__alien_day',]
+-- Pass Only Elements: ['booking__ds__alien_day']
 SELECT
   subq_2.alien_day AS booking__ds__alien_day
 FROM ***************************.fct_bookings bookings_source_src_28000

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Redshift/test_no_metrics_with_custom_granularity_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Redshift/test_no_metrics_with_custom_granularity_filter__plan0.sql
@@ -4,7 +4,7 @@ docstring:
   Group by items only queried with a filter on a custom grain, where that grain is not used in the group by.
 sql_engine: Redshift
 ---
--- Pass Only Elements: ['listing__ds__day',]
+-- Pass Only Elements: ['listing__ds__day']
 SELECT
   subq_2.listing__ds__day
 FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Redshift/test_no_metrics_with_custom_granularity_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Redshift/test_no_metrics_with_custom_granularity_filter__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: Redshift
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['listing__ds__day',]
+-- Pass Only Elements: ['listing__ds__day']
 SELECT
   listing__ds__day
 FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Redshift/test_no_metrics_with_custom_granularity_in_filter_and_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Redshift/test_no_metrics_with_custom_granularity_in_filter_and_group_by__plan0.sql
@@ -4,7 +4,7 @@ docstring:
   Group by items only queried with a filter on a custom grain, where that grain is also used in the group by.
 sql_engine: Redshift
 ---
--- Pass Only Elements: ['listing__ds__alien_day',]
+-- Pass Only Elements: ['listing__ds__alien_day']
 SELECT
   subq_2.listing__ds__alien_day
 FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Redshift/test_no_metrics_with_custom_granularity_in_filter_and_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Redshift/test_no_metrics_with_custom_granularity_in_filter_and_group_by__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: Redshift
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['listing__ds__alien_day',]
+-- Pass Only Elements: ['listing__ds__alien_day']
 SELECT
   listing__ds__alien_day
 FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Redshift/test_offset_metric_with_custom_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Redshift/test_offset_metric_with_custom_granularity__plan0.sql
@@ -125,7 +125,7 @@ FROM (
           , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           , subq_5.alien_day AS booking__ds__alien_day
         FROM (
-          -- Pass Only Elements: ['booking__ds__day',]
+          -- Pass Only Elements: ['booking__ds__day']
           SELECT
             subq_3.booking__ds__day
           FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Redshift/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Redshift/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
@@ -227,7 +227,7 @@ FROM (
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             , subq_5.alien_day AS metric_time__alien_day
           FROM (
-            -- Pass Only Elements: ['metric_time__day',]
+            -- Pass Only Elements: ['metric_time__day']
             SELECT
               subq_3.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Redshift/test_simple_metric_with_custom_granularity_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Redshift/test_simple_metric_with_custom_granularity_filter__plan0.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     SUM(subq_4.bookings) AS bookings
   FROM (
-    -- Pass Only Elements: ['bookings',]
+    -- Pass Only Elements: ['bookings']
     SELECT
       subq_3.bookings
     FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Redshift/test_simple_metric_with_custom_granularity_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Redshift/test_simple_metric_with_custom_granularity_filter__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: Redshift
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['bookings',]
+-- Pass Only Elements: ['bookings']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Snowflake/test_conversion_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Snowflake/test_conversion_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
@@ -15,7 +15,7 @@ FROM (
     SELECT
       SUM(subq_4.visits) AS visits
     FROM (
-      -- Pass Only Elements: ['visits',]
+      -- Pass Only Elements: ['visits']
       SELECT
         subq_3.visits
       FROM (
@@ -158,7 +158,7 @@ FROM (
     SELECT
       SUM(subq_15.buys) AS buys
     FROM (
-      -- Pass Only Elements: ['buys',]
+      -- Pass Only Elements: ['buys']
       SELECT
         subq_14.buys
       FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Snowflake/test_conversion_metric_with_custom_granularity_filter_not_in_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Snowflake/test_conversion_metric_with_custom_granularity_filter_not_in_group_by__plan0_optimized.sql
@@ -18,7 +18,7 @@ SELECT
   CAST(MAX(subq_34.buys) AS DOUBLE) / CAST(NULLIF(MAX(subq_23.visits), 0) AS DOUBLE) AS visit_buy_conversion_rate_7days
 FROM (
   -- Constrain Output with WHERE
-  -- Pass Only Elements: ['visits',]
+  -- Pass Only Elements: ['visits']
   -- Aggregate Measures
   SELECT
     SUM(visits) AS visits
@@ -38,7 +38,7 @@ FROM (
 ) subq_23
 CROSS JOIN (
   -- Find conversions for user within the range of 7 day
-  -- Pass Only Elements: ['buys',]
+  -- Pass Only Elements: ['buys']
   -- Aggregate Measures
   SELECT
     SUM(buys) AS buys

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Snowflake/test_join_to_time_spine_metric_grouped_by_custom_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Snowflake/test_join_to_time_spine_metric_grouped_by_custom_grain__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_7.metric_time__alien_day AS metric_time__alien_day
     , subq_4.bookings AS bookings
   FROM (
-    -- Pass Only Elements: ['metric_time__alien_day',]
+    -- Pass Only Elements: ['metric_time__alien_day']
     SELECT
       subq_6.metric_time__alien_day
     FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Snowflake/test_join_to_time_spine_metric_grouped_by_custom_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Snowflake/test_join_to_time_spine_metric_grouped_by_custom_grain__plan0_optimized.sql
@@ -10,7 +10,7 @@ SELECT
 FROM (
   -- Read From Time Spine 'mf_time_spine'
   -- Change Column Aliases
-  -- Pass Only Elements: ['metric_time__alien_day',]
+  -- Pass Only Elements: ['metric_time__alien_day']
   SELECT
     alien_day AS metric_time__alien_day
   FROM ***************************.mf_time_spine time_spine_src_28006

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Snowflake/test_join_to_timespine_metric_with_custom_granularity_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Snowflake/test_join_to_timespine_metric_with_custom_granularity_filter__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_9.metric_time__alien_day AS metric_time__alien_day
     , subq_5.bookings AS bookings
   FROM (
-    -- Pass Only Elements: ['metric_time__alien_day',]
+    -- Pass Only Elements: ['metric_time__alien_day']
     SELECT
       subq_8.metric_time__alien_day
     FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Snowflake/test_join_to_timespine_metric_with_custom_granularity_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Snowflake/test_join_to_timespine_metric_with_custom_granularity_filter__plan0_optimized.sql
@@ -9,7 +9,7 @@ SELECT
   , subq_16.bookings AS bookings_join_to_time_spine
 FROM (
   -- Constrain Output with WHERE
-  -- Pass Only Elements: ['metric_time__alien_day',]
+  -- Pass Only Elements: ['metric_time__alien_day']
   SELECT
     metric_time__alien_day
   FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Snowflake/test_join_to_timespine_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Snowflake/test_join_to_timespine_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_9.metric_time__day AS metric_time__day
     , subq_5.bookings AS bookings
   FROM (
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       subq_8.metric_time__day
     FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Snowflake/test_join_to_timespine_metric_with_custom_granularity_filter_not_in_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Snowflake/test_join_to_timespine_metric_with_custom_granularity_filter_not_in_group_by__plan0_optimized.sql
@@ -9,7 +9,7 @@ SELECT
   , subq_16.bookings AS bookings_join_to_time_spine
 FROM (
   -- Constrain Output with WHERE
-  -- Pass Only Elements: ['metric_time__day',]
+  -- Pass Only Elements: ['metric_time__day']
   SELECT
     metric_time__day
   FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Snowflake/test_no_metric_custom_granularity_joined_to_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Snowflake/test_no_metric_custom_granularity_joined_to_non_default_grain__plan0.sql
@@ -380,7 +380,7 @@ FROM (
     FROM ***************************.dim_users users_ds_source_src_28000
   ) subq_0
   CROSS JOIN (
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       subq_2.metric_time__day
     FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Snowflake/test_no_metric_custom_granularity_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Snowflake/test_no_metric_custom_granularity_metric_time__plan0.sql
@@ -2,7 +2,7 @@ test_name: test_no_metric_custom_granularity_metric_time
 test_filename: test_custom_granularity.py
 sql_engine: Snowflake
 ---
--- Pass Only Elements: ['metric_time__alien_day',]
+-- Pass Only Elements: ['metric_time__alien_day']
 SELECT
   subq_2.metric_time__alien_day
 FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Snowflake/test_no_metric_custom_granularity_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Snowflake/test_no_metric_custom_granularity_metric_time__plan0_optimized.sql
@@ -4,7 +4,7 @@ sql_engine: Snowflake
 ---
 -- Metric Time Dimension 'ds'
 -- Join to Custom Granularity Dataset
--- Pass Only Elements: ['metric_time__alien_day',]
+-- Pass Only Elements: ['metric_time__alien_day']
 SELECT
   subq_4.alien_day AS metric_time__alien_day
 FROM ***************************.mf_time_spine time_spine_src_28006

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Snowflake/test_no_metric_custom_granularity_non_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Snowflake/test_no_metric_custom_granularity_non_metric_time__plan0.sql
@@ -2,7 +2,7 @@ test_name: test_no_metric_custom_granularity_non_metric_time
 test_filename: test_custom_granularity.py
 sql_engine: Snowflake
 ---
--- Pass Only Elements: ['booking__ds__alien_day',]
+-- Pass Only Elements: ['booking__ds__alien_day']
 SELECT
   subq_1.booking__ds__alien_day
 FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Snowflake/test_no_metric_custom_granularity_non_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Snowflake/test_no_metric_custom_granularity_non_metric_time__plan0_optimized.sql
@@ -4,7 +4,7 @@ sql_engine: Snowflake
 ---
 -- Read Elements From Semantic Model 'bookings_source'
 -- Join to Custom Granularity Dataset
--- Pass Only Elements: ['booking__ds__alien_day',]
+-- Pass Only Elements: ['booking__ds__alien_day']
 SELECT
   subq_2.alien_day AS booking__ds__alien_day
 FROM ***************************.fct_bookings bookings_source_src_28000

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Snowflake/test_no_metrics_with_custom_granularity_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Snowflake/test_no_metrics_with_custom_granularity_filter__plan0.sql
@@ -4,7 +4,7 @@ docstring:
   Group by items only queried with a filter on a custom grain, where that grain is not used in the group by.
 sql_engine: Snowflake
 ---
--- Pass Only Elements: ['listing__ds__day',]
+-- Pass Only Elements: ['listing__ds__day']
 SELECT
   subq_2.listing__ds__day
 FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Snowflake/test_no_metrics_with_custom_granularity_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Snowflake/test_no_metrics_with_custom_granularity_filter__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: Snowflake
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['listing__ds__day',]
+-- Pass Only Elements: ['listing__ds__day']
 SELECT
   listing__ds__day
 FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Snowflake/test_no_metrics_with_custom_granularity_in_filter_and_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Snowflake/test_no_metrics_with_custom_granularity_in_filter_and_group_by__plan0.sql
@@ -4,7 +4,7 @@ docstring:
   Group by items only queried with a filter on a custom grain, where that grain is also used in the group by.
 sql_engine: Snowflake
 ---
--- Pass Only Elements: ['listing__ds__alien_day',]
+-- Pass Only Elements: ['listing__ds__alien_day']
 SELECT
   subq_2.listing__ds__alien_day
 FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Snowflake/test_no_metrics_with_custom_granularity_in_filter_and_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Snowflake/test_no_metrics_with_custom_granularity_in_filter_and_group_by__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: Snowflake
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['listing__ds__alien_day',]
+-- Pass Only Elements: ['listing__ds__alien_day']
 SELECT
   listing__ds__alien_day
 FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Snowflake/test_offset_metric_with_custom_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Snowflake/test_offset_metric_with_custom_granularity__plan0.sql
@@ -125,7 +125,7 @@ FROM (
           , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           , subq_5.alien_day AS booking__ds__alien_day
         FROM (
-          -- Pass Only Elements: ['booking__ds__day',]
+          -- Pass Only Elements: ['booking__ds__day']
           SELECT
             subq_3.booking__ds__day
           FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Snowflake/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Snowflake/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
@@ -227,7 +227,7 @@ FROM (
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             , subq_5.alien_day AS metric_time__alien_day
           FROM (
-            -- Pass Only Elements: ['metric_time__day',]
+            -- Pass Only Elements: ['metric_time__day']
             SELECT
               subq_3.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Snowflake/test_simple_metric_with_custom_granularity_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Snowflake/test_simple_metric_with_custom_granularity_filter__plan0.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     SUM(subq_4.bookings) AS bookings
   FROM (
-    -- Pass Only Elements: ['bookings',]
+    -- Pass Only Elements: ['bookings']
     SELECT
       subq_3.bookings
     FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Snowflake/test_simple_metric_with_custom_granularity_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Snowflake/test_simple_metric_with_custom_granularity_filter__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: Snowflake
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['bookings',]
+-- Pass Only Elements: ['bookings']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Trino/test_conversion_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Trino/test_conversion_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
@@ -15,7 +15,7 @@ FROM (
     SELECT
       SUM(subq_4.visits) AS visits
     FROM (
-      -- Pass Only Elements: ['visits',]
+      -- Pass Only Elements: ['visits']
       SELECT
         subq_3.visits
       FROM (
@@ -158,7 +158,7 @@ FROM (
     SELECT
       SUM(subq_15.buys) AS buys
     FROM (
-      -- Pass Only Elements: ['buys',]
+      -- Pass Only Elements: ['buys']
       SELECT
         subq_14.buys
       FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Trino/test_conversion_metric_with_custom_granularity_filter_not_in_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Trino/test_conversion_metric_with_custom_granularity_filter_not_in_group_by__plan0_optimized.sql
@@ -18,7 +18,7 @@ SELECT
   CAST(MAX(subq_34.buys) AS DOUBLE) / CAST(NULLIF(MAX(subq_23.visits), 0) AS DOUBLE) AS visit_buy_conversion_rate_7days
 FROM (
   -- Constrain Output with WHERE
-  -- Pass Only Elements: ['visits',]
+  -- Pass Only Elements: ['visits']
   -- Aggregate Measures
   SELECT
     SUM(visits) AS visits
@@ -38,7 +38,7 @@ FROM (
 ) subq_23
 CROSS JOIN (
   -- Find conversions for user within the range of 7 day
-  -- Pass Only Elements: ['buys',]
+  -- Pass Only Elements: ['buys']
   -- Aggregate Measures
   SELECT
     SUM(buys) AS buys

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Trino/test_join_to_time_spine_metric_grouped_by_custom_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Trino/test_join_to_time_spine_metric_grouped_by_custom_grain__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_7.metric_time__alien_day AS metric_time__alien_day
     , subq_4.bookings AS bookings
   FROM (
-    -- Pass Only Elements: ['metric_time__alien_day',]
+    -- Pass Only Elements: ['metric_time__alien_day']
     SELECT
       subq_6.metric_time__alien_day
     FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Trino/test_join_to_time_spine_metric_grouped_by_custom_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Trino/test_join_to_time_spine_metric_grouped_by_custom_grain__plan0_optimized.sql
@@ -10,7 +10,7 @@ SELECT
 FROM (
   -- Read From Time Spine 'mf_time_spine'
   -- Change Column Aliases
-  -- Pass Only Elements: ['metric_time__alien_day',]
+  -- Pass Only Elements: ['metric_time__alien_day']
   SELECT
     alien_day AS metric_time__alien_day
   FROM ***************************.mf_time_spine time_spine_src_28006

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Trino/test_join_to_timespine_metric_with_custom_granularity_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Trino/test_join_to_timespine_metric_with_custom_granularity_filter__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_9.metric_time__alien_day AS metric_time__alien_day
     , subq_5.bookings AS bookings
   FROM (
-    -- Pass Only Elements: ['metric_time__alien_day',]
+    -- Pass Only Elements: ['metric_time__alien_day']
     SELECT
       subq_8.metric_time__alien_day
     FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Trino/test_join_to_timespine_metric_with_custom_granularity_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Trino/test_join_to_timespine_metric_with_custom_granularity_filter__plan0_optimized.sql
@@ -9,7 +9,7 @@ SELECT
   , subq_16.bookings AS bookings_join_to_time_spine
 FROM (
   -- Constrain Output with WHERE
-  -- Pass Only Elements: ['metric_time__alien_day',]
+  -- Pass Only Elements: ['metric_time__alien_day']
   SELECT
     metric_time__alien_day
   FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Trino/test_join_to_timespine_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Trino/test_join_to_timespine_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_9.metric_time__day AS metric_time__day
     , subq_5.bookings AS bookings
   FROM (
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       subq_8.metric_time__day
     FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Trino/test_join_to_timespine_metric_with_custom_granularity_filter_not_in_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Trino/test_join_to_timespine_metric_with_custom_granularity_filter_not_in_group_by__plan0_optimized.sql
@@ -9,7 +9,7 @@ SELECT
   , subq_16.bookings AS bookings_join_to_time_spine
 FROM (
   -- Constrain Output with WHERE
-  -- Pass Only Elements: ['metric_time__day',]
+  -- Pass Only Elements: ['metric_time__day']
   SELECT
     metric_time__day
   FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Trino/test_no_metric_custom_granularity_joined_to_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Trino/test_no_metric_custom_granularity_joined_to_non_default_grain__plan0.sql
@@ -380,7 +380,7 @@ FROM (
     FROM ***************************.dim_users users_ds_source_src_28000
   ) subq_0
   CROSS JOIN (
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       subq_2.metric_time__day
     FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Trino/test_no_metric_custom_granularity_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Trino/test_no_metric_custom_granularity_metric_time__plan0.sql
@@ -2,7 +2,7 @@ test_name: test_no_metric_custom_granularity_metric_time
 test_filename: test_custom_granularity.py
 sql_engine: Trino
 ---
--- Pass Only Elements: ['metric_time__alien_day',]
+-- Pass Only Elements: ['metric_time__alien_day']
 SELECT
   subq_2.metric_time__alien_day
 FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Trino/test_no_metric_custom_granularity_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Trino/test_no_metric_custom_granularity_metric_time__plan0_optimized.sql
@@ -4,7 +4,7 @@ sql_engine: Trino
 ---
 -- Metric Time Dimension 'ds'
 -- Join to Custom Granularity Dataset
--- Pass Only Elements: ['metric_time__alien_day',]
+-- Pass Only Elements: ['metric_time__alien_day']
 SELECT
   subq_4.alien_day AS metric_time__alien_day
 FROM ***************************.mf_time_spine time_spine_src_28006

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Trino/test_no_metric_custom_granularity_non_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Trino/test_no_metric_custom_granularity_non_metric_time__plan0.sql
@@ -2,7 +2,7 @@ test_name: test_no_metric_custom_granularity_non_metric_time
 test_filename: test_custom_granularity.py
 sql_engine: Trino
 ---
--- Pass Only Elements: ['booking__ds__alien_day',]
+-- Pass Only Elements: ['booking__ds__alien_day']
 SELECT
   subq_1.booking__ds__alien_day
 FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Trino/test_no_metric_custom_granularity_non_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Trino/test_no_metric_custom_granularity_non_metric_time__plan0_optimized.sql
@@ -4,7 +4,7 @@ sql_engine: Trino
 ---
 -- Read Elements From Semantic Model 'bookings_source'
 -- Join to Custom Granularity Dataset
--- Pass Only Elements: ['booking__ds__alien_day',]
+-- Pass Only Elements: ['booking__ds__alien_day']
 SELECT
   subq_2.alien_day AS booking__ds__alien_day
 FROM ***************************.fct_bookings bookings_source_src_28000

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Trino/test_no_metrics_with_custom_granularity_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Trino/test_no_metrics_with_custom_granularity_filter__plan0.sql
@@ -4,7 +4,7 @@ docstring:
   Group by items only queried with a filter on a custom grain, where that grain is not used in the group by.
 sql_engine: Trino
 ---
--- Pass Only Elements: ['listing__ds__day',]
+-- Pass Only Elements: ['listing__ds__day']
 SELECT
   subq_2.listing__ds__day
 FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Trino/test_no_metrics_with_custom_granularity_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Trino/test_no_metrics_with_custom_granularity_filter__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: Trino
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['listing__ds__day',]
+-- Pass Only Elements: ['listing__ds__day']
 SELECT
   listing__ds__day
 FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Trino/test_no_metrics_with_custom_granularity_in_filter_and_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Trino/test_no_metrics_with_custom_granularity_in_filter_and_group_by__plan0.sql
@@ -4,7 +4,7 @@ docstring:
   Group by items only queried with a filter on a custom grain, where that grain is also used in the group by.
 sql_engine: Trino
 ---
--- Pass Only Elements: ['listing__ds__alien_day',]
+-- Pass Only Elements: ['listing__ds__alien_day']
 SELECT
   subq_2.listing__ds__alien_day
 FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Trino/test_no_metrics_with_custom_granularity_in_filter_and_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Trino/test_no_metrics_with_custom_granularity_in_filter_and_group_by__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: Trino
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['listing__ds__alien_day',]
+-- Pass Only Elements: ['listing__ds__alien_day']
 SELECT
   listing__ds__alien_day
 FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Trino/test_offset_metric_with_custom_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Trino/test_offset_metric_with_custom_granularity__plan0.sql
@@ -125,7 +125,7 @@ FROM (
           , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           , subq_5.alien_day AS booking__ds__alien_day
         FROM (
-          -- Pass Only Elements: ['booking__ds__day',]
+          -- Pass Only Elements: ['booking__ds__day']
           SELECT
             subq_3.booking__ds__day
           FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Trino/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Trino/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
@@ -227,7 +227,7 @@ FROM (
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             , subq_5.alien_day AS metric_time__alien_day
           FROM (
-            -- Pass Only Elements: ['metric_time__day',]
+            -- Pass Only Elements: ['metric_time__day']
             SELECT
               subq_3.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Trino/test_simple_metric_with_custom_granularity_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Trino/test_simple_metric_with_custom_granularity_filter__plan0.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     SUM(subq_4.bookings) AS bookings
   FROM (
-    -- Pass Only Elements: ['bookings',]
+    -- Pass Only Elements: ['bookings']
     SELECT
       subq_3.bookings
     FROM (

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Trino/test_simple_metric_with_custom_granularity_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Trino/test_simple_metric_with_custom_granularity_filter__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: Trino
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['bookings',]
+-- Pass Only Elements: ['bookings']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_cumulative_metric_no_window_or_grain_without_metric_time__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_cumulative_metric_no_window_or_grain_without_metric_time__dfp_0.xml
@@ -13,7 +13,7 @@ test_filename: test_dataflow_plan_builder.py
                 <!-- description = 'Aggregate Measures' -->
                 <!-- node_id = NodeId(id_str='am_0') -->
                 <FilterElementsNode>
-                    <!-- description = "Pass Only Elements: ['txn_revenue',]" -->
+                    <!-- description = "Pass Only Elements: ['txn_revenue']" -->
                     <!-- node_id = NodeId(id_str='pfe_0') -->
                     <!-- include_spec = MeasureSpec(element_name='txn_revenue') -->
                     <!-- distinct = False -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_metric_offset_to_grain__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_metric_offset_to_grain__dfp_0.xml
@@ -96,7 +96,7 @@ docstring:
                                     </ReadSqlSourceNode>
                                 </MetricTimeDimensionTransformNode>
                                 <FilterElementsNode>
-                                    <!-- description = "Pass Only Elements: ['metric_time__day',]" -->
+                                    <!-- description = "Pass Only Elements: ['metric_time__day']" -->
                                     <!-- node_id = NodeId(id_str='pfe_1') -->
                                     <!-- include_spec =                                                                  -->
                                     <!--   TimeDimensionSpec(                                                            -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_metric_offset_window__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_metric_offset_window__dfp_0.xml
@@ -62,7 +62,7 @@ docstring:
                                 </ReadSqlSourceNode>
                             </MetricTimeDimensionTransformNode>
                             <FilterElementsNode>
-                                <!-- description = "Pass Only Elements: ['metric_time__day',]" -->
+                                <!-- description = "Pass Only Elements: ['metric_time__day']" -->
                                 <!-- node_id = NodeId(id_str='pfe_0') -->
                                 <!-- include_spec =                                                                  -->
                                 <!--   TimeDimensionSpec(                                                            -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_offset_cumulative_metric__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_offset_cumulative_metric__dfp_0.xml
@@ -73,7 +73,7 @@ test_filename: test_dataflow_plan_builder.py
                                 </MetricTimeDimensionTransformNode>
                             </JoinOverTimeRangeNode>
                             <FilterElementsNode>
-                                <!-- description = "Pass Only Elements: ['metric_time__day',]" -->
+                                <!-- description = "Pass Only Elements: ['metric_time__day']" -->
                                 <!-- node_id = NodeId(id_str='pfe_0') -->
                                 <!-- include_spec =                                                                  -->
                                 <!--   TimeDimensionSpec(                                                            -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_dimensions_with_time_constraint__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_dimensions_with_time_constraint__dfp_0.xml
@@ -32,7 +32,7 @@ test_filename: test_dataflow_plan_builder.py
                         <!-- data_set = SemanticModelDataSet('listings_latest') -->
                     </ReadSqlSourceNode>
                     <FilterElementsNode>
-                        <!-- description = "Pass Only Elements: ['metric_time__month',]" -->
+                        <!-- description = "Pass Only Elements: ['metric_time__month']" -->
                         <!-- node_id = NodeId(id_str='pfe_0') -->
                         <!-- include_spec =                                                                      -->
                         <!--   TimeDimensionSpec(                                                                -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_distinct_values_plan__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_distinct_values_plan__dfp_0.xml
@@ -20,7 +20,7 @@ docstring:
             <!--   )                                                            -->
             <!-- limit = '100' -->
             <FilterElementsNode>
-                <!-- description = "Pass Only Elements: ['listing__country_latest',]" -->
+                <!-- description = "Pass Only Elements: ['listing__country_latest']" -->
                 <!-- node_id = NodeId(id_str='pfe_0') -->
                 <!-- include_spec =                                               -->
                 <!--   DimensionSpec(                                             -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_dont_join_to_time_spine_if_no_time_dimension_requested__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_dont_join_to_time_spine_if_no_time_dimension_requested__dfp_0.xml
@@ -14,7 +14,7 @@ test_filename: test_dataflow_plan_builder.py
                 <!-- description = 'Aggregate Measures' -->
                 <!-- node_id = NodeId(id_str='am_0') -->
                 <FilterElementsNode>
-                    <!-- description = "Pass Only Elements: ['bookings',]" -->
+                    <!-- description = "Pass Only Elements: ['bookings']" -->
                     <!-- node_id = NodeId(id_str='pfe_0') -->
                     <!-- include_spec = MeasureSpec(element_name='bookings') -->
                     <!-- distinct = False -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_join_to_time_spine_derived_metric__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_join_to_time_spine_derived_metric__dfp_0.xml
@@ -63,7 +63,7 @@ test_filename: test_dataflow_plan_builder.py
                             </FilterElementsNode>
                         </AggregateMeasuresNode>
                         <FilterElementsNode>
-                            <!-- description = "Pass Only Elements: ['metric_time__day',]" -->
+                            <!-- description = "Pass Only Elements: ['metric_time__day']" -->
                             <!-- node_id = NodeId(id_str='pfe_1') -->
                             <!-- include_spec =                                                                  -->
                             <!--   TimeDimensionSpec(                                                            -->
@@ -169,7 +169,7 @@ test_filename: test_dataflow_plan_builder.py
                                         </ReadSqlSourceNode>
                                     </MetricTimeDimensionTransformNode>
                                     <FilterElementsNode>
-                                        <!-- description = "Pass Only Elements: ['metric_time__day',]" -->
+                                        <!-- description = "Pass Only Elements: ['metric_time__day']" -->
                                         <!-- node_id = NodeId(id_str='pfe_2') -->
                                         <!-- include_spec =                                -->
                                         <!--   TimeDimensionSpec(                          -->
@@ -213,7 +213,7 @@ test_filename: test_dataflow_plan_builder.py
                             </FilterElementsNode>
                         </AggregateMeasuresNode>
                         <FilterElementsNode>
-                            <!-- description = "Pass Only Elements: ['metric_time__day',]" -->
+                            <!-- description = "Pass Only Elements: ['metric_time__day']" -->
                             <!-- node_id = NodeId(id_str='pfe_4') -->
                             <!-- include_spec =                                                                  -->
                             <!--   TimeDimensionSpec(                                                            -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_join_to_time_spine_with_filters__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_join_to_time_spine_with_filters__dfp_0.xml
@@ -151,7 +151,7 @@ docstring:
                         </FilterElementsNode>
                     </AggregateMeasuresNode>
                     <FilterElementsNode>
-                        <!-- description = "Pass Only Elements: ['metric_time__day',]" -->
+                        <!-- description = "Pass Only Elements: ['metric_time__day']" -->
                         <!-- node_id = NodeId(id_str='pfe_1') -->
                         <!-- include_spec =                                                                  -->
                         <!--   TimeDimensionSpec(                                                            -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_join_to_time_spine_with_metric_time__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_join_to_time_spine_with_metric_time__dfp_0.xml
@@ -52,7 +52,7 @@ test_filename: test_dataflow_plan_builder.py
                     </FilterElementsNode>
                 </AggregateMeasuresNode>
                 <FilterElementsNode>
-                    <!-- description = "Pass Only Elements: ['metric_time__day',]" -->
+                    <!-- description = "Pass Only Elements: ['metric_time__day']" -->
                     <!-- node_id = NodeId(id_str='pfe_1') -->
                     <!-- include_spec =                                                                  -->
                     <!--   TimeDimensionSpec(                                                            -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_metric_in_metric_where_filter__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_metric_in_metric_where_filter__dfp_0.xml
@@ -15,7 +15,7 @@ docstring:
                 <!-- description = 'Aggregate Measures' -->
                 <!-- node_id = NodeId(id_str='am_1') -->
                 <FilterElementsNode>
-                    <!-- description = "Pass Only Elements: ['listings',]" -->
+                    <!-- description = "Pass Only Elements: ['listings']" -->
                     <!-- node_id = NodeId(id_str='pfe_2') -->
                     <!-- include_spec = MeasureSpec(element_name='listings') -->
                     <!-- distinct = False -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_metric_in_query_where_filter__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_metric_in_query_where_filter__dfp_0.xml
@@ -43,7 +43,7 @@ docstring:
                 <!-- description = 'Aggregate Measures' -->
                 <!-- node_id = NodeId(id_str='am_1') -->
                 <FilterElementsNode>
-                    <!-- description = "Pass Only Elements: ['listings',]" -->
+                    <!-- description = "Pass Only Elements: ['listings']" -->
                     <!-- node_id = NodeId(id_str='pfe_2') -->
                     <!-- include_spec = MeasureSpec(element_name='listings') -->
                     <!-- distinct = False -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_metric_time_only__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_metric_time_only__dfp_0.xml
@@ -6,7 +6,7 @@ test_filename: test_dataflow_plan_builder.py
         <!-- description = 'Write to DataTable' -->
         <!-- node_id = NodeId(id_str='wrd_0') -->
         <FilterElementsNode>
-            <!-- description = "Pass Only Elements: ['metric_time__day',]" -->
+            <!-- description = "Pass Only Elements: ['metric_time__day']" -->
             <!-- node_id = NodeId(id_str='pfe_0') -->
             <!-- include_spec =                                                                  -->
             <!--   TimeDimensionSpec(                                                            -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_metric_time_quarter__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_metric_time_quarter__dfp_0.xml
@@ -6,7 +6,7 @@ test_filename: test_dataflow_plan_builder.py
         <!-- description = 'Write to DataTable' -->
         <!-- node_id = NodeId(id_str='wrd_0') -->
         <FilterElementsNode>
-            <!-- description = "Pass Only Elements: ['metric_time__quarter',]" -->
+            <!-- description = "Pass Only Elements: ['metric_time__quarter']" -->
             <!-- node_id = NodeId(id_str='pfe_0') -->
             <!-- include_spec =                                                                          -->
             <!--   TimeDimensionSpec(                                                                    -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_min_max_metric_time__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_min_max_metric_time__dfp_0.xml
@@ -11,7 +11,7 @@ docstring:
             <!-- description = 'Calculate min and max' -->
             <!-- node_id = NodeId(id_str='mm_0') -->
             <FilterElementsNode>
-                <!-- description = "Pass Only Elements: ['metric_time__day',]" -->
+                <!-- description = "Pass Only Elements: ['metric_time__day']" -->
                 <!-- node_id = NodeId(id_str='pfe_0') -->
                 <!-- include_spec =                                                                  -->
                 <!--   TimeDimensionSpec(                                                            -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_min_max_metric_time_week__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_min_max_metric_time_week__dfp_0.xml
@@ -11,7 +11,7 @@ docstring:
             <!-- description = 'Calculate min and max' -->
             <!-- node_id = NodeId(id_str='mm_0') -->
             <FilterElementsNode>
-                <!-- description = "Pass Only Elements: ['metric_time__week',]" -->
+                <!-- description = "Pass Only Elements: ['metric_time__week']" -->
                 <!-- node_id = NodeId(id_str='pfe_0') -->
                 <!-- include_spec =                                                                    -->
                 <!--   TimeDimensionSpec(                                                              -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_min_max_only_categorical__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_min_max_only_categorical__dfp_0.xml
@@ -11,7 +11,7 @@ docstring:
             <!-- description = 'Calculate min and max' -->
             <!-- node_id = NodeId(id_str='mm_0') -->
             <FilterElementsNode>
-                <!-- description = "Pass Only Elements: ['listing__country_latest',]" -->
+                <!-- description = "Pass Only Elements: ['listing__country_latest']" -->
                 <!-- node_id = NodeId(id_str='pfe_0') -->
                 <!-- include_spec =                                               -->
                 <!--   DimensionSpec(                                             -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_min_max_only_time__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_min_max_only_time__dfp_0.xml
@@ -11,7 +11,7 @@ docstring:
             <!-- description = 'Calculate min and max' -->
             <!-- node_id = NodeId(id_str='mm_0') -->
             <FilterElementsNode>
-                <!-- description = "Pass Only Elements: ['booking__paid_at__day',]" -->
+                <!-- description = "Pass Only Elements: ['booking__paid_at__day']" -->
                 <!-- node_id = NodeId(id_str='pfe_0') -->
                 <!-- include_spec =                                                                  -->
                 <!--   TimeDimensionSpec(                                                            -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_min_max_only_time_year__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_min_max_only_time_year__dfp_0.xml
@@ -11,7 +11,7 @@ docstring:
             <!-- description = 'Calculate min and max' -->
             <!-- node_id = NodeId(id_str='mm_0') -->
             <FilterElementsNode>
-                <!-- description = "Pass Only Elements: ['booking__paid_at__year',]" -->
+                <!-- description = "Pass Only Elements: ['booking__paid_at__year']" -->
                 <!-- node_id = NodeId(id_str='pfe_0') -->
                 <!-- include_spec =                                                                    -->
                 <!--   TimeDimensionSpec(                                                              -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_nested_derived_metric_with_outer_offset__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_nested_derived_metric_with_outer_offset__dfp_0.xml
@@ -85,7 +85,7 @@ test_filename: test_dataflow_plan_builder.py
                                         </ReadSqlSourceNode>
                                     </MetricTimeDimensionTransformNode>
                                     <FilterElementsNode>
-                                        <!-- description = "Pass Only Elements: ['metric_time__day',]" -->
+                                        <!-- description = "Pass Only Elements: ['metric_time__day']" -->
                                         <!-- node_id = NodeId(id_str='pfe_0') -->
                                         <!-- include_spec =                                -->
                                         <!--   TimeDimensionSpec(                          -->
@@ -131,7 +131,7 @@ test_filename: test_dataflow_plan_builder.py
                     </ComputeMetricsNode>
                 </ComputeMetricsNode>
                 <FilterElementsNode>
-                    <!-- description = "Pass Only Elements: ['metric_time__day',]" -->
+                    <!-- description = "Pass Only Elements: ['metric_time__day']" -->
                     <!-- node_id = NodeId(id_str='pfe_2') -->
                     <!-- include_spec =                                                                  -->
                     <!--   TimeDimensionSpec(                                                            -->

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/BigQuery/test_dimension_with_joined_where_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/BigQuery/test_dimension_with_joined_where_constraint__plan0.sql
@@ -4,7 +4,7 @@ docstring:
   Tests querying 2 dimensions that require a join.
 sql_engine: BigQuery
 ---
--- Pass Only Elements: ['user__home_state_latest',]
+-- Pass Only Elements: ['user__home_state_latest']
 SELECT
   subq_4.user__home_state_latest
 FROM (

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/BigQuery/test_dimension_with_joined_where_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/BigQuery/test_dimension_with_joined_where_constraint__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: BigQuery
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['user__home_state_latest',]
+-- Pass Only Elements: ['user__home_state_latest']
 SELECT
   user__home_state_latest
 FROM (

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/BigQuery/test_filter_node__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/BigQuery/test_filter_node__plan0.sql
@@ -4,7 +4,7 @@ docstring:
   Tests converting a dataflow plan to a SQL query plan where there is a leaf pass filter node.
 sql_engine: BigQuery
 ---
--- Pass Only Elements: ['bookings',]
+-- Pass Only Elements: ['bookings']
 SELECT
   subq_0.bookings
 FROM (

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/BigQuery/test_filter_node__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/BigQuery/test_filter_node__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: BigQuery
 ---
 -- Read Elements From Semantic Model 'bookings_source'
--- Pass Only Elements: ['bookings',]
+-- Pass Only Elements: ['bookings']
 SELECT
   1 AS bookings
 FROM ***************************.fct_bookings bookings_source_src_28000

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/Databricks/test_dimension_with_joined_where_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/Databricks/test_dimension_with_joined_where_constraint__plan0.sql
@@ -4,7 +4,7 @@ docstring:
   Tests querying 2 dimensions that require a join.
 sql_engine: Databricks
 ---
--- Pass Only Elements: ['user__home_state_latest',]
+-- Pass Only Elements: ['user__home_state_latest']
 SELECT
   subq_4.user__home_state_latest
 FROM (

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/Databricks/test_dimension_with_joined_where_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/Databricks/test_dimension_with_joined_where_constraint__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: Databricks
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['user__home_state_latest',]
+-- Pass Only Elements: ['user__home_state_latest']
 SELECT
   user__home_state_latest
 FROM (

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/Databricks/test_filter_node__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/Databricks/test_filter_node__plan0.sql
@@ -4,7 +4,7 @@ docstring:
   Tests converting a dataflow plan to a SQL query plan where there is a leaf pass filter node.
 sql_engine: Databricks
 ---
--- Pass Only Elements: ['bookings',]
+-- Pass Only Elements: ['bookings']
 SELECT
   subq_0.bookings
 FROM (

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/Databricks/test_filter_node__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/Databricks/test_filter_node__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: Databricks
 ---
 -- Read Elements From Semantic Model 'bookings_source'
--- Pass Only Elements: ['bookings',]
+-- Pass Only Elements: ['bookings']
 SELECT
   1 AS bookings
 FROM ***************************.fct_bookings bookings_source_src_28000

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/DuckDB/test_dimension_with_joined_where_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/DuckDB/test_dimension_with_joined_where_constraint__plan0.sql
@@ -4,7 +4,7 @@ docstring:
   Tests querying 2 dimensions that require a join.
 sql_engine: DuckDB
 ---
--- Pass Only Elements: ['user__home_state_latest',]
+-- Pass Only Elements: ['user__home_state_latest']
 SELECT
   subq_4.user__home_state_latest
 FROM (

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/DuckDB/test_dimension_with_joined_where_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/DuckDB/test_dimension_with_joined_where_constraint__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: DuckDB
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['user__home_state_latest',]
+-- Pass Only Elements: ['user__home_state_latest']
 SELECT
   user__home_state_latest
 FROM (

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/DuckDB/test_filter_node__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/DuckDB/test_filter_node__plan0.sql
@@ -4,7 +4,7 @@ docstring:
   Tests converting a dataflow plan to a SQL query plan where there is a leaf pass filter node.
 sql_engine: DuckDB
 ---
--- Pass Only Elements: ['bookings',]
+-- Pass Only Elements: ['bookings']
 SELECT
   subq_0.bookings
 FROM (

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/DuckDB/test_filter_node__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/DuckDB/test_filter_node__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: DuckDB
 ---
 -- Read Elements From Semantic Model 'bookings_source'
--- Pass Only Elements: ['bookings',]
+-- Pass Only Elements: ['bookings']
 SELECT
   1 AS bookings
 FROM ***************************.fct_bookings bookings_source_src_28000

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/Postgres/test_dimension_with_joined_where_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/Postgres/test_dimension_with_joined_where_constraint__plan0.sql
@@ -4,7 +4,7 @@ docstring:
   Tests querying 2 dimensions that require a join.
 sql_engine: Postgres
 ---
--- Pass Only Elements: ['user__home_state_latest',]
+-- Pass Only Elements: ['user__home_state_latest']
 SELECT
   subq_4.user__home_state_latest
 FROM (

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/Postgres/test_dimension_with_joined_where_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/Postgres/test_dimension_with_joined_where_constraint__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: Postgres
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['user__home_state_latest',]
+-- Pass Only Elements: ['user__home_state_latest']
 SELECT
   user__home_state_latest
 FROM (

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/Postgres/test_filter_node__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/Postgres/test_filter_node__plan0.sql
@@ -4,7 +4,7 @@ docstring:
   Tests converting a dataflow plan to a SQL query plan where there is a leaf pass filter node.
 sql_engine: Postgres
 ---
--- Pass Only Elements: ['bookings',]
+-- Pass Only Elements: ['bookings']
 SELECT
   subq_0.bookings
 FROM (

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/Postgres/test_filter_node__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/Postgres/test_filter_node__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: Postgres
 ---
 -- Read Elements From Semantic Model 'bookings_source'
--- Pass Only Elements: ['bookings',]
+-- Pass Only Elements: ['bookings']
 SELECT
   1 AS bookings
 FROM ***************************.fct_bookings bookings_source_src_28000

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/Redshift/test_dimension_with_joined_where_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/Redshift/test_dimension_with_joined_where_constraint__plan0.sql
@@ -4,7 +4,7 @@ docstring:
   Tests querying 2 dimensions that require a join.
 sql_engine: Redshift
 ---
--- Pass Only Elements: ['user__home_state_latest',]
+-- Pass Only Elements: ['user__home_state_latest']
 SELECT
   subq_4.user__home_state_latest
 FROM (

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/Redshift/test_dimension_with_joined_where_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/Redshift/test_dimension_with_joined_where_constraint__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: Redshift
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['user__home_state_latest',]
+-- Pass Only Elements: ['user__home_state_latest']
 SELECT
   user__home_state_latest
 FROM (

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/Redshift/test_filter_node__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/Redshift/test_filter_node__plan0.sql
@@ -4,7 +4,7 @@ docstring:
   Tests converting a dataflow plan to a SQL query plan where there is a leaf pass filter node.
 sql_engine: Redshift
 ---
--- Pass Only Elements: ['bookings',]
+-- Pass Only Elements: ['bookings']
 SELECT
   subq_0.bookings
 FROM (

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/Redshift/test_filter_node__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/Redshift/test_filter_node__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: Redshift
 ---
 -- Read Elements From Semantic Model 'bookings_source'
--- Pass Only Elements: ['bookings',]
+-- Pass Only Elements: ['bookings']
 SELECT
   1 AS bookings
 FROM ***************************.fct_bookings bookings_source_src_28000

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/Snowflake/test_dimension_with_joined_where_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/Snowflake/test_dimension_with_joined_where_constraint__plan0.sql
@@ -4,7 +4,7 @@ docstring:
   Tests querying 2 dimensions that require a join.
 sql_engine: Snowflake
 ---
--- Pass Only Elements: ['user__home_state_latest',]
+-- Pass Only Elements: ['user__home_state_latest']
 SELECT
   subq_4.user__home_state_latest
 FROM (

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/Snowflake/test_dimension_with_joined_where_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/Snowflake/test_dimension_with_joined_where_constraint__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: Snowflake
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['user__home_state_latest',]
+-- Pass Only Elements: ['user__home_state_latest']
 SELECT
   user__home_state_latest
 FROM (

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/Snowflake/test_filter_node__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/Snowflake/test_filter_node__plan0.sql
@@ -4,7 +4,7 @@ docstring:
   Tests converting a dataflow plan to a SQL query plan where there is a leaf pass filter node.
 sql_engine: Snowflake
 ---
--- Pass Only Elements: ['bookings',]
+-- Pass Only Elements: ['bookings']
 SELECT
   subq_0.bookings
 FROM (

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/Snowflake/test_filter_node__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/Snowflake/test_filter_node__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: Snowflake
 ---
 -- Read Elements From Semantic Model 'bookings_source'
--- Pass Only Elements: ['bookings',]
+-- Pass Only Elements: ['bookings']
 SELECT
   1 AS bookings
 FROM ***************************.fct_bookings bookings_source_src_28000

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/Trino/test_dimension_with_joined_where_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/Trino/test_dimension_with_joined_where_constraint__plan0.sql
@@ -4,7 +4,7 @@ docstring:
   Tests querying 2 dimensions that require a join.
 sql_engine: Trino
 ---
--- Pass Only Elements: ['user__home_state_latest',]
+-- Pass Only Elements: ['user__home_state_latest']
 SELECT
   subq_4.user__home_state_latest
 FROM (

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/Trino/test_dimension_with_joined_where_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/Trino/test_dimension_with_joined_where_constraint__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: Trino
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['user__home_state_latest',]
+-- Pass Only Elements: ['user__home_state_latest']
 SELECT
   user__home_state_latest
 FROM (

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/Trino/test_filter_node__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/Trino/test_filter_node__plan0.sql
@@ -4,7 +4,7 @@ docstring:
   Tests converting a dataflow plan to a SQL query plan where there is a leaf pass filter node.
 sql_engine: Trino
 ---
--- Pass Only Elements: ['bookings',]
+-- Pass Only Elements: ['bookings']
 SELECT
   subq_0.bookings
 FROM (

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/Trino/test_filter_node__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/Trino/test_filter_node__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: Trino
 ---
 -- Read Elements From Semantic Model 'bookings_source'
--- Pass Only Elements: ['bookings',]
+-- Pass Only Elements: ['bookings']
 SELECT
   1 AS bookings
 FROM ***************************.fct_bookings bookings_source_src_28000

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/test_dimension_with_joined_where_constraint__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/test_dimension_with_joined_where_constraint__plan0.xml
@@ -5,7 +5,7 @@ docstring:
 ---
 <SqlPlan>
     <SqlSelectStatementNode>
-        <!-- description = "Pass Only Elements: ['user__home_state_latest',]" -->
+        <!-- description = "Pass Only Elements: ['user__home_state_latest']" -->
         <!-- node_id = NodeId(id_str='ss_71') -->
         <!-- col0 =                                                                                                       -->
         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_118), column_alias='user__home_state_latest') -->

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/test_filter_node__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/test_filter_node__plan0.xml
@@ -5,7 +5,7 @@ docstring:
 ---
 <SqlPlan>
     <SqlSelectStatementNode>
-        <!-- description = "Pass Only Elements: ['bookings',]" -->
+        <!-- description = "Pass Only Elements: ['bookings']" -->
         <!-- node_id = NodeId(id_str='ss_1') -->
         <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_0), column_alias='bookings') -->
         <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
@@ -224,7 +224,7 @@ FROM (
             , subq_4.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_4.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day',]
+            -- Pass Only Elements: ['metric_time__day']
             SELECT
               subq_6.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
@@ -46,7 +46,7 @@ FROM (
           , subq_1.booking_monthly__listing AS booking_monthly__listing
           , subq_1.bookings_monthly AS bookings_monthly
         FROM (
-          -- Pass Only Elements: ['metric_time__month',]
+          -- Pass Only Elements: ['metric_time__month']
           SELECT
             subq_3.metric_time__month
           FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_derived_metric_with_month_dimension_and_offset_window__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_derived_metric_with_month_dimension_and_offset_window__plan0_optimized.sql
@@ -17,7 +17,7 @@ FROM (
   FROM (
     -- Read From Time Spine 'mf_time_spine'
     -- Change Column Aliases
-    -- Pass Only Elements: ['metric_time__month',]
+    -- Pass Only Elements: ['metric_time__month']
     SELECT
       DATETIME_TRUNC(ds, month) AS metric_time__month
     FROM ***************************.mf_time_spine time_spine_src_16006

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_derived_metric_with_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_derived_metric_with_offset_to_grain__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_5.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_5.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day',]
+            -- Pass Only Elements: ['metric_time__day']
             SELECT
               subq_7.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_derived_metric_with_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_derived_metric_with_offset_window__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_5.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_5.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day',]
+            -- Pass Only Elements: ['metric_time__day']
             SELECT
               subq_7.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
@@ -129,7 +129,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day',]
+            -- Pass Only Elements: ['metric_time__day']
             SELECT
               subq_3.metric_time__day
             FROM (
@@ -486,7 +486,7 @@ FROM (
             , subq_9.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_9.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day',]
+            -- Pass Only Elements: ['metric_time__day']
             SELECT
               subq_11.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
@@ -548,7 +548,7 @@ FROM (
               , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
               , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             FROM (
-              -- Pass Only Elements: ['metric_time__day',]
+              -- Pass Only Elements: ['metric_time__day']
               SELECT
                 subq_8.metric_time__day
               FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_derived_offset_cumulative_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_derived_offset_cumulative_metric__plan0.sql
@@ -123,7 +123,7 @@ FROM (
           , subq_4.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
           , subq_4.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
         FROM (
-          -- Pass Only Elements: ['metric_time__day',]
+          -- Pass Only Elements: ['metric_time__day']
           SELECT
             subq_6.metric_time__day
           FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_derived_offset_metric_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_derived_offset_metric_with_agg_time_dim__plan0.sql
@@ -129,7 +129,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['booking__ds__day',]
+            -- Pass Only Elements: ['booking__ds__day']
             SELECT
               subq_3.booking__ds__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_derived_offset_metric_with_one_input_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_derived_offset_metric_with_one_input_metric__plan0.sql
@@ -123,7 +123,7 @@ FROM (
           , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
           , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
         FROM (
-          -- Pass Only Elements: ['metric_time__day',]
+          -- Pass Only Elements: ['metric_time__day']
           SELECT
             subq_3.metric_time__day
           FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0.sql
@@ -24,7 +24,7 @@ FROM (
         , subq_9.booking__is_instant AS booking__is_instant
         , subq_9.bookings_offset_once AS bookings_offset_once
       FROM (
-        -- Pass Only Elements: ['metric_time__day',]
+        -- Pass Only Elements: ['metric_time__day']
         SELECT
           subq_11.metric_time__day
         FROM (
@@ -187,7 +187,7 @@ FROM (
                   , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                   , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
                 FROM (
-                  -- Pass Only Elements: ['metric_time__day',]
+                  -- Pass Only Elements: ['metric_time__day']
                   SELECT
                     subq_3.metric_time__day
                   FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0.sql
@@ -18,7 +18,7 @@ FROM (
       subq_8.metric_time__day AS metric_time__day
       , subq_5.booking_fees_start_of_month AS booking_fees_start_of_month
     FROM (
-      -- Pass Only Elements: ['metric_time__day',]
+      -- Pass Only Elements: ['metric_time__day']
       SELECT
         subq_7.metric_time__day
       FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_nested_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_nested_filters__plan0.sql
@@ -26,7 +26,7 @@ FROM (
         SELECT
           AVG(subq_7.average_booking_value) AS average_booking_value
         FROM (
-          -- Pass Only Elements: ['average_booking_value',]
+          -- Pass Only Elements: ['average_booking_value']
           SELECT
             subq_6.average_booking_value
           FROM (
@@ -583,7 +583,7 @@ FROM (
         SELECT
           SUM(subq_15.bookings) AS bookings
         FROM (
-          -- Pass Only Elements: ['bookings',]
+          -- Pass Only Elements: ['bookings']
           SELECT
             subq_14.bookings
           FROM (
@@ -1140,7 +1140,7 @@ FROM (
         SELECT
           SUM(subq_20.booking_value) AS booking_value
         FROM (
-          -- Pass Only Elements: ['booking_value',]
+          -- Pass Only Elements: ['booking_value']
           SELECT
             subq_19.booking_value
           FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_nested_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_nested_filters__plan0_optimized.sql
@@ -51,7 +51,7 @@ FROM (
     ) subq_34
     CROSS JOIN (
       -- Constrain Output with WHERE
-      -- Pass Only Elements: ['booking_value',]
+      -- Pass Only Elements: ['booking_value']
       -- Aggregate Measures
       -- Compute Metrics via Expressions
       SELECT

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_nested_offsets__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_nested_offsets__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_12.metric_time__day AS metric_time__day
     , subq_9.bookings_offset_once AS bookings_offset_once
   FROM (
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       subq_11.metric_time__day
     FROM (
@@ -171,7 +171,7 @@ FROM (
               , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
               , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             FROM (
-              -- Pass Only Elements: ['metric_time__day',]
+              -- Pass Only Elements: ['metric_time__day']
               SELECT
                 subq_3.metric_time__day
               FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_nested_offsets_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_nested_offsets_with_time_constraint__plan0.sql
@@ -17,7 +17,7 @@ FROM (
       subq_12.metric_time__day AS metric_time__day
       , subq_9.bookings_offset_once AS bookings_offset_once
     FROM (
-      -- Pass Only Elements: ['metric_time__day',]
+      -- Pass Only Elements: ['metric_time__day']
       SELECT
         subq_11.metric_time__day
       FROM (
@@ -176,7 +176,7 @@ FROM (
                 , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                 , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
               FROM (
-                -- Pass Only Elements: ['metric_time__day',]
+                -- Pass Only Elements: ['metric_time__day']
                 SELECT
                   subq_3.metric_time__day
                 FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_nested_offsets_with_where_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_nested_offsets_with_where_constraint__plan0.sql
@@ -17,7 +17,7 @@ FROM (
       subq_12.metric_time__day AS metric_time__day
       , subq_9.bookings_offset_once AS bookings_offset_once
     FROM (
-      -- Pass Only Elements: ['metric_time__day',]
+      -- Pass Only Elements: ['metric_time__day']
       SELECT
         subq_11.metric_time__day
       FROM (
@@ -176,7 +176,7 @@ FROM (
                 , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                 , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
               FROM (
-                -- Pass Only Elements: ['metric_time__day',]
+                -- Pass Only Elements: ['metric_time__day']
                 SELECT
                   subq_3.metric_time__day
                 FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_offset_to_grain_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_offset_to_grain_with_agg_time_dim__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_5.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_5.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['booking__ds__day',]
+            -- Pass Only Elements: ['booking__ds__day']
             SELECT
               subq_7.booking__ds__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_offset_window_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_offset_window_with_agg_time_dim__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_5.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_5.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['booking__ds__day',]
+            -- Pass Only Elements: ['booking__ds__day']
             SELECT
               subq_7.booking__ds__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_time_offset_metric_with_time_constraint__plan0.sql
@@ -224,7 +224,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day',]
+            -- Pass Only Elements: ['metric_time__day']
             SELECT
               subq_3.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
@@ -224,7 +224,7 @@ FROM (
             , subq_4.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_4.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day',]
+            -- Pass Only Elements: ['metric_time__day']
             SELECT
               subq_6.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
@@ -46,7 +46,7 @@ FROM (
           , subq_1.booking_monthly__listing AS booking_monthly__listing
           , subq_1.bookings_monthly AS bookings_monthly
         FROM (
-          -- Pass Only Elements: ['metric_time__month',]
+          -- Pass Only Elements: ['metric_time__month']
           SELECT
             subq_3.metric_time__month
           FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_derived_metric_with_month_dimension_and_offset_window__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_derived_metric_with_month_dimension_and_offset_window__plan0_optimized.sql
@@ -17,7 +17,7 @@ FROM (
   FROM (
     -- Read From Time Spine 'mf_time_spine'
     -- Change Column Aliases
-    -- Pass Only Elements: ['metric_time__month',]
+    -- Pass Only Elements: ['metric_time__month']
     SELECT
       DATE_TRUNC('month', ds) AS metric_time__month
     FROM ***************************.mf_time_spine time_spine_src_16006

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_derived_metric_with_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_derived_metric_with_offset_to_grain__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_5.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_5.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day',]
+            -- Pass Only Elements: ['metric_time__day']
             SELECT
               subq_7.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_derived_metric_with_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_derived_metric_with_offset_window__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_5.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_5.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day',]
+            -- Pass Only Elements: ['metric_time__day']
             SELECT
               subq_7.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
@@ -129,7 +129,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day',]
+            -- Pass Only Elements: ['metric_time__day']
             SELECT
               subq_3.metric_time__day
             FROM (
@@ -486,7 +486,7 @@ FROM (
             , subq_9.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_9.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day',]
+            -- Pass Only Elements: ['metric_time__day']
             SELECT
               subq_11.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
@@ -548,7 +548,7 @@ FROM (
               , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
               , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             FROM (
-              -- Pass Only Elements: ['metric_time__day',]
+              -- Pass Only Elements: ['metric_time__day']
               SELECT
                 subq_8.metric_time__day
               FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_derived_offset_cumulative_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_derived_offset_cumulative_metric__plan0.sql
@@ -123,7 +123,7 @@ FROM (
           , subq_4.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
           , subq_4.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
         FROM (
-          -- Pass Only Elements: ['metric_time__day',]
+          -- Pass Only Elements: ['metric_time__day']
           SELECT
             subq_6.metric_time__day
           FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_derived_offset_metric_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_derived_offset_metric_with_agg_time_dim__plan0.sql
@@ -129,7 +129,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['booking__ds__day',]
+            -- Pass Only Elements: ['booking__ds__day']
             SELECT
               subq_3.booking__ds__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_derived_offset_metric_with_one_input_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_derived_offset_metric_with_one_input_metric__plan0.sql
@@ -123,7 +123,7 @@ FROM (
           , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
           , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
         FROM (
-          -- Pass Only Elements: ['metric_time__day',]
+          -- Pass Only Elements: ['metric_time__day']
           SELECT
             subq_3.metric_time__day
           FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0.sql
@@ -24,7 +24,7 @@ FROM (
         , subq_9.booking__is_instant AS booking__is_instant
         , subq_9.bookings_offset_once AS bookings_offset_once
       FROM (
-        -- Pass Only Elements: ['metric_time__day',]
+        -- Pass Only Elements: ['metric_time__day']
         SELECT
           subq_11.metric_time__day
         FROM (
@@ -187,7 +187,7 @@ FROM (
                   , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                   , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
                 FROM (
-                  -- Pass Only Elements: ['metric_time__day',]
+                  -- Pass Only Elements: ['metric_time__day']
                   SELECT
                     subq_3.metric_time__day
                   FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0.sql
@@ -18,7 +18,7 @@ FROM (
       subq_8.metric_time__day AS metric_time__day
       , subq_5.booking_fees_start_of_month AS booking_fees_start_of_month
     FROM (
-      -- Pass Only Elements: ['metric_time__day',]
+      -- Pass Only Elements: ['metric_time__day']
       SELECT
         subq_7.metric_time__day
       FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_nested_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_nested_filters__plan0.sql
@@ -26,7 +26,7 @@ FROM (
         SELECT
           AVG(subq_7.average_booking_value) AS average_booking_value
         FROM (
-          -- Pass Only Elements: ['average_booking_value',]
+          -- Pass Only Elements: ['average_booking_value']
           SELECT
             subq_6.average_booking_value
           FROM (
@@ -583,7 +583,7 @@ FROM (
         SELECT
           SUM(subq_15.bookings) AS bookings
         FROM (
-          -- Pass Only Elements: ['bookings',]
+          -- Pass Only Elements: ['bookings']
           SELECT
             subq_14.bookings
           FROM (
@@ -1140,7 +1140,7 @@ FROM (
         SELECT
           SUM(subq_20.booking_value) AS booking_value
         FROM (
-          -- Pass Only Elements: ['booking_value',]
+          -- Pass Only Elements: ['booking_value']
           SELECT
             subq_19.booking_value
           FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_nested_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_nested_filters__plan0_optimized.sql
@@ -51,7 +51,7 @@ FROM (
     ) subq_34
     CROSS JOIN (
       -- Constrain Output with WHERE
-      -- Pass Only Elements: ['booking_value',]
+      -- Pass Only Elements: ['booking_value']
       -- Aggregate Measures
       -- Compute Metrics via Expressions
       SELECT

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_nested_offsets__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_nested_offsets__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_12.metric_time__day AS metric_time__day
     , subq_9.bookings_offset_once AS bookings_offset_once
   FROM (
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       subq_11.metric_time__day
     FROM (
@@ -171,7 +171,7 @@ FROM (
               , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
               , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             FROM (
-              -- Pass Only Elements: ['metric_time__day',]
+              -- Pass Only Elements: ['metric_time__day']
               SELECT
                 subq_3.metric_time__day
               FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_nested_offsets_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_nested_offsets_with_time_constraint__plan0.sql
@@ -17,7 +17,7 @@ FROM (
       subq_12.metric_time__day AS metric_time__day
       , subq_9.bookings_offset_once AS bookings_offset_once
     FROM (
-      -- Pass Only Elements: ['metric_time__day',]
+      -- Pass Only Elements: ['metric_time__day']
       SELECT
         subq_11.metric_time__day
       FROM (
@@ -176,7 +176,7 @@ FROM (
                 , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                 , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
               FROM (
-                -- Pass Only Elements: ['metric_time__day',]
+                -- Pass Only Elements: ['metric_time__day']
                 SELECT
                   subq_3.metric_time__day
                 FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_nested_offsets_with_where_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_nested_offsets_with_where_constraint__plan0.sql
@@ -17,7 +17,7 @@ FROM (
       subq_12.metric_time__day AS metric_time__day
       , subq_9.bookings_offset_once AS bookings_offset_once
     FROM (
-      -- Pass Only Elements: ['metric_time__day',]
+      -- Pass Only Elements: ['metric_time__day']
       SELECT
         subq_11.metric_time__day
       FROM (
@@ -176,7 +176,7 @@ FROM (
                 , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                 , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
               FROM (
-                -- Pass Only Elements: ['metric_time__day',]
+                -- Pass Only Elements: ['metric_time__day']
                 SELECT
                   subq_3.metric_time__day
                 FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_offset_to_grain_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_offset_to_grain_with_agg_time_dim__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_5.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_5.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['booking__ds__day',]
+            -- Pass Only Elements: ['booking__ds__day']
             SELECT
               subq_7.booking__ds__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_offset_window_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_offset_window_with_agg_time_dim__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_5.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_5.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['booking__ds__day',]
+            -- Pass Only Elements: ['booking__ds__day']
             SELECT
               subq_7.booking__ds__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_time_offset_metric_with_time_constraint__plan0.sql
@@ -224,7 +224,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day',]
+            -- Pass Only Elements: ['metric_time__day']
             SELECT
               subq_3.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
@@ -224,7 +224,7 @@ FROM (
             , subq_4.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_4.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day',]
+            -- Pass Only Elements: ['metric_time__day']
             SELECT
               subq_6.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
@@ -46,7 +46,7 @@ FROM (
           , subq_1.booking_monthly__listing AS booking_monthly__listing
           , subq_1.bookings_monthly AS bookings_monthly
         FROM (
-          -- Pass Only Elements: ['metric_time__month',]
+          -- Pass Only Elements: ['metric_time__month']
           SELECT
             subq_3.metric_time__month
           FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_derived_metric_with_month_dimension_and_offset_window__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_derived_metric_with_month_dimension_and_offset_window__plan0_optimized.sql
@@ -17,7 +17,7 @@ FROM (
   FROM (
     -- Read From Time Spine 'mf_time_spine'
     -- Change Column Aliases
-    -- Pass Only Elements: ['metric_time__month',]
+    -- Pass Only Elements: ['metric_time__month']
     SELECT
       DATE_TRUNC('month', ds) AS metric_time__month
     FROM ***************************.mf_time_spine time_spine_src_16006

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_derived_metric_with_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_derived_metric_with_offset_to_grain__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_5.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_5.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day',]
+            -- Pass Only Elements: ['metric_time__day']
             SELECT
               subq_7.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_derived_metric_with_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_derived_metric_with_offset_window__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_5.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_5.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day',]
+            -- Pass Only Elements: ['metric_time__day']
             SELECT
               subq_7.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
@@ -129,7 +129,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day',]
+            -- Pass Only Elements: ['metric_time__day']
             SELECT
               subq_3.metric_time__day
             FROM (
@@ -486,7 +486,7 @@ FROM (
             , subq_9.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_9.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day',]
+            -- Pass Only Elements: ['metric_time__day']
             SELECT
               subq_11.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
@@ -548,7 +548,7 @@ FROM (
               , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
               , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             FROM (
-              -- Pass Only Elements: ['metric_time__day',]
+              -- Pass Only Elements: ['metric_time__day']
               SELECT
                 subq_8.metric_time__day
               FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_derived_offset_cumulative_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_derived_offset_cumulative_metric__plan0.sql
@@ -123,7 +123,7 @@ FROM (
           , subq_4.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
           , subq_4.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
         FROM (
-          -- Pass Only Elements: ['metric_time__day',]
+          -- Pass Only Elements: ['metric_time__day']
           SELECT
             subq_6.metric_time__day
           FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_derived_offset_metric_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_derived_offset_metric_with_agg_time_dim__plan0.sql
@@ -129,7 +129,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['booking__ds__day',]
+            -- Pass Only Elements: ['booking__ds__day']
             SELECT
               subq_3.booking__ds__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_derived_offset_metric_with_one_input_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_derived_offset_metric_with_one_input_metric__plan0.sql
@@ -123,7 +123,7 @@ FROM (
           , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
           , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
         FROM (
-          -- Pass Only Elements: ['metric_time__day',]
+          -- Pass Only Elements: ['metric_time__day']
           SELECT
             subq_3.metric_time__day
           FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0.sql
@@ -24,7 +24,7 @@ FROM (
         , subq_9.booking__is_instant AS booking__is_instant
         , subq_9.bookings_offset_once AS bookings_offset_once
       FROM (
-        -- Pass Only Elements: ['metric_time__day',]
+        -- Pass Only Elements: ['metric_time__day']
         SELECT
           subq_11.metric_time__day
         FROM (
@@ -187,7 +187,7 @@ FROM (
                   , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                   , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
                 FROM (
-                  -- Pass Only Elements: ['metric_time__day',]
+                  -- Pass Only Elements: ['metric_time__day']
                   SELECT
                     subq_3.metric_time__day
                   FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0.sql
@@ -18,7 +18,7 @@ FROM (
       subq_8.metric_time__day AS metric_time__day
       , subq_5.booking_fees_start_of_month AS booking_fees_start_of_month
     FROM (
-      -- Pass Only Elements: ['metric_time__day',]
+      -- Pass Only Elements: ['metric_time__day']
       SELECT
         subq_7.metric_time__day
       FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_nested_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_nested_filters__plan0.sql
@@ -26,7 +26,7 @@ FROM (
         SELECT
           AVG(subq_7.average_booking_value) AS average_booking_value
         FROM (
-          -- Pass Only Elements: ['average_booking_value',]
+          -- Pass Only Elements: ['average_booking_value']
           SELECT
             subq_6.average_booking_value
           FROM (
@@ -583,7 +583,7 @@ FROM (
         SELECT
           SUM(subq_15.bookings) AS bookings
         FROM (
-          -- Pass Only Elements: ['bookings',]
+          -- Pass Only Elements: ['bookings']
           SELECT
             subq_14.bookings
           FROM (
@@ -1140,7 +1140,7 @@ FROM (
         SELECT
           SUM(subq_20.booking_value) AS booking_value
         FROM (
-          -- Pass Only Elements: ['booking_value',]
+          -- Pass Only Elements: ['booking_value']
           SELECT
             subq_19.booking_value
           FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_nested_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_nested_filters__plan0_optimized.sql
@@ -51,7 +51,7 @@ FROM (
     ) subq_34
     CROSS JOIN (
       -- Constrain Output with WHERE
-      -- Pass Only Elements: ['booking_value',]
+      -- Pass Only Elements: ['booking_value']
       -- Aggregate Measures
       -- Compute Metrics via Expressions
       SELECT

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_nested_offsets__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_nested_offsets__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_12.metric_time__day AS metric_time__day
     , subq_9.bookings_offset_once AS bookings_offset_once
   FROM (
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       subq_11.metric_time__day
     FROM (
@@ -171,7 +171,7 @@ FROM (
               , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
               , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             FROM (
-              -- Pass Only Elements: ['metric_time__day',]
+              -- Pass Only Elements: ['metric_time__day']
               SELECT
                 subq_3.metric_time__day
               FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_nested_offsets_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_nested_offsets_with_time_constraint__plan0.sql
@@ -17,7 +17,7 @@ FROM (
       subq_12.metric_time__day AS metric_time__day
       , subq_9.bookings_offset_once AS bookings_offset_once
     FROM (
-      -- Pass Only Elements: ['metric_time__day',]
+      -- Pass Only Elements: ['metric_time__day']
       SELECT
         subq_11.metric_time__day
       FROM (
@@ -176,7 +176,7 @@ FROM (
                 , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                 , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
               FROM (
-                -- Pass Only Elements: ['metric_time__day',]
+                -- Pass Only Elements: ['metric_time__day']
                 SELECT
                   subq_3.metric_time__day
                 FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_nested_offsets_with_where_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_nested_offsets_with_where_constraint__plan0.sql
@@ -17,7 +17,7 @@ FROM (
       subq_12.metric_time__day AS metric_time__day
       , subq_9.bookings_offset_once AS bookings_offset_once
     FROM (
-      -- Pass Only Elements: ['metric_time__day',]
+      -- Pass Only Elements: ['metric_time__day']
       SELECT
         subq_11.metric_time__day
       FROM (
@@ -176,7 +176,7 @@ FROM (
                 , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                 , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
               FROM (
-                -- Pass Only Elements: ['metric_time__day',]
+                -- Pass Only Elements: ['metric_time__day']
                 SELECT
                   subq_3.metric_time__day
                 FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_offset_to_grain_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_offset_to_grain_with_agg_time_dim__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_5.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_5.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['booking__ds__day',]
+            -- Pass Only Elements: ['booking__ds__day']
             SELECT
               subq_7.booking__ds__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_offset_window_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_offset_window_with_agg_time_dim__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_5.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_5.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['booking__ds__day',]
+            -- Pass Only Elements: ['booking__ds__day']
             SELECT
               subq_7.booking__ds__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_time_offset_metric_with_time_constraint__plan0.sql
@@ -224,7 +224,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day',]
+            -- Pass Only Elements: ['metric_time__day']
             SELECT
               subq_3.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
@@ -224,7 +224,7 @@ FROM (
             , subq_4.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_4.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day',]
+            -- Pass Only Elements: ['metric_time__day']
             SELECT
               subq_6.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
@@ -46,7 +46,7 @@ FROM (
           , subq_1.booking_monthly__listing AS booking_monthly__listing
           , subq_1.bookings_monthly AS bookings_monthly
         FROM (
-          -- Pass Only Elements: ['metric_time__month',]
+          -- Pass Only Elements: ['metric_time__month']
           SELECT
             subq_3.metric_time__month
           FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_derived_metric_with_month_dimension_and_offset_window__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_derived_metric_with_month_dimension_and_offset_window__plan0_optimized.sql
@@ -17,7 +17,7 @@ FROM (
   FROM (
     -- Read From Time Spine 'mf_time_spine'
     -- Change Column Aliases
-    -- Pass Only Elements: ['metric_time__month',]
+    -- Pass Only Elements: ['metric_time__month']
     SELECT
       DATE_TRUNC('month', ds) AS metric_time__month
     FROM ***************************.mf_time_spine time_spine_src_16006

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_derived_metric_with_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_derived_metric_with_offset_to_grain__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_5.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_5.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day',]
+            -- Pass Only Elements: ['metric_time__day']
             SELECT
               subq_7.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_derived_metric_with_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_derived_metric_with_offset_window__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_5.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_5.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day',]
+            -- Pass Only Elements: ['metric_time__day']
             SELECT
               subq_7.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
@@ -129,7 +129,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day',]
+            -- Pass Only Elements: ['metric_time__day']
             SELECT
               subq_3.metric_time__day
             FROM (
@@ -486,7 +486,7 @@ FROM (
             , subq_9.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_9.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day',]
+            -- Pass Only Elements: ['metric_time__day']
             SELECT
               subq_11.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
@@ -548,7 +548,7 @@ FROM (
               , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
               , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             FROM (
-              -- Pass Only Elements: ['metric_time__day',]
+              -- Pass Only Elements: ['metric_time__day']
               SELECT
                 subq_8.metric_time__day
               FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_derived_offset_cumulative_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_derived_offset_cumulative_metric__plan0.sql
@@ -123,7 +123,7 @@ FROM (
           , subq_4.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
           , subq_4.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
         FROM (
-          -- Pass Only Elements: ['metric_time__day',]
+          -- Pass Only Elements: ['metric_time__day']
           SELECT
             subq_6.metric_time__day
           FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_derived_offset_metric_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_derived_offset_metric_with_agg_time_dim__plan0.sql
@@ -129,7 +129,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['booking__ds__day',]
+            -- Pass Only Elements: ['booking__ds__day']
             SELECT
               subq_3.booking__ds__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_derived_offset_metric_with_one_input_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_derived_offset_metric_with_one_input_metric__plan0.sql
@@ -123,7 +123,7 @@ FROM (
           , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
           , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
         FROM (
-          -- Pass Only Elements: ['metric_time__day',]
+          -- Pass Only Elements: ['metric_time__day']
           SELECT
             subq_3.metric_time__day
           FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0.sql
@@ -24,7 +24,7 @@ FROM (
         , subq_9.booking__is_instant AS booking__is_instant
         , subq_9.bookings_offset_once AS bookings_offset_once
       FROM (
-        -- Pass Only Elements: ['metric_time__day',]
+        -- Pass Only Elements: ['metric_time__day']
         SELECT
           subq_11.metric_time__day
         FROM (
@@ -187,7 +187,7 @@ FROM (
                   , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                   , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
                 FROM (
-                  -- Pass Only Elements: ['metric_time__day',]
+                  -- Pass Only Elements: ['metric_time__day']
                   SELECT
                     subq_3.metric_time__day
                   FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0.sql
@@ -18,7 +18,7 @@ FROM (
       subq_8.metric_time__day AS metric_time__day
       , subq_5.booking_fees_start_of_month AS booking_fees_start_of_month
     FROM (
-      -- Pass Only Elements: ['metric_time__day',]
+      -- Pass Only Elements: ['metric_time__day']
       SELECT
         subq_7.metric_time__day
       FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_nested_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_nested_filters__plan0.sql
@@ -26,7 +26,7 @@ FROM (
         SELECT
           AVG(subq_7.average_booking_value) AS average_booking_value
         FROM (
-          -- Pass Only Elements: ['average_booking_value',]
+          -- Pass Only Elements: ['average_booking_value']
           SELECT
             subq_6.average_booking_value
           FROM (
@@ -583,7 +583,7 @@ FROM (
         SELECT
           SUM(subq_15.bookings) AS bookings
         FROM (
-          -- Pass Only Elements: ['bookings',]
+          -- Pass Only Elements: ['bookings']
           SELECT
             subq_14.bookings
           FROM (
@@ -1140,7 +1140,7 @@ FROM (
         SELECT
           SUM(subq_20.booking_value) AS booking_value
         FROM (
-          -- Pass Only Elements: ['booking_value',]
+          -- Pass Only Elements: ['booking_value']
           SELECT
             subq_19.booking_value
           FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_nested_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_nested_filters__plan0_optimized.sql
@@ -51,7 +51,7 @@ FROM (
     ) subq_34
     CROSS JOIN (
       -- Constrain Output with WHERE
-      -- Pass Only Elements: ['booking_value',]
+      -- Pass Only Elements: ['booking_value']
       -- Aggregate Measures
       -- Compute Metrics via Expressions
       SELECT

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_nested_offsets__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_nested_offsets__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_12.metric_time__day AS metric_time__day
     , subq_9.bookings_offset_once AS bookings_offset_once
   FROM (
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       subq_11.metric_time__day
     FROM (
@@ -171,7 +171,7 @@ FROM (
               , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
               , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             FROM (
-              -- Pass Only Elements: ['metric_time__day',]
+              -- Pass Only Elements: ['metric_time__day']
               SELECT
                 subq_3.metric_time__day
               FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_nested_offsets_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_nested_offsets_with_time_constraint__plan0.sql
@@ -17,7 +17,7 @@ FROM (
       subq_12.metric_time__day AS metric_time__day
       , subq_9.bookings_offset_once AS bookings_offset_once
     FROM (
-      -- Pass Only Elements: ['metric_time__day',]
+      -- Pass Only Elements: ['metric_time__day']
       SELECT
         subq_11.metric_time__day
       FROM (
@@ -176,7 +176,7 @@ FROM (
                 , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                 , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
               FROM (
-                -- Pass Only Elements: ['metric_time__day',]
+                -- Pass Only Elements: ['metric_time__day']
                 SELECT
                   subq_3.metric_time__day
                 FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_nested_offsets_with_where_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_nested_offsets_with_where_constraint__plan0.sql
@@ -17,7 +17,7 @@ FROM (
       subq_12.metric_time__day AS metric_time__day
       , subq_9.bookings_offset_once AS bookings_offset_once
     FROM (
-      -- Pass Only Elements: ['metric_time__day',]
+      -- Pass Only Elements: ['metric_time__day']
       SELECT
         subq_11.metric_time__day
       FROM (
@@ -176,7 +176,7 @@ FROM (
                 , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                 , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
               FROM (
-                -- Pass Only Elements: ['metric_time__day',]
+                -- Pass Only Elements: ['metric_time__day']
                 SELECT
                   subq_3.metric_time__day
                 FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_offset_to_grain_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_offset_to_grain_with_agg_time_dim__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_5.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_5.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['booking__ds__day',]
+            -- Pass Only Elements: ['booking__ds__day']
             SELECT
               subq_7.booking__ds__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_offset_window_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_offset_window_with_agg_time_dim__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_5.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_5.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['booking__ds__day',]
+            -- Pass Only Elements: ['booking__ds__day']
             SELECT
               subq_7.booking__ds__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_time_offset_metric_with_time_constraint__plan0.sql
@@ -224,7 +224,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day',]
+            -- Pass Only Elements: ['metric_time__day']
             SELECT
               subq_3.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
@@ -224,7 +224,7 @@ FROM (
             , subq_4.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_4.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day',]
+            -- Pass Only Elements: ['metric_time__day']
             SELECT
               subq_6.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
@@ -46,7 +46,7 @@ FROM (
           , subq_1.booking_monthly__listing AS booking_monthly__listing
           , subq_1.bookings_monthly AS bookings_monthly
         FROM (
-          -- Pass Only Elements: ['metric_time__month',]
+          -- Pass Only Elements: ['metric_time__month']
           SELECT
             subq_3.metric_time__month
           FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_derived_metric_with_month_dimension_and_offset_window__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_derived_metric_with_month_dimension_and_offset_window__plan0_optimized.sql
@@ -17,7 +17,7 @@ FROM (
   FROM (
     -- Read From Time Spine 'mf_time_spine'
     -- Change Column Aliases
-    -- Pass Only Elements: ['metric_time__month',]
+    -- Pass Only Elements: ['metric_time__month']
     SELECT
       DATE_TRUNC('month', ds) AS metric_time__month
     FROM ***************************.mf_time_spine time_spine_src_16006

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_derived_metric_with_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_derived_metric_with_offset_to_grain__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_5.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_5.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day',]
+            -- Pass Only Elements: ['metric_time__day']
             SELECT
               subq_7.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_derived_metric_with_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_derived_metric_with_offset_window__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_5.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_5.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day',]
+            -- Pass Only Elements: ['metric_time__day']
             SELECT
               subq_7.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
@@ -129,7 +129,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day',]
+            -- Pass Only Elements: ['metric_time__day']
             SELECT
               subq_3.metric_time__day
             FROM (
@@ -486,7 +486,7 @@ FROM (
             , subq_9.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_9.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day',]
+            -- Pass Only Elements: ['metric_time__day']
             SELECT
               subq_11.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
@@ -548,7 +548,7 @@ FROM (
               , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
               , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             FROM (
-              -- Pass Only Elements: ['metric_time__day',]
+              -- Pass Only Elements: ['metric_time__day']
               SELECT
                 subq_8.metric_time__day
               FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_derived_offset_cumulative_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_derived_offset_cumulative_metric__plan0.sql
@@ -123,7 +123,7 @@ FROM (
           , subq_4.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
           , subq_4.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
         FROM (
-          -- Pass Only Elements: ['metric_time__day',]
+          -- Pass Only Elements: ['metric_time__day']
           SELECT
             subq_6.metric_time__day
           FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_derived_offset_metric_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_derived_offset_metric_with_agg_time_dim__plan0.sql
@@ -129,7 +129,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['booking__ds__day',]
+            -- Pass Only Elements: ['booking__ds__day']
             SELECT
               subq_3.booking__ds__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_derived_offset_metric_with_one_input_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_derived_offset_metric_with_one_input_metric__plan0.sql
@@ -123,7 +123,7 @@ FROM (
           , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
           , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
         FROM (
-          -- Pass Only Elements: ['metric_time__day',]
+          -- Pass Only Elements: ['metric_time__day']
           SELECT
             subq_3.metric_time__day
           FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0.sql
@@ -24,7 +24,7 @@ FROM (
         , subq_9.booking__is_instant AS booking__is_instant
         , subq_9.bookings_offset_once AS bookings_offset_once
       FROM (
-        -- Pass Only Elements: ['metric_time__day',]
+        -- Pass Only Elements: ['metric_time__day']
         SELECT
           subq_11.metric_time__day
         FROM (
@@ -187,7 +187,7 @@ FROM (
                   , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                   , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
                 FROM (
-                  -- Pass Only Elements: ['metric_time__day',]
+                  -- Pass Only Elements: ['metric_time__day']
                   SELECT
                     subq_3.metric_time__day
                   FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0.sql
@@ -18,7 +18,7 @@ FROM (
       subq_8.metric_time__day AS metric_time__day
       , subq_5.booking_fees_start_of_month AS booking_fees_start_of_month
     FROM (
-      -- Pass Only Elements: ['metric_time__day',]
+      -- Pass Only Elements: ['metric_time__day']
       SELECT
         subq_7.metric_time__day
       FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_nested_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_nested_filters__plan0.sql
@@ -26,7 +26,7 @@ FROM (
         SELECT
           AVG(subq_7.average_booking_value) AS average_booking_value
         FROM (
-          -- Pass Only Elements: ['average_booking_value',]
+          -- Pass Only Elements: ['average_booking_value']
           SELECT
             subq_6.average_booking_value
           FROM (
@@ -583,7 +583,7 @@ FROM (
         SELECT
           SUM(subq_15.bookings) AS bookings
         FROM (
-          -- Pass Only Elements: ['bookings',]
+          -- Pass Only Elements: ['bookings']
           SELECT
             subq_14.bookings
           FROM (
@@ -1140,7 +1140,7 @@ FROM (
         SELECT
           SUM(subq_20.booking_value) AS booking_value
         FROM (
-          -- Pass Only Elements: ['booking_value',]
+          -- Pass Only Elements: ['booking_value']
           SELECT
             subq_19.booking_value
           FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_nested_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_nested_filters__plan0_optimized.sql
@@ -51,7 +51,7 @@ FROM (
     ) subq_34
     CROSS JOIN (
       -- Constrain Output with WHERE
-      -- Pass Only Elements: ['booking_value',]
+      -- Pass Only Elements: ['booking_value']
       -- Aggregate Measures
       -- Compute Metrics via Expressions
       SELECT

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_nested_offsets__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_nested_offsets__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_12.metric_time__day AS metric_time__day
     , subq_9.bookings_offset_once AS bookings_offset_once
   FROM (
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       subq_11.metric_time__day
     FROM (
@@ -171,7 +171,7 @@ FROM (
               , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
               , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             FROM (
-              -- Pass Only Elements: ['metric_time__day',]
+              -- Pass Only Elements: ['metric_time__day']
               SELECT
                 subq_3.metric_time__day
               FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_nested_offsets_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_nested_offsets_with_time_constraint__plan0.sql
@@ -17,7 +17,7 @@ FROM (
       subq_12.metric_time__day AS metric_time__day
       , subq_9.bookings_offset_once AS bookings_offset_once
     FROM (
-      -- Pass Only Elements: ['metric_time__day',]
+      -- Pass Only Elements: ['metric_time__day']
       SELECT
         subq_11.metric_time__day
       FROM (
@@ -176,7 +176,7 @@ FROM (
                 , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                 , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
               FROM (
-                -- Pass Only Elements: ['metric_time__day',]
+                -- Pass Only Elements: ['metric_time__day']
                 SELECT
                   subq_3.metric_time__day
                 FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_nested_offsets_with_where_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_nested_offsets_with_where_constraint__plan0.sql
@@ -17,7 +17,7 @@ FROM (
       subq_12.metric_time__day AS metric_time__day
       , subq_9.bookings_offset_once AS bookings_offset_once
     FROM (
-      -- Pass Only Elements: ['metric_time__day',]
+      -- Pass Only Elements: ['metric_time__day']
       SELECT
         subq_11.metric_time__day
       FROM (
@@ -176,7 +176,7 @@ FROM (
                 , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                 , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
               FROM (
-                -- Pass Only Elements: ['metric_time__day',]
+                -- Pass Only Elements: ['metric_time__day']
                 SELECT
                   subq_3.metric_time__day
                 FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_offset_to_grain_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_offset_to_grain_with_agg_time_dim__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_5.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_5.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['booking__ds__day',]
+            -- Pass Only Elements: ['booking__ds__day']
             SELECT
               subq_7.booking__ds__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_offset_window_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_offset_window_with_agg_time_dim__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_5.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_5.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['booking__ds__day',]
+            -- Pass Only Elements: ['booking__ds__day']
             SELECT
               subq_7.booking__ds__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_time_offset_metric_with_time_constraint__plan0.sql
@@ -224,7 +224,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day',]
+            -- Pass Only Elements: ['metric_time__day']
             SELECT
               subq_3.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
@@ -224,7 +224,7 @@ FROM (
             , subq_4.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_4.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day',]
+            -- Pass Only Elements: ['metric_time__day']
             SELECT
               subq_6.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
@@ -46,7 +46,7 @@ FROM (
           , subq_1.booking_monthly__listing AS booking_monthly__listing
           , subq_1.bookings_monthly AS bookings_monthly
         FROM (
-          -- Pass Only Elements: ['metric_time__month',]
+          -- Pass Only Elements: ['metric_time__month']
           SELECT
             subq_3.metric_time__month
           FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_derived_metric_with_month_dimension_and_offset_window__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_derived_metric_with_month_dimension_and_offset_window__plan0_optimized.sql
@@ -17,7 +17,7 @@ FROM (
   FROM (
     -- Read From Time Spine 'mf_time_spine'
     -- Change Column Aliases
-    -- Pass Only Elements: ['metric_time__month',]
+    -- Pass Only Elements: ['metric_time__month']
     SELECT
       DATE_TRUNC('month', ds) AS metric_time__month
     FROM ***************************.mf_time_spine time_spine_src_16006

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_derived_metric_with_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_derived_metric_with_offset_to_grain__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_5.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_5.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day',]
+            -- Pass Only Elements: ['metric_time__day']
             SELECT
               subq_7.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_derived_metric_with_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_derived_metric_with_offset_window__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_5.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_5.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day',]
+            -- Pass Only Elements: ['metric_time__day']
             SELECT
               subq_7.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
@@ -129,7 +129,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day',]
+            -- Pass Only Elements: ['metric_time__day']
             SELECT
               subq_3.metric_time__day
             FROM (
@@ -486,7 +486,7 @@ FROM (
             , subq_9.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_9.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day',]
+            -- Pass Only Elements: ['metric_time__day']
             SELECT
               subq_11.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
@@ -548,7 +548,7 @@ FROM (
               , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
               , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             FROM (
-              -- Pass Only Elements: ['metric_time__day',]
+              -- Pass Only Elements: ['metric_time__day']
               SELECT
                 subq_8.metric_time__day
               FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_derived_offset_cumulative_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_derived_offset_cumulative_metric__plan0.sql
@@ -123,7 +123,7 @@ FROM (
           , subq_4.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
           , subq_4.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
         FROM (
-          -- Pass Only Elements: ['metric_time__day',]
+          -- Pass Only Elements: ['metric_time__day']
           SELECT
             subq_6.metric_time__day
           FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_derived_offset_metric_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_derived_offset_metric_with_agg_time_dim__plan0.sql
@@ -129,7 +129,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['booking__ds__day',]
+            -- Pass Only Elements: ['booking__ds__day']
             SELECT
               subq_3.booking__ds__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_derived_offset_metric_with_one_input_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_derived_offset_metric_with_one_input_metric__plan0.sql
@@ -123,7 +123,7 @@ FROM (
           , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
           , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
         FROM (
-          -- Pass Only Elements: ['metric_time__day',]
+          -- Pass Only Elements: ['metric_time__day']
           SELECT
             subq_3.metric_time__day
           FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0.sql
@@ -24,7 +24,7 @@ FROM (
         , subq_9.booking__is_instant AS booking__is_instant
         , subq_9.bookings_offset_once AS bookings_offset_once
       FROM (
-        -- Pass Only Elements: ['metric_time__day',]
+        -- Pass Only Elements: ['metric_time__day']
         SELECT
           subq_11.metric_time__day
         FROM (
@@ -187,7 +187,7 @@ FROM (
                   , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                   , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
                 FROM (
-                  -- Pass Only Elements: ['metric_time__day',]
+                  -- Pass Only Elements: ['metric_time__day']
                   SELECT
                     subq_3.metric_time__day
                   FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0.sql
@@ -18,7 +18,7 @@ FROM (
       subq_8.metric_time__day AS metric_time__day
       , subq_5.booking_fees_start_of_month AS booking_fees_start_of_month
     FROM (
-      -- Pass Only Elements: ['metric_time__day',]
+      -- Pass Only Elements: ['metric_time__day']
       SELECT
         subq_7.metric_time__day
       FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_nested_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_nested_filters__plan0.sql
@@ -26,7 +26,7 @@ FROM (
         SELECT
           AVG(subq_7.average_booking_value) AS average_booking_value
         FROM (
-          -- Pass Only Elements: ['average_booking_value',]
+          -- Pass Only Elements: ['average_booking_value']
           SELECT
             subq_6.average_booking_value
           FROM (
@@ -583,7 +583,7 @@ FROM (
         SELECT
           SUM(subq_15.bookings) AS bookings
         FROM (
-          -- Pass Only Elements: ['bookings',]
+          -- Pass Only Elements: ['bookings']
           SELECT
             subq_14.bookings
           FROM (
@@ -1140,7 +1140,7 @@ FROM (
         SELECT
           SUM(subq_20.booking_value) AS booking_value
         FROM (
-          -- Pass Only Elements: ['booking_value',]
+          -- Pass Only Elements: ['booking_value']
           SELECT
             subq_19.booking_value
           FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_nested_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_nested_filters__plan0_optimized.sql
@@ -51,7 +51,7 @@ FROM (
     ) subq_34
     CROSS JOIN (
       -- Constrain Output with WHERE
-      -- Pass Only Elements: ['booking_value',]
+      -- Pass Only Elements: ['booking_value']
       -- Aggregate Measures
       -- Compute Metrics via Expressions
       SELECT

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_nested_offsets__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_nested_offsets__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_12.metric_time__day AS metric_time__day
     , subq_9.bookings_offset_once AS bookings_offset_once
   FROM (
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       subq_11.metric_time__day
     FROM (
@@ -171,7 +171,7 @@ FROM (
               , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
               , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             FROM (
-              -- Pass Only Elements: ['metric_time__day',]
+              -- Pass Only Elements: ['metric_time__day']
               SELECT
                 subq_3.metric_time__day
               FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_nested_offsets_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_nested_offsets_with_time_constraint__plan0.sql
@@ -17,7 +17,7 @@ FROM (
       subq_12.metric_time__day AS metric_time__day
       , subq_9.bookings_offset_once AS bookings_offset_once
     FROM (
-      -- Pass Only Elements: ['metric_time__day',]
+      -- Pass Only Elements: ['metric_time__day']
       SELECT
         subq_11.metric_time__day
       FROM (
@@ -176,7 +176,7 @@ FROM (
                 , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                 , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
               FROM (
-                -- Pass Only Elements: ['metric_time__day',]
+                -- Pass Only Elements: ['metric_time__day']
                 SELECT
                   subq_3.metric_time__day
                 FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_nested_offsets_with_where_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_nested_offsets_with_where_constraint__plan0.sql
@@ -17,7 +17,7 @@ FROM (
       subq_12.metric_time__day AS metric_time__day
       , subq_9.bookings_offset_once AS bookings_offset_once
     FROM (
-      -- Pass Only Elements: ['metric_time__day',]
+      -- Pass Only Elements: ['metric_time__day']
       SELECT
         subq_11.metric_time__day
       FROM (
@@ -176,7 +176,7 @@ FROM (
                 , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                 , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
               FROM (
-                -- Pass Only Elements: ['metric_time__day',]
+                -- Pass Only Elements: ['metric_time__day']
                 SELECT
                   subq_3.metric_time__day
                 FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_offset_to_grain_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_offset_to_grain_with_agg_time_dim__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_5.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_5.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['booking__ds__day',]
+            -- Pass Only Elements: ['booking__ds__day']
             SELECT
               subq_7.booking__ds__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_offset_window_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_offset_window_with_agg_time_dim__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_5.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_5.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['booking__ds__day',]
+            -- Pass Only Elements: ['booking__ds__day']
             SELECT
               subq_7.booking__ds__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_time_offset_metric_with_time_constraint__plan0.sql
@@ -224,7 +224,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day',]
+            -- Pass Only Elements: ['metric_time__day']
             SELECT
               subq_3.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
@@ -224,7 +224,7 @@ FROM (
             , subq_4.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_4.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day',]
+            -- Pass Only Elements: ['metric_time__day']
             SELECT
               subq_6.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
@@ -46,7 +46,7 @@ FROM (
           , subq_1.booking_monthly__listing AS booking_monthly__listing
           , subq_1.bookings_monthly AS bookings_monthly
         FROM (
-          -- Pass Only Elements: ['metric_time__month',]
+          -- Pass Only Elements: ['metric_time__month']
           SELECT
             subq_3.metric_time__month
           FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_derived_metric_with_month_dimension_and_offset_window__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_derived_metric_with_month_dimension_and_offset_window__plan0_optimized.sql
@@ -17,7 +17,7 @@ FROM (
   FROM (
     -- Read From Time Spine 'mf_time_spine'
     -- Change Column Aliases
-    -- Pass Only Elements: ['metric_time__month',]
+    -- Pass Only Elements: ['metric_time__month']
     SELECT
       DATE_TRUNC('month', ds) AS metric_time__month
     FROM ***************************.mf_time_spine time_spine_src_16006

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_derived_metric_with_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_derived_metric_with_offset_to_grain__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_5.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_5.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day',]
+            -- Pass Only Elements: ['metric_time__day']
             SELECT
               subq_7.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_derived_metric_with_offset_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_derived_metric_with_offset_window__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_5.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_5.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day',]
+            -- Pass Only Elements: ['metric_time__day']
             SELECT
               subq_7.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_derived_metric_with_offset_window_and_offset_to_grain__plan0.sql
@@ -129,7 +129,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day',]
+            -- Pass Only Elements: ['metric_time__day']
             SELECT
               subq_3.metric_time__day
             FROM (
@@ -486,7 +486,7 @@ FROM (
             , subq_9.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_9.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day',]
+            -- Pass Only Elements: ['metric_time__day']
             SELECT
               subq_11.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
@@ -548,7 +548,7 @@ FROM (
               , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
               , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             FROM (
-              -- Pass Only Elements: ['metric_time__day',]
+              -- Pass Only Elements: ['metric_time__day']
               SELECT
                 subq_8.metric_time__day
               FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_derived_offset_cumulative_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_derived_offset_cumulative_metric__plan0.sql
@@ -123,7 +123,7 @@ FROM (
           , subq_4.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
           , subq_4.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
         FROM (
-          -- Pass Only Elements: ['metric_time__day',]
+          -- Pass Only Elements: ['metric_time__day']
           SELECT
             subq_6.metric_time__day
           FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_derived_offset_metric_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_derived_offset_metric_with_agg_time_dim__plan0.sql
@@ -129,7 +129,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['booking__ds__day',]
+            -- Pass Only Elements: ['booking__ds__day']
             SELECT
               subq_3.booking__ds__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_derived_offset_metric_with_one_input_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_derived_offset_metric_with_one_input_metric__plan0.sql
@@ -123,7 +123,7 @@ FROM (
           , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
           , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
         FROM (
-          -- Pass Only Elements: ['metric_time__day',]
+          -- Pass Only Elements: ['metric_time__day']
           SELECT
             subq_3.metric_time__day
           FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0.sql
@@ -24,7 +24,7 @@ FROM (
         , subq_9.booking__is_instant AS booking__is_instant
         , subq_9.bookings_offset_once AS bookings_offset_once
       FROM (
-        -- Pass Only Elements: ['metric_time__day',]
+        -- Pass Only Elements: ['metric_time__day']
         SELECT
           subq_11.metric_time__day
         FROM (
@@ -187,7 +187,7 @@ FROM (
                   , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                   , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
                 FROM (
-                  -- Pass Only Elements: ['metric_time__day',]
+                  -- Pass Only Elements: ['metric_time__day']
                   SELECT
                     subq_3.metric_time__day
                   FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0.sql
@@ -18,7 +18,7 @@ FROM (
       subq_8.metric_time__day AS metric_time__day
       , subq_5.booking_fees_start_of_month AS booking_fees_start_of_month
     FROM (
-      -- Pass Only Elements: ['metric_time__day',]
+      -- Pass Only Elements: ['metric_time__day']
       SELECT
         subq_7.metric_time__day
       FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_nested_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_nested_filters__plan0.sql
@@ -26,7 +26,7 @@ FROM (
         SELECT
           AVG(subq_7.average_booking_value) AS average_booking_value
         FROM (
-          -- Pass Only Elements: ['average_booking_value',]
+          -- Pass Only Elements: ['average_booking_value']
           SELECT
             subq_6.average_booking_value
           FROM (
@@ -583,7 +583,7 @@ FROM (
         SELECT
           SUM(subq_15.bookings) AS bookings
         FROM (
-          -- Pass Only Elements: ['bookings',]
+          -- Pass Only Elements: ['bookings']
           SELECT
             subq_14.bookings
           FROM (
@@ -1140,7 +1140,7 @@ FROM (
         SELECT
           SUM(subq_20.booking_value) AS booking_value
         FROM (
-          -- Pass Only Elements: ['booking_value',]
+          -- Pass Only Elements: ['booking_value']
           SELECT
             subq_19.booking_value
           FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_nested_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_nested_filters__plan0_optimized.sql
@@ -51,7 +51,7 @@ FROM (
     ) subq_34
     CROSS JOIN (
       -- Constrain Output with WHERE
-      -- Pass Only Elements: ['booking_value',]
+      -- Pass Only Elements: ['booking_value']
       -- Aggregate Measures
       -- Compute Metrics via Expressions
       SELECT

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_nested_offsets__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_nested_offsets__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_12.metric_time__day AS metric_time__day
     , subq_9.bookings_offset_once AS bookings_offset_once
   FROM (
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       subq_11.metric_time__day
     FROM (
@@ -171,7 +171,7 @@ FROM (
               , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
               , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             FROM (
-              -- Pass Only Elements: ['metric_time__day',]
+              -- Pass Only Elements: ['metric_time__day']
               SELECT
                 subq_3.metric_time__day
               FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_nested_offsets_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_nested_offsets_with_time_constraint__plan0.sql
@@ -17,7 +17,7 @@ FROM (
       subq_12.metric_time__day AS metric_time__day
       , subq_9.bookings_offset_once AS bookings_offset_once
     FROM (
-      -- Pass Only Elements: ['metric_time__day',]
+      -- Pass Only Elements: ['metric_time__day']
       SELECT
         subq_11.metric_time__day
       FROM (
@@ -176,7 +176,7 @@ FROM (
                 , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                 , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
               FROM (
-                -- Pass Only Elements: ['metric_time__day',]
+                -- Pass Only Elements: ['metric_time__day']
                 SELECT
                   subq_3.metric_time__day
                 FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_nested_offsets_with_where_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_nested_offsets_with_where_constraint__plan0.sql
@@ -17,7 +17,7 @@ FROM (
       subq_12.metric_time__day AS metric_time__day
       , subq_9.bookings_offset_once AS bookings_offset_once
     FROM (
-      -- Pass Only Elements: ['metric_time__day',]
+      -- Pass Only Elements: ['metric_time__day']
       SELECT
         subq_11.metric_time__day
       FROM (
@@ -176,7 +176,7 @@ FROM (
                 , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                 , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
               FROM (
-                -- Pass Only Elements: ['metric_time__day',]
+                -- Pass Only Elements: ['metric_time__day']
                 SELECT
                   subq_3.metric_time__day
                 FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_offset_to_grain_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_offset_to_grain_with_agg_time_dim__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_5.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_5.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['booking__ds__day',]
+            -- Pass Only Elements: ['booking__ds__day']
             SELECT
               subq_7.booking__ds__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_offset_window_with_agg_time_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_offset_window_with_agg_time_dim__plan0.sql
@@ -344,7 +344,7 @@ FROM (
             , subq_5.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_5.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['booking__ds__day',]
+            -- Pass Only Elements: ['booking__ds__day']
             SELECT
               subq_7.booking__ds__day
             FROM (

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_time_offset_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_time_offset_metric_with_time_constraint__plan0.sql
@@ -224,7 +224,7 @@ FROM (
             , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day',]
+            -- Pass Only Elements: ['metric_time__day']
             SELECT
               subq_3.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/BigQuery/test_cumulative_fill_nulls__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/BigQuery/test_cumulative_fill_nulls__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_9.metric_time__day AS metric_time__day
     , subq_6.bookers AS bookers
   FROM (
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       subq_8.metric_time__day
     FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/BigQuery/test_derived_fill_nulls_for_one_input_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/BigQuery/test_derived_fill_nulls_for_one_input_metric__plan0.sql
@@ -23,7 +23,7 @@ FROM (
         subq_6.metric_time__day AS metric_time__day
         , subq_3.bookings AS bookings
       FROM (
-        -- Pass Only Elements: ['metric_time__day',]
+        -- Pass Only Elements: ['metric_time__day']
         SELECT
           subq_5.metric_time__day
         FROM (
@@ -390,7 +390,7 @@ FROM (
             , subq_9.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_9.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day',]
+            -- Pass Only Elements: ['metric_time__day']
             SELECT
               subq_11.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/BigQuery/test_join_to_time_spine_with_filter_not_in_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/BigQuery/test_join_to_time_spine_with_filter_not_in_group_by__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_8.metric_time__day AS metric_time__day
     , subq_4.bookings AS bookings
   FROM (
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       subq_7.metric_time__day
     FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/BigQuery/test_join_to_time_spine_with_filter_not_in_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/BigQuery/test_join_to_time_spine_with_filter_not_in_group_by__plan0_optimized.sql
@@ -9,7 +9,7 @@ SELECT
   , subq_14.bookings AS bookings_join_to_time_spine_with_tiered_filters
 FROM (
   -- Constrain Output with WHERE
-  -- Pass Only Elements: ['metric_time__day',]
+  -- Pass Only Elements: ['metric_time__day']
   SELECT
     metric_time__day
   FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/BigQuery/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/BigQuery/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_8.booking__ds__day AS booking__ds__day
     , subq_4.bookings AS bookings
   FROM (
-    -- Pass Only Elements: ['booking__ds__day',]
+    -- Pass Only Elements: ['booking__ds__day']
     SELECT
       subq_7.booking__ds__day
     FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/BigQuery/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/BigQuery/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time__plan0_optimized.sql
@@ -9,7 +9,7 @@ SELECT
   , subq_14.bookings AS bookings_join_to_time_spine_with_tiered_filters
 FROM (
   -- Constrain Output with WHERE
-  -- Pass Only Elements: ['booking__ds__day',]
+  -- Pass Only Elements: ['booking__ds__day']
   SELECT
     booking__ds__day
   FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/BigQuery/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time_and_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/BigQuery/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time_and_metric_time__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_8.metric_time__day AS metric_time__day
     , subq_4.bookings AS bookings
   FROM (
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       subq_7.metric_time__day
     FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/BigQuery/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time_and_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/BigQuery/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time_and_metric_time__plan0_optimized.sql
@@ -9,7 +9,7 @@ SELECT
   , subq_14.bookings AS bookings_join_to_time_spine_with_tiered_filters
 FROM (
   -- Constrain Output with WHERE
-  -- Pass Only Elements: ['metric_time__day',]
+  -- Pass Only Elements: ['metric_time__day']
   SELECT
     metric_time__day
   FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/BigQuery/test_join_to_time_spine_with_filter_smaller_than_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/BigQuery/test_join_to_time_spine_with_filter_smaller_than_group_by__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_8.metric_time__day AS metric_time__day
     , subq_4.archived_users AS archived_users
   FROM (
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       subq_7.metric_time__day
     FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/BigQuery/test_join_to_time_spine_with_filter_smaller_than_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/BigQuery/test_join_to_time_spine_with_filter_smaller_than_group_by__plan0_optimized.sql
@@ -9,7 +9,7 @@ SELECT
   , subq_14.archived_users AS archived_users_join_to_time_spine
 FROM (
   -- Constrain Output with WHERE
-  -- Pass Only Elements: ['metric_time__day',]
+  -- Pass Only Elements: ['metric_time__day']
   SELECT
     metric_time__day
   FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/BigQuery/test_join_to_time_spine_with_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/BigQuery/test_join_to_time_spine_with_filters__plan0.sql
@@ -17,7 +17,7 @@ FROM (
       subq_11.metric_time__day AS metric_time__day
       , subq_6.bookings AS bookings
     FROM (
-      -- Pass Only Elements: ['metric_time__day',]
+      -- Pass Only Elements: ['metric_time__day']
       SELECT
         subq_10.metric_time__day
       FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/BigQuery/test_join_to_time_spine_with_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/BigQuery/test_join_to_time_spine_with_filters__plan0_optimized.sql
@@ -15,7 +15,7 @@ FROM (
   FROM (
     -- Constrain Output with WHERE
     -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       metric_time__day
     FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/BigQuery/test_simple_fill_nulls_with_0_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/BigQuery/test_simple_fill_nulls_with_0_metric_time__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_6.metric_time__day AS metric_time__day
     , subq_3.bookings AS bookings
   FROM (
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       subq_5.metric_time__day
     FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/BigQuery/test_simple_fill_nulls_with_0_month__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/BigQuery/test_simple_fill_nulls_with_0_month__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_6.metric_time__month AS metric_time__month
     , subq_3.bookings AS bookings
   FROM (
-    -- Pass Only Elements: ['metric_time__month',]
+    -- Pass Only Elements: ['metric_time__month']
     SELECT
       subq_5.metric_time__month
     FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/BigQuery/test_simple_fill_nulls_with_0_month__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/BigQuery/test_simple_fill_nulls_with_0_month__plan0_optimized.sql
@@ -14,7 +14,7 @@ FROM (
   FROM (
     -- Read From Time Spine 'mf_time_spine'
     -- Change Column Aliases
-    -- Pass Only Elements: ['metric_time__month',]
+    -- Pass Only Elements: ['metric_time__month']
     SELECT
       DATETIME_TRUNC(ds, month) AS metric_time__month
     FROM ***************************.mf_time_spine time_spine_src_28006

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Databricks/test_cumulative_fill_nulls__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Databricks/test_cumulative_fill_nulls__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_9.metric_time__day AS metric_time__day
     , subq_6.bookers AS bookers
   FROM (
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       subq_8.metric_time__day
     FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Databricks/test_derived_fill_nulls_for_one_input_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Databricks/test_derived_fill_nulls_for_one_input_metric__plan0.sql
@@ -23,7 +23,7 @@ FROM (
         subq_6.metric_time__day AS metric_time__day
         , subq_3.bookings AS bookings
       FROM (
-        -- Pass Only Elements: ['metric_time__day',]
+        -- Pass Only Elements: ['metric_time__day']
         SELECT
           subq_5.metric_time__day
         FROM (
@@ -390,7 +390,7 @@ FROM (
             , subq_9.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_9.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day',]
+            -- Pass Only Elements: ['metric_time__day']
             SELECT
               subq_11.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Databricks/test_join_to_time_spine_with_filter_not_in_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Databricks/test_join_to_time_spine_with_filter_not_in_group_by__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_8.metric_time__day AS metric_time__day
     , subq_4.bookings AS bookings
   FROM (
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       subq_7.metric_time__day
     FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Databricks/test_join_to_time_spine_with_filter_not_in_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Databricks/test_join_to_time_spine_with_filter_not_in_group_by__plan0_optimized.sql
@@ -9,7 +9,7 @@ SELECT
   , subq_14.bookings AS bookings_join_to_time_spine_with_tiered_filters
 FROM (
   -- Constrain Output with WHERE
-  -- Pass Only Elements: ['metric_time__day',]
+  -- Pass Only Elements: ['metric_time__day']
   SELECT
     metric_time__day
   FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Databricks/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Databricks/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_8.booking__ds__day AS booking__ds__day
     , subq_4.bookings AS bookings
   FROM (
-    -- Pass Only Elements: ['booking__ds__day',]
+    -- Pass Only Elements: ['booking__ds__day']
     SELECT
       subq_7.booking__ds__day
     FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Databricks/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Databricks/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time__plan0_optimized.sql
@@ -9,7 +9,7 @@ SELECT
   , subq_14.bookings AS bookings_join_to_time_spine_with_tiered_filters
 FROM (
   -- Constrain Output with WHERE
-  -- Pass Only Elements: ['booking__ds__day',]
+  -- Pass Only Elements: ['booking__ds__day']
   SELECT
     booking__ds__day
   FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Databricks/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time_and_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Databricks/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time_and_metric_time__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_8.metric_time__day AS metric_time__day
     , subq_4.bookings AS bookings
   FROM (
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       subq_7.metric_time__day
     FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Databricks/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time_and_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Databricks/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time_and_metric_time__plan0_optimized.sql
@@ -9,7 +9,7 @@ SELECT
   , subq_14.bookings AS bookings_join_to_time_spine_with_tiered_filters
 FROM (
   -- Constrain Output with WHERE
-  -- Pass Only Elements: ['metric_time__day',]
+  -- Pass Only Elements: ['metric_time__day']
   SELECT
     metric_time__day
   FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Databricks/test_join_to_time_spine_with_filter_smaller_than_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Databricks/test_join_to_time_spine_with_filter_smaller_than_group_by__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_8.metric_time__day AS metric_time__day
     , subq_4.archived_users AS archived_users
   FROM (
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       subq_7.metric_time__day
     FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Databricks/test_join_to_time_spine_with_filter_smaller_than_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Databricks/test_join_to_time_spine_with_filter_smaller_than_group_by__plan0_optimized.sql
@@ -9,7 +9,7 @@ SELECT
   , subq_14.archived_users AS archived_users_join_to_time_spine
 FROM (
   -- Constrain Output with WHERE
-  -- Pass Only Elements: ['metric_time__day',]
+  -- Pass Only Elements: ['metric_time__day']
   SELECT
     metric_time__day
   FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Databricks/test_join_to_time_spine_with_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Databricks/test_join_to_time_spine_with_filters__plan0.sql
@@ -17,7 +17,7 @@ FROM (
       subq_11.metric_time__day AS metric_time__day
       , subq_6.bookings AS bookings
     FROM (
-      -- Pass Only Elements: ['metric_time__day',]
+      -- Pass Only Elements: ['metric_time__day']
       SELECT
         subq_10.metric_time__day
       FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Databricks/test_join_to_time_spine_with_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Databricks/test_join_to_time_spine_with_filters__plan0_optimized.sql
@@ -15,7 +15,7 @@ FROM (
   FROM (
     -- Constrain Output with WHERE
     -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       metric_time__day
     FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Databricks/test_simple_fill_nulls_with_0_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Databricks/test_simple_fill_nulls_with_0_metric_time__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_6.metric_time__day AS metric_time__day
     , subq_3.bookings AS bookings
   FROM (
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       subq_5.metric_time__day
     FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Databricks/test_simple_fill_nulls_with_0_month__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Databricks/test_simple_fill_nulls_with_0_month__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_6.metric_time__month AS metric_time__month
     , subq_3.bookings AS bookings
   FROM (
-    -- Pass Only Elements: ['metric_time__month',]
+    -- Pass Only Elements: ['metric_time__month']
     SELECT
       subq_5.metric_time__month
     FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Databricks/test_simple_fill_nulls_with_0_month__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Databricks/test_simple_fill_nulls_with_0_month__plan0_optimized.sql
@@ -14,7 +14,7 @@ FROM (
   FROM (
     -- Read From Time Spine 'mf_time_spine'
     -- Change Column Aliases
-    -- Pass Only Elements: ['metric_time__month',]
+    -- Pass Only Elements: ['metric_time__month']
     SELECT
       DATE_TRUNC('month', ds) AS metric_time__month
     FROM ***************************.mf_time_spine time_spine_src_28006

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/DuckDB/test_cumulative_fill_nulls__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/DuckDB/test_cumulative_fill_nulls__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_9.metric_time__day AS metric_time__day
     , subq_6.bookers AS bookers
   FROM (
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       subq_8.metric_time__day
     FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/DuckDB/test_derived_fill_nulls_for_one_input_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/DuckDB/test_derived_fill_nulls_for_one_input_metric__plan0.sql
@@ -23,7 +23,7 @@ FROM (
         subq_6.metric_time__day AS metric_time__day
         , subq_3.bookings AS bookings
       FROM (
-        -- Pass Only Elements: ['metric_time__day',]
+        -- Pass Only Elements: ['metric_time__day']
         SELECT
           subq_5.metric_time__day
         FROM (
@@ -390,7 +390,7 @@ FROM (
             , subq_9.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_9.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day',]
+            -- Pass Only Elements: ['metric_time__day']
             SELECT
               subq_11.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/DuckDB/test_join_to_time_spine_with_filter_not_in_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/DuckDB/test_join_to_time_spine_with_filter_not_in_group_by__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_8.metric_time__day AS metric_time__day
     , subq_4.bookings AS bookings
   FROM (
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       subq_7.metric_time__day
     FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/DuckDB/test_join_to_time_spine_with_filter_not_in_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/DuckDB/test_join_to_time_spine_with_filter_not_in_group_by__plan0_optimized.sql
@@ -9,7 +9,7 @@ SELECT
   , subq_14.bookings AS bookings_join_to_time_spine_with_tiered_filters
 FROM (
   -- Constrain Output with WHERE
-  -- Pass Only Elements: ['metric_time__day',]
+  -- Pass Only Elements: ['metric_time__day']
   SELECT
     metric_time__day
   FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/DuckDB/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/DuckDB/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_8.booking__ds__day AS booking__ds__day
     , subq_4.bookings AS bookings
   FROM (
-    -- Pass Only Elements: ['booking__ds__day',]
+    -- Pass Only Elements: ['booking__ds__day']
     SELECT
       subq_7.booking__ds__day
     FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/DuckDB/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/DuckDB/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time__plan0_optimized.sql
@@ -9,7 +9,7 @@ SELECT
   , subq_14.bookings AS bookings_join_to_time_spine_with_tiered_filters
 FROM (
   -- Constrain Output with WHERE
-  -- Pass Only Elements: ['booking__ds__day',]
+  -- Pass Only Elements: ['booking__ds__day']
   SELECT
     booking__ds__day
   FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/DuckDB/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time_and_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/DuckDB/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time_and_metric_time__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_8.metric_time__day AS metric_time__day
     , subq_4.bookings AS bookings
   FROM (
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       subq_7.metric_time__day
     FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/DuckDB/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time_and_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/DuckDB/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time_and_metric_time__plan0_optimized.sql
@@ -9,7 +9,7 @@ SELECT
   , subq_14.bookings AS bookings_join_to_time_spine_with_tiered_filters
 FROM (
   -- Constrain Output with WHERE
-  -- Pass Only Elements: ['metric_time__day',]
+  -- Pass Only Elements: ['metric_time__day']
   SELECT
     metric_time__day
   FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/DuckDB/test_join_to_time_spine_with_filter_smaller_than_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/DuckDB/test_join_to_time_spine_with_filter_smaller_than_group_by__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_8.metric_time__day AS metric_time__day
     , subq_4.archived_users AS archived_users
   FROM (
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       subq_7.metric_time__day
     FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/DuckDB/test_join_to_time_spine_with_filter_smaller_than_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/DuckDB/test_join_to_time_spine_with_filter_smaller_than_group_by__plan0_optimized.sql
@@ -9,7 +9,7 @@ SELECT
   , subq_14.archived_users AS archived_users_join_to_time_spine
 FROM (
   -- Constrain Output with WHERE
-  -- Pass Only Elements: ['metric_time__day',]
+  -- Pass Only Elements: ['metric_time__day']
   SELECT
     metric_time__day
   FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/DuckDB/test_join_to_time_spine_with_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/DuckDB/test_join_to_time_spine_with_filters__plan0.sql
@@ -17,7 +17,7 @@ FROM (
       subq_11.metric_time__day AS metric_time__day
       , subq_6.bookings AS bookings
     FROM (
-      -- Pass Only Elements: ['metric_time__day',]
+      -- Pass Only Elements: ['metric_time__day']
       SELECT
         subq_10.metric_time__day
       FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/DuckDB/test_join_to_time_spine_with_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/DuckDB/test_join_to_time_spine_with_filters__plan0_optimized.sql
@@ -15,7 +15,7 @@ FROM (
   FROM (
     -- Constrain Output with WHERE
     -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       metric_time__day
     FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/DuckDB/test_simple_fill_nulls_with_0_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/DuckDB/test_simple_fill_nulls_with_0_metric_time__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_6.metric_time__day AS metric_time__day
     , subq_3.bookings AS bookings
   FROM (
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       subq_5.metric_time__day
     FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/DuckDB/test_simple_fill_nulls_with_0_month__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/DuckDB/test_simple_fill_nulls_with_0_month__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_6.metric_time__month AS metric_time__month
     , subq_3.bookings AS bookings
   FROM (
-    -- Pass Only Elements: ['metric_time__month',]
+    -- Pass Only Elements: ['metric_time__month']
     SELECT
       subq_5.metric_time__month
     FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/DuckDB/test_simple_fill_nulls_with_0_month__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/DuckDB/test_simple_fill_nulls_with_0_month__plan0_optimized.sql
@@ -14,7 +14,7 @@ FROM (
   FROM (
     -- Read From Time Spine 'mf_time_spine'
     -- Change Column Aliases
-    -- Pass Only Elements: ['metric_time__month',]
+    -- Pass Only Elements: ['metric_time__month']
     SELECT
       DATE_TRUNC('month', ds) AS metric_time__month
     FROM ***************************.mf_time_spine time_spine_src_28006

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Postgres/test_cumulative_fill_nulls__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Postgres/test_cumulative_fill_nulls__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_9.metric_time__day AS metric_time__day
     , subq_6.bookers AS bookers
   FROM (
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       subq_8.metric_time__day
     FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Postgres/test_derived_fill_nulls_for_one_input_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Postgres/test_derived_fill_nulls_for_one_input_metric__plan0.sql
@@ -23,7 +23,7 @@ FROM (
         subq_6.metric_time__day AS metric_time__day
         , subq_3.bookings AS bookings
       FROM (
-        -- Pass Only Elements: ['metric_time__day',]
+        -- Pass Only Elements: ['metric_time__day']
         SELECT
           subq_5.metric_time__day
         FROM (
@@ -390,7 +390,7 @@ FROM (
             , subq_9.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_9.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day',]
+            -- Pass Only Elements: ['metric_time__day']
             SELECT
               subq_11.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Postgres/test_join_to_time_spine_with_filter_not_in_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Postgres/test_join_to_time_spine_with_filter_not_in_group_by__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_8.metric_time__day AS metric_time__day
     , subq_4.bookings AS bookings
   FROM (
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       subq_7.metric_time__day
     FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Postgres/test_join_to_time_spine_with_filter_not_in_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Postgres/test_join_to_time_spine_with_filter_not_in_group_by__plan0_optimized.sql
@@ -9,7 +9,7 @@ SELECT
   , subq_14.bookings AS bookings_join_to_time_spine_with_tiered_filters
 FROM (
   -- Constrain Output with WHERE
-  -- Pass Only Elements: ['metric_time__day',]
+  -- Pass Only Elements: ['metric_time__day']
   SELECT
     metric_time__day
   FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Postgres/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Postgres/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_8.booking__ds__day AS booking__ds__day
     , subq_4.bookings AS bookings
   FROM (
-    -- Pass Only Elements: ['booking__ds__day',]
+    -- Pass Only Elements: ['booking__ds__day']
     SELECT
       subq_7.booking__ds__day
     FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Postgres/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Postgres/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time__plan0_optimized.sql
@@ -9,7 +9,7 @@ SELECT
   , subq_14.bookings AS bookings_join_to_time_spine_with_tiered_filters
 FROM (
   -- Constrain Output with WHERE
-  -- Pass Only Elements: ['booking__ds__day',]
+  -- Pass Only Elements: ['booking__ds__day']
   SELECT
     booking__ds__day
   FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Postgres/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time_and_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Postgres/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time_and_metric_time__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_8.metric_time__day AS metric_time__day
     , subq_4.bookings AS bookings
   FROM (
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       subq_7.metric_time__day
     FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Postgres/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time_and_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Postgres/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time_and_metric_time__plan0_optimized.sql
@@ -9,7 +9,7 @@ SELECT
   , subq_14.bookings AS bookings_join_to_time_spine_with_tiered_filters
 FROM (
   -- Constrain Output with WHERE
-  -- Pass Only Elements: ['metric_time__day',]
+  -- Pass Only Elements: ['metric_time__day']
   SELECT
     metric_time__day
   FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Postgres/test_join_to_time_spine_with_filter_smaller_than_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Postgres/test_join_to_time_spine_with_filter_smaller_than_group_by__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_8.metric_time__day AS metric_time__day
     , subq_4.archived_users AS archived_users
   FROM (
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       subq_7.metric_time__day
     FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Postgres/test_join_to_time_spine_with_filter_smaller_than_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Postgres/test_join_to_time_spine_with_filter_smaller_than_group_by__plan0_optimized.sql
@@ -9,7 +9,7 @@ SELECT
   , subq_14.archived_users AS archived_users_join_to_time_spine
 FROM (
   -- Constrain Output with WHERE
-  -- Pass Only Elements: ['metric_time__day',]
+  -- Pass Only Elements: ['metric_time__day']
   SELECT
     metric_time__day
   FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Postgres/test_join_to_time_spine_with_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Postgres/test_join_to_time_spine_with_filters__plan0.sql
@@ -17,7 +17,7 @@ FROM (
       subq_11.metric_time__day AS metric_time__day
       , subq_6.bookings AS bookings
     FROM (
-      -- Pass Only Elements: ['metric_time__day',]
+      -- Pass Only Elements: ['metric_time__day']
       SELECT
         subq_10.metric_time__day
       FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Postgres/test_join_to_time_spine_with_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Postgres/test_join_to_time_spine_with_filters__plan0_optimized.sql
@@ -15,7 +15,7 @@ FROM (
   FROM (
     -- Constrain Output with WHERE
     -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       metric_time__day
     FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Postgres/test_simple_fill_nulls_with_0_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Postgres/test_simple_fill_nulls_with_0_metric_time__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_6.metric_time__day AS metric_time__day
     , subq_3.bookings AS bookings
   FROM (
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       subq_5.metric_time__day
     FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Postgres/test_simple_fill_nulls_with_0_month__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Postgres/test_simple_fill_nulls_with_0_month__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_6.metric_time__month AS metric_time__month
     , subq_3.bookings AS bookings
   FROM (
-    -- Pass Only Elements: ['metric_time__month',]
+    -- Pass Only Elements: ['metric_time__month']
     SELECT
       subq_5.metric_time__month
     FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Postgres/test_simple_fill_nulls_with_0_month__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Postgres/test_simple_fill_nulls_with_0_month__plan0_optimized.sql
@@ -14,7 +14,7 @@ FROM (
   FROM (
     -- Read From Time Spine 'mf_time_spine'
     -- Change Column Aliases
-    -- Pass Only Elements: ['metric_time__month',]
+    -- Pass Only Elements: ['metric_time__month']
     SELECT
       DATE_TRUNC('month', ds) AS metric_time__month
     FROM ***************************.mf_time_spine time_spine_src_28006

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Redshift/test_cumulative_fill_nulls__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Redshift/test_cumulative_fill_nulls__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_9.metric_time__day AS metric_time__day
     , subq_6.bookers AS bookers
   FROM (
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       subq_8.metric_time__day
     FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Redshift/test_derived_fill_nulls_for_one_input_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Redshift/test_derived_fill_nulls_for_one_input_metric__plan0.sql
@@ -23,7 +23,7 @@ FROM (
         subq_6.metric_time__day AS metric_time__day
         , subq_3.bookings AS bookings
       FROM (
-        -- Pass Only Elements: ['metric_time__day',]
+        -- Pass Only Elements: ['metric_time__day']
         SELECT
           subq_5.metric_time__day
         FROM (
@@ -390,7 +390,7 @@ FROM (
             , subq_9.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_9.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day',]
+            -- Pass Only Elements: ['metric_time__day']
             SELECT
               subq_11.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Redshift/test_join_to_time_spine_with_filter_not_in_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Redshift/test_join_to_time_spine_with_filter_not_in_group_by__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_8.metric_time__day AS metric_time__day
     , subq_4.bookings AS bookings
   FROM (
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       subq_7.metric_time__day
     FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Redshift/test_join_to_time_spine_with_filter_not_in_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Redshift/test_join_to_time_spine_with_filter_not_in_group_by__plan0_optimized.sql
@@ -9,7 +9,7 @@ SELECT
   , subq_14.bookings AS bookings_join_to_time_spine_with_tiered_filters
 FROM (
   -- Constrain Output with WHERE
-  -- Pass Only Elements: ['metric_time__day',]
+  -- Pass Only Elements: ['metric_time__day']
   SELECT
     metric_time__day
   FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Redshift/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Redshift/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_8.booking__ds__day AS booking__ds__day
     , subq_4.bookings AS bookings
   FROM (
-    -- Pass Only Elements: ['booking__ds__day',]
+    -- Pass Only Elements: ['booking__ds__day']
     SELECT
       subq_7.booking__ds__day
     FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Redshift/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Redshift/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time__plan0_optimized.sql
@@ -9,7 +9,7 @@ SELECT
   , subq_14.bookings AS bookings_join_to_time_spine_with_tiered_filters
 FROM (
   -- Constrain Output with WHERE
-  -- Pass Only Elements: ['booking__ds__day',]
+  -- Pass Only Elements: ['booking__ds__day']
   SELECT
     booking__ds__day
   FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Redshift/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time_and_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Redshift/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time_and_metric_time__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_8.metric_time__day AS metric_time__day
     , subq_4.bookings AS bookings
   FROM (
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       subq_7.metric_time__day
     FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Redshift/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time_and_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Redshift/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time_and_metric_time__plan0_optimized.sql
@@ -9,7 +9,7 @@ SELECT
   , subq_14.bookings AS bookings_join_to_time_spine_with_tiered_filters
 FROM (
   -- Constrain Output with WHERE
-  -- Pass Only Elements: ['metric_time__day',]
+  -- Pass Only Elements: ['metric_time__day']
   SELECT
     metric_time__day
   FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Redshift/test_join_to_time_spine_with_filter_smaller_than_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Redshift/test_join_to_time_spine_with_filter_smaller_than_group_by__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_8.metric_time__day AS metric_time__day
     , subq_4.archived_users AS archived_users
   FROM (
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       subq_7.metric_time__day
     FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Redshift/test_join_to_time_spine_with_filter_smaller_than_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Redshift/test_join_to_time_spine_with_filter_smaller_than_group_by__plan0_optimized.sql
@@ -9,7 +9,7 @@ SELECT
   , subq_14.archived_users AS archived_users_join_to_time_spine
 FROM (
   -- Constrain Output with WHERE
-  -- Pass Only Elements: ['metric_time__day',]
+  -- Pass Only Elements: ['metric_time__day']
   SELECT
     metric_time__day
   FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Redshift/test_join_to_time_spine_with_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Redshift/test_join_to_time_spine_with_filters__plan0.sql
@@ -17,7 +17,7 @@ FROM (
       subq_11.metric_time__day AS metric_time__day
       , subq_6.bookings AS bookings
     FROM (
-      -- Pass Only Elements: ['metric_time__day',]
+      -- Pass Only Elements: ['metric_time__day']
       SELECT
         subq_10.metric_time__day
       FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Redshift/test_join_to_time_spine_with_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Redshift/test_join_to_time_spine_with_filters__plan0_optimized.sql
@@ -15,7 +15,7 @@ FROM (
   FROM (
     -- Constrain Output with WHERE
     -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       metric_time__day
     FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Redshift/test_simple_fill_nulls_with_0_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Redshift/test_simple_fill_nulls_with_0_metric_time__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_6.metric_time__day AS metric_time__day
     , subq_3.bookings AS bookings
   FROM (
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       subq_5.metric_time__day
     FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Redshift/test_simple_fill_nulls_with_0_month__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Redshift/test_simple_fill_nulls_with_0_month__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_6.metric_time__month AS metric_time__month
     , subq_3.bookings AS bookings
   FROM (
-    -- Pass Only Elements: ['metric_time__month',]
+    -- Pass Only Elements: ['metric_time__month']
     SELECT
       subq_5.metric_time__month
     FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Redshift/test_simple_fill_nulls_with_0_month__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Redshift/test_simple_fill_nulls_with_0_month__plan0_optimized.sql
@@ -14,7 +14,7 @@ FROM (
   FROM (
     -- Read From Time Spine 'mf_time_spine'
     -- Change Column Aliases
-    -- Pass Only Elements: ['metric_time__month',]
+    -- Pass Only Elements: ['metric_time__month']
     SELECT
       DATE_TRUNC('month', ds) AS metric_time__month
     FROM ***************************.mf_time_spine time_spine_src_28006

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Snowflake/test_cumulative_fill_nulls__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Snowflake/test_cumulative_fill_nulls__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_9.metric_time__day AS metric_time__day
     , subq_6.bookers AS bookers
   FROM (
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       subq_8.metric_time__day
     FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Snowflake/test_derived_fill_nulls_for_one_input_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Snowflake/test_derived_fill_nulls_for_one_input_metric__plan0.sql
@@ -23,7 +23,7 @@ FROM (
         subq_6.metric_time__day AS metric_time__day
         , subq_3.bookings AS bookings
       FROM (
-        -- Pass Only Elements: ['metric_time__day',]
+        -- Pass Only Elements: ['metric_time__day']
         SELECT
           subq_5.metric_time__day
         FROM (
@@ -390,7 +390,7 @@ FROM (
             , subq_9.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_9.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day',]
+            -- Pass Only Elements: ['metric_time__day']
             SELECT
               subq_11.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Snowflake/test_join_to_time_spine_with_filter_not_in_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Snowflake/test_join_to_time_spine_with_filter_not_in_group_by__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_8.metric_time__day AS metric_time__day
     , subq_4.bookings AS bookings
   FROM (
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       subq_7.metric_time__day
     FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Snowflake/test_join_to_time_spine_with_filter_not_in_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Snowflake/test_join_to_time_spine_with_filter_not_in_group_by__plan0_optimized.sql
@@ -9,7 +9,7 @@ SELECT
   , subq_14.bookings AS bookings_join_to_time_spine_with_tiered_filters
 FROM (
   -- Constrain Output with WHERE
-  -- Pass Only Elements: ['metric_time__day',]
+  -- Pass Only Elements: ['metric_time__day']
   SELECT
     metric_time__day
   FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Snowflake/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Snowflake/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_8.booking__ds__day AS booking__ds__day
     , subq_4.bookings AS bookings
   FROM (
-    -- Pass Only Elements: ['booking__ds__day',]
+    -- Pass Only Elements: ['booking__ds__day']
     SELECT
       subq_7.booking__ds__day
     FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Snowflake/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Snowflake/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time__plan0_optimized.sql
@@ -9,7 +9,7 @@ SELECT
   , subq_14.bookings AS bookings_join_to_time_spine_with_tiered_filters
 FROM (
   -- Constrain Output with WHERE
-  -- Pass Only Elements: ['booking__ds__day',]
+  -- Pass Only Elements: ['booking__ds__day']
   SELECT
     booking__ds__day
   FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Snowflake/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time_and_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Snowflake/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time_and_metric_time__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_8.metric_time__day AS metric_time__day
     , subq_4.bookings AS bookings
   FROM (
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       subq_7.metric_time__day
     FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Snowflake/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time_and_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Snowflake/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time_and_metric_time__plan0_optimized.sql
@@ -9,7 +9,7 @@ SELECT
   , subq_14.bookings AS bookings_join_to_time_spine_with_tiered_filters
 FROM (
   -- Constrain Output with WHERE
-  -- Pass Only Elements: ['metric_time__day',]
+  -- Pass Only Elements: ['metric_time__day']
   SELECT
     metric_time__day
   FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Snowflake/test_join_to_time_spine_with_filter_smaller_than_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Snowflake/test_join_to_time_spine_with_filter_smaller_than_group_by__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_8.metric_time__day AS metric_time__day
     , subq_4.archived_users AS archived_users
   FROM (
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       subq_7.metric_time__day
     FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Snowflake/test_join_to_time_spine_with_filter_smaller_than_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Snowflake/test_join_to_time_spine_with_filter_smaller_than_group_by__plan0_optimized.sql
@@ -9,7 +9,7 @@ SELECT
   , subq_14.archived_users AS archived_users_join_to_time_spine
 FROM (
   -- Constrain Output with WHERE
-  -- Pass Only Elements: ['metric_time__day',]
+  -- Pass Only Elements: ['metric_time__day']
   SELECT
     metric_time__day
   FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Snowflake/test_join_to_time_spine_with_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Snowflake/test_join_to_time_spine_with_filters__plan0.sql
@@ -17,7 +17,7 @@ FROM (
       subq_11.metric_time__day AS metric_time__day
       , subq_6.bookings AS bookings
     FROM (
-      -- Pass Only Elements: ['metric_time__day',]
+      -- Pass Only Elements: ['metric_time__day']
       SELECT
         subq_10.metric_time__day
       FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Snowflake/test_join_to_time_spine_with_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Snowflake/test_join_to_time_spine_with_filters__plan0_optimized.sql
@@ -15,7 +15,7 @@ FROM (
   FROM (
     -- Constrain Output with WHERE
     -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       metric_time__day
     FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Snowflake/test_simple_fill_nulls_with_0_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Snowflake/test_simple_fill_nulls_with_0_metric_time__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_6.metric_time__day AS metric_time__day
     , subq_3.bookings AS bookings
   FROM (
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       subq_5.metric_time__day
     FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Snowflake/test_simple_fill_nulls_with_0_month__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Snowflake/test_simple_fill_nulls_with_0_month__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_6.metric_time__month AS metric_time__month
     , subq_3.bookings AS bookings
   FROM (
-    -- Pass Only Elements: ['metric_time__month',]
+    -- Pass Only Elements: ['metric_time__month']
     SELECT
       subq_5.metric_time__month
     FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Snowflake/test_simple_fill_nulls_with_0_month__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Snowflake/test_simple_fill_nulls_with_0_month__plan0_optimized.sql
@@ -14,7 +14,7 @@ FROM (
   FROM (
     -- Read From Time Spine 'mf_time_spine'
     -- Change Column Aliases
-    -- Pass Only Elements: ['metric_time__month',]
+    -- Pass Only Elements: ['metric_time__month']
     SELECT
       DATE_TRUNC('month', ds) AS metric_time__month
     FROM ***************************.mf_time_spine time_spine_src_28006

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Trino/test_cumulative_fill_nulls__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Trino/test_cumulative_fill_nulls__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_9.metric_time__day AS metric_time__day
     , subq_6.bookers AS bookers
   FROM (
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       subq_8.metric_time__day
     FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Trino/test_derived_fill_nulls_for_one_input_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Trino/test_derived_fill_nulls_for_one_input_metric__plan0.sql
@@ -23,7 +23,7 @@ FROM (
         subq_6.metric_time__day AS metric_time__day
         , subq_3.bookings AS bookings
       FROM (
-        -- Pass Only Elements: ['metric_time__day',]
+        -- Pass Only Elements: ['metric_time__day']
         SELECT
           subq_5.metric_time__day
         FROM (
@@ -390,7 +390,7 @@ FROM (
             , subq_9.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
             , subq_9.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Pass Only Elements: ['metric_time__day',]
+            -- Pass Only Elements: ['metric_time__day']
             SELECT
               subq_11.metric_time__day
             FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Trino/test_join_to_time_spine_with_filter_not_in_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Trino/test_join_to_time_spine_with_filter_not_in_group_by__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_8.metric_time__day AS metric_time__day
     , subq_4.bookings AS bookings
   FROM (
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       subq_7.metric_time__day
     FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Trino/test_join_to_time_spine_with_filter_not_in_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Trino/test_join_to_time_spine_with_filter_not_in_group_by__plan0_optimized.sql
@@ -9,7 +9,7 @@ SELECT
   , subq_14.bookings AS bookings_join_to_time_spine_with_tiered_filters
 FROM (
   -- Constrain Output with WHERE
-  -- Pass Only Elements: ['metric_time__day',]
+  -- Pass Only Elements: ['metric_time__day']
   SELECT
     metric_time__day
   FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Trino/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Trino/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_8.booking__ds__day AS booking__ds__day
     , subq_4.bookings AS bookings
   FROM (
-    -- Pass Only Elements: ['booking__ds__day',]
+    -- Pass Only Elements: ['booking__ds__day']
     SELECT
       subq_7.booking__ds__day
     FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Trino/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Trino/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time__plan0_optimized.sql
@@ -9,7 +9,7 @@ SELECT
   , subq_14.bookings AS bookings_join_to_time_spine_with_tiered_filters
 FROM (
   -- Constrain Output with WHERE
-  -- Pass Only Elements: ['booking__ds__day',]
+  -- Pass Only Elements: ['booking__ds__day']
   SELECT
     booking__ds__day
   FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Trino/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time_and_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Trino/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time_and_metric_time__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_8.metric_time__day AS metric_time__day
     , subq_4.bookings AS bookings
   FROM (
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       subq_7.metric_time__day
     FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Trino/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time_and_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Trino/test_join_to_time_spine_with_filter_not_in_group_by_using_agg_time_and_metric_time__plan0_optimized.sql
@@ -9,7 +9,7 @@ SELECT
   , subq_14.bookings AS bookings_join_to_time_spine_with_tiered_filters
 FROM (
   -- Constrain Output with WHERE
-  -- Pass Only Elements: ['metric_time__day',]
+  -- Pass Only Elements: ['metric_time__day']
   SELECT
     metric_time__day
   FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Trino/test_join_to_time_spine_with_filter_smaller_than_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Trino/test_join_to_time_spine_with_filter_smaller_than_group_by__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_8.metric_time__day AS metric_time__day
     , subq_4.archived_users AS archived_users
   FROM (
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       subq_7.metric_time__day
     FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Trino/test_join_to_time_spine_with_filter_smaller_than_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Trino/test_join_to_time_spine_with_filter_smaller_than_group_by__plan0_optimized.sql
@@ -9,7 +9,7 @@ SELECT
   , subq_14.archived_users AS archived_users_join_to_time_spine
 FROM (
   -- Constrain Output with WHERE
-  -- Pass Only Elements: ['metric_time__day',]
+  -- Pass Only Elements: ['metric_time__day']
   SELECT
     metric_time__day
   FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Trino/test_join_to_time_spine_with_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Trino/test_join_to_time_spine_with_filters__plan0.sql
@@ -17,7 +17,7 @@ FROM (
       subq_11.metric_time__day AS metric_time__day
       , subq_6.bookings AS bookings
     FROM (
-      -- Pass Only Elements: ['metric_time__day',]
+      -- Pass Only Elements: ['metric_time__day']
       SELECT
         subq_10.metric_time__day
       FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Trino/test_join_to_time_spine_with_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Trino/test_join_to_time_spine_with_filters__plan0_optimized.sql
@@ -15,7 +15,7 @@ FROM (
   FROM (
     -- Constrain Output with WHERE
     -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       metric_time__day
     FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Trino/test_simple_fill_nulls_with_0_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Trino/test_simple_fill_nulls_with_0_metric_time__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_6.metric_time__day AS metric_time__day
     , subq_3.bookings AS bookings
   FROM (
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       subq_5.metric_time__day
     FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Trino/test_simple_fill_nulls_with_0_month__plan0.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Trino/test_simple_fill_nulls_with_0_month__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_6.metric_time__month AS metric_time__month
     , subq_3.bookings AS bookings
   FROM (
-    -- Pass Only Elements: ['metric_time__month',]
+    -- Pass Only Elements: ['metric_time__month']
     SELECT
       subq_5.metric_time__month
     FROM (

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Trino/test_simple_fill_nulls_with_0_month__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlPlan/Trino/test_simple_fill_nulls_with_0_month__plan0_optimized.sql
@@ -14,7 +14,7 @@ FROM (
   FROM (
     -- Read From Time Spine 'mf_time_spine'
     -- Change Column Aliases
-    -- Pass Only Elements: ['metric_time__month',]
+    -- Pass Only Elements: ['metric_time__month']
     SELECT
       DATE_TRUNC('month', ds) AS metric_time__month
     FROM ***************************.mf_time_spine time_spine_src_28006

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/BigQuery/test_metric_time_date_part__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/BigQuery/test_metric_time_date_part__plan0.sql
@@ -2,7 +2,7 @@ test_name: test_metric_time_date_part
 test_filename: test_granularity_date_part_rendering.py
 sql_engine: BigQuery
 ---
--- Pass Only Elements: ['metric_time__extract_year',]
+-- Pass Only Elements: ['metric_time__extract_year']
 SELECT
   subq_1.metric_time__extract_year
 FROM (

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/BigQuery/test_metric_time_date_part__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/BigQuery/test_metric_time_date_part__plan0_optimized.sql
@@ -4,7 +4,7 @@ sql_engine: BigQuery
 ---
 -- Read From Time Spine 'mf_time_spine'
 -- Metric Time Dimension 'ds'
--- Pass Only Elements: ['metric_time__extract_year',]
+-- Pass Only Elements: ['metric_time__extract_year']
 SELECT
   EXTRACT(year FROM ds) AS metric_time__extract_year
 FROM ***************************.mf_time_spine time_spine_src_28006

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/BigQuery/test_sub_daily_dimension__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/BigQuery/test_sub_daily_dimension__plan0.sql
@@ -2,7 +2,7 @@ test_name: test_sub_daily_dimension
 test_filename: test_granularity_date_part_rendering.py
 sql_engine: BigQuery
 ---
--- Pass Only Elements: ['user__bio_added_ts__second',]
+-- Pass Only Elements: ['user__bio_added_ts__second']
 SELECT
   subq_0.user__bio_added_ts__second
 FROM (

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/BigQuery/test_sub_daily_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/BigQuery/test_sub_daily_dimension__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_granularity_date_part_rendering.py
 sql_engine: BigQuery
 ---
 -- Read Elements From Semantic Model 'users_ds_source'
--- Pass Only Elements: ['user__bio_added_ts__second',]
+-- Pass Only Elements: ['user__bio_added_ts__second']
 SELECT
   DATETIME_TRUNC(bio_added_ts, second) AS user__bio_added_ts__second
 FROM ***************************.dim_users users_ds_source_src_28000

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/BigQuery/test_sub_daily_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/BigQuery/test_sub_daily_metric_time__plan0.sql
@@ -2,7 +2,7 @@ test_name: test_sub_daily_metric_time
 test_filename: test_granularity_date_part_rendering.py
 sql_engine: BigQuery
 ---
--- Pass Only Elements: ['metric_time__millisecond',]
+-- Pass Only Elements: ['metric_time__millisecond']
 SELECT
   subq_1.metric_time__millisecond
 FROM (

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/BigQuery/test_sub_daily_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/BigQuery/test_sub_daily_metric_time__plan0_optimized.sql
@@ -4,7 +4,7 @@ sql_engine: BigQuery
 ---
 -- Read From Time Spine 'mf_time_spine_millisecond'
 -- Metric Time Dimension 'ts'
--- Pass Only Elements: ['metric_time__millisecond',]
+-- Pass Only Elements: ['metric_time__millisecond']
 SELECT
   ts AS metric_time__millisecond
 FROM ***************************.mf_time_spine_millisecond time_spine_src_28002

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/BigQuery/test_subdaily_granularity_overrides_metric_default_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/BigQuery/test_subdaily_granularity_overrides_metric_default_granularity__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_6.metric_time__hour AS metric_time__hour
     , subq_3.archived_users AS archived_users
   FROM (
-    -- Pass Only Elements: ['metric_time__hour',]
+    -- Pass Only Elements: ['metric_time__hour']
     SELECT
       subq_5.metric_time__hour
     FROM (

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/BigQuery/test_subdaily_join_to_time_spine_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/BigQuery/test_subdaily_join_to_time_spine_metric__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_6.metric_time__hour AS metric_time__hour
     , subq_3.archived_users AS archived_users
   FROM (
-    -- Pass Only Elements: ['metric_time__hour',]
+    -- Pass Only Elements: ['metric_time__hour']
     SELECT
       subq_5.metric_time__hour
     FROM (

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/BigQuery/test_subdaily_offset_to_grain_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/BigQuery/test_subdaily_offset_to_grain_metric__plan0.sql
@@ -215,7 +215,7 @@ FROM (
           , subq_1.user__home_state AS user__home_state
           , subq_1.archived_users AS archived_users
         FROM (
-          -- Pass Only Elements: ['metric_time__hour',]
+          -- Pass Only Elements: ['metric_time__hour']
           SELECT
             subq_3.metric_time__hour
           FROM (

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/BigQuery/test_subdaily_offset_window_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/BigQuery/test_subdaily_offset_window_metric__plan0.sql
@@ -215,7 +215,7 @@ FROM (
           , subq_1.user__home_state AS user__home_state
           , subq_1.archived_users AS archived_users
         FROM (
-          -- Pass Only Elements: ['metric_time__hour',]
+          -- Pass Only Elements: ['metric_time__hour']
           SELECT
             subq_3.metric_time__hour
           FROM (

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/BigQuery/test_subdaily_time_constraint_with_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/BigQuery/test_subdaily_time_constraint_with_metric__plan0.sql
@@ -17,7 +17,7 @@ FROM (
       subq_9.metric_time__hour AS metric_time__hour
       , subq_5.archived_users AS archived_users
     FROM (
-      -- Pass Only Elements: ['metric_time__hour',]
+      -- Pass Only Elements: ['metric_time__hour']
       SELECT
         subq_8.metric_time__hour
       FROM (

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/BigQuery/test_subdaily_time_constraint_with_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/BigQuery/test_subdaily_time_constraint_with_metric__plan0_optimized.sql
@@ -12,7 +12,7 @@ FROM (
   -- Read From Time Spine 'mf_time_spine_hour'
   -- Change Column Aliases
   -- Constrain Time Range to [2020-01-01T02:00:00, 2020-01-01T05:00:00]
-  -- Pass Only Elements: ['metric_time__hour',]
+  -- Pass Only Elements: ['metric_time__hour']
   SELECT
     ts AS metric_time__hour
   FROM ***************************.mf_time_spine_hour time_spine_src_28005

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/BigQuery/test_subdaily_time_constraint_without_metrics__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/BigQuery/test_subdaily_time_constraint_without_metrics__plan0.sql
@@ -2,7 +2,7 @@ test_name: test_subdaily_time_constraint_without_metrics
 test_filename: test_granularity_date_part_rendering.py
 sql_engine: BigQuery
 ---
--- Pass Only Elements: ['metric_time__second',]
+-- Pass Only Elements: ['metric_time__second']
 SELECT
   subq_2.metric_time__second
 FROM (

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/BigQuery/test_subdaily_time_constraint_without_metrics__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/BigQuery/test_subdaily_time_constraint_without_metrics__plan0_optimized.sql
@@ -5,7 +5,7 @@ sql_engine: BigQuery
 -- Read From Time Spine 'mf_time_spine_second'
 -- Metric Time Dimension 'ts'
 -- Constrain Time Range to [2020-01-01T00:00:02, 2020-01-01T00:00:08]
--- Pass Only Elements: ['metric_time__second',]
+-- Pass Only Elements: ['metric_time__second']
 SELECT
   ts AS metric_time__second
 FROM ***************************.mf_time_spine_second time_spine_src_28003

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Databricks/test_metric_time_date_part__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Databricks/test_metric_time_date_part__plan0.sql
@@ -2,7 +2,7 @@ test_name: test_metric_time_date_part
 test_filename: test_granularity_date_part_rendering.py
 sql_engine: Databricks
 ---
--- Pass Only Elements: ['metric_time__extract_year',]
+-- Pass Only Elements: ['metric_time__extract_year']
 SELECT
   subq_1.metric_time__extract_year
 FROM (

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Databricks/test_metric_time_date_part__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Databricks/test_metric_time_date_part__plan0_optimized.sql
@@ -4,7 +4,7 @@ sql_engine: Databricks
 ---
 -- Read From Time Spine 'mf_time_spine'
 -- Metric Time Dimension 'ds'
--- Pass Only Elements: ['metric_time__extract_year',]
+-- Pass Only Elements: ['metric_time__extract_year']
 SELECT
   EXTRACT(year FROM ds) AS metric_time__extract_year
 FROM ***************************.mf_time_spine time_spine_src_28006

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Databricks/test_sub_daily_dimension__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Databricks/test_sub_daily_dimension__plan0.sql
@@ -2,7 +2,7 @@ test_name: test_sub_daily_dimension
 test_filename: test_granularity_date_part_rendering.py
 sql_engine: Databricks
 ---
--- Pass Only Elements: ['user__bio_added_ts__second',]
+-- Pass Only Elements: ['user__bio_added_ts__second']
 SELECT
   subq_0.user__bio_added_ts__second
 FROM (

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Databricks/test_sub_daily_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Databricks/test_sub_daily_dimension__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_granularity_date_part_rendering.py
 sql_engine: Databricks
 ---
 -- Read Elements From Semantic Model 'users_ds_source'
--- Pass Only Elements: ['user__bio_added_ts__second',]
+-- Pass Only Elements: ['user__bio_added_ts__second']
 SELECT
   DATE_TRUNC('second', bio_added_ts) AS user__bio_added_ts__second
 FROM ***************************.dim_users users_ds_source_src_28000

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Databricks/test_sub_daily_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Databricks/test_sub_daily_metric_time__plan0.sql
@@ -2,7 +2,7 @@ test_name: test_sub_daily_metric_time
 test_filename: test_granularity_date_part_rendering.py
 sql_engine: Databricks
 ---
--- Pass Only Elements: ['metric_time__millisecond',]
+-- Pass Only Elements: ['metric_time__millisecond']
 SELECT
   subq_1.metric_time__millisecond
 FROM (

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Databricks/test_sub_daily_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Databricks/test_sub_daily_metric_time__plan0_optimized.sql
@@ -4,7 +4,7 @@ sql_engine: Databricks
 ---
 -- Read From Time Spine 'mf_time_spine_millisecond'
 -- Metric Time Dimension 'ts'
--- Pass Only Elements: ['metric_time__millisecond',]
+-- Pass Only Elements: ['metric_time__millisecond']
 SELECT
   ts AS metric_time__millisecond
 FROM ***************************.mf_time_spine_millisecond time_spine_src_28002

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Databricks/test_subdaily_granularity_overrides_metric_default_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Databricks/test_subdaily_granularity_overrides_metric_default_granularity__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_6.metric_time__hour AS metric_time__hour
     , subq_3.archived_users AS archived_users
   FROM (
-    -- Pass Only Elements: ['metric_time__hour',]
+    -- Pass Only Elements: ['metric_time__hour']
     SELECT
       subq_5.metric_time__hour
     FROM (

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Databricks/test_subdaily_join_to_time_spine_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Databricks/test_subdaily_join_to_time_spine_metric__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_6.metric_time__hour AS metric_time__hour
     , subq_3.archived_users AS archived_users
   FROM (
-    -- Pass Only Elements: ['metric_time__hour',]
+    -- Pass Only Elements: ['metric_time__hour']
     SELECT
       subq_5.metric_time__hour
     FROM (

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Databricks/test_subdaily_offset_to_grain_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Databricks/test_subdaily_offset_to_grain_metric__plan0.sql
@@ -215,7 +215,7 @@ FROM (
           , subq_1.user__home_state AS user__home_state
           , subq_1.archived_users AS archived_users
         FROM (
-          -- Pass Only Elements: ['metric_time__hour',]
+          -- Pass Only Elements: ['metric_time__hour']
           SELECT
             subq_3.metric_time__hour
           FROM (

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Databricks/test_subdaily_offset_window_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Databricks/test_subdaily_offset_window_metric__plan0.sql
@@ -215,7 +215,7 @@ FROM (
           , subq_1.user__home_state AS user__home_state
           , subq_1.archived_users AS archived_users
         FROM (
-          -- Pass Only Elements: ['metric_time__hour',]
+          -- Pass Only Elements: ['metric_time__hour']
           SELECT
             subq_3.metric_time__hour
           FROM (

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Databricks/test_subdaily_time_constraint_with_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Databricks/test_subdaily_time_constraint_with_metric__plan0.sql
@@ -17,7 +17,7 @@ FROM (
       subq_9.metric_time__hour AS metric_time__hour
       , subq_5.archived_users AS archived_users
     FROM (
-      -- Pass Only Elements: ['metric_time__hour',]
+      -- Pass Only Elements: ['metric_time__hour']
       SELECT
         subq_8.metric_time__hour
       FROM (

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Databricks/test_subdaily_time_constraint_with_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Databricks/test_subdaily_time_constraint_with_metric__plan0_optimized.sql
@@ -12,7 +12,7 @@ FROM (
   -- Read From Time Spine 'mf_time_spine_hour'
   -- Change Column Aliases
   -- Constrain Time Range to [2020-01-01T02:00:00, 2020-01-01T05:00:00]
-  -- Pass Only Elements: ['metric_time__hour',]
+  -- Pass Only Elements: ['metric_time__hour']
   SELECT
     ts AS metric_time__hour
   FROM ***************************.mf_time_spine_hour time_spine_src_28005

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Databricks/test_subdaily_time_constraint_without_metrics__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Databricks/test_subdaily_time_constraint_without_metrics__plan0.sql
@@ -2,7 +2,7 @@ test_name: test_subdaily_time_constraint_without_metrics
 test_filename: test_granularity_date_part_rendering.py
 sql_engine: Databricks
 ---
--- Pass Only Elements: ['metric_time__second',]
+-- Pass Only Elements: ['metric_time__second']
 SELECT
   subq_2.metric_time__second
 FROM (

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Databricks/test_subdaily_time_constraint_without_metrics__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Databricks/test_subdaily_time_constraint_without_metrics__plan0_optimized.sql
@@ -5,7 +5,7 @@ sql_engine: Databricks
 -- Read From Time Spine 'mf_time_spine_second'
 -- Metric Time Dimension 'ts'
 -- Constrain Time Range to [2020-01-01T00:00:02, 2020-01-01T00:00:08]
--- Pass Only Elements: ['metric_time__second',]
+-- Pass Only Elements: ['metric_time__second']
 SELECT
   ts AS metric_time__second
 FROM ***************************.mf_time_spine_second time_spine_src_28003

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/DuckDB/test_metric_time_date_part__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/DuckDB/test_metric_time_date_part__plan0.sql
@@ -2,7 +2,7 @@ test_name: test_metric_time_date_part
 test_filename: test_granularity_date_part_rendering.py
 sql_engine: DuckDB
 ---
--- Pass Only Elements: ['metric_time__extract_year',]
+-- Pass Only Elements: ['metric_time__extract_year']
 SELECT
   subq_1.metric_time__extract_year
 FROM (

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/DuckDB/test_metric_time_date_part__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/DuckDB/test_metric_time_date_part__plan0_optimized.sql
@@ -4,7 +4,7 @@ sql_engine: DuckDB
 ---
 -- Read From Time Spine 'mf_time_spine'
 -- Metric Time Dimension 'ds'
--- Pass Only Elements: ['metric_time__extract_year',]
+-- Pass Only Elements: ['metric_time__extract_year']
 SELECT
   EXTRACT(year FROM ds) AS metric_time__extract_year
 FROM ***************************.mf_time_spine time_spine_src_28006

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/DuckDB/test_sub_daily_dimension__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/DuckDB/test_sub_daily_dimension__plan0.sql
@@ -2,7 +2,7 @@ test_name: test_sub_daily_dimension
 test_filename: test_granularity_date_part_rendering.py
 sql_engine: DuckDB
 ---
--- Pass Only Elements: ['user__bio_added_ts__second',]
+-- Pass Only Elements: ['user__bio_added_ts__second']
 SELECT
   subq_0.user__bio_added_ts__second
 FROM (

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/DuckDB/test_sub_daily_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/DuckDB/test_sub_daily_dimension__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_granularity_date_part_rendering.py
 sql_engine: DuckDB
 ---
 -- Read Elements From Semantic Model 'users_ds_source'
--- Pass Only Elements: ['user__bio_added_ts__second',]
+-- Pass Only Elements: ['user__bio_added_ts__second']
 SELECT
   DATE_TRUNC('second', bio_added_ts) AS user__bio_added_ts__second
 FROM ***************************.dim_users users_ds_source_src_28000

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/DuckDB/test_sub_daily_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/DuckDB/test_sub_daily_metric_time__plan0.sql
@@ -2,7 +2,7 @@ test_name: test_sub_daily_metric_time
 test_filename: test_granularity_date_part_rendering.py
 sql_engine: DuckDB
 ---
--- Pass Only Elements: ['metric_time__millisecond',]
+-- Pass Only Elements: ['metric_time__millisecond']
 SELECT
   subq_1.metric_time__millisecond
 FROM (

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/DuckDB/test_sub_daily_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/DuckDB/test_sub_daily_metric_time__plan0_optimized.sql
@@ -4,7 +4,7 @@ sql_engine: DuckDB
 ---
 -- Read From Time Spine 'mf_time_spine_millisecond'
 -- Metric Time Dimension 'ts'
--- Pass Only Elements: ['metric_time__millisecond',]
+-- Pass Only Elements: ['metric_time__millisecond']
 SELECT
   ts AS metric_time__millisecond
 FROM ***************************.mf_time_spine_millisecond time_spine_src_28002

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/DuckDB/test_subdaily_granularity_overrides_metric_default_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/DuckDB/test_subdaily_granularity_overrides_metric_default_granularity__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_6.metric_time__hour AS metric_time__hour
     , subq_3.archived_users AS archived_users
   FROM (
-    -- Pass Only Elements: ['metric_time__hour',]
+    -- Pass Only Elements: ['metric_time__hour']
     SELECT
       subq_5.metric_time__hour
     FROM (

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/DuckDB/test_subdaily_join_to_time_spine_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/DuckDB/test_subdaily_join_to_time_spine_metric__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_6.metric_time__hour AS metric_time__hour
     , subq_3.archived_users AS archived_users
   FROM (
-    -- Pass Only Elements: ['metric_time__hour',]
+    -- Pass Only Elements: ['metric_time__hour']
     SELECT
       subq_5.metric_time__hour
     FROM (

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/DuckDB/test_subdaily_offset_to_grain_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/DuckDB/test_subdaily_offset_to_grain_metric__plan0.sql
@@ -215,7 +215,7 @@ FROM (
           , subq_1.user__home_state AS user__home_state
           , subq_1.archived_users AS archived_users
         FROM (
-          -- Pass Only Elements: ['metric_time__hour',]
+          -- Pass Only Elements: ['metric_time__hour']
           SELECT
             subq_3.metric_time__hour
           FROM (

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/DuckDB/test_subdaily_offset_window_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/DuckDB/test_subdaily_offset_window_metric__plan0.sql
@@ -215,7 +215,7 @@ FROM (
           , subq_1.user__home_state AS user__home_state
           , subq_1.archived_users AS archived_users
         FROM (
-          -- Pass Only Elements: ['metric_time__hour',]
+          -- Pass Only Elements: ['metric_time__hour']
           SELECT
             subq_3.metric_time__hour
           FROM (

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/DuckDB/test_subdaily_time_constraint_with_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/DuckDB/test_subdaily_time_constraint_with_metric__plan0.sql
@@ -17,7 +17,7 @@ FROM (
       subq_9.metric_time__hour AS metric_time__hour
       , subq_5.archived_users AS archived_users
     FROM (
-      -- Pass Only Elements: ['metric_time__hour',]
+      -- Pass Only Elements: ['metric_time__hour']
       SELECT
         subq_8.metric_time__hour
       FROM (

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/DuckDB/test_subdaily_time_constraint_with_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/DuckDB/test_subdaily_time_constraint_with_metric__plan0_optimized.sql
@@ -12,7 +12,7 @@ FROM (
   -- Read From Time Spine 'mf_time_spine_hour'
   -- Change Column Aliases
   -- Constrain Time Range to [2020-01-01T02:00:00, 2020-01-01T05:00:00]
-  -- Pass Only Elements: ['metric_time__hour',]
+  -- Pass Only Elements: ['metric_time__hour']
   SELECT
     ts AS metric_time__hour
   FROM ***************************.mf_time_spine_hour time_spine_src_28005

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/DuckDB/test_subdaily_time_constraint_without_metrics__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/DuckDB/test_subdaily_time_constraint_without_metrics__plan0.sql
@@ -2,7 +2,7 @@ test_name: test_subdaily_time_constraint_without_metrics
 test_filename: test_granularity_date_part_rendering.py
 sql_engine: DuckDB
 ---
--- Pass Only Elements: ['metric_time__second',]
+-- Pass Only Elements: ['metric_time__second']
 SELECT
   subq_2.metric_time__second
 FROM (

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/DuckDB/test_subdaily_time_constraint_without_metrics__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/DuckDB/test_subdaily_time_constraint_without_metrics__plan0_optimized.sql
@@ -5,7 +5,7 @@ sql_engine: DuckDB
 -- Read From Time Spine 'mf_time_spine_second'
 -- Metric Time Dimension 'ts'
 -- Constrain Time Range to [2020-01-01T00:00:02, 2020-01-01T00:00:08]
--- Pass Only Elements: ['metric_time__second',]
+-- Pass Only Elements: ['metric_time__second']
 SELECT
   ts AS metric_time__second
 FROM ***************************.mf_time_spine_second time_spine_src_28003

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Postgres/test_metric_time_date_part__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Postgres/test_metric_time_date_part__plan0.sql
@@ -2,7 +2,7 @@ test_name: test_metric_time_date_part
 test_filename: test_granularity_date_part_rendering.py
 sql_engine: Postgres
 ---
--- Pass Only Elements: ['metric_time__extract_year',]
+-- Pass Only Elements: ['metric_time__extract_year']
 SELECT
   subq_1.metric_time__extract_year
 FROM (

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Postgres/test_metric_time_date_part__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Postgres/test_metric_time_date_part__plan0_optimized.sql
@@ -4,7 +4,7 @@ sql_engine: Postgres
 ---
 -- Read From Time Spine 'mf_time_spine'
 -- Metric Time Dimension 'ds'
--- Pass Only Elements: ['metric_time__extract_year',]
+-- Pass Only Elements: ['metric_time__extract_year']
 SELECT
   EXTRACT(year FROM ds) AS metric_time__extract_year
 FROM ***************************.mf_time_spine time_spine_src_28006

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Postgres/test_sub_daily_dimension__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Postgres/test_sub_daily_dimension__plan0.sql
@@ -2,7 +2,7 @@ test_name: test_sub_daily_dimension
 test_filename: test_granularity_date_part_rendering.py
 sql_engine: Postgres
 ---
--- Pass Only Elements: ['user__bio_added_ts__second',]
+-- Pass Only Elements: ['user__bio_added_ts__second']
 SELECT
   subq_0.user__bio_added_ts__second
 FROM (

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Postgres/test_sub_daily_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Postgres/test_sub_daily_dimension__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_granularity_date_part_rendering.py
 sql_engine: Postgres
 ---
 -- Read Elements From Semantic Model 'users_ds_source'
--- Pass Only Elements: ['user__bio_added_ts__second',]
+-- Pass Only Elements: ['user__bio_added_ts__second']
 SELECT
   DATE_TRUNC('second', bio_added_ts) AS user__bio_added_ts__second
 FROM ***************************.dim_users users_ds_source_src_28000

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Postgres/test_sub_daily_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Postgres/test_sub_daily_metric_time__plan0.sql
@@ -2,7 +2,7 @@ test_name: test_sub_daily_metric_time
 test_filename: test_granularity_date_part_rendering.py
 sql_engine: Postgres
 ---
--- Pass Only Elements: ['metric_time__millisecond',]
+-- Pass Only Elements: ['metric_time__millisecond']
 SELECT
   subq_1.metric_time__millisecond
 FROM (

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Postgres/test_sub_daily_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Postgres/test_sub_daily_metric_time__plan0_optimized.sql
@@ -4,7 +4,7 @@ sql_engine: Postgres
 ---
 -- Read From Time Spine 'mf_time_spine_millisecond'
 -- Metric Time Dimension 'ts'
--- Pass Only Elements: ['metric_time__millisecond',]
+-- Pass Only Elements: ['metric_time__millisecond']
 SELECT
   ts AS metric_time__millisecond
 FROM ***************************.mf_time_spine_millisecond time_spine_src_28002

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Postgres/test_subdaily_granularity_overrides_metric_default_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Postgres/test_subdaily_granularity_overrides_metric_default_granularity__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_6.metric_time__hour AS metric_time__hour
     , subq_3.archived_users AS archived_users
   FROM (
-    -- Pass Only Elements: ['metric_time__hour',]
+    -- Pass Only Elements: ['metric_time__hour']
     SELECT
       subq_5.metric_time__hour
     FROM (

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Postgres/test_subdaily_join_to_time_spine_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Postgres/test_subdaily_join_to_time_spine_metric__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_6.metric_time__hour AS metric_time__hour
     , subq_3.archived_users AS archived_users
   FROM (
-    -- Pass Only Elements: ['metric_time__hour',]
+    -- Pass Only Elements: ['metric_time__hour']
     SELECT
       subq_5.metric_time__hour
     FROM (

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Postgres/test_subdaily_offset_to_grain_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Postgres/test_subdaily_offset_to_grain_metric__plan0.sql
@@ -215,7 +215,7 @@ FROM (
           , subq_1.user__home_state AS user__home_state
           , subq_1.archived_users AS archived_users
         FROM (
-          -- Pass Only Elements: ['metric_time__hour',]
+          -- Pass Only Elements: ['metric_time__hour']
           SELECT
             subq_3.metric_time__hour
           FROM (

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Postgres/test_subdaily_offset_window_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Postgres/test_subdaily_offset_window_metric__plan0.sql
@@ -215,7 +215,7 @@ FROM (
           , subq_1.user__home_state AS user__home_state
           , subq_1.archived_users AS archived_users
         FROM (
-          -- Pass Only Elements: ['metric_time__hour',]
+          -- Pass Only Elements: ['metric_time__hour']
           SELECT
             subq_3.metric_time__hour
           FROM (

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Postgres/test_subdaily_time_constraint_with_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Postgres/test_subdaily_time_constraint_with_metric__plan0.sql
@@ -17,7 +17,7 @@ FROM (
       subq_9.metric_time__hour AS metric_time__hour
       , subq_5.archived_users AS archived_users
     FROM (
-      -- Pass Only Elements: ['metric_time__hour',]
+      -- Pass Only Elements: ['metric_time__hour']
       SELECT
         subq_8.metric_time__hour
       FROM (

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Postgres/test_subdaily_time_constraint_with_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Postgres/test_subdaily_time_constraint_with_metric__plan0_optimized.sql
@@ -12,7 +12,7 @@ FROM (
   -- Read From Time Spine 'mf_time_spine_hour'
   -- Change Column Aliases
   -- Constrain Time Range to [2020-01-01T02:00:00, 2020-01-01T05:00:00]
-  -- Pass Only Elements: ['metric_time__hour',]
+  -- Pass Only Elements: ['metric_time__hour']
   SELECT
     ts AS metric_time__hour
   FROM ***************************.mf_time_spine_hour time_spine_src_28005

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Postgres/test_subdaily_time_constraint_without_metrics__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Postgres/test_subdaily_time_constraint_without_metrics__plan0.sql
@@ -2,7 +2,7 @@ test_name: test_subdaily_time_constraint_without_metrics
 test_filename: test_granularity_date_part_rendering.py
 sql_engine: Postgres
 ---
--- Pass Only Elements: ['metric_time__second',]
+-- Pass Only Elements: ['metric_time__second']
 SELECT
   subq_2.metric_time__second
 FROM (

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Postgres/test_subdaily_time_constraint_without_metrics__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Postgres/test_subdaily_time_constraint_without_metrics__plan0_optimized.sql
@@ -5,7 +5,7 @@ sql_engine: Postgres
 -- Read From Time Spine 'mf_time_spine_second'
 -- Metric Time Dimension 'ts'
 -- Constrain Time Range to [2020-01-01T00:00:02, 2020-01-01T00:00:08]
--- Pass Only Elements: ['metric_time__second',]
+-- Pass Only Elements: ['metric_time__second']
 SELECT
   ts AS metric_time__second
 FROM ***************************.mf_time_spine_second time_spine_src_28003

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Redshift/test_metric_time_date_part__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Redshift/test_metric_time_date_part__plan0.sql
@@ -2,7 +2,7 @@ test_name: test_metric_time_date_part
 test_filename: test_granularity_date_part_rendering.py
 sql_engine: Redshift
 ---
--- Pass Only Elements: ['metric_time__extract_year',]
+-- Pass Only Elements: ['metric_time__extract_year']
 SELECT
   subq_1.metric_time__extract_year
 FROM (

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Redshift/test_metric_time_date_part__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Redshift/test_metric_time_date_part__plan0_optimized.sql
@@ -4,7 +4,7 @@ sql_engine: Redshift
 ---
 -- Read From Time Spine 'mf_time_spine'
 -- Metric Time Dimension 'ds'
--- Pass Only Elements: ['metric_time__extract_year',]
+-- Pass Only Elements: ['metric_time__extract_year']
 SELECT
   EXTRACT(year FROM ds) AS metric_time__extract_year
 FROM ***************************.mf_time_spine time_spine_src_28006

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Redshift/test_sub_daily_dimension__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Redshift/test_sub_daily_dimension__plan0.sql
@@ -2,7 +2,7 @@ test_name: test_sub_daily_dimension
 test_filename: test_granularity_date_part_rendering.py
 sql_engine: Redshift
 ---
--- Pass Only Elements: ['user__bio_added_ts__second',]
+-- Pass Only Elements: ['user__bio_added_ts__second']
 SELECT
   subq_0.user__bio_added_ts__second
 FROM (

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Redshift/test_sub_daily_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Redshift/test_sub_daily_dimension__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_granularity_date_part_rendering.py
 sql_engine: Redshift
 ---
 -- Read Elements From Semantic Model 'users_ds_source'
--- Pass Only Elements: ['user__bio_added_ts__second',]
+-- Pass Only Elements: ['user__bio_added_ts__second']
 SELECT
   DATE_TRUNC('second', bio_added_ts) AS user__bio_added_ts__second
 FROM ***************************.dim_users users_ds_source_src_28000

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Redshift/test_sub_daily_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Redshift/test_sub_daily_metric_time__plan0.sql
@@ -2,7 +2,7 @@ test_name: test_sub_daily_metric_time
 test_filename: test_granularity_date_part_rendering.py
 sql_engine: Redshift
 ---
--- Pass Only Elements: ['metric_time__millisecond',]
+-- Pass Only Elements: ['metric_time__millisecond']
 SELECT
   subq_1.metric_time__millisecond
 FROM (

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Redshift/test_sub_daily_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Redshift/test_sub_daily_metric_time__plan0_optimized.sql
@@ -4,7 +4,7 @@ sql_engine: Redshift
 ---
 -- Read From Time Spine 'mf_time_spine_millisecond'
 -- Metric Time Dimension 'ts'
--- Pass Only Elements: ['metric_time__millisecond',]
+-- Pass Only Elements: ['metric_time__millisecond']
 SELECT
   ts AS metric_time__millisecond
 FROM ***************************.mf_time_spine_millisecond time_spine_src_28002

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Redshift/test_subdaily_granularity_overrides_metric_default_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Redshift/test_subdaily_granularity_overrides_metric_default_granularity__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_6.metric_time__hour AS metric_time__hour
     , subq_3.archived_users AS archived_users
   FROM (
-    -- Pass Only Elements: ['metric_time__hour',]
+    -- Pass Only Elements: ['metric_time__hour']
     SELECT
       subq_5.metric_time__hour
     FROM (

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Redshift/test_subdaily_join_to_time_spine_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Redshift/test_subdaily_join_to_time_spine_metric__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_6.metric_time__hour AS metric_time__hour
     , subq_3.archived_users AS archived_users
   FROM (
-    -- Pass Only Elements: ['metric_time__hour',]
+    -- Pass Only Elements: ['metric_time__hour']
     SELECT
       subq_5.metric_time__hour
     FROM (

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Redshift/test_subdaily_offset_to_grain_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Redshift/test_subdaily_offset_to_grain_metric__plan0.sql
@@ -215,7 +215,7 @@ FROM (
           , subq_1.user__home_state AS user__home_state
           , subq_1.archived_users AS archived_users
         FROM (
-          -- Pass Only Elements: ['metric_time__hour',]
+          -- Pass Only Elements: ['metric_time__hour']
           SELECT
             subq_3.metric_time__hour
           FROM (

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Redshift/test_subdaily_offset_window_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Redshift/test_subdaily_offset_window_metric__plan0.sql
@@ -215,7 +215,7 @@ FROM (
           , subq_1.user__home_state AS user__home_state
           , subq_1.archived_users AS archived_users
         FROM (
-          -- Pass Only Elements: ['metric_time__hour',]
+          -- Pass Only Elements: ['metric_time__hour']
           SELECT
             subq_3.metric_time__hour
           FROM (

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Redshift/test_subdaily_time_constraint_with_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Redshift/test_subdaily_time_constraint_with_metric__plan0.sql
@@ -17,7 +17,7 @@ FROM (
       subq_9.metric_time__hour AS metric_time__hour
       , subq_5.archived_users AS archived_users
     FROM (
-      -- Pass Only Elements: ['metric_time__hour',]
+      -- Pass Only Elements: ['metric_time__hour']
       SELECT
         subq_8.metric_time__hour
       FROM (

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Redshift/test_subdaily_time_constraint_with_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Redshift/test_subdaily_time_constraint_with_metric__plan0_optimized.sql
@@ -12,7 +12,7 @@ FROM (
   -- Read From Time Spine 'mf_time_spine_hour'
   -- Change Column Aliases
   -- Constrain Time Range to [2020-01-01T02:00:00, 2020-01-01T05:00:00]
-  -- Pass Only Elements: ['metric_time__hour',]
+  -- Pass Only Elements: ['metric_time__hour']
   SELECT
     ts AS metric_time__hour
   FROM ***************************.mf_time_spine_hour time_spine_src_28005

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Redshift/test_subdaily_time_constraint_without_metrics__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Redshift/test_subdaily_time_constraint_without_metrics__plan0.sql
@@ -2,7 +2,7 @@ test_name: test_subdaily_time_constraint_without_metrics
 test_filename: test_granularity_date_part_rendering.py
 sql_engine: Redshift
 ---
--- Pass Only Elements: ['metric_time__second',]
+-- Pass Only Elements: ['metric_time__second']
 SELECT
   subq_2.metric_time__second
 FROM (

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Redshift/test_subdaily_time_constraint_without_metrics__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Redshift/test_subdaily_time_constraint_without_metrics__plan0_optimized.sql
@@ -5,7 +5,7 @@ sql_engine: Redshift
 -- Read From Time Spine 'mf_time_spine_second'
 -- Metric Time Dimension 'ts'
 -- Constrain Time Range to [2020-01-01T00:00:02, 2020-01-01T00:00:08]
--- Pass Only Elements: ['metric_time__second',]
+-- Pass Only Elements: ['metric_time__second']
 SELECT
   ts AS metric_time__second
 FROM ***************************.mf_time_spine_second time_spine_src_28003

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Snowflake/test_metric_time_date_part__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Snowflake/test_metric_time_date_part__plan0.sql
@@ -2,7 +2,7 @@ test_name: test_metric_time_date_part
 test_filename: test_granularity_date_part_rendering.py
 sql_engine: Snowflake
 ---
--- Pass Only Elements: ['metric_time__extract_year',]
+-- Pass Only Elements: ['metric_time__extract_year']
 SELECT
   subq_1.metric_time__extract_year
 FROM (

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Snowflake/test_metric_time_date_part__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Snowflake/test_metric_time_date_part__plan0_optimized.sql
@@ -4,7 +4,7 @@ sql_engine: Snowflake
 ---
 -- Read From Time Spine 'mf_time_spine'
 -- Metric Time Dimension 'ds'
--- Pass Only Elements: ['metric_time__extract_year',]
+-- Pass Only Elements: ['metric_time__extract_year']
 SELECT
   EXTRACT(year FROM ds) AS metric_time__extract_year
 FROM ***************************.mf_time_spine time_spine_src_28006

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Snowflake/test_sub_daily_dimension__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Snowflake/test_sub_daily_dimension__plan0.sql
@@ -2,7 +2,7 @@ test_name: test_sub_daily_dimension
 test_filename: test_granularity_date_part_rendering.py
 sql_engine: Snowflake
 ---
--- Pass Only Elements: ['user__bio_added_ts__second',]
+-- Pass Only Elements: ['user__bio_added_ts__second']
 SELECT
   subq_0.user__bio_added_ts__second
 FROM (

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Snowflake/test_sub_daily_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Snowflake/test_sub_daily_dimension__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_granularity_date_part_rendering.py
 sql_engine: Snowflake
 ---
 -- Read Elements From Semantic Model 'users_ds_source'
--- Pass Only Elements: ['user__bio_added_ts__second',]
+-- Pass Only Elements: ['user__bio_added_ts__second']
 SELECT
   DATE_TRUNC('second', bio_added_ts) AS user__bio_added_ts__second
 FROM ***************************.dim_users users_ds_source_src_28000

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Snowflake/test_sub_daily_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Snowflake/test_sub_daily_metric_time__plan0.sql
@@ -2,7 +2,7 @@ test_name: test_sub_daily_metric_time
 test_filename: test_granularity_date_part_rendering.py
 sql_engine: Snowflake
 ---
--- Pass Only Elements: ['metric_time__millisecond',]
+-- Pass Only Elements: ['metric_time__millisecond']
 SELECT
   subq_1.metric_time__millisecond
 FROM (

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Snowflake/test_sub_daily_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Snowflake/test_sub_daily_metric_time__plan0_optimized.sql
@@ -4,7 +4,7 @@ sql_engine: Snowflake
 ---
 -- Read From Time Spine 'mf_time_spine_millisecond'
 -- Metric Time Dimension 'ts'
--- Pass Only Elements: ['metric_time__millisecond',]
+-- Pass Only Elements: ['metric_time__millisecond']
 SELECT
   ts AS metric_time__millisecond
 FROM ***************************.mf_time_spine_millisecond time_spine_src_28002

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Snowflake/test_subdaily_granularity_overrides_metric_default_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Snowflake/test_subdaily_granularity_overrides_metric_default_granularity__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_6.metric_time__hour AS metric_time__hour
     , subq_3.archived_users AS archived_users
   FROM (
-    -- Pass Only Elements: ['metric_time__hour',]
+    -- Pass Only Elements: ['metric_time__hour']
     SELECT
       subq_5.metric_time__hour
     FROM (

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Snowflake/test_subdaily_join_to_time_spine_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Snowflake/test_subdaily_join_to_time_spine_metric__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_6.metric_time__hour AS metric_time__hour
     , subq_3.archived_users AS archived_users
   FROM (
-    -- Pass Only Elements: ['metric_time__hour',]
+    -- Pass Only Elements: ['metric_time__hour']
     SELECT
       subq_5.metric_time__hour
     FROM (

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Snowflake/test_subdaily_offset_to_grain_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Snowflake/test_subdaily_offset_to_grain_metric__plan0.sql
@@ -215,7 +215,7 @@ FROM (
           , subq_1.user__home_state AS user__home_state
           , subq_1.archived_users AS archived_users
         FROM (
-          -- Pass Only Elements: ['metric_time__hour',]
+          -- Pass Only Elements: ['metric_time__hour']
           SELECT
             subq_3.metric_time__hour
           FROM (

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Snowflake/test_subdaily_offset_window_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Snowflake/test_subdaily_offset_window_metric__plan0.sql
@@ -215,7 +215,7 @@ FROM (
           , subq_1.user__home_state AS user__home_state
           , subq_1.archived_users AS archived_users
         FROM (
-          -- Pass Only Elements: ['metric_time__hour',]
+          -- Pass Only Elements: ['metric_time__hour']
           SELECT
             subq_3.metric_time__hour
           FROM (

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Snowflake/test_subdaily_time_constraint_with_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Snowflake/test_subdaily_time_constraint_with_metric__plan0.sql
@@ -17,7 +17,7 @@ FROM (
       subq_9.metric_time__hour AS metric_time__hour
       , subq_5.archived_users AS archived_users
     FROM (
-      -- Pass Only Elements: ['metric_time__hour',]
+      -- Pass Only Elements: ['metric_time__hour']
       SELECT
         subq_8.metric_time__hour
       FROM (

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Snowflake/test_subdaily_time_constraint_with_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Snowflake/test_subdaily_time_constraint_with_metric__plan0_optimized.sql
@@ -12,7 +12,7 @@ FROM (
   -- Read From Time Spine 'mf_time_spine_hour'
   -- Change Column Aliases
   -- Constrain Time Range to [2020-01-01T02:00:00, 2020-01-01T05:00:00]
-  -- Pass Only Elements: ['metric_time__hour',]
+  -- Pass Only Elements: ['metric_time__hour']
   SELECT
     ts AS metric_time__hour
   FROM ***************************.mf_time_spine_hour time_spine_src_28005

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Snowflake/test_subdaily_time_constraint_without_metrics__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Snowflake/test_subdaily_time_constraint_without_metrics__plan0.sql
@@ -2,7 +2,7 @@ test_name: test_subdaily_time_constraint_without_metrics
 test_filename: test_granularity_date_part_rendering.py
 sql_engine: Snowflake
 ---
--- Pass Only Elements: ['metric_time__second',]
+-- Pass Only Elements: ['metric_time__second']
 SELECT
   subq_2.metric_time__second
 FROM (

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Snowflake/test_subdaily_time_constraint_without_metrics__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Snowflake/test_subdaily_time_constraint_without_metrics__plan0_optimized.sql
@@ -5,7 +5,7 @@ sql_engine: Snowflake
 -- Read From Time Spine 'mf_time_spine_second'
 -- Metric Time Dimension 'ts'
 -- Constrain Time Range to [2020-01-01T00:00:02, 2020-01-01T00:00:08]
--- Pass Only Elements: ['metric_time__second',]
+-- Pass Only Elements: ['metric_time__second']
 SELECT
   ts AS metric_time__second
 FROM ***************************.mf_time_spine_second time_spine_src_28003

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Trino/test_metric_time_date_part__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Trino/test_metric_time_date_part__plan0.sql
@@ -2,7 +2,7 @@ test_name: test_metric_time_date_part
 test_filename: test_granularity_date_part_rendering.py
 sql_engine: Trino
 ---
--- Pass Only Elements: ['metric_time__extract_year',]
+-- Pass Only Elements: ['metric_time__extract_year']
 SELECT
   subq_1.metric_time__extract_year
 FROM (

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Trino/test_metric_time_date_part__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Trino/test_metric_time_date_part__plan0_optimized.sql
@@ -4,7 +4,7 @@ sql_engine: Trino
 ---
 -- Read From Time Spine 'mf_time_spine'
 -- Metric Time Dimension 'ds'
--- Pass Only Elements: ['metric_time__extract_year',]
+-- Pass Only Elements: ['metric_time__extract_year']
 SELECT
   EXTRACT(year FROM ds) AS metric_time__extract_year
 FROM ***************************.mf_time_spine time_spine_src_28006

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Trino/test_sub_daily_dimension__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Trino/test_sub_daily_dimension__plan0.sql
@@ -2,7 +2,7 @@ test_name: test_sub_daily_dimension
 test_filename: test_granularity_date_part_rendering.py
 sql_engine: Trino
 ---
--- Pass Only Elements: ['user__bio_added_ts__second',]
+-- Pass Only Elements: ['user__bio_added_ts__second']
 SELECT
   subq_0.user__bio_added_ts__second
 FROM (

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Trino/test_sub_daily_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Trino/test_sub_daily_dimension__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_granularity_date_part_rendering.py
 sql_engine: Trino
 ---
 -- Read Elements From Semantic Model 'users_ds_source'
--- Pass Only Elements: ['user__bio_added_ts__second',]
+-- Pass Only Elements: ['user__bio_added_ts__second']
 SELECT
   DATE_TRUNC('second', bio_added_ts) AS user__bio_added_ts__second
 FROM ***************************.dim_users users_ds_source_src_28000

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Trino/test_sub_daily_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Trino/test_sub_daily_metric_time__plan0.sql
@@ -2,7 +2,7 @@ test_name: test_sub_daily_metric_time
 test_filename: test_granularity_date_part_rendering.py
 sql_engine: Trino
 ---
--- Pass Only Elements: ['metric_time__millisecond',]
+-- Pass Only Elements: ['metric_time__millisecond']
 SELECT
   subq_1.metric_time__millisecond
 FROM (

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Trino/test_sub_daily_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Trino/test_sub_daily_metric_time__plan0_optimized.sql
@@ -4,7 +4,7 @@ sql_engine: Trino
 ---
 -- Read From Time Spine 'mf_time_spine_millisecond'
 -- Metric Time Dimension 'ts'
--- Pass Only Elements: ['metric_time__millisecond',]
+-- Pass Only Elements: ['metric_time__millisecond']
 SELECT
   ts AS metric_time__millisecond
 FROM ***************************.mf_time_spine_millisecond time_spine_src_28002

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Trino/test_subdaily_granularity_overrides_metric_default_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Trino/test_subdaily_granularity_overrides_metric_default_granularity__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_6.metric_time__hour AS metric_time__hour
     , subq_3.archived_users AS archived_users
   FROM (
-    -- Pass Only Elements: ['metric_time__hour',]
+    -- Pass Only Elements: ['metric_time__hour']
     SELECT
       subq_5.metric_time__hour
     FROM (

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Trino/test_subdaily_join_to_time_spine_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Trino/test_subdaily_join_to_time_spine_metric__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_6.metric_time__hour AS metric_time__hour
     , subq_3.archived_users AS archived_users
   FROM (
-    -- Pass Only Elements: ['metric_time__hour',]
+    -- Pass Only Elements: ['metric_time__hour']
     SELECT
       subq_5.metric_time__hour
     FROM (

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Trino/test_subdaily_offset_to_grain_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Trino/test_subdaily_offset_to_grain_metric__plan0.sql
@@ -215,7 +215,7 @@ FROM (
           , subq_1.user__home_state AS user__home_state
           , subq_1.archived_users AS archived_users
         FROM (
-          -- Pass Only Elements: ['metric_time__hour',]
+          -- Pass Only Elements: ['metric_time__hour']
           SELECT
             subq_3.metric_time__hour
           FROM (

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Trino/test_subdaily_offset_window_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Trino/test_subdaily_offset_window_metric__plan0.sql
@@ -215,7 +215,7 @@ FROM (
           , subq_1.user__home_state AS user__home_state
           , subq_1.archived_users AS archived_users
         FROM (
-          -- Pass Only Elements: ['metric_time__hour',]
+          -- Pass Only Elements: ['metric_time__hour']
           SELECT
             subq_3.metric_time__hour
           FROM (

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Trino/test_subdaily_time_constraint_with_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Trino/test_subdaily_time_constraint_with_metric__plan0.sql
@@ -17,7 +17,7 @@ FROM (
       subq_9.metric_time__hour AS metric_time__hour
       , subq_5.archived_users AS archived_users
     FROM (
-      -- Pass Only Elements: ['metric_time__hour',]
+      -- Pass Only Elements: ['metric_time__hour']
       SELECT
         subq_8.metric_time__hour
       FROM (

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Trino/test_subdaily_time_constraint_with_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Trino/test_subdaily_time_constraint_with_metric__plan0_optimized.sql
@@ -12,7 +12,7 @@ FROM (
   -- Read From Time Spine 'mf_time_spine_hour'
   -- Change Column Aliases
   -- Constrain Time Range to [2020-01-01T02:00:00, 2020-01-01T05:00:00]
-  -- Pass Only Elements: ['metric_time__hour',]
+  -- Pass Only Elements: ['metric_time__hour']
   SELECT
     ts AS metric_time__hour
   FROM ***************************.mf_time_spine_hour time_spine_src_28005

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Trino/test_subdaily_time_constraint_without_metrics__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Trino/test_subdaily_time_constraint_without_metrics__plan0.sql
@@ -2,7 +2,7 @@ test_name: test_subdaily_time_constraint_without_metrics
 test_filename: test_granularity_date_part_rendering.py
 sql_engine: Trino
 ---
--- Pass Only Elements: ['metric_time__second',]
+-- Pass Only Elements: ['metric_time__second']
 SELECT
   subq_2.metric_time__second
 FROM (

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Trino/test_subdaily_time_constraint_without_metrics__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlPlan/Trino/test_subdaily_time_constraint_without_metrics__plan0_optimized.sql
@@ -5,7 +5,7 @@ sql_engine: Trino
 -- Read From Time Spine 'mf_time_spine_second'
 -- Metric Time Dimension 'ts'
 -- Constrain Time Range to [2020-01-01T00:00:02, 2020-01-01T00:00:08]
--- Pass Only Elements: ['metric_time__second',]
+-- Pass Only Elements: ['metric_time__second']
 SELECT
   ts AS metric_time__second
 FROM ***************************.mf_time_spine_second time_spine_src_28003

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/BigQuery/test_distinct_values_query_with_metric_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/BigQuery/test_distinct_values_query_with_metric_filter__plan0.sql
@@ -4,7 +4,7 @@ docstring:
   Tests a distinct values query with a metric in the query-level where filter.
 sql_engine: BigQuery
 ---
--- Pass Only Elements: ['listing',]
+-- Pass Only Elements: ['listing']
 SELECT
   subq_11.listing
 FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/BigQuery/test_distinct_values_query_with_metric_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/BigQuery/test_distinct_values_query_with_metric_filter__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: BigQuery
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['listing',]
+-- Pass Only Elements: ['listing']
 SELECT
   listing
 FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/BigQuery/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/BigQuery/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     COUNT(DISTINCT subq_12.bookers) AS bookers
   FROM (
-    -- Pass Only Elements: ['bookers',]
+    -- Pass Only Elements: ['bookers']
     SELECT
       subq_11.bookers
     FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/BigQuery/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/BigQuery/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: BigQuery
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['bookers',]
+-- Pass Only Elements: ['bookers']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 WITH sma_28009_cte AS (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/BigQuery/test_filter_with_conversion_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/BigQuery/test_filter_with_conversion_metric__plan0.sql
@@ -10,7 +10,7 @@ FROM (
   SELECT
     SUM(subq_32.listings) AS listings
   FROM (
-    -- Pass Only Elements: ['listings',]
+    -- Pass Only Elements: ['listings']
     SELECT
       subq_31.listings
     FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/BigQuery/test_filter_with_conversion_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/BigQuery/test_filter_with_conversion_metric__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_metric_filter_rendering.py
 sql_engine: BigQuery
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['listings',]
+-- Pass Only Elements: ['listings']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 WITH sma_28019_cte AS (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/BigQuery/test_group_by_has_local_entity_prefix__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/BigQuery/test_group_by_has_local_entity_prefix__plan0.sql
@@ -10,7 +10,7 @@ FROM (
   SELECT
     SUM(subq_19.listings) AS listings
   FROM (
-    -- Pass Only Elements: ['listings',]
+    -- Pass Only Elements: ['listings']
     SELECT
       subq_18.listings
     FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/BigQuery/test_group_by_has_local_entity_prefix__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/BigQuery/test_group_by_has_local_entity_prefix__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_metric_filter_rendering.py
 sql_engine: BigQuery
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['listings',]
+-- Pass Only Elements: ['listings']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 WITH sma_28014_cte AS (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/BigQuery/test_inner_query_multi_hop__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/BigQuery/test_inner_query_multi_hop__plan0.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     COUNT(DISTINCT subq_27.third_hop_count) AS third_hop_count
   FROM (
-    -- Pass Only Elements: ['third_hop_count',]
+    -- Pass Only Elements: ['third_hop_count']
     SELECT
       subq_26.third_hop_count
     FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/BigQuery/test_inner_query_multi_hop__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/BigQuery/test_inner_query_multi_hop__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: BigQuery
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['third_hop_count',]
+-- Pass Only Elements: ['third_hop_count']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/BigQuery/test_inner_query_single_hop__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/BigQuery/test_inner_query_single_hop__plan0.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     COUNT(DISTINCT subq_15.third_hop_count) AS third_hop_count
   FROM (
-    -- Pass Only Elements: ['third_hop_count',]
+    -- Pass Only Elements: ['third_hop_count']
     SELECT
       subq_14.third_hop_count
     FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/BigQuery/test_inner_query_single_hop__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/BigQuery/test_inner_query_single_hop__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: BigQuery
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['third_hop_count',]
+-- Pass Only Elements: ['third_hop_count']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/BigQuery/test_metric_filtered_by_itself__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/BigQuery/test_metric_filtered_by_itself__plan0.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     COUNT(DISTINCT subq_12.bookers) AS bookers
   FROM (
-    -- Pass Only Elements: ['bookers',]
+    -- Pass Only Elements: ['bookers']
     SELECT
       subq_11.bookers
     FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/BigQuery/test_metric_filtered_by_itself__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/BigQuery/test_metric_filtered_by_itself__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: BigQuery
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['bookers',]
+-- Pass Only Elements: ['bookers']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 WITH sma_28009_cte AS (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/BigQuery/test_query_with_cumulative_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/BigQuery/test_query_with_cumulative_metric_in_where_filter__plan0.sql
@@ -14,7 +14,7 @@ FROM (
   SELECT
     SUM(subq_13.listings) AS listings
   FROM (
-    -- Pass Only Elements: ['listings',]
+    -- Pass Only Elements: ['listings']
     SELECT
       subq_12.listings
     FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/BigQuery/test_query_with_cumulative_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/BigQuery/test_query_with_cumulative_metric_in_where_filter__plan0_optimized.sql
@@ -7,7 +7,7 @@ docstring:
 sql_engine: BigQuery
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['listings',]
+-- Pass Only Elements: ['listings']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/BigQuery/test_query_with_derived_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/BigQuery/test_query_with_derived_metric_in_where_filter__plan0.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     SUM(subq_26.listings) AS listings
   FROM (
-    -- Pass Only Elements: ['listings',]
+    -- Pass Only Elements: ['listings']
     SELECT
       subq_25.listings
     FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/BigQuery/test_query_with_derived_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/BigQuery/test_query_with_derived_metric_in_where_filter__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: BigQuery
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['listings',]
+-- Pass Only Elements: ['listings']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/BigQuery/test_query_with_multiple_metrics_in_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/BigQuery/test_query_with_multiple_metrics_in_filter__plan0.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     SUM(subq_21.listings) AS listings
   FROM (
-    -- Pass Only Elements: ['listings',]
+    -- Pass Only Elements: ['listings']
     SELECT
       subq_20.listings
     FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/BigQuery/test_query_with_multiple_metrics_in_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/BigQuery/test_query_with_multiple_metrics_in_filter__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: BigQuery
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['listings',]
+-- Pass Only Elements: ['listings']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 WITH sma_28009_cte AS (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/BigQuery/test_query_with_ratio_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/BigQuery/test_query_with_ratio_metric_in_where_filter__plan0.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     SUM(subq_25.listings) AS listings
   FROM (
-    -- Pass Only Elements: ['listings',]
+    -- Pass Only Elements: ['listings']
     SELECT
       subq_24.listings
     FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/BigQuery/test_query_with_ratio_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/BigQuery/test_query_with_ratio_metric_in_where_filter__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: BigQuery
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['listings',]
+-- Pass Only Elements: ['listings']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/BigQuery/test_query_with_simple_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/BigQuery/test_query_with_simple_metric_in_where_filter__plan0.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     SUM(subq_13.listings) AS listings
   FROM (
-    -- Pass Only Elements: ['listings',]
+    -- Pass Only Elements: ['listings']
     SELECT
       subq_12.listings
     FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/BigQuery/test_query_with_simple_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/BigQuery/test_query_with_simple_metric_in_where_filter__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: BigQuery
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['listings',]
+-- Pass Only Elements: ['listings']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Databricks/test_distinct_values_query_with_metric_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Databricks/test_distinct_values_query_with_metric_filter__plan0.sql
@@ -4,7 +4,7 @@ docstring:
   Tests a distinct values query with a metric in the query-level where filter.
 sql_engine: Databricks
 ---
--- Pass Only Elements: ['listing',]
+-- Pass Only Elements: ['listing']
 SELECT
   subq_11.listing
 FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Databricks/test_distinct_values_query_with_metric_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Databricks/test_distinct_values_query_with_metric_filter__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: Databricks
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['listing',]
+-- Pass Only Elements: ['listing']
 SELECT
   listing
 FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Databricks/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Databricks/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     COUNT(DISTINCT subq_12.bookers) AS bookers
   FROM (
-    -- Pass Only Elements: ['bookers',]
+    -- Pass Only Elements: ['bookers']
     SELECT
       subq_11.bookers
     FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Databricks/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Databricks/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: Databricks
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['bookers',]
+-- Pass Only Elements: ['bookers']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 WITH sma_28009_cte AS (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Databricks/test_filter_with_conversion_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Databricks/test_filter_with_conversion_metric__plan0.sql
@@ -10,7 +10,7 @@ FROM (
   SELECT
     SUM(subq_32.listings) AS listings
   FROM (
-    -- Pass Only Elements: ['listings',]
+    -- Pass Only Elements: ['listings']
     SELECT
       subq_31.listings
     FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Databricks/test_filter_with_conversion_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Databricks/test_filter_with_conversion_metric__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_metric_filter_rendering.py
 sql_engine: Databricks
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['listings',]
+-- Pass Only Elements: ['listings']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 WITH sma_28019_cte AS (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Databricks/test_group_by_has_local_entity_prefix__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Databricks/test_group_by_has_local_entity_prefix__plan0.sql
@@ -10,7 +10,7 @@ FROM (
   SELECT
     SUM(subq_19.listings) AS listings
   FROM (
-    -- Pass Only Elements: ['listings',]
+    -- Pass Only Elements: ['listings']
     SELECT
       subq_18.listings
     FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Databricks/test_group_by_has_local_entity_prefix__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Databricks/test_group_by_has_local_entity_prefix__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_metric_filter_rendering.py
 sql_engine: Databricks
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['listings',]
+-- Pass Only Elements: ['listings']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 WITH sma_28014_cte AS (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Databricks/test_inner_query_multi_hop__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Databricks/test_inner_query_multi_hop__plan0.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     COUNT(DISTINCT subq_27.third_hop_count) AS third_hop_count
   FROM (
-    -- Pass Only Elements: ['third_hop_count',]
+    -- Pass Only Elements: ['third_hop_count']
     SELECT
       subq_26.third_hop_count
     FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Databricks/test_inner_query_multi_hop__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Databricks/test_inner_query_multi_hop__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: Databricks
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['third_hop_count',]
+-- Pass Only Elements: ['third_hop_count']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Databricks/test_inner_query_single_hop__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Databricks/test_inner_query_single_hop__plan0.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     COUNT(DISTINCT subq_15.third_hop_count) AS third_hop_count
   FROM (
-    -- Pass Only Elements: ['third_hop_count',]
+    -- Pass Only Elements: ['third_hop_count']
     SELECT
       subq_14.third_hop_count
     FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Databricks/test_inner_query_single_hop__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Databricks/test_inner_query_single_hop__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: Databricks
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['third_hop_count',]
+-- Pass Only Elements: ['third_hop_count']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Databricks/test_metric_filtered_by_itself__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Databricks/test_metric_filtered_by_itself__plan0.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     COUNT(DISTINCT subq_12.bookers) AS bookers
   FROM (
-    -- Pass Only Elements: ['bookers',]
+    -- Pass Only Elements: ['bookers']
     SELECT
       subq_11.bookers
     FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Databricks/test_metric_filtered_by_itself__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Databricks/test_metric_filtered_by_itself__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: Databricks
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['bookers',]
+-- Pass Only Elements: ['bookers']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 WITH sma_28009_cte AS (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Databricks/test_query_with_cumulative_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Databricks/test_query_with_cumulative_metric_in_where_filter__plan0.sql
@@ -14,7 +14,7 @@ FROM (
   SELECT
     SUM(subq_13.listings) AS listings
   FROM (
-    -- Pass Only Elements: ['listings',]
+    -- Pass Only Elements: ['listings']
     SELECT
       subq_12.listings
     FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Databricks/test_query_with_cumulative_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Databricks/test_query_with_cumulative_metric_in_where_filter__plan0_optimized.sql
@@ -7,7 +7,7 @@ docstring:
 sql_engine: Databricks
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['listings',]
+-- Pass Only Elements: ['listings']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Databricks/test_query_with_derived_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Databricks/test_query_with_derived_metric_in_where_filter__plan0.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     SUM(subq_26.listings) AS listings
   FROM (
-    -- Pass Only Elements: ['listings',]
+    -- Pass Only Elements: ['listings']
     SELECT
       subq_25.listings
     FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Databricks/test_query_with_derived_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Databricks/test_query_with_derived_metric_in_where_filter__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: Databricks
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['listings',]
+-- Pass Only Elements: ['listings']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Databricks/test_query_with_multiple_metrics_in_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Databricks/test_query_with_multiple_metrics_in_filter__plan0.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     SUM(subq_21.listings) AS listings
   FROM (
-    -- Pass Only Elements: ['listings',]
+    -- Pass Only Elements: ['listings']
     SELECT
       subq_20.listings
     FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Databricks/test_query_with_multiple_metrics_in_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Databricks/test_query_with_multiple_metrics_in_filter__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: Databricks
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['listings',]
+-- Pass Only Elements: ['listings']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 WITH sma_28009_cte AS (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Databricks/test_query_with_ratio_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Databricks/test_query_with_ratio_metric_in_where_filter__plan0.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     SUM(subq_25.listings) AS listings
   FROM (
-    -- Pass Only Elements: ['listings',]
+    -- Pass Only Elements: ['listings']
     SELECT
       subq_24.listings
     FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Databricks/test_query_with_ratio_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Databricks/test_query_with_ratio_metric_in_where_filter__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: Databricks
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['listings',]
+-- Pass Only Elements: ['listings']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Databricks/test_query_with_simple_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Databricks/test_query_with_simple_metric_in_where_filter__plan0.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     SUM(subq_13.listings) AS listings
   FROM (
-    -- Pass Only Elements: ['listings',]
+    -- Pass Only Elements: ['listings']
     SELECT
       subq_12.listings
     FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Databricks/test_query_with_simple_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Databricks/test_query_with_simple_metric_in_where_filter__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: Databricks
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['listings',]
+-- Pass Only Elements: ['listings']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/DuckDB/test_distinct_values_query_with_metric_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/DuckDB/test_distinct_values_query_with_metric_filter__plan0.sql
@@ -4,7 +4,7 @@ docstring:
   Tests a distinct values query with a metric in the query-level where filter.
 sql_engine: DuckDB
 ---
--- Pass Only Elements: ['listing',]
+-- Pass Only Elements: ['listing']
 SELECT
   subq_11.listing
 FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/DuckDB/test_distinct_values_query_with_metric_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/DuckDB/test_distinct_values_query_with_metric_filter__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: DuckDB
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['listing',]
+-- Pass Only Elements: ['listing']
 SELECT
   listing
 FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/DuckDB/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/DuckDB/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     COUNT(DISTINCT subq_12.bookers) AS bookers
   FROM (
-    -- Pass Only Elements: ['bookers',]
+    -- Pass Only Elements: ['bookers']
     SELECT
       subq_11.bookers
     FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/DuckDB/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/DuckDB/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: DuckDB
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['bookers',]
+-- Pass Only Elements: ['bookers']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 WITH sma_28009_cte AS (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/DuckDB/test_filter_with_conversion_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/DuckDB/test_filter_with_conversion_metric__plan0.sql
@@ -10,7 +10,7 @@ FROM (
   SELECT
     SUM(subq_32.listings) AS listings
   FROM (
-    -- Pass Only Elements: ['listings',]
+    -- Pass Only Elements: ['listings']
     SELECT
       subq_31.listings
     FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/DuckDB/test_filter_with_conversion_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/DuckDB/test_filter_with_conversion_metric__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_metric_filter_rendering.py
 sql_engine: DuckDB
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['listings',]
+-- Pass Only Elements: ['listings']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 WITH sma_28019_cte AS (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/DuckDB/test_group_by_has_local_entity_prefix__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/DuckDB/test_group_by_has_local_entity_prefix__plan0.sql
@@ -10,7 +10,7 @@ FROM (
   SELECT
     SUM(subq_19.listings) AS listings
   FROM (
-    -- Pass Only Elements: ['listings',]
+    -- Pass Only Elements: ['listings']
     SELECT
       subq_18.listings
     FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/DuckDB/test_group_by_has_local_entity_prefix__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/DuckDB/test_group_by_has_local_entity_prefix__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_metric_filter_rendering.py
 sql_engine: DuckDB
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['listings',]
+-- Pass Only Elements: ['listings']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 WITH sma_28014_cte AS (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/DuckDB/test_inner_query_multi_hop__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/DuckDB/test_inner_query_multi_hop__plan0.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     COUNT(DISTINCT subq_27.third_hop_count) AS third_hop_count
   FROM (
-    -- Pass Only Elements: ['third_hop_count',]
+    -- Pass Only Elements: ['third_hop_count']
     SELECT
       subq_26.third_hop_count
     FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/DuckDB/test_inner_query_multi_hop__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/DuckDB/test_inner_query_multi_hop__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: DuckDB
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['third_hop_count',]
+-- Pass Only Elements: ['third_hop_count']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/DuckDB/test_inner_query_single_hop__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/DuckDB/test_inner_query_single_hop__plan0.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     COUNT(DISTINCT subq_15.third_hop_count) AS third_hop_count
   FROM (
-    -- Pass Only Elements: ['third_hop_count',]
+    -- Pass Only Elements: ['third_hop_count']
     SELECT
       subq_14.third_hop_count
     FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/DuckDB/test_inner_query_single_hop__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/DuckDB/test_inner_query_single_hop__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: DuckDB
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['third_hop_count',]
+-- Pass Only Elements: ['third_hop_count']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/DuckDB/test_metric_filtered_by_itself__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/DuckDB/test_metric_filtered_by_itself__plan0.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     COUNT(DISTINCT subq_12.bookers) AS bookers
   FROM (
-    -- Pass Only Elements: ['bookers',]
+    -- Pass Only Elements: ['bookers']
     SELECT
       subq_11.bookers
     FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/DuckDB/test_metric_filtered_by_itself__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/DuckDB/test_metric_filtered_by_itself__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: DuckDB
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['bookers',]
+-- Pass Only Elements: ['bookers']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 WITH sma_28009_cte AS (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/DuckDB/test_query_with_cumulative_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/DuckDB/test_query_with_cumulative_metric_in_where_filter__plan0.sql
@@ -14,7 +14,7 @@ FROM (
   SELECT
     SUM(subq_13.listings) AS listings
   FROM (
-    -- Pass Only Elements: ['listings',]
+    -- Pass Only Elements: ['listings']
     SELECT
       subq_12.listings
     FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/DuckDB/test_query_with_cumulative_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/DuckDB/test_query_with_cumulative_metric_in_where_filter__plan0_optimized.sql
@@ -7,7 +7,7 @@ docstring:
 sql_engine: DuckDB
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['listings',]
+-- Pass Only Elements: ['listings']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/DuckDB/test_query_with_derived_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/DuckDB/test_query_with_derived_metric_in_where_filter__plan0.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     SUM(subq_26.listings) AS listings
   FROM (
-    -- Pass Only Elements: ['listings',]
+    -- Pass Only Elements: ['listings']
     SELECT
       subq_25.listings
     FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/DuckDB/test_query_with_derived_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/DuckDB/test_query_with_derived_metric_in_where_filter__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: DuckDB
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['listings',]
+-- Pass Only Elements: ['listings']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/DuckDB/test_query_with_multiple_metrics_in_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/DuckDB/test_query_with_multiple_metrics_in_filter__plan0.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     SUM(subq_21.listings) AS listings
   FROM (
-    -- Pass Only Elements: ['listings',]
+    -- Pass Only Elements: ['listings']
     SELECT
       subq_20.listings
     FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/DuckDB/test_query_with_multiple_metrics_in_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/DuckDB/test_query_with_multiple_metrics_in_filter__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: DuckDB
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['listings',]
+-- Pass Only Elements: ['listings']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 WITH sma_28009_cte AS (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/DuckDB/test_query_with_ratio_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/DuckDB/test_query_with_ratio_metric_in_where_filter__plan0.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     SUM(subq_25.listings) AS listings
   FROM (
-    -- Pass Only Elements: ['listings',]
+    -- Pass Only Elements: ['listings']
     SELECT
       subq_24.listings
     FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/DuckDB/test_query_with_ratio_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/DuckDB/test_query_with_ratio_metric_in_where_filter__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: DuckDB
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['listings',]
+-- Pass Only Elements: ['listings']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/DuckDB/test_query_with_simple_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/DuckDB/test_query_with_simple_metric_in_where_filter__plan0.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     SUM(subq_13.listings) AS listings
   FROM (
-    -- Pass Only Elements: ['listings',]
+    -- Pass Only Elements: ['listings']
     SELECT
       subq_12.listings
     FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/DuckDB/test_query_with_simple_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/DuckDB/test_query_with_simple_metric_in_where_filter__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: DuckDB
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['listings',]
+-- Pass Only Elements: ['listings']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Postgres/test_distinct_values_query_with_metric_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Postgres/test_distinct_values_query_with_metric_filter__plan0.sql
@@ -4,7 +4,7 @@ docstring:
   Tests a distinct values query with a metric in the query-level where filter.
 sql_engine: Postgres
 ---
--- Pass Only Elements: ['listing',]
+-- Pass Only Elements: ['listing']
 SELECT
   subq_11.listing
 FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Postgres/test_distinct_values_query_with_metric_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Postgres/test_distinct_values_query_with_metric_filter__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: Postgres
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['listing',]
+-- Pass Only Elements: ['listing']
 SELECT
   listing
 FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Postgres/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Postgres/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     COUNT(DISTINCT subq_12.bookers) AS bookers
   FROM (
-    -- Pass Only Elements: ['bookers',]
+    -- Pass Only Elements: ['bookers']
     SELECT
       subq_11.bookers
     FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Postgres/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Postgres/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: Postgres
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['bookers',]
+-- Pass Only Elements: ['bookers']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 WITH sma_28009_cte AS (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Postgres/test_filter_with_conversion_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Postgres/test_filter_with_conversion_metric__plan0.sql
@@ -10,7 +10,7 @@ FROM (
   SELECT
     SUM(subq_32.listings) AS listings
   FROM (
-    -- Pass Only Elements: ['listings',]
+    -- Pass Only Elements: ['listings']
     SELECT
       subq_31.listings
     FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Postgres/test_filter_with_conversion_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Postgres/test_filter_with_conversion_metric__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_metric_filter_rendering.py
 sql_engine: Postgres
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['listings',]
+-- Pass Only Elements: ['listings']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 WITH sma_28019_cte AS (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Postgres/test_group_by_has_local_entity_prefix__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Postgres/test_group_by_has_local_entity_prefix__plan0.sql
@@ -10,7 +10,7 @@ FROM (
   SELECT
     SUM(subq_19.listings) AS listings
   FROM (
-    -- Pass Only Elements: ['listings',]
+    -- Pass Only Elements: ['listings']
     SELECT
       subq_18.listings
     FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Postgres/test_group_by_has_local_entity_prefix__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Postgres/test_group_by_has_local_entity_prefix__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_metric_filter_rendering.py
 sql_engine: Postgres
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['listings',]
+-- Pass Only Elements: ['listings']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 WITH sma_28014_cte AS (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Postgres/test_inner_query_multi_hop__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Postgres/test_inner_query_multi_hop__plan0.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     COUNT(DISTINCT subq_27.third_hop_count) AS third_hop_count
   FROM (
-    -- Pass Only Elements: ['third_hop_count',]
+    -- Pass Only Elements: ['third_hop_count']
     SELECT
       subq_26.third_hop_count
     FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Postgres/test_inner_query_multi_hop__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Postgres/test_inner_query_multi_hop__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: Postgres
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['third_hop_count',]
+-- Pass Only Elements: ['third_hop_count']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Postgres/test_inner_query_single_hop__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Postgres/test_inner_query_single_hop__plan0.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     COUNT(DISTINCT subq_15.third_hop_count) AS third_hop_count
   FROM (
-    -- Pass Only Elements: ['third_hop_count',]
+    -- Pass Only Elements: ['third_hop_count']
     SELECT
       subq_14.third_hop_count
     FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Postgres/test_inner_query_single_hop__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Postgres/test_inner_query_single_hop__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: Postgres
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['third_hop_count',]
+-- Pass Only Elements: ['third_hop_count']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Postgres/test_metric_filtered_by_itself__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Postgres/test_metric_filtered_by_itself__plan0.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     COUNT(DISTINCT subq_12.bookers) AS bookers
   FROM (
-    -- Pass Only Elements: ['bookers',]
+    -- Pass Only Elements: ['bookers']
     SELECT
       subq_11.bookers
     FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Postgres/test_metric_filtered_by_itself__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Postgres/test_metric_filtered_by_itself__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: Postgres
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['bookers',]
+-- Pass Only Elements: ['bookers']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 WITH sma_28009_cte AS (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Postgres/test_query_with_cumulative_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Postgres/test_query_with_cumulative_metric_in_where_filter__plan0.sql
@@ -14,7 +14,7 @@ FROM (
   SELECT
     SUM(subq_13.listings) AS listings
   FROM (
-    -- Pass Only Elements: ['listings',]
+    -- Pass Only Elements: ['listings']
     SELECT
       subq_12.listings
     FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Postgres/test_query_with_cumulative_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Postgres/test_query_with_cumulative_metric_in_where_filter__plan0_optimized.sql
@@ -7,7 +7,7 @@ docstring:
 sql_engine: Postgres
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['listings',]
+-- Pass Only Elements: ['listings']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Postgres/test_query_with_derived_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Postgres/test_query_with_derived_metric_in_where_filter__plan0.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     SUM(subq_26.listings) AS listings
   FROM (
-    -- Pass Only Elements: ['listings',]
+    -- Pass Only Elements: ['listings']
     SELECT
       subq_25.listings
     FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Postgres/test_query_with_derived_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Postgres/test_query_with_derived_metric_in_where_filter__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: Postgres
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['listings',]
+-- Pass Only Elements: ['listings']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Postgres/test_query_with_multiple_metrics_in_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Postgres/test_query_with_multiple_metrics_in_filter__plan0.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     SUM(subq_21.listings) AS listings
   FROM (
-    -- Pass Only Elements: ['listings',]
+    -- Pass Only Elements: ['listings']
     SELECT
       subq_20.listings
     FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Postgres/test_query_with_multiple_metrics_in_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Postgres/test_query_with_multiple_metrics_in_filter__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: Postgres
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['listings',]
+-- Pass Only Elements: ['listings']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 WITH sma_28009_cte AS (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Postgres/test_query_with_ratio_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Postgres/test_query_with_ratio_metric_in_where_filter__plan0.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     SUM(subq_25.listings) AS listings
   FROM (
-    -- Pass Only Elements: ['listings',]
+    -- Pass Only Elements: ['listings']
     SELECT
       subq_24.listings
     FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Postgres/test_query_with_ratio_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Postgres/test_query_with_ratio_metric_in_where_filter__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: Postgres
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['listings',]
+-- Pass Only Elements: ['listings']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Postgres/test_query_with_simple_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Postgres/test_query_with_simple_metric_in_where_filter__plan0.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     SUM(subq_13.listings) AS listings
   FROM (
-    -- Pass Only Elements: ['listings',]
+    -- Pass Only Elements: ['listings']
     SELECT
       subq_12.listings
     FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Postgres/test_query_with_simple_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Postgres/test_query_with_simple_metric_in_where_filter__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: Postgres
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['listings',]
+-- Pass Only Elements: ['listings']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Redshift/test_distinct_values_query_with_metric_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Redshift/test_distinct_values_query_with_metric_filter__plan0.sql
@@ -4,7 +4,7 @@ docstring:
   Tests a distinct values query with a metric in the query-level where filter.
 sql_engine: Redshift
 ---
--- Pass Only Elements: ['listing',]
+-- Pass Only Elements: ['listing']
 SELECT
   subq_11.listing
 FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Redshift/test_distinct_values_query_with_metric_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Redshift/test_distinct_values_query_with_metric_filter__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: Redshift
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['listing',]
+-- Pass Only Elements: ['listing']
 SELECT
   listing
 FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Redshift/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Redshift/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     COUNT(DISTINCT subq_12.bookers) AS bookers
   FROM (
-    -- Pass Only Elements: ['bookers',]
+    -- Pass Only Elements: ['bookers']
     SELECT
       subq_11.bookers
     FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Redshift/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Redshift/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: Redshift
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['bookers',]
+-- Pass Only Elements: ['bookers']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 WITH sma_28009_cte AS (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Redshift/test_filter_with_conversion_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Redshift/test_filter_with_conversion_metric__plan0.sql
@@ -10,7 +10,7 @@ FROM (
   SELECT
     SUM(subq_32.listings) AS listings
   FROM (
-    -- Pass Only Elements: ['listings',]
+    -- Pass Only Elements: ['listings']
     SELECT
       subq_31.listings
     FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Redshift/test_filter_with_conversion_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Redshift/test_filter_with_conversion_metric__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_metric_filter_rendering.py
 sql_engine: Redshift
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['listings',]
+-- Pass Only Elements: ['listings']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 WITH sma_28019_cte AS (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Redshift/test_group_by_has_local_entity_prefix__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Redshift/test_group_by_has_local_entity_prefix__plan0.sql
@@ -10,7 +10,7 @@ FROM (
   SELECT
     SUM(subq_19.listings) AS listings
   FROM (
-    -- Pass Only Elements: ['listings',]
+    -- Pass Only Elements: ['listings']
     SELECT
       subq_18.listings
     FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Redshift/test_group_by_has_local_entity_prefix__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Redshift/test_group_by_has_local_entity_prefix__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_metric_filter_rendering.py
 sql_engine: Redshift
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['listings',]
+-- Pass Only Elements: ['listings']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 WITH sma_28014_cte AS (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Redshift/test_inner_query_multi_hop__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Redshift/test_inner_query_multi_hop__plan0.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     COUNT(DISTINCT subq_27.third_hop_count) AS third_hop_count
   FROM (
-    -- Pass Only Elements: ['third_hop_count',]
+    -- Pass Only Elements: ['third_hop_count']
     SELECT
       subq_26.third_hop_count
     FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Redshift/test_inner_query_multi_hop__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Redshift/test_inner_query_multi_hop__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: Redshift
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['third_hop_count',]
+-- Pass Only Elements: ['third_hop_count']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Redshift/test_inner_query_single_hop__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Redshift/test_inner_query_single_hop__plan0.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     COUNT(DISTINCT subq_15.third_hop_count) AS third_hop_count
   FROM (
-    -- Pass Only Elements: ['third_hop_count',]
+    -- Pass Only Elements: ['third_hop_count']
     SELECT
       subq_14.third_hop_count
     FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Redshift/test_inner_query_single_hop__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Redshift/test_inner_query_single_hop__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: Redshift
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['third_hop_count',]
+-- Pass Only Elements: ['third_hop_count']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Redshift/test_metric_filtered_by_itself__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Redshift/test_metric_filtered_by_itself__plan0.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     COUNT(DISTINCT subq_12.bookers) AS bookers
   FROM (
-    -- Pass Only Elements: ['bookers',]
+    -- Pass Only Elements: ['bookers']
     SELECT
       subq_11.bookers
     FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Redshift/test_metric_filtered_by_itself__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Redshift/test_metric_filtered_by_itself__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: Redshift
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['bookers',]
+-- Pass Only Elements: ['bookers']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 WITH sma_28009_cte AS (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Redshift/test_query_with_cumulative_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Redshift/test_query_with_cumulative_metric_in_where_filter__plan0.sql
@@ -14,7 +14,7 @@ FROM (
   SELECT
     SUM(subq_13.listings) AS listings
   FROM (
-    -- Pass Only Elements: ['listings',]
+    -- Pass Only Elements: ['listings']
     SELECT
       subq_12.listings
     FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Redshift/test_query_with_cumulative_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Redshift/test_query_with_cumulative_metric_in_where_filter__plan0_optimized.sql
@@ -7,7 +7,7 @@ docstring:
 sql_engine: Redshift
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['listings',]
+-- Pass Only Elements: ['listings']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Redshift/test_query_with_derived_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Redshift/test_query_with_derived_metric_in_where_filter__plan0.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     SUM(subq_26.listings) AS listings
   FROM (
-    -- Pass Only Elements: ['listings',]
+    -- Pass Only Elements: ['listings']
     SELECT
       subq_25.listings
     FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Redshift/test_query_with_derived_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Redshift/test_query_with_derived_metric_in_where_filter__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: Redshift
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['listings',]
+-- Pass Only Elements: ['listings']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Redshift/test_query_with_multiple_metrics_in_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Redshift/test_query_with_multiple_metrics_in_filter__plan0.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     SUM(subq_21.listings) AS listings
   FROM (
-    -- Pass Only Elements: ['listings',]
+    -- Pass Only Elements: ['listings']
     SELECT
       subq_20.listings
     FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Redshift/test_query_with_multiple_metrics_in_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Redshift/test_query_with_multiple_metrics_in_filter__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: Redshift
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['listings',]
+-- Pass Only Elements: ['listings']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 WITH sma_28009_cte AS (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Redshift/test_query_with_ratio_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Redshift/test_query_with_ratio_metric_in_where_filter__plan0.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     SUM(subq_25.listings) AS listings
   FROM (
-    -- Pass Only Elements: ['listings',]
+    -- Pass Only Elements: ['listings']
     SELECT
       subq_24.listings
     FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Redshift/test_query_with_ratio_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Redshift/test_query_with_ratio_metric_in_where_filter__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: Redshift
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['listings',]
+-- Pass Only Elements: ['listings']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Redshift/test_query_with_simple_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Redshift/test_query_with_simple_metric_in_where_filter__plan0.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     SUM(subq_13.listings) AS listings
   FROM (
-    -- Pass Only Elements: ['listings',]
+    -- Pass Only Elements: ['listings']
     SELECT
       subq_12.listings
     FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Redshift/test_query_with_simple_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Redshift/test_query_with_simple_metric_in_where_filter__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: Redshift
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['listings',]
+-- Pass Only Elements: ['listings']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Snowflake/test_distinct_values_query_with_metric_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Snowflake/test_distinct_values_query_with_metric_filter__plan0.sql
@@ -4,7 +4,7 @@ docstring:
   Tests a distinct values query with a metric in the query-level where filter.
 sql_engine: Snowflake
 ---
--- Pass Only Elements: ['listing',]
+-- Pass Only Elements: ['listing']
 SELECT
   subq_11.listing
 FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Snowflake/test_distinct_values_query_with_metric_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Snowflake/test_distinct_values_query_with_metric_filter__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: Snowflake
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['listing',]
+-- Pass Only Elements: ['listing']
 SELECT
   listing
 FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Snowflake/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Snowflake/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     COUNT(DISTINCT subq_12.bookers) AS bookers
   FROM (
-    -- Pass Only Elements: ['bookers',]
+    -- Pass Only Elements: ['bookers']
     SELECT
       subq_11.bookers
     FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Snowflake/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Snowflake/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: Snowflake
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['bookers',]
+-- Pass Only Elements: ['bookers']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 WITH sma_28009_cte AS (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Snowflake/test_filter_with_conversion_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Snowflake/test_filter_with_conversion_metric__plan0.sql
@@ -10,7 +10,7 @@ FROM (
   SELECT
     SUM(subq_32.listings) AS listings
   FROM (
-    -- Pass Only Elements: ['listings',]
+    -- Pass Only Elements: ['listings']
     SELECT
       subq_31.listings
     FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Snowflake/test_filter_with_conversion_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Snowflake/test_filter_with_conversion_metric__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_metric_filter_rendering.py
 sql_engine: Snowflake
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['listings',]
+-- Pass Only Elements: ['listings']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 WITH sma_28019_cte AS (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Snowflake/test_group_by_has_local_entity_prefix__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Snowflake/test_group_by_has_local_entity_prefix__plan0.sql
@@ -10,7 +10,7 @@ FROM (
   SELECT
     SUM(subq_19.listings) AS listings
   FROM (
-    -- Pass Only Elements: ['listings',]
+    -- Pass Only Elements: ['listings']
     SELECT
       subq_18.listings
     FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Snowflake/test_group_by_has_local_entity_prefix__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Snowflake/test_group_by_has_local_entity_prefix__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_metric_filter_rendering.py
 sql_engine: Snowflake
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['listings',]
+-- Pass Only Elements: ['listings']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 WITH sma_28014_cte AS (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Snowflake/test_inner_query_multi_hop__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Snowflake/test_inner_query_multi_hop__plan0.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     COUNT(DISTINCT subq_27.third_hop_count) AS third_hop_count
   FROM (
-    -- Pass Only Elements: ['third_hop_count',]
+    -- Pass Only Elements: ['third_hop_count']
     SELECT
       subq_26.third_hop_count
     FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Snowflake/test_inner_query_multi_hop__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Snowflake/test_inner_query_multi_hop__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: Snowflake
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['third_hop_count',]
+-- Pass Only Elements: ['third_hop_count']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Snowflake/test_inner_query_single_hop__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Snowflake/test_inner_query_single_hop__plan0.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     COUNT(DISTINCT subq_15.third_hop_count) AS third_hop_count
   FROM (
-    -- Pass Only Elements: ['third_hop_count',]
+    -- Pass Only Elements: ['third_hop_count']
     SELECT
       subq_14.third_hop_count
     FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Snowflake/test_inner_query_single_hop__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Snowflake/test_inner_query_single_hop__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: Snowflake
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['third_hop_count',]
+-- Pass Only Elements: ['third_hop_count']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Snowflake/test_metric_filtered_by_itself__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Snowflake/test_metric_filtered_by_itself__plan0.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     COUNT(DISTINCT subq_12.bookers) AS bookers
   FROM (
-    -- Pass Only Elements: ['bookers',]
+    -- Pass Only Elements: ['bookers']
     SELECT
       subq_11.bookers
     FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Snowflake/test_metric_filtered_by_itself__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Snowflake/test_metric_filtered_by_itself__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: Snowflake
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['bookers',]
+-- Pass Only Elements: ['bookers']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 WITH sma_28009_cte AS (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Snowflake/test_query_with_cumulative_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Snowflake/test_query_with_cumulative_metric_in_where_filter__plan0.sql
@@ -14,7 +14,7 @@ FROM (
   SELECT
     SUM(subq_13.listings) AS listings
   FROM (
-    -- Pass Only Elements: ['listings',]
+    -- Pass Only Elements: ['listings']
     SELECT
       subq_12.listings
     FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Snowflake/test_query_with_cumulative_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Snowflake/test_query_with_cumulative_metric_in_where_filter__plan0_optimized.sql
@@ -7,7 +7,7 @@ docstring:
 sql_engine: Snowflake
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['listings',]
+-- Pass Only Elements: ['listings']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Snowflake/test_query_with_derived_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Snowflake/test_query_with_derived_metric_in_where_filter__plan0.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     SUM(subq_26.listings) AS listings
   FROM (
-    -- Pass Only Elements: ['listings',]
+    -- Pass Only Elements: ['listings']
     SELECT
       subq_25.listings
     FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Snowflake/test_query_with_derived_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Snowflake/test_query_with_derived_metric_in_where_filter__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: Snowflake
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['listings',]
+-- Pass Only Elements: ['listings']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Snowflake/test_query_with_multiple_metrics_in_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Snowflake/test_query_with_multiple_metrics_in_filter__plan0.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     SUM(subq_21.listings) AS listings
   FROM (
-    -- Pass Only Elements: ['listings',]
+    -- Pass Only Elements: ['listings']
     SELECT
       subq_20.listings
     FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Snowflake/test_query_with_multiple_metrics_in_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Snowflake/test_query_with_multiple_metrics_in_filter__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: Snowflake
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['listings',]
+-- Pass Only Elements: ['listings']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 WITH sma_28009_cte AS (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Snowflake/test_query_with_ratio_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Snowflake/test_query_with_ratio_metric_in_where_filter__plan0.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     SUM(subq_25.listings) AS listings
   FROM (
-    -- Pass Only Elements: ['listings',]
+    -- Pass Only Elements: ['listings']
     SELECT
       subq_24.listings
     FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Snowflake/test_query_with_ratio_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Snowflake/test_query_with_ratio_metric_in_where_filter__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: Snowflake
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['listings',]
+-- Pass Only Elements: ['listings']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Snowflake/test_query_with_simple_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Snowflake/test_query_with_simple_metric_in_where_filter__plan0.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     SUM(subq_13.listings) AS listings
   FROM (
-    -- Pass Only Elements: ['listings',]
+    -- Pass Only Elements: ['listings']
     SELECT
       subq_12.listings
     FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Snowflake/test_query_with_simple_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Snowflake/test_query_with_simple_metric_in_where_filter__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: Snowflake
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['listings',]
+-- Pass Only Elements: ['listings']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Trino/test_distinct_values_query_with_metric_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Trino/test_distinct_values_query_with_metric_filter__plan0.sql
@@ -4,7 +4,7 @@ docstring:
   Tests a distinct values query with a metric in the query-level where filter.
 sql_engine: Trino
 ---
--- Pass Only Elements: ['listing',]
+-- Pass Only Elements: ['listing']
 SELECT
   subq_11.listing
 FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Trino/test_distinct_values_query_with_metric_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Trino/test_distinct_values_query_with_metric_filter__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: Trino
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['listing',]
+-- Pass Only Elements: ['listing']
 SELECT
   listing
 FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Trino/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Trino/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     COUNT(DISTINCT subq_12.bookers) AS bookers
   FROM (
-    -- Pass Only Elements: ['bookers',]
+    -- Pass Only Elements: ['bookers']
     SELECT
       subq_11.bookers
     FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Trino/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Trino/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: Trino
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['bookers',]
+-- Pass Only Elements: ['bookers']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 WITH sma_28009_cte AS (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Trino/test_filter_with_conversion_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Trino/test_filter_with_conversion_metric__plan0.sql
@@ -10,7 +10,7 @@ FROM (
   SELECT
     SUM(subq_32.listings) AS listings
   FROM (
-    -- Pass Only Elements: ['listings',]
+    -- Pass Only Elements: ['listings']
     SELECT
       subq_31.listings
     FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Trino/test_filter_with_conversion_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Trino/test_filter_with_conversion_metric__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_metric_filter_rendering.py
 sql_engine: Trino
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['listings',]
+-- Pass Only Elements: ['listings']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 WITH sma_28019_cte AS (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Trino/test_group_by_has_local_entity_prefix__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Trino/test_group_by_has_local_entity_prefix__plan0.sql
@@ -10,7 +10,7 @@ FROM (
   SELECT
     SUM(subq_19.listings) AS listings
   FROM (
-    -- Pass Only Elements: ['listings',]
+    -- Pass Only Elements: ['listings']
     SELECT
       subq_18.listings
     FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Trino/test_group_by_has_local_entity_prefix__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Trino/test_group_by_has_local_entity_prefix__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_metric_filter_rendering.py
 sql_engine: Trino
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['listings',]
+-- Pass Only Elements: ['listings']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 WITH sma_28014_cte AS (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Trino/test_inner_query_multi_hop__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Trino/test_inner_query_multi_hop__plan0.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     COUNT(DISTINCT subq_27.third_hop_count) AS third_hop_count
   FROM (
-    -- Pass Only Elements: ['third_hop_count',]
+    -- Pass Only Elements: ['third_hop_count']
     SELECT
       subq_26.third_hop_count
     FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Trino/test_inner_query_multi_hop__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Trino/test_inner_query_multi_hop__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: Trino
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['third_hop_count',]
+-- Pass Only Elements: ['third_hop_count']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Trino/test_inner_query_single_hop__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Trino/test_inner_query_single_hop__plan0.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     COUNT(DISTINCT subq_15.third_hop_count) AS third_hop_count
   FROM (
-    -- Pass Only Elements: ['third_hop_count',]
+    -- Pass Only Elements: ['third_hop_count']
     SELECT
       subq_14.third_hop_count
     FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Trino/test_inner_query_single_hop__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Trino/test_inner_query_single_hop__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: Trino
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['third_hop_count',]
+-- Pass Only Elements: ['third_hop_count']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Trino/test_metric_filtered_by_itself__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Trino/test_metric_filtered_by_itself__plan0.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     COUNT(DISTINCT subq_12.bookers) AS bookers
   FROM (
-    -- Pass Only Elements: ['bookers',]
+    -- Pass Only Elements: ['bookers']
     SELECT
       subq_11.bookers
     FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Trino/test_metric_filtered_by_itself__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Trino/test_metric_filtered_by_itself__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: Trino
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['bookers',]
+-- Pass Only Elements: ['bookers']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 WITH sma_28009_cte AS (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Trino/test_query_with_cumulative_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Trino/test_query_with_cumulative_metric_in_where_filter__plan0.sql
@@ -14,7 +14,7 @@ FROM (
   SELECT
     SUM(subq_13.listings) AS listings
   FROM (
-    -- Pass Only Elements: ['listings',]
+    -- Pass Only Elements: ['listings']
     SELECT
       subq_12.listings
     FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Trino/test_query_with_cumulative_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Trino/test_query_with_cumulative_metric_in_where_filter__plan0_optimized.sql
@@ -7,7 +7,7 @@ docstring:
 sql_engine: Trino
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['listings',]
+-- Pass Only Elements: ['listings']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Trino/test_query_with_derived_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Trino/test_query_with_derived_metric_in_where_filter__plan0.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     SUM(subq_26.listings) AS listings
   FROM (
-    -- Pass Only Elements: ['listings',]
+    -- Pass Only Elements: ['listings']
     SELECT
       subq_25.listings
     FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Trino/test_query_with_derived_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Trino/test_query_with_derived_metric_in_where_filter__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: Trino
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['listings',]
+-- Pass Only Elements: ['listings']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Trino/test_query_with_multiple_metrics_in_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Trino/test_query_with_multiple_metrics_in_filter__plan0.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     SUM(subq_21.listings) AS listings
   FROM (
-    -- Pass Only Elements: ['listings',]
+    -- Pass Only Elements: ['listings']
     SELECT
       subq_20.listings
     FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Trino/test_query_with_multiple_metrics_in_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Trino/test_query_with_multiple_metrics_in_filter__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: Trino
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['listings',]
+-- Pass Only Elements: ['listings']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 WITH sma_28009_cte AS (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Trino/test_query_with_ratio_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Trino/test_query_with_ratio_metric_in_where_filter__plan0.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     SUM(subq_25.listings) AS listings
   FROM (
-    -- Pass Only Elements: ['listings',]
+    -- Pass Only Elements: ['listings']
     SELECT
       subq_24.listings
     FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Trino/test_query_with_ratio_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Trino/test_query_with_ratio_metric_in_where_filter__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: Trino
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['listings',]
+-- Pass Only Elements: ['listings']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Trino/test_query_with_simple_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Trino/test_query_with_simple_metric_in_where_filter__plan0.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     SUM(subq_13.listings) AS listings
   FROM (
-    -- Pass Only Elements: ['listings',]
+    -- Pass Only Elements: ['listings']
     SELECT
       subq_12.listings
     FROM (

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Trino/test_query_with_simple_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Trino/test_query_with_simple_metric_in_where_filter__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: Trino
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['listings',]
+-- Pass Only Elements: ['listings']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/BigQuery/test_dimensions_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/BigQuery/test_dimensions_with_time_constraint__plan0.sql
@@ -191,7 +191,7 @@ FROM (
       FROM ***************************.dim_listings_latest listings_latest_src_28000
     ) subq_0
     CROSS JOIN (
-      -- Pass Only Elements: ['metric_time__day',]
+      -- Pass Only Elements: ['metric_time__day']
       SELECT
         subq_2.metric_time__day
       FROM (

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/BigQuery/test_metric_time_only__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/BigQuery/test_metric_time_only__plan0.sql
@@ -4,7 +4,7 @@ docstring:
   Tests querying only metric time.
 sql_engine: BigQuery
 ---
--- Pass Only Elements: ['metric_time__day',]
+-- Pass Only Elements: ['metric_time__day']
 SELECT
   subq_1.metric_time__day
 FROM (

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/BigQuery/test_metric_time_only__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/BigQuery/test_metric_time_only__plan0_optimized.sql
@@ -6,7 +6,7 @@ sql_engine: BigQuery
 ---
 -- Read From Time Spine 'mf_time_spine'
 -- Metric Time Dimension 'ds'
--- Pass Only Elements: ['metric_time__day',]
+-- Pass Only Elements: ['metric_time__day']
 SELECT
   ds AS metric_time__day
 FROM ***************************.mf_time_spine time_spine_src_28006

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/BigQuery/test_metric_time_quarter_alone__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/BigQuery/test_metric_time_quarter_alone__plan0.sql
@@ -2,7 +2,7 @@ test_name: test_metric_time_quarter_alone
 test_filename: test_metric_time_without_metrics.py
 sql_engine: BigQuery
 ---
--- Pass Only Elements: ['metric_time__quarter',]
+-- Pass Only Elements: ['metric_time__quarter']
 SELECT
   subq_1.metric_time__quarter
 FROM (

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/BigQuery/test_metric_time_quarter_alone__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/BigQuery/test_metric_time_quarter_alone__plan0_optimized.sql
@@ -4,7 +4,7 @@ sql_engine: BigQuery
 ---
 -- Read From Time Spine 'mf_time_spine'
 -- Metric Time Dimension 'ds'
--- Pass Only Elements: ['metric_time__quarter',]
+-- Pass Only Elements: ['metric_time__quarter']
 SELECT
   DATETIME_TRUNC(ds, quarter) AS metric_time__quarter
 FROM ***************************.mf_time_spine time_spine_src_28006

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/BigQuery/test_metric_time_with_other_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/BigQuery/test_metric_time_with_other_dimensions__plan0.sql
@@ -130,7 +130,7 @@ FROM (
     FROM ***************************.dim_listings_latest listings_latest_src_28000
   ) subq_0
   CROSS JOIN (
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       subq_2.metric_time__day
     FROM (

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/Databricks/test_dimensions_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/Databricks/test_dimensions_with_time_constraint__plan0.sql
@@ -191,7 +191,7 @@ FROM (
       FROM ***************************.dim_listings_latest listings_latest_src_28000
     ) subq_0
     CROSS JOIN (
-      -- Pass Only Elements: ['metric_time__day',]
+      -- Pass Only Elements: ['metric_time__day']
       SELECT
         subq_2.metric_time__day
       FROM (

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/Databricks/test_metric_time_only__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/Databricks/test_metric_time_only__plan0.sql
@@ -4,7 +4,7 @@ docstring:
   Tests querying only metric time.
 sql_engine: Databricks
 ---
--- Pass Only Elements: ['metric_time__day',]
+-- Pass Only Elements: ['metric_time__day']
 SELECT
   subq_1.metric_time__day
 FROM (

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/Databricks/test_metric_time_only__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/Databricks/test_metric_time_only__plan0_optimized.sql
@@ -6,7 +6,7 @@ sql_engine: Databricks
 ---
 -- Read From Time Spine 'mf_time_spine'
 -- Metric Time Dimension 'ds'
--- Pass Only Elements: ['metric_time__day',]
+-- Pass Only Elements: ['metric_time__day']
 SELECT
   ds AS metric_time__day
 FROM ***************************.mf_time_spine time_spine_src_28006

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/Databricks/test_metric_time_quarter_alone__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/Databricks/test_metric_time_quarter_alone__plan0.sql
@@ -2,7 +2,7 @@ test_name: test_metric_time_quarter_alone
 test_filename: test_metric_time_without_metrics.py
 sql_engine: Databricks
 ---
--- Pass Only Elements: ['metric_time__quarter',]
+-- Pass Only Elements: ['metric_time__quarter']
 SELECT
   subq_1.metric_time__quarter
 FROM (

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/Databricks/test_metric_time_quarter_alone__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/Databricks/test_metric_time_quarter_alone__plan0_optimized.sql
@@ -4,7 +4,7 @@ sql_engine: Databricks
 ---
 -- Read From Time Spine 'mf_time_spine'
 -- Metric Time Dimension 'ds'
--- Pass Only Elements: ['metric_time__quarter',]
+-- Pass Only Elements: ['metric_time__quarter']
 SELECT
   DATE_TRUNC('quarter', ds) AS metric_time__quarter
 FROM ***************************.mf_time_spine time_spine_src_28006

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/Databricks/test_metric_time_with_other_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/Databricks/test_metric_time_with_other_dimensions__plan0.sql
@@ -130,7 +130,7 @@ FROM (
     FROM ***************************.dim_listings_latest listings_latest_src_28000
   ) subq_0
   CROSS JOIN (
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       subq_2.metric_time__day
     FROM (

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/DuckDB/test_dimensions_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/DuckDB/test_dimensions_with_time_constraint__plan0.sql
@@ -191,7 +191,7 @@ FROM (
       FROM ***************************.dim_listings_latest listings_latest_src_28000
     ) subq_0
     CROSS JOIN (
-      -- Pass Only Elements: ['metric_time__day',]
+      -- Pass Only Elements: ['metric_time__day']
       SELECT
         subq_2.metric_time__day
       FROM (

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/DuckDB/test_metric_time_only__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/DuckDB/test_metric_time_only__plan0.sql
@@ -4,7 +4,7 @@ docstring:
   Tests querying only metric time.
 sql_engine: DuckDB
 ---
--- Pass Only Elements: ['metric_time__day',]
+-- Pass Only Elements: ['metric_time__day']
 SELECT
   subq_1.metric_time__day
 FROM (

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/DuckDB/test_metric_time_only__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/DuckDB/test_metric_time_only__plan0_optimized.sql
@@ -6,7 +6,7 @@ sql_engine: DuckDB
 ---
 -- Read From Time Spine 'mf_time_spine'
 -- Metric Time Dimension 'ds'
--- Pass Only Elements: ['metric_time__day',]
+-- Pass Only Elements: ['metric_time__day']
 SELECT
   ds AS metric_time__day
 FROM ***************************.mf_time_spine time_spine_src_28006

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/DuckDB/test_metric_time_quarter_alone__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/DuckDB/test_metric_time_quarter_alone__plan0.sql
@@ -2,7 +2,7 @@ test_name: test_metric_time_quarter_alone
 test_filename: test_metric_time_without_metrics.py
 sql_engine: DuckDB
 ---
--- Pass Only Elements: ['metric_time__quarter',]
+-- Pass Only Elements: ['metric_time__quarter']
 SELECT
   subq_1.metric_time__quarter
 FROM (

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/DuckDB/test_metric_time_quarter_alone__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/DuckDB/test_metric_time_quarter_alone__plan0_optimized.sql
@@ -4,7 +4,7 @@ sql_engine: DuckDB
 ---
 -- Read From Time Spine 'mf_time_spine'
 -- Metric Time Dimension 'ds'
--- Pass Only Elements: ['metric_time__quarter',]
+-- Pass Only Elements: ['metric_time__quarter']
 SELECT
   DATE_TRUNC('quarter', ds) AS metric_time__quarter
 FROM ***************************.mf_time_spine time_spine_src_28006

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/DuckDB/test_metric_time_with_other_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/DuckDB/test_metric_time_with_other_dimensions__plan0.sql
@@ -130,7 +130,7 @@ FROM (
     FROM ***************************.dim_listings_latest listings_latest_src_28000
   ) subq_0
   CROSS JOIN (
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       subq_2.metric_time__day
     FROM (

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/Postgres/test_dimensions_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/Postgres/test_dimensions_with_time_constraint__plan0.sql
@@ -191,7 +191,7 @@ FROM (
       FROM ***************************.dim_listings_latest listings_latest_src_28000
     ) subq_0
     CROSS JOIN (
-      -- Pass Only Elements: ['metric_time__day',]
+      -- Pass Only Elements: ['metric_time__day']
       SELECT
         subq_2.metric_time__day
       FROM (

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/Postgres/test_metric_time_only__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/Postgres/test_metric_time_only__plan0.sql
@@ -4,7 +4,7 @@ docstring:
   Tests querying only metric time.
 sql_engine: Postgres
 ---
--- Pass Only Elements: ['metric_time__day',]
+-- Pass Only Elements: ['metric_time__day']
 SELECT
   subq_1.metric_time__day
 FROM (

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/Postgres/test_metric_time_only__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/Postgres/test_metric_time_only__plan0_optimized.sql
@@ -6,7 +6,7 @@ sql_engine: Postgres
 ---
 -- Read From Time Spine 'mf_time_spine'
 -- Metric Time Dimension 'ds'
--- Pass Only Elements: ['metric_time__day',]
+-- Pass Only Elements: ['metric_time__day']
 SELECT
   ds AS metric_time__day
 FROM ***************************.mf_time_spine time_spine_src_28006

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/Postgres/test_metric_time_quarter_alone__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/Postgres/test_metric_time_quarter_alone__plan0.sql
@@ -2,7 +2,7 @@ test_name: test_metric_time_quarter_alone
 test_filename: test_metric_time_without_metrics.py
 sql_engine: Postgres
 ---
--- Pass Only Elements: ['metric_time__quarter',]
+-- Pass Only Elements: ['metric_time__quarter']
 SELECT
   subq_1.metric_time__quarter
 FROM (

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/Postgres/test_metric_time_quarter_alone__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/Postgres/test_metric_time_quarter_alone__plan0_optimized.sql
@@ -4,7 +4,7 @@ sql_engine: Postgres
 ---
 -- Read From Time Spine 'mf_time_spine'
 -- Metric Time Dimension 'ds'
--- Pass Only Elements: ['metric_time__quarter',]
+-- Pass Only Elements: ['metric_time__quarter']
 SELECT
   DATE_TRUNC('quarter', ds) AS metric_time__quarter
 FROM ***************************.mf_time_spine time_spine_src_28006

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/Postgres/test_metric_time_with_other_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/Postgres/test_metric_time_with_other_dimensions__plan0.sql
@@ -130,7 +130,7 @@ FROM (
     FROM ***************************.dim_listings_latest listings_latest_src_28000
   ) subq_0
   CROSS JOIN (
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       subq_2.metric_time__day
     FROM (

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/Redshift/test_dimensions_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/Redshift/test_dimensions_with_time_constraint__plan0.sql
@@ -191,7 +191,7 @@ FROM (
       FROM ***************************.dim_listings_latest listings_latest_src_28000
     ) subq_0
     CROSS JOIN (
-      -- Pass Only Elements: ['metric_time__day',]
+      -- Pass Only Elements: ['metric_time__day']
       SELECT
         subq_2.metric_time__day
       FROM (

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/Redshift/test_metric_time_only__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/Redshift/test_metric_time_only__plan0.sql
@@ -4,7 +4,7 @@ docstring:
   Tests querying only metric time.
 sql_engine: Redshift
 ---
--- Pass Only Elements: ['metric_time__day',]
+-- Pass Only Elements: ['metric_time__day']
 SELECT
   subq_1.metric_time__day
 FROM (

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/Redshift/test_metric_time_only__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/Redshift/test_metric_time_only__plan0_optimized.sql
@@ -6,7 +6,7 @@ sql_engine: Redshift
 ---
 -- Read From Time Spine 'mf_time_spine'
 -- Metric Time Dimension 'ds'
--- Pass Only Elements: ['metric_time__day',]
+-- Pass Only Elements: ['metric_time__day']
 SELECT
   ds AS metric_time__day
 FROM ***************************.mf_time_spine time_spine_src_28006

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/Redshift/test_metric_time_quarter_alone__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/Redshift/test_metric_time_quarter_alone__plan0.sql
@@ -2,7 +2,7 @@ test_name: test_metric_time_quarter_alone
 test_filename: test_metric_time_without_metrics.py
 sql_engine: Redshift
 ---
--- Pass Only Elements: ['metric_time__quarter',]
+-- Pass Only Elements: ['metric_time__quarter']
 SELECT
   subq_1.metric_time__quarter
 FROM (

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/Redshift/test_metric_time_quarter_alone__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/Redshift/test_metric_time_quarter_alone__plan0_optimized.sql
@@ -4,7 +4,7 @@ sql_engine: Redshift
 ---
 -- Read From Time Spine 'mf_time_spine'
 -- Metric Time Dimension 'ds'
--- Pass Only Elements: ['metric_time__quarter',]
+-- Pass Only Elements: ['metric_time__quarter']
 SELECT
   DATE_TRUNC('quarter', ds) AS metric_time__quarter
 FROM ***************************.mf_time_spine time_spine_src_28006

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/Redshift/test_metric_time_with_other_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/Redshift/test_metric_time_with_other_dimensions__plan0.sql
@@ -130,7 +130,7 @@ FROM (
     FROM ***************************.dim_listings_latest listings_latest_src_28000
   ) subq_0
   CROSS JOIN (
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       subq_2.metric_time__day
     FROM (

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/Snowflake/test_dimensions_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/Snowflake/test_dimensions_with_time_constraint__plan0.sql
@@ -191,7 +191,7 @@ FROM (
       FROM ***************************.dim_listings_latest listings_latest_src_28000
     ) subq_0
     CROSS JOIN (
-      -- Pass Only Elements: ['metric_time__day',]
+      -- Pass Only Elements: ['metric_time__day']
       SELECT
         subq_2.metric_time__day
       FROM (

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/Snowflake/test_metric_time_only__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/Snowflake/test_metric_time_only__plan0.sql
@@ -4,7 +4,7 @@ docstring:
   Tests querying only metric time.
 sql_engine: Snowflake
 ---
--- Pass Only Elements: ['metric_time__day',]
+-- Pass Only Elements: ['metric_time__day']
 SELECT
   subq_1.metric_time__day
 FROM (

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/Snowflake/test_metric_time_only__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/Snowflake/test_metric_time_only__plan0_optimized.sql
@@ -6,7 +6,7 @@ sql_engine: Snowflake
 ---
 -- Read From Time Spine 'mf_time_spine'
 -- Metric Time Dimension 'ds'
--- Pass Only Elements: ['metric_time__day',]
+-- Pass Only Elements: ['metric_time__day']
 SELECT
   ds AS metric_time__day
 FROM ***************************.mf_time_spine time_spine_src_28006

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/Snowflake/test_metric_time_quarter_alone__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/Snowflake/test_metric_time_quarter_alone__plan0.sql
@@ -2,7 +2,7 @@ test_name: test_metric_time_quarter_alone
 test_filename: test_metric_time_without_metrics.py
 sql_engine: Snowflake
 ---
--- Pass Only Elements: ['metric_time__quarter',]
+-- Pass Only Elements: ['metric_time__quarter']
 SELECT
   subq_1.metric_time__quarter
 FROM (

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/Snowflake/test_metric_time_quarter_alone__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/Snowflake/test_metric_time_quarter_alone__plan0_optimized.sql
@@ -4,7 +4,7 @@ sql_engine: Snowflake
 ---
 -- Read From Time Spine 'mf_time_spine'
 -- Metric Time Dimension 'ds'
--- Pass Only Elements: ['metric_time__quarter',]
+-- Pass Only Elements: ['metric_time__quarter']
 SELECT
   DATE_TRUNC('quarter', ds) AS metric_time__quarter
 FROM ***************************.mf_time_spine time_spine_src_28006

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/Snowflake/test_metric_time_with_other_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/Snowflake/test_metric_time_with_other_dimensions__plan0.sql
@@ -130,7 +130,7 @@ FROM (
     FROM ***************************.dim_listings_latest listings_latest_src_28000
   ) subq_0
   CROSS JOIN (
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       subq_2.metric_time__day
     FROM (

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/Trino/test_dimensions_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/Trino/test_dimensions_with_time_constraint__plan0.sql
@@ -191,7 +191,7 @@ FROM (
       FROM ***************************.dim_listings_latest listings_latest_src_28000
     ) subq_0
     CROSS JOIN (
-      -- Pass Only Elements: ['metric_time__day',]
+      -- Pass Only Elements: ['metric_time__day']
       SELECT
         subq_2.metric_time__day
       FROM (

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/Trino/test_metric_time_only__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/Trino/test_metric_time_only__plan0.sql
@@ -4,7 +4,7 @@ docstring:
   Tests querying only metric time.
 sql_engine: Trino
 ---
--- Pass Only Elements: ['metric_time__day',]
+-- Pass Only Elements: ['metric_time__day']
 SELECT
   subq_1.metric_time__day
 FROM (

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/Trino/test_metric_time_only__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/Trino/test_metric_time_only__plan0_optimized.sql
@@ -6,7 +6,7 @@ sql_engine: Trino
 ---
 -- Read From Time Spine 'mf_time_spine'
 -- Metric Time Dimension 'ds'
--- Pass Only Elements: ['metric_time__day',]
+-- Pass Only Elements: ['metric_time__day']
 SELECT
   ds AS metric_time__day
 FROM ***************************.mf_time_spine time_spine_src_28006

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/Trino/test_metric_time_quarter_alone__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/Trino/test_metric_time_quarter_alone__plan0.sql
@@ -2,7 +2,7 @@ test_name: test_metric_time_quarter_alone
 test_filename: test_metric_time_without_metrics.py
 sql_engine: Trino
 ---
--- Pass Only Elements: ['metric_time__quarter',]
+-- Pass Only Elements: ['metric_time__quarter']
 SELECT
   subq_1.metric_time__quarter
 FROM (

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/Trino/test_metric_time_quarter_alone__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/Trino/test_metric_time_quarter_alone__plan0_optimized.sql
@@ -4,7 +4,7 @@ sql_engine: Trino
 ---
 -- Read From Time Spine 'mf_time_spine'
 -- Metric Time Dimension 'ds'
--- Pass Only Elements: ['metric_time__quarter',]
+-- Pass Only Elements: ['metric_time__quarter']
 SELECT
   DATE_TRUNC('quarter', ds) AS metric_time__quarter
 FROM ***************************.mf_time_spine time_spine_src_28006

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/Trino/test_metric_time_with_other_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/Trino/test_metric_time_with_other_dimensions__plan0.sql
@@ -130,7 +130,7 @@ FROM (
     FROM ***************************.dim_listings_latest listings_latest_src_28000
   ) subq_0
   CROSS JOIN (
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       subq_2.metric_time__day
     FROM (

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/test_dimensions_with_time_constraint__plan0.xml
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/test_dimensions_with_time_constraint__plan0.xml
@@ -676,7 +676,7 @@ test_filename: test_metric_time_without_metrics.py
                     </SqlTableNode>
                 </SqlSelectStatementNode>
                 <SqlSelectStatementNode>
-                    <!-- description = "Pass Only Elements: ['metric_time__day',]" -->
+                    <!-- description = "Pass Only Elements: ['metric_time__day']" -->
                     <!-- node_id = NodeId(id_str='ss_97') -->
                     <!-- col0 =                                                -->
                     <!--   SqlSelectColumn(                                    -->

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/test_metric_time_only__plan0.xml
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/test_metric_time_only__plan0.xml
@@ -5,7 +5,7 @@ docstring:
 ---
 <SqlPlan>
     <SqlSelectStatementNode>
-        <!-- description = "Pass Only Elements: ['metric_time__day',]" -->
+        <!-- description = "Pass Only Elements: ['metric_time__day']" -->
         <!-- node_id = NodeId(id_str='ss_38') -->
         <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_24), column_alias='metric_time__day') -->
         <!-- from_source = SqlSelectStatementNode(node_id=ss_37) -->

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/test_metric_time_quarter_alone__plan0.xml
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/test_metric_time_quarter_alone__plan0.xml
@@ -3,7 +3,7 @@ test_filename: test_metric_time_without_metrics.py
 ---
 <SqlPlan>
     <SqlSelectStatementNode>
-        <!-- description = "Pass Only Elements: ['metric_time__quarter',]" -->
+        <!-- description = "Pass Only Elements: ['metric_time__quarter']" -->
         <!-- node_id = NodeId(id_str='ss_38') -->
         <!-- col0 =                                                                                                   -->
         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_24), column_alias='metric_time__quarter') -->

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/test_metric_time_with_other_dimensions__plan0.xml
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlPlan/test_metric_time_with_other_dimensions__plan0.xml
@@ -432,7 +432,7 @@ test_filename: test_metric_time_without_metrics.py
                 </SqlTableNode>
             </SqlSelectStatementNode>
             <SqlSelectStatementNode>
-                <!-- description = "Pass Only Elements: ['metric_time__day',]" -->
+                <!-- description = "Pass Only Elements: ['metric_time__day']" -->
                 <!-- node_id = NodeId(id_str='ss_97') -->
                 <!-- col0 =                                                                                               -->
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_24), column_alias='metric_time__day') -->

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/BigQuery/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/BigQuery/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
@@ -31,7 +31,7 @@ FROM (
         , subq_8.listing__country_latest AS listing__country_latest
         , subq_8.bookings AS bookings
       FROM (
-        -- Pass Only Elements: ['metric_time__day',]
+        -- Pass Only Elements: ['metric_time__day']
         SELECT
           subq_10.metric_time__day
         FROM (
@@ -644,7 +644,7 @@ FROM (
         , subq_24.listing__country_latest AS listing__country_latest
         , subq_24.bookings AS bookings
       FROM (
-        -- Pass Only Elements: ['metric_time__day',]
+        -- Pass Only Elements: ['metric_time__day']
         SELECT
           subq_26.metric_time__day
         FROM (
@@ -999,7 +999,7 @@ FROM (
                   , subq_14.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                   , subq_14.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
                 FROM (
-                  -- Pass Only Elements: ['metric_time__day',]
+                  -- Pass Only Elements: ['metric_time__day']
                   SELECT
                     subq_16.metric_time__day
                   FROM (

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/BigQuery/test_offset_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/BigQuery/test_offset_metric_with_query_time_filters__plan0.sql
@@ -908,7 +908,7 @@ FROM (
                 , subq_10.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                 , subq_10.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
               FROM (
-                -- Pass Only Elements: ['metric_time__day',]
+                -- Pass Only Elements: ['metric_time__day']
                 SELECT
                   subq_12.metric_time__day
                 FROM (

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/BigQuery/test_simple_join_to_time_spine_pushdown_filter_application__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/BigQuery/test_simple_join_to_time_spine_pushdown_filter_application__plan0.sql
@@ -24,7 +24,7 @@ FROM (
       , subq_4.booking__is_instant AS booking__is_instant
       , subq_4.bookings AS bookings
     FROM (
-      -- Pass Only Elements: ['metric_time__day',]
+      -- Pass Only Elements: ['metric_time__day']
       SELECT
         subq_6.metric_time__day
       FROM (

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Databricks/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Databricks/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
@@ -31,7 +31,7 @@ FROM (
         , subq_8.listing__country_latest AS listing__country_latest
         , subq_8.bookings AS bookings
       FROM (
-        -- Pass Only Elements: ['metric_time__day',]
+        -- Pass Only Elements: ['metric_time__day']
         SELECT
           subq_10.metric_time__day
         FROM (
@@ -644,7 +644,7 @@ FROM (
         , subq_24.listing__country_latest AS listing__country_latest
         , subq_24.bookings AS bookings
       FROM (
-        -- Pass Only Elements: ['metric_time__day',]
+        -- Pass Only Elements: ['metric_time__day']
         SELECT
           subq_26.metric_time__day
         FROM (
@@ -999,7 +999,7 @@ FROM (
                   , subq_14.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                   , subq_14.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
                 FROM (
-                  -- Pass Only Elements: ['metric_time__day',]
+                  -- Pass Only Elements: ['metric_time__day']
                   SELECT
                     subq_16.metric_time__day
                   FROM (

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Databricks/test_offset_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Databricks/test_offset_metric_with_query_time_filters__plan0.sql
@@ -908,7 +908,7 @@ FROM (
                 , subq_10.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                 , subq_10.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
               FROM (
-                -- Pass Only Elements: ['metric_time__day',]
+                -- Pass Only Elements: ['metric_time__day']
                 SELECT
                   subq_12.metric_time__day
                 FROM (

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Databricks/test_simple_join_to_time_spine_pushdown_filter_application__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Databricks/test_simple_join_to_time_spine_pushdown_filter_application__plan0.sql
@@ -24,7 +24,7 @@ FROM (
       , subq_4.booking__is_instant AS booking__is_instant
       , subq_4.bookings AS bookings
     FROM (
-      -- Pass Only Elements: ['metric_time__day',]
+      -- Pass Only Elements: ['metric_time__day']
       SELECT
         subq_6.metric_time__day
       FROM (

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/DuckDB/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/DuckDB/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
@@ -31,7 +31,7 @@ FROM (
         , subq_8.listing__country_latest AS listing__country_latest
         , subq_8.bookings AS bookings
       FROM (
-        -- Pass Only Elements: ['metric_time__day',]
+        -- Pass Only Elements: ['metric_time__day']
         SELECT
           subq_10.metric_time__day
         FROM (
@@ -644,7 +644,7 @@ FROM (
         , subq_24.listing__country_latest AS listing__country_latest
         , subq_24.bookings AS bookings
       FROM (
-        -- Pass Only Elements: ['metric_time__day',]
+        -- Pass Only Elements: ['metric_time__day']
         SELECT
           subq_26.metric_time__day
         FROM (
@@ -999,7 +999,7 @@ FROM (
                   , subq_14.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                   , subq_14.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
                 FROM (
-                  -- Pass Only Elements: ['metric_time__day',]
+                  -- Pass Only Elements: ['metric_time__day']
                   SELECT
                     subq_16.metric_time__day
                   FROM (

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/DuckDB/test_offset_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/DuckDB/test_offset_metric_with_query_time_filters__plan0.sql
@@ -908,7 +908,7 @@ FROM (
                 , subq_10.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                 , subq_10.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
               FROM (
-                -- Pass Only Elements: ['metric_time__day',]
+                -- Pass Only Elements: ['metric_time__day']
                 SELECT
                   subq_12.metric_time__day
                 FROM (

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/DuckDB/test_simple_join_to_time_spine_pushdown_filter_application__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/DuckDB/test_simple_join_to_time_spine_pushdown_filter_application__plan0.sql
@@ -24,7 +24,7 @@ FROM (
       , subq_4.booking__is_instant AS booking__is_instant
       , subq_4.bookings AS bookings
     FROM (
-      -- Pass Only Elements: ['metric_time__day',]
+      -- Pass Only Elements: ['metric_time__day']
       SELECT
         subq_6.metric_time__day
       FROM (

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Postgres/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Postgres/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
@@ -31,7 +31,7 @@ FROM (
         , subq_8.listing__country_latest AS listing__country_latest
         , subq_8.bookings AS bookings
       FROM (
-        -- Pass Only Elements: ['metric_time__day',]
+        -- Pass Only Elements: ['metric_time__day']
         SELECT
           subq_10.metric_time__day
         FROM (
@@ -644,7 +644,7 @@ FROM (
         , subq_24.listing__country_latest AS listing__country_latest
         , subq_24.bookings AS bookings
       FROM (
-        -- Pass Only Elements: ['metric_time__day',]
+        -- Pass Only Elements: ['metric_time__day']
         SELECT
           subq_26.metric_time__day
         FROM (
@@ -999,7 +999,7 @@ FROM (
                   , subq_14.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                   , subq_14.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
                 FROM (
-                  -- Pass Only Elements: ['metric_time__day',]
+                  -- Pass Only Elements: ['metric_time__day']
                   SELECT
                     subq_16.metric_time__day
                   FROM (

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Postgres/test_offset_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Postgres/test_offset_metric_with_query_time_filters__plan0.sql
@@ -908,7 +908,7 @@ FROM (
                 , subq_10.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                 , subq_10.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
               FROM (
-                -- Pass Only Elements: ['metric_time__day',]
+                -- Pass Only Elements: ['metric_time__day']
                 SELECT
                   subq_12.metric_time__day
                 FROM (

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Postgres/test_simple_join_to_time_spine_pushdown_filter_application__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Postgres/test_simple_join_to_time_spine_pushdown_filter_application__plan0.sql
@@ -24,7 +24,7 @@ FROM (
       , subq_4.booking__is_instant AS booking__is_instant
       , subq_4.bookings AS bookings
     FROM (
-      -- Pass Only Elements: ['metric_time__day',]
+      -- Pass Only Elements: ['metric_time__day']
       SELECT
         subq_6.metric_time__day
       FROM (

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Redshift/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Redshift/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
@@ -31,7 +31,7 @@ FROM (
         , subq_8.listing__country_latest AS listing__country_latest
         , subq_8.bookings AS bookings
       FROM (
-        -- Pass Only Elements: ['metric_time__day',]
+        -- Pass Only Elements: ['metric_time__day']
         SELECT
           subq_10.metric_time__day
         FROM (
@@ -644,7 +644,7 @@ FROM (
         , subq_24.listing__country_latest AS listing__country_latest
         , subq_24.bookings AS bookings
       FROM (
-        -- Pass Only Elements: ['metric_time__day',]
+        -- Pass Only Elements: ['metric_time__day']
         SELECT
           subq_26.metric_time__day
         FROM (
@@ -999,7 +999,7 @@ FROM (
                   , subq_14.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                   , subq_14.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
                 FROM (
-                  -- Pass Only Elements: ['metric_time__day',]
+                  -- Pass Only Elements: ['metric_time__day']
                   SELECT
                     subq_16.metric_time__day
                   FROM (

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Redshift/test_offset_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Redshift/test_offset_metric_with_query_time_filters__plan0.sql
@@ -908,7 +908,7 @@ FROM (
                 , subq_10.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                 , subq_10.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
               FROM (
-                -- Pass Only Elements: ['metric_time__day',]
+                -- Pass Only Elements: ['metric_time__day']
                 SELECT
                   subq_12.metric_time__day
                 FROM (

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Redshift/test_simple_join_to_time_spine_pushdown_filter_application__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Redshift/test_simple_join_to_time_spine_pushdown_filter_application__plan0.sql
@@ -24,7 +24,7 @@ FROM (
       , subq_4.booking__is_instant AS booking__is_instant
       , subq_4.bookings AS bookings
     FROM (
-      -- Pass Only Elements: ['metric_time__day',]
+      -- Pass Only Elements: ['metric_time__day']
       SELECT
         subq_6.metric_time__day
       FROM (

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Snowflake/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Snowflake/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
@@ -31,7 +31,7 @@ FROM (
         , subq_8.listing__country_latest AS listing__country_latest
         , subq_8.bookings AS bookings
       FROM (
-        -- Pass Only Elements: ['metric_time__day',]
+        -- Pass Only Elements: ['metric_time__day']
         SELECT
           subq_10.metric_time__day
         FROM (
@@ -644,7 +644,7 @@ FROM (
         , subq_24.listing__country_latest AS listing__country_latest
         , subq_24.bookings AS bookings
       FROM (
-        -- Pass Only Elements: ['metric_time__day',]
+        -- Pass Only Elements: ['metric_time__day']
         SELECT
           subq_26.metric_time__day
         FROM (
@@ -999,7 +999,7 @@ FROM (
                   , subq_14.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                   , subq_14.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
                 FROM (
-                  -- Pass Only Elements: ['metric_time__day',]
+                  -- Pass Only Elements: ['metric_time__day']
                   SELECT
                     subq_16.metric_time__day
                   FROM (

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Snowflake/test_offset_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Snowflake/test_offset_metric_with_query_time_filters__plan0.sql
@@ -908,7 +908,7 @@ FROM (
                 , subq_10.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                 , subq_10.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
               FROM (
-                -- Pass Only Elements: ['metric_time__day',]
+                -- Pass Only Elements: ['metric_time__day']
                 SELECT
                   subq_12.metric_time__day
                 FROM (

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Snowflake/test_simple_join_to_time_spine_pushdown_filter_application__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Snowflake/test_simple_join_to_time_spine_pushdown_filter_application__plan0.sql
@@ -24,7 +24,7 @@ FROM (
       , subq_4.booking__is_instant AS booking__is_instant
       , subq_4.bookings AS bookings
     FROM (
-      -- Pass Only Elements: ['metric_time__day',]
+      -- Pass Only Elements: ['metric_time__day']
       SELECT
         subq_6.metric_time__day
       FROM (

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Trino/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Trino/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
@@ -31,7 +31,7 @@ FROM (
         , subq_8.listing__country_latest AS listing__country_latest
         , subq_8.bookings AS bookings
       FROM (
-        -- Pass Only Elements: ['metric_time__day',]
+        -- Pass Only Elements: ['metric_time__day']
         SELECT
           subq_10.metric_time__day
         FROM (
@@ -644,7 +644,7 @@ FROM (
         , subq_24.listing__country_latest AS listing__country_latest
         , subq_24.bookings AS bookings
       FROM (
-        -- Pass Only Elements: ['metric_time__day',]
+        -- Pass Only Elements: ['metric_time__day']
         SELECT
           subq_26.metric_time__day
         FROM (
@@ -999,7 +999,7 @@ FROM (
                   , subq_14.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                   , subq_14.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
                 FROM (
-                  -- Pass Only Elements: ['metric_time__day',]
+                  -- Pass Only Elements: ['metric_time__day']
                   SELECT
                     subq_16.metric_time__day
                   FROM (

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Trino/test_offset_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Trino/test_offset_metric_with_query_time_filters__plan0.sql
@@ -908,7 +908,7 @@ FROM (
                 , subq_10.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
                 , subq_10.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
               FROM (
-                -- Pass Only Elements: ['metric_time__day',]
+                -- Pass Only Elements: ['metric_time__day']
                 SELECT
                   subq_12.metric_time__day
                 FROM (

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Trino/test_simple_join_to_time_spine_pushdown_filter_application__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Trino/test_simple_join_to_time_spine_pushdown_filter_application__plan0.sql
@@ -24,7 +24,7 @@ FROM (
       , subq_4.booking__is_instant AS booking__is_instant
       , subq_4.bookings AS bookings
     FROM (
-      -- Pass Only Elements: ['metric_time__day',]
+      -- Pass Only Elements: ['metric_time__day']
       SELECT
         subq_6.metric_time__day
       FROM (

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/BigQuery/test_distinct_values__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/BigQuery/test_distinct_values__plan0.sql
@@ -8,7 +8,7 @@ sql_engine: BigQuery
 SELECT
   subq_2.listing__country_latest
 FROM (
-  -- Pass Only Elements: ['listing__country_latest',]
+  -- Pass Only Elements: ['listing__country_latest']
   SELECT
     subq_1.listing__country_latest
   FROM (

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/BigQuery/test_distinct_values__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/BigQuery/test_distinct_values__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: BigQuery
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['listing__country_latest',]
+-- Pass Only Elements: ['listing__country_latest']
 -- Order By ['listing__country_latest'] Limit 100
 SELECT
   listing__country_latest

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/BigQuery/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/BigQuery/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0.sql
@@ -19,7 +19,7 @@ FROM (
       SELECT
         SUM(subq_2.bookings) AS bookings
       FROM (
-        -- Pass Only Elements: ['bookings',]
+        -- Pass Only Elements: ['bookings']
         SELECT
           subq_1.bookings
         FROM (
@@ -229,7 +229,7 @@ FROM (
       SELECT
         SUM(subq_7.listings) AS listings
       FROM (
-        -- Pass Only Elements: ['listings',]
+        -- Pass Only Elements: ['listings']
         SELECT
           subq_6.listings
         FROM (

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/BigQuery/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/BigQuery/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0_optimized.sql
@@ -9,7 +9,7 @@ SELECT
 FROM (
   -- Read Elements From Semantic Model 'bookings_source'
   -- Metric Time Dimension 'ds'
-  -- Pass Only Elements: ['bookings',]
+  -- Pass Only Elements: ['bookings']
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT
@@ -19,7 +19,7 @@ FROM (
 CROSS JOIN (
   -- Read Elements From Semantic Model 'listings_latest'
   -- Metric Time Dimension 'ds'
-  -- Pass Only Elements: ['listings',]
+  -- Pass Only Elements: ['listings']
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/BigQuery/test_min_max_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/BigQuery/test_min_max_metric_time__plan0.sql
@@ -9,7 +9,7 @@ SELECT
   MIN(subq_2.metric_time__day) AS metric_time__day__min
   , MAX(subq_2.metric_time__day) AS metric_time__day__max
 FROM (
-  -- Pass Only Elements: ['metric_time__day',]
+  -- Pass Only Elements: ['metric_time__day']
   SELECT
     subq_1.metric_time__day
   FROM (

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/BigQuery/test_min_max_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/BigQuery/test_min_max_metric_time__plan0_optimized.sql
@@ -11,7 +11,7 @@ SELECT
 FROM (
   -- Read From Time Spine 'mf_time_spine'
   -- Metric Time Dimension 'ds'
-  -- Pass Only Elements: ['metric_time__day',]
+  -- Pass Only Elements: ['metric_time__day']
   SELECT
     ds AS metric_time__day
   FROM ***************************.mf_time_spine time_spine_src_28006

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/BigQuery/test_min_max_metric_time_week__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/BigQuery/test_min_max_metric_time_week__plan0.sql
@@ -9,7 +9,7 @@ SELECT
   MIN(subq_2.metric_time__week) AS metric_time__week__min
   , MAX(subq_2.metric_time__week) AS metric_time__week__max
 FROM (
-  -- Pass Only Elements: ['metric_time__week',]
+  -- Pass Only Elements: ['metric_time__week']
   SELECT
     subq_1.metric_time__week
   FROM (

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/BigQuery/test_min_max_metric_time_week__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/BigQuery/test_min_max_metric_time_week__plan0_optimized.sql
@@ -11,7 +11,7 @@ SELECT
 FROM (
   -- Read From Time Spine 'mf_time_spine'
   -- Metric Time Dimension 'ds'
-  -- Pass Only Elements: ['metric_time__week',]
+  -- Pass Only Elements: ['metric_time__week']
   SELECT
     DATETIME_TRUNC(ds, isoweek) AS metric_time__week
   FROM ***************************.mf_time_spine time_spine_src_28006

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/BigQuery/test_min_max_only_categorical__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/BigQuery/test_min_max_only_categorical__plan0.sql
@@ -9,7 +9,7 @@ SELECT
   MIN(subq_1.listing__country_latest) AS listing__country_latest__min
   , MAX(subq_1.listing__country_latest) AS listing__country_latest__max
 FROM (
-  -- Pass Only Elements: ['listing__country_latest',]
+  -- Pass Only Elements: ['listing__country_latest']
   SELECT
     subq_0.listing__country_latest
   FROM (

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/BigQuery/test_min_max_only_categorical__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/BigQuery/test_min_max_only_categorical__plan0_optimized.sql
@@ -10,7 +10,7 @@ SELECT
   , MAX(listing__country_latest) AS listing__country_latest__max
 FROM (
   -- Read Elements From Semantic Model 'listings_latest'
-  -- Pass Only Elements: ['listing__country_latest',]
+  -- Pass Only Elements: ['listing__country_latest']
   SELECT
     country AS listing__country_latest
   FROM ***************************.dim_listings_latest listings_latest_src_28000

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/BigQuery/test_min_max_only_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/BigQuery/test_min_max_only_time__plan0.sql
@@ -9,7 +9,7 @@ SELECT
   MIN(subq_1.booking__paid_at__day) AS booking__paid_at__day__min
   , MAX(subq_1.booking__paid_at__day) AS booking__paid_at__day__max
 FROM (
-  -- Pass Only Elements: ['booking__paid_at__day',]
+  -- Pass Only Elements: ['booking__paid_at__day']
   SELECT
     subq_0.booking__paid_at__day
   FROM (

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/BigQuery/test_min_max_only_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/BigQuery/test_min_max_only_time__plan0_optimized.sql
@@ -10,7 +10,7 @@ SELECT
   , MAX(booking__paid_at__day) AS booking__paid_at__day__max
 FROM (
   -- Read Elements From Semantic Model 'bookings_source'
-  -- Pass Only Elements: ['booking__paid_at__day',]
+  -- Pass Only Elements: ['booking__paid_at__day']
   SELECT
     DATETIME_TRUNC(paid_at, day) AS booking__paid_at__day
   FROM ***************************.fct_bookings bookings_source_src_28000

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/BigQuery/test_min_max_only_time_quarter__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/BigQuery/test_min_max_only_time_quarter__plan0.sql
@@ -9,7 +9,7 @@ SELECT
   MIN(subq_1.booking__paid_at__quarter) AS booking__paid_at__quarter__min
   , MAX(subq_1.booking__paid_at__quarter) AS booking__paid_at__quarter__max
 FROM (
-  -- Pass Only Elements: ['booking__paid_at__quarter',]
+  -- Pass Only Elements: ['booking__paid_at__quarter']
   SELECT
     subq_0.booking__paid_at__quarter
   FROM (

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/BigQuery/test_min_max_only_time_quarter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/BigQuery/test_min_max_only_time_quarter__plan0_optimized.sql
@@ -10,7 +10,7 @@ SELECT
   , MAX(booking__paid_at__quarter) AS booking__paid_at__quarter__max
 FROM (
   -- Read Elements From Semantic Model 'bookings_source'
-  -- Pass Only Elements: ['booking__paid_at__quarter',]
+  -- Pass Only Elements: ['booking__paid_at__quarter']
   SELECT
     DATETIME_TRUNC(paid_at, quarter) AS booking__paid_at__quarter
   FROM ***************************.fct_bookings bookings_source_src_28000

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/BigQuery/test_multiple_metrics_no_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/BigQuery/test_multiple_metrics_no_dimensions__plan0.sql
@@ -15,7 +15,7 @@ FROM (
     SELECT
       SUM(subq_5.bookings) AS bookings
     FROM (
-      -- Pass Only Elements: ['bookings',]
+      -- Pass Only Elements: ['bookings']
       SELECT
         subq_4.bookings
       FROM (
@@ -328,7 +328,7 @@ CROSS JOIN (
     SELECT
       SUM(subq_11.listings) AS listings
     FROM (
-      -- Pass Only Elements: ['listings',]
+      -- Pass Only Elements: ['listings']
       SELECT
         subq_10.listings
       FROM (

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/BigQuery/test_multiple_metrics_no_dimensions__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/BigQuery/test_multiple_metrics_no_dimensions__plan0_optimized.sql
@@ -10,7 +10,7 @@ FROM (
   -- Read Elements From Semantic Model 'bookings_source'
   -- Metric Time Dimension 'ds'
   -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
-  -- Pass Only Elements: ['bookings',]
+  -- Pass Only Elements: ['bookings']
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT
@@ -22,7 +22,7 @@ CROSS JOIN (
   -- Read Elements From Semantic Model 'listings_latest'
   -- Metric Time Dimension 'ds'
   -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
-  -- Pass Only Elements: ['listings',]
+  -- Pass Only Elements: ['listings']
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/BigQuery/test_no_dedupe__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/BigQuery/test_no_dedupe__plan0.sql
@@ -181,7 +181,7 @@ FROM (
       FROM ***************************.dim_listings listings_src_26000
     ) subq_0
     CROSS JOIN (
-      -- Pass Only Elements: ['metric_time__month',]
+      -- Pass Only Elements: ['metric_time__month']
       SELECT
         subq_2.metric_time__month
       FROM (

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/BigQuery/test_no_dedupe_saved_query__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/BigQuery/test_no_dedupe_saved_query__plan0.sql
@@ -190,7 +190,7 @@ FROM (
       FROM ***************************.dim_listings_latest listings_latest_src_28000
     ) subq_0
     CROSS JOIN (
-      -- Pass Only Elements: ['metric_time__month',]
+      -- Pass Only Elements: ['metric_time__month']
       SELECT
         subq_2.metric_time__month
       FROM (

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/BigQuery/test_non_additive_dimension_with_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/BigQuery/test_non_additive_dimension_with_non_default_grain__plan0.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     SUM(subq_5.total_account_balance_first_day_of_month) AS total_account_balance_first_day_of_month
   FROM (
-    -- Pass Only Elements: ['total_account_balance_first_day_of_month',]
+    -- Pass Only Elements: ['total_account_balance_first_day_of_month']
     SELECT
       subq_4.total_account_balance_first_day_of_month
     FROM (

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/BigQuery/test_non_additive_dimension_with_non_default_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/BigQuery/test_non_additive_dimension_with_non_default_grain__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: BigQuery
 ---
 -- Join on MIN(ds_month) and [] grouping by None
--- Pass Only Elements: ['total_account_balance_first_day_of_month',]
+-- Pass Only Elements: ['total_account_balance_first_day_of_month']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/BigQuery/test_scd_dimension_filter_without_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/BigQuery/test_scd_dimension_filter_without_metric_time__plan0.sql
@@ -10,7 +10,7 @@ FROM (
   SELECT
     SUM(subq_6.bookings) AS bookings
   FROM (
-    -- Pass Only Elements: ['bookings',]
+    -- Pass Only Elements: ['bookings']
     SELECT
       subq_5.bookings
     FROM (

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/BigQuery/test_scd_dimension_filter_without_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/BigQuery/test_scd_dimension_filter_without_metric_time__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_query_rendering.py
 sql_engine: BigQuery
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['bookings',]
+-- Pass Only Elements: ['bookings']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Databricks/test_distinct_values__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Databricks/test_distinct_values__plan0.sql
@@ -8,7 +8,7 @@ sql_engine: Databricks
 SELECT
   subq_2.listing__country_latest
 FROM (
-  -- Pass Only Elements: ['listing__country_latest',]
+  -- Pass Only Elements: ['listing__country_latest']
   SELECT
     subq_1.listing__country_latest
   FROM (

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Databricks/test_distinct_values__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Databricks/test_distinct_values__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: Databricks
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['listing__country_latest',]
+-- Pass Only Elements: ['listing__country_latest']
 -- Order By ['listing__country_latest'] Limit 100
 SELECT
   listing__country_latest

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Databricks/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Databricks/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0.sql
@@ -19,7 +19,7 @@ FROM (
       SELECT
         SUM(subq_2.bookings) AS bookings
       FROM (
-        -- Pass Only Elements: ['bookings',]
+        -- Pass Only Elements: ['bookings']
         SELECT
           subq_1.bookings
         FROM (
@@ -229,7 +229,7 @@ FROM (
       SELECT
         SUM(subq_7.listings) AS listings
       FROM (
-        -- Pass Only Elements: ['listings',]
+        -- Pass Only Elements: ['listings']
         SELECT
           subq_6.listings
         FROM (

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Databricks/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Databricks/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0_optimized.sql
@@ -9,7 +9,7 @@ SELECT
 FROM (
   -- Read Elements From Semantic Model 'bookings_source'
   -- Metric Time Dimension 'ds'
-  -- Pass Only Elements: ['bookings',]
+  -- Pass Only Elements: ['bookings']
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT
@@ -19,7 +19,7 @@ FROM (
 CROSS JOIN (
   -- Read Elements From Semantic Model 'listings_latest'
   -- Metric Time Dimension 'ds'
-  -- Pass Only Elements: ['listings',]
+  -- Pass Only Elements: ['listings']
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Databricks/test_min_max_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Databricks/test_min_max_metric_time__plan0.sql
@@ -9,7 +9,7 @@ SELECT
   MIN(subq_2.metric_time__day) AS metric_time__day__min
   , MAX(subq_2.metric_time__day) AS metric_time__day__max
 FROM (
-  -- Pass Only Elements: ['metric_time__day',]
+  -- Pass Only Elements: ['metric_time__day']
   SELECT
     subq_1.metric_time__day
   FROM (

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Databricks/test_min_max_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Databricks/test_min_max_metric_time__plan0_optimized.sql
@@ -11,7 +11,7 @@ SELECT
 FROM (
   -- Read From Time Spine 'mf_time_spine'
   -- Metric Time Dimension 'ds'
-  -- Pass Only Elements: ['metric_time__day',]
+  -- Pass Only Elements: ['metric_time__day']
   SELECT
     ds AS metric_time__day
   FROM ***************************.mf_time_spine time_spine_src_28006

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Databricks/test_min_max_metric_time_week__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Databricks/test_min_max_metric_time_week__plan0.sql
@@ -9,7 +9,7 @@ SELECT
   MIN(subq_2.metric_time__week) AS metric_time__week__min
   , MAX(subq_2.metric_time__week) AS metric_time__week__max
 FROM (
-  -- Pass Only Elements: ['metric_time__week',]
+  -- Pass Only Elements: ['metric_time__week']
   SELECT
     subq_1.metric_time__week
   FROM (

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Databricks/test_min_max_metric_time_week__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Databricks/test_min_max_metric_time_week__plan0_optimized.sql
@@ -11,7 +11,7 @@ SELECT
 FROM (
   -- Read From Time Spine 'mf_time_spine'
   -- Metric Time Dimension 'ds'
-  -- Pass Only Elements: ['metric_time__week',]
+  -- Pass Only Elements: ['metric_time__week']
   SELECT
     DATE_TRUNC('week', ds) AS metric_time__week
   FROM ***************************.mf_time_spine time_spine_src_28006

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Databricks/test_min_max_only_categorical__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Databricks/test_min_max_only_categorical__plan0.sql
@@ -9,7 +9,7 @@ SELECT
   MIN(subq_1.listing__country_latest) AS listing__country_latest__min
   , MAX(subq_1.listing__country_latest) AS listing__country_latest__max
 FROM (
-  -- Pass Only Elements: ['listing__country_latest',]
+  -- Pass Only Elements: ['listing__country_latest']
   SELECT
     subq_0.listing__country_latest
   FROM (

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Databricks/test_min_max_only_categorical__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Databricks/test_min_max_only_categorical__plan0_optimized.sql
@@ -10,7 +10,7 @@ SELECT
   , MAX(listing__country_latest) AS listing__country_latest__max
 FROM (
   -- Read Elements From Semantic Model 'listings_latest'
-  -- Pass Only Elements: ['listing__country_latest',]
+  -- Pass Only Elements: ['listing__country_latest']
   SELECT
     country AS listing__country_latest
   FROM ***************************.dim_listings_latest listings_latest_src_28000

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Databricks/test_min_max_only_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Databricks/test_min_max_only_time__plan0.sql
@@ -9,7 +9,7 @@ SELECT
   MIN(subq_1.booking__paid_at__day) AS booking__paid_at__day__min
   , MAX(subq_1.booking__paid_at__day) AS booking__paid_at__day__max
 FROM (
-  -- Pass Only Elements: ['booking__paid_at__day',]
+  -- Pass Only Elements: ['booking__paid_at__day']
   SELECT
     subq_0.booking__paid_at__day
   FROM (

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Databricks/test_min_max_only_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Databricks/test_min_max_only_time__plan0_optimized.sql
@@ -10,7 +10,7 @@ SELECT
   , MAX(booking__paid_at__day) AS booking__paid_at__day__max
 FROM (
   -- Read Elements From Semantic Model 'bookings_source'
-  -- Pass Only Elements: ['booking__paid_at__day',]
+  -- Pass Only Elements: ['booking__paid_at__day']
   SELECT
     DATE_TRUNC('day', paid_at) AS booking__paid_at__day
   FROM ***************************.fct_bookings bookings_source_src_28000

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Databricks/test_min_max_only_time_quarter__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Databricks/test_min_max_only_time_quarter__plan0.sql
@@ -9,7 +9,7 @@ SELECT
   MIN(subq_1.booking__paid_at__quarter) AS booking__paid_at__quarter__min
   , MAX(subq_1.booking__paid_at__quarter) AS booking__paid_at__quarter__max
 FROM (
-  -- Pass Only Elements: ['booking__paid_at__quarter',]
+  -- Pass Only Elements: ['booking__paid_at__quarter']
   SELECT
     subq_0.booking__paid_at__quarter
   FROM (

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Databricks/test_min_max_only_time_quarter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Databricks/test_min_max_only_time_quarter__plan0_optimized.sql
@@ -10,7 +10,7 @@ SELECT
   , MAX(booking__paid_at__quarter) AS booking__paid_at__quarter__max
 FROM (
   -- Read Elements From Semantic Model 'bookings_source'
-  -- Pass Only Elements: ['booking__paid_at__quarter',]
+  -- Pass Only Elements: ['booking__paid_at__quarter']
   SELECT
     DATE_TRUNC('quarter', paid_at) AS booking__paid_at__quarter
   FROM ***************************.fct_bookings bookings_source_src_28000

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Databricks/test_multiple_metrics_no_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Databricks/test_multiple_metrics_no_dimensions__plan0.sql
@@ -15,7 +15,7 @@ FROM (
     SELECT
       SUM(subq_5.bookings) AS bookings
     FROM (
-      -- Pass Only Elements: ['bookings',]
+      -- Pass Only Elements: ['bookings']
       SELECT
         subq_4.bookings
       FROM (
@@ -328,7 +328,7 @@ CROSS JOIN (
     SELECT
       SUM(subq_11.listings) AS listings
     FROM (
-      -- Pass Only Elements: ['listings',]
+      -- Pass Only Elements: ['listings']
       SELECT
         subq_10.listings
       FROM (

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Databricks/test_multiple_metrics_no_dimensions__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Databricks/test_multiple_metrics_no_dimensions__plan0_optimized.sql
@@ -10,7 +10,7 @@ FROM (
   -- Read Elements From Semantic Model 'bookings_source'
   -- Metric Time Dimension 'ds'
   -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
-  -- Pass Only Elements: ['bookings',]
+  -- Pass Only Elements: ['bookings']
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT
@@ -22,7 +22,7 @@ CROSS JOIN (
   -- Read Elements From Semantic Model 'listings_latest'
   -- Metric Time Dimension 'ds'
   -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
-  -- Pass Only Elements: ['listings',]
+  -- Pass Only Elements: ['listings']
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Databricks/test_no_dedupe__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Databricks/test_no_dedupe__plan0.sql
@@ -181,7 +181,7 @@ FROM (
       FROM ***************************.dim_listings listings_src_26000
     ) subq_0
     CROSS JOIN (
-      -- Pass Only Elements: ['metric_time__month',]
+      -- Pass Only Elements: ['metric_time__month']
       SELECT
         subq_2.metric_time__month
       FROM (

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Databricks/test_no_dedupe_saved_query__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Databricks/test_no_dedupe_saved_query__plan0.sql
@@ -190,7 +190,7 @@ FROM (
       FROM ***************************.dim_listings_latest listings_latest_src_28000
     ) subq_0
     CROSS JOIN (
-      -- Pass Only Elements: ['metric_time__month',]
+      -- Pass Only Elements: ['metric_time__month']
       SELECT
         subq_2.metric_time__month
       FROM (

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Databricks/test_non_additive_dimension_with_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Databricks/test_non_additive_dimension_with_non_default_grain__plan0.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     SUM(subq_5.total_account_balance_first_day_of_month) AS total_account_balance_first_day_of_month
   FROM (
-    -- Pass Only Elements: ['total_account_balance_first_day_of_month',]
+    -- Pass Only Elements: ['total_account_balance_first_day_of_month']
     SELECT
       subq_4.total_account_balance_first_day_of_month
     FROM (

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Databricks/test_non_additive_dimension_with_non_default_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Databricks/test_non_additive_dimension_with_non_default_grain__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: Databricks
 ---
 -- Join on MIN(ds_month) and [] grouping by None
--- Pass Only Elements: ['total_account_balance_first_day_of_month',]
+-- Pass Only Elements: ['total_account_balance_first_day_of_month']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Databricks/test_scd_dimension_filter_without_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Databricks/test_scd_dimension_filter_without_metric_time__plan0.sql
@@ -10,7 +10,7 @@ FROM (
   SELECT
     SUM(subq_6.bookings) AS bookings
   FROM (
-    -- Pass Only Elements: ['bookings',]
+    -- Pass Only Elements: ['bookings']
     SELECT
       subq_5.bookings
     FROM (

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Databricks/test_scd_dimension_filter_without_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Databricks/test_scd_dimension_filter_without_metric_time__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_query_rendering.py
 sql_engine: Databricks
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['bookings',]
+-- Pass Only Elements: ['bookings']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/DuckDB/test_distinct_values__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/DuckDB/test_distinct_values__plan0.sql
@@ -8,7 +8,7 @@ sql_engine: DuckDB
 SELECT
   subq_2.listing__country_latest
 FROM (
-  -- Pass Only Elements: ['listing__country_latest',]
+  -- Pass Only Elements: ['listing__country_latest']
   SELECT
     subq_1.listing__country_latest
   FROM (

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/DuckDB/test_distinct_values__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/DuckDB/test_distinct_values__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: DuckDB
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['listing__country_latest',]
+-- Pass Only Elements: ['listing__country_latest']
 -- Order By ['listing__country_latest'] Limit 100
 SELECT
   listing__country_latest

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/DuckDB/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/DuckDB/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0.sql
@@ -19,7 +19,7 @@ FROM (
       SELECT
         SUM(subq_2.bookings) AS bookings
       FROM (
-        -- Pass Only Elements: ['bookings',]
+        -- Pass Only Elements: ['bookings']
         SELECT
           subq_1.bookings
         FROM (
@@ -229,7 +229,7 @@ FROM (
       SELECT
         SUM(subq_7.listings) AS listings
       FROM (
-        -- Pass Only Elements: ['listings',]
+        -- Pass Only Elements: ['listings']
         SELECT
           subq_6.listings
         FROM (

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/DuckDB/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/DuckDB/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0_optimized.sql
@@ -9,7 +9,7 @@ SELECT
 FROM (
   -- Read Elements From Semantic Model 'bookings_source'
   -- Metric Time Dimension 'ds'
-  -- Pass Only Elements: ['bookings',]
+  -- Pass Only Elements: ['bookings']
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT
@@ -19,7 +19,7 @@ FROM (
 CROSS JOIN (
   -- Read Elements From Semantic Model 'listings_latest'
   -- Metric Time Dimension 'ds'
-  -- Pass Only Elements: ['listings',]
+  -- Pass Only Elements: ['listings']
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/DuckDB/test_min_max_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/DuckDB/test_min_max_metric_time__plan0.sql
@@ -9,7 +9,7 @@ SELECT
   MIN(subq_2.metric_time__day) AS metric_time__day__min
   , MAX(subq_2.metric_time__day) AS metric_time__day__max
 FROM (
-  -- Pass Only Elements: ['metric_time__day',]
+  -- Pass Only Elements: ['metric_time__day']
   SELECT
     subq_1.metric_time__day
   FROM (

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/DuckDB/test_min_max_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/DuckDB/test_min_max_metric_time__plan0_optimized.sql
@@ -11,7 +11,7 @@ SELECT
 FROM (
   -- Read From Time Spine 'mf_time_spine'
   -- Metric Time Dimension 'ds'
-  -- Pass Only Elements: ['metric_time__day',]
+  -- Pass Only Elements: ['metric_time__day']
   SELECT
     ds AS metric_time__day
   FROM ***************************.mf_time_spine time_spine_src_28006

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/DuckDB/test_min_max_metric_time_week__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/DuckDB/test_min_max_metric_time_week__plan0.sql
@@ -9,7 +9,7 @@ SELECT
   MIN(subq_2.metric_time__week) AS metric_time__week__min
   , MAX(subq_2.metric_time__week) AS metric_time__week__max
 FROM (
-  -- Pass Only Elements: ['metric_time__week',]
+  -- Pass Only Elements: ['metric_time__week']
   SELECT
     subq_1.metric_time__week
   FROM (

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/DuckDB/test_min_max_metric_time_week__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/DuckDB/test_min_max_metric_time_week__plan0_optimized.sql
@@ -11,7 +11,7 @@ SELECT
 FROM (
   -- Read From Time Spine 'mf_time_spine'
   -- Metric Time Dimension 'ds'
-  -- Pass Only Elements: ['metric_time__week',]
+  -- Pass Only Elements: ['metric_time__week']
   SELECT
     DATE_TRUNC('week', ds) AS metric_time__week
   FROM ***************************.mf_time_spine time_spine_src_28006

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/DuckDB/test_min_max_only_categorical__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/DuckDB/test_min_max_only_categorical__plan0.sql
@@ -9,7 +9,7 @@ SELECT
   MIN(subq_1.listing__country_latest) AS listing__country_latest__min
   , MAX(subq_1.listing__country_latest) AS listing__country_latest__max
 FROM (
-  -- Pass Only Elements: ['listing__country_latest',]
+  -- Pass Only Elements: ['listing__country_latest']
   SELECT
     subq_0.listing__country_latest
   FROM (

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/DuckDB/test_min_max_only_categorical__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/DuckDB/test_min_max_only_categorical__plan0_optimized.sql
@@ -10,7 +10,7 @@ SELECT
   , MAX(listing__country_latest) AS listing__country_latest__max
 FROM (
   -- Read Elements From Semantic Model 'listings_latest'
-  -- Pass Only Elements: ['listing__country_latest',]
+  -- Pass Only Elements: ['listing__country_latest']
   SELECT
     country AS listing__country_latest
   FROM ***************************.dim_listings_latest listings_latest_src_28000

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/DuckDB/test_min_max_only_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/DuckDB/test_min_max_only_time__plan0.sql
@@ -9,7 +9,7 @@ SELECT
   MIN(subq_1.booking__paid_at__day) AS booking__paid_at__day__min
   , MAX(subq_1.booking__paid_at__day) AS booking__paid_at__day__max
 FROM (
-  -- Pass Only Elements: ['booking__paid_at__day',]
+  -- Pass Only Elements: ['booking__paid_at__day']
   SELECT
     subq_0.booking__paid_at__day
   FROM (

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/DuckDB/test_min_max_only_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/DuckDB/test_min_max_only_time__plan0_optimized.sql
@@ -10,7 +10,7 @@ SELECT
   , MAX(booking__paid_at__day) AS booking__paid_at__day__max
 FROM (
   -- Read Elements From Semantic Model 'bookings_source'
-  -- Pass Only Elements: ['booking__paid_at__day',]
+  -- Pass Only Elements: ['booking__paid_at__day']
   SELECT
     DATE_TRUNC('day', paid_at) AS booking__paid_at__day
   FROM ***************************.fct_bookings bookings_source_src_28000

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/DuckDB/test_min_max_only_time_quarter__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/DuckDB/test_min_max_only_time_quarter__plan0.sql
@@ -9,7 +9,7 @@ SELECT
   MIN(subq_1.booking__paid_at__quarter) AS booking__paid_at__quarter__min
   , MAX(subq_1.booking__paid_at__quarter) AS booking__paid_at__quarter__max
 FROM (
-  -- Pass Only Elements: ['booking__paid_at__quarter',]
+  -- Pass Only Elements: ['booking__paid_at__quarter']
   SELECT
     subq_0.booking__paid_at__quarter
   FROM (

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/DuckDB/test_min_max_only_time_quarter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/DuckDB/test_min_max_only_time_quarter__plan0_optimized.sql
@@ -10,7 +10,7 @@ SELECT
   , MAX(booking__paid_at__quarter) AS booking__paid_at__quarter__max
 FROM (
   -- Read Elements From Semantic Model 'bookings_source'
-  -- Pass Only Elements: ['booking__paid_at__quarter',]
+  -- Pass Only Elements: ['booking__paid_at__quarter']
   SELECT
     DATE_TRUNC('quarter', paid_at) AS booking__paid_at__quarter
   FROM ***************************.fct_bookings bookings_source_src_28000

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/DuckDB/test_multiple_metrics_no_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/DuckDB/test_multiple_metrics_no_dimensions__plan0.sql
@@ -15,7 +15,7 @@ FROM (
     SELECT
       SUM(subq_5.bookings) AS bookings
     FROM (
-      -- Pass Only Elements: ['bookings',]
+      -- Pass Only Elements: ['bookings']
       SELECT
         subq_4.bookings
       FROM (
@@ -328,7 +328,7 @@ CROSS JOIN (
     SELECT
       SUM(subq_11.listings) AS listings
     FROM (
-      -- Pass Only Elements: ['listings',]
+      -- Pass Only Elements: ['listings']
       SELECT
         subq_10.listings
       FROM (

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/DuckDB/test_multiple_metrics_no_dimensions__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/DuckDB/test_multiple_metrics_no_dimensions__plan0_optimized.sql
@@ -10,7 +10,7 @@ FROM (
   -- Read Elements From Semantic Model 'bookings_source'
   -- Metric Time Dimension 'ds'
   -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
-  -- Pass Only Elements: ['bookings',]
+  -- Pass Only Elements: ['bookings']
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT
@@ -22,7 +22,7 @@ CROSS JOIN (
   -- Read Elements From Semantic Model 'listings_latest'
   -- Metric Time Dimension 'ds'
   -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
-  -- Pass Only Elements: ['listings',]
+  -- Pass Only Elements: ['listings']
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/DuckDB/test_no_dedupe__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/DuckDB/test_no_dedupe__plan0.sql
@@ -181,7 +181,7 @@ FROM (
       FROM ***************************.dim_listings listings_src_26000
     ) subq_0
     CROSS JOIN (
-      -- Pass Only Elements: ['metric_time__month',]
+      -- Pass Only Elements: ['metric_time__month']
       SELECT
         subq_2.metric_time__month
       FROM (

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/DuckDB/test_no_dedupe_saved_query__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/DuckDB/test_no_dedupe_saved_query__plan0.sql
@@ -190,7 +190,7 @@ FROM (
       FROM ***************************.dim_listings_latest listings_latest_src_28000
     ) subq_0
     CROSS JOIN (
-      -- Pass Only Elements: ['metric_time__month',]
+      -- Pass Only Elements: ['metric_time__month']
       SELECT
         subq_2.metric_time__month
       FROM (

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/DuckDB/test_non_additive_dimension_with_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/DuckDB/test_non_additive_dimension_with_non_default_grain__plan0.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     SUM(subq_5.total_account_balance_first_day_of_month) AS total_account_balance_first_day_of_month
   FROM (
-    -- Pass Only Elements: ['total_account_balance_first_day_of_month',]
+    -- Pass Only Elements: ['total_account_balance_first_day_of_month']
     SELECT
       subq_4.total_account_balance_first_day_of_month
     FROM (

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/DuckDB/test_non_additive_dimension_with_non_default_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/DuckDB/test_non_additive_dimension_with_non_default_grain__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: DuckDB
 ---
 -- Join on MIN(ds_month) and [] grouping by None
--- Pass Only Elements: ['total_account_balance_first_day_of_month',]
+-- Pass Only Elements: ['total_account_balance_first_day_of_month']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/DuckDB/test_scd_dimension_filter_without_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/DuckDB/test_scd_dimension_filter_without_metric_time__plan0.sql
@@ -10,7 +10,7 @@ FROM (
   SELECT
     SUM(subq_6.bookings) AS bookings
   FROM (
-    -- Pass Only Elements: ['bookings',]
+    -- Pass Only Elements: ['bookings']
     SELECT
       subq_5.bookings
     FROM (

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/DuckDB/test_scd_dimension_filter_without_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/DuckDB/test_scd_dimension_filter_without_metric_time__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_query_rendering.py
 sql_engine: DuckDB
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['bookings',]
+-- Pass Only Elements: ['bookings']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Postgres/test_distinct_values__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Postgres/test_distinct_values__plan0.sql
@@ -8,7 +8,7 @@ sql_engine: Postgres
 SELECT
   subq_2.listing__country_latest
 FROM (
-  -- Pass Only Elements: ['listing__country_latest',]
+  -- Pass Only Elements: ['listing__country_latest']
   SELECT
     subq_1.listing__country_latest
   FROM (

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Postgres/test_distinct_values__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Postgres/test_distinct_values__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: Postgres
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['listing__country_latest',]
+-- Pass Only Elements: ['listing__country_latest']
 -- Order By ['listing__country_latest'] Limit 100
 SELECT
   listing__country_latest

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Postgres/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Postgres/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0.sql
@@ -19,7 +19,7 @@ FROM (
       SELECT
         SUM(subq_2.bookings) AS bookings
       FROM (
-        -- Pass Only Elements: ['bookings',]
+        -- Pass Only Elements: ['bookings']
         SELECT
           subq_1.bookings
         FROM (
@@ -229,7 +229,7 @@ FROM (
       SELECT
         SUM(subq_7.listings) AS listings
       FROM (
-        -- Pass Only Elements: ['listings',]
+        -- Pass Only Elements: ['listings']
         SELECT
           subq_6.listings
         FROM (

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Postgres/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Postgres/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0_optimized.sql
@@ -9,7 +9,7 @@ SELECT
 FROM (
   -- Read Elements From Semantic Model 'bookings_source'
   -- Metric Time Dimension 'ds'
-  -- Pass Only Elements: ['bookings',]
+  -- Pass Only Elements: ['bookings']
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT
@@ -19,7 +19,7 @@ FROM (
 CROSS JOIN (
   -- Read Elements From Semantic Model 'listings_latest'
   -- Metric Time Dimension 'ds'
-  -- Pass Only Elements: ['listings',]
+  -- Pass Only Elements: ['listings']
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Postgres/test_min_max_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Postgres/test_min_max_metric_time__plan0.sql
@@ -9,7 +9,7 @@ SELECT
   MIN(subq_2.metric_time__day) AS metric_time__day__min
   , MAX(subq_2.metric_time__day) AS metric_time__day__max
 FROM (
-  -- Pass Only Elements: ['metric_time__day',]
+  -- Pass Only Elements: ['metric_time__day']
   SELECT
     subq_1.metric_time__day
   FROM (

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Postgres/test_min_max_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Postgres/test_min_max_metric_time__plan0_optimized.sql
@@ -11,7 +11,7 @@ SELECT
 FROM (
   -- Read From Time Spine 'mf_time_spine'
   -- Metric Time Dimension 'ds'
-  -- Pass Only Elements: ['metric_time__day',]
+  -- Pass Only Elements: ['metric_time__day']
   SELECT
     ds AS metric_time__day
   FROM ***************************.mf_time_spine time_spine_src_28006

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Postgres/test_min_max_metric_time_week__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Postgres/test_min_max_metric_time_week__plan0.sql
@@ -9,7 +9,7 @@ SELECT
   MIN(subq_2.metric_time__week) AS metric_time__week__min
   , MAX(subq_2.metric_time__week) AS metric_time__week__max
 FROM (
-  -- Pass Only Elements: ['metric_time__week',]
+  -- Pass Only Elements: ['metric_time__week']
   SELECT
     subq_1.metric_time__week
   FROM (

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Postgres/test_min_max_metric_time_week__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Postgres/test_min_max_metric_time_week__plan0_optimized.sql
@@ -11,7 +11,7 @@ SELECT
 FROM (
   -- Read From Time Spine 'mf_time_spine'
   -- Metric Time Dimension 'ds'
-  -- Pass Only Elements: ['metric_time__week',]
+  -- Pass Only Elements: ['metric_time__week']
   SELECT
     DATE_TRUNC('week', ds) AS metric_time__week
   FROM ***************************.mf_time_spine time_spine_src_28006

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Postgres/test_min_max_only_categorical__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Postgres/test_min_max_only_categorical__plan0.sql
@@ -9,7 +9,7 @@ SELECT
   MIN(subq_1.listing__country_latest) AS listing__country_latest__min
   , MAX(subq_1.listing__country_latest) AS listing__country_latest__max
 FROM (
-  -- Pass Only Elements: ['listing__country_latest',]
+  -- Pass Only Elements: ['listing__country_latest']
   SELECT
     subq_0.listing__country_latest
   FROM (

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Postgres/test_min_max_only_categorical__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Postgres/test_min_max_only_categorical__plan0_optimized.sql
@@ -10,7 +10,7 @@ SELECT
   , MAX(listing__country_latest) AS listing__country_latest__max
 FROM (
   -- Read Elements From Semantic Model 'listings_latest'
-  -- Pass Only Elements: ['listing__country_latest',]
+  -- Pass Only Elements: ['listing__country_latest']
   SELECT
     country AS listing__country_latest
   FROM ***************************.dim_listings_latest listings_latest_src_28000

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Postgres/test_min_max_only_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Postgres/test_min_max_only_time__plan0.sql
@@ -9,7 +9,7 @@ SELECT
   MIN(subq_1.booking__paid_at__day) AS booking__paid_at__day__min
   , MAX(subq_1.booking__paid_at__day) AS booking__paid_at__day__max
 FROM (
-  -- Pass Only Elements: ['booking__paid_at__day',]
+  -- Pass Only Elements: ['booking__paid_at__day']
   SELECT
     subq_0.booking__paid_at__day
   FROM (

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Postgres/test_min_max_only_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Postgres/test_min_max_only_time__plan0_optimized.sql
@@ -10,7 +10,7 @@ SELECT
   , MAX(booking__paid_at__day) AS booking__paid_at__day__max
 FROM (
   -- Read Elements From Semantic Model 'bookings_source'
-  -- Pass Only Elements: ['booking__paid_at__day',]
+  -- Pass Only Elements: ['booking__paid_at__day']
   SELECT
     DATE_TRUNC('day', paid_at) AS booking__paid_at__day
   FROM ***************************.fct_bookings bookings_source_src_28000

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Postgres/test_min_max_only_time_quarter__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Postgres/test_min_max_only_time_quarter__plan0.sql
@@ -9,7 +9,7 @@ SELECT
   MIN(subq_1.booking__paid_at__quarter) AS booking__paid_at__quarter__min
   , MAX(subq_1.booking__paid_at__quarter) AS booking__paid_at__quarter__max
 FROM (
-  -- Pass Only Elements: ['booking__paid_at__quarter',]
+  -- Pass Only Elements: ['booking__paid_at__quarter']
   SELECT
     subq_0.booking__paid_at__quarter
   FROM (

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Postgres/test_min_max_only_time_quarter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Postgres/test_min_max_only_time_quarter__plan0_optimized.sql
@@ -10,7 +10,7 @@ SELECT
   , MAX(booking__paid_at__quarter) AS booking__paid_at__quarter__max
 FROM (
   -- Read Elements From Semantic Model 'bookings_source'
-  -- Pass Only Elements: ['booking__paid_at__quarter',]
+  -- Pass Only Elements: ['booking__paid_at__quarter']
   SELECT
     DATE_TRUNC('quarter', paid_at) AS booking__paid_at__quarter
   FROM ***************************.fct_bookings bookings_source_src_28000

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Postgres/test_multiple_metrics_no_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Postgres/test_multiple_metrics_no_dimensions__plan0.sql
@@ -15,7 +15,7 @@ FROM (
     SELECT
       SUM(subq_5.bookings) AS bookings
     FROM (
-      -- Pass Only Elements: ['bookings',]
+      -- Pass Only Elements: ['bookings']
       SELECT
         subq_4.bookings
       FROM (
@@ -328,7 +328,7 @@ CROSS JOIN (
     SELECT
       SUM(subq_11.listings) AS listings
     FROM (
-      -- Pass Only Elements: ['listings',]
+      -- Pass Only Elements: ['listings']
       SELECT
         subq_10.listings
       FROM (

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Postgres/test_multiple_metrics_no_dimensions__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Postgres/test_multiple_metrics_no_dimensions__plan0_optimized.sql
@@ -10,7 +10,7 @@ FROM (
   -- Read Elements From Semantic Model 'bookings_source'
   -- Metric Time Dimension 'ds'
   -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
-  -- Pass Only Elements: ['bookings',]
+  -- Pass Only Elements: ['bookings']
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT
@@ -22,7 +22,7 @@ CROSS JOIN (
   -- Read Elements From Semantic Model 'listings_latest'
   -- Metric Time Dimension 'ds'
   -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
-  -- Pass Only Elements: ['listings',]
+  -- Pass Only Elements: ['listings']
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Postgres/test_no_dedupe__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Postgres/test_no_dedupe__plan0.sql
@@ -181,7 +181,7 @@ FROM (
       FROM ***************************.dim_listings listings_src_26000
     ) subq_0
     CROSS JOIN (
-      -- Pass Only Elements: ['metric_time__month',]
+      -- Pass Only Elements: ['metric_time__month']
       SELECT
         subq_2.metric_time__month
       FROM (

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Postgres/test_no_dedupe_saved_query__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Postgres/test_no_dedupe_saved_query__plan0.sql
@@ -190,7 +190,7 @@ FROM (
       FROM ***************************.dim_listings_latest listings_latest_src_28000
     ) subq_0
     CROSS JOIN (
-      -- Pass Only Elements: ['metric_time__month',]
+      -- Pass Only Elements: ['metric_time__month']
       SELECT
         subq_2.metric_time__month
       FROM (

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Postgres/test_non_additive_dimension_with_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Postgres/test_non_additive_dimension_with_non_default_grain__plan0.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     SUM(subq_5.total_account_balance_first_day_of_month) AS total_account_balance_first_day_of_month
   FROM (
-    -- Pass Only Elements: ['total_account_balance_first_day_of_month',]
+    -- Pass Only Elements: ['total_account_balance_first_day_of_month']
     SELECT
       subq_4.total_account_balance_first_day_of_month
     FROM (

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Postgres/test_non_additive_dimension_with_non_default_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Postgres/test_non_additive_dimension_with_non_default_grain__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: Postgres
 ---
 -- Join on MIN(ds_month) and [] grouping by None
--- Pass Only Elements: ['total_account_balance_first_day_of_month',]
+-- Pass Only Elements: ['total_account_balance_first_day_of_month']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Postgres/test_scd_dimension_filter_without_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Postgres/test_scd_dimension_filter_without_metric_time__plan0.sql
@@ -10,7 +10,7 @@ FROM (
   SELECT
     SUM(subq_6.bookings) AS bookings
   FROM (
-    -- Pass Only Elements: ['bookings',]
+    -- Pass Only Elements: ['bookings']
     SELECT
       subq_5.bookings
     FROM (

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Postgres/test_scd_dimension_filter_without_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Postgres/test_scd_dimension_filter_without_metric_time__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_query_rendering.py
 sql_engine: Postgres
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['bookings',]
+-- Pass Only Elements: ['bookings']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Redshift/test_distinct_values__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Redshift/test_distinct_values__plan0.sql
@@ -8,7 +8,7 @@ sql_engine: Redshift
 SELECT
   subq_2.listing__country_latest
 FROM (
-  -- Pass Only Elements: ['listing__country_latest',]
+  -- Pass Only Elements: ['listing__country_latest']
   SELECT
     subq_1.listing__country_latest
   FROM (

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Redshift/test_distinct_values__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Redshift/test_distinct_values__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: Redshift
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['listing__country_latest',]
+-- Pass Only Elements: ['listing__country_latest']
 -- Order By ['listing__country_latest'] Limit 100
 SELECT
   listing__country_latest

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Redshift/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Redshift/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0.sql
@@ -19,7 +19,7 @@ FROM (
       SELECT
         SUM(subq_2.bookings) AS bookings
       FROM (
-        -- Pass Only Elements: ['bookings',]
+        -- Pass Only Elements: ['bookings']
         SELECT
           subq_1.bookings
         FROM (
@@ -229,7 +229,7 @@ FROM (
       SELECT
         SUM(subq_7.listings) AS listings
       FROM (
-        -- Pass Only Elements: ['listings',]
+        -- Pass Only Elements: ['listings']
         SELECT
           subq_6.listings
         FROM (

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Redshift/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Redshift/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0_optimized.sql
@@ -9,7 +9,7 @@ SELECT
 FROM (
   -- Read Elements From Semantic Model 'bookings_source'
   -- Metric Time Dimension 'ds'
-  -- Pass Only Elements: ['bookings',]
+  -- Pass Only Elements: ['bookings']
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT
@@ -19,7 +19,7 @@ FROM (
 CROSS JOIN (
   -- Read Elements From Semantic Model 'listings_latest'
   -- Metric Time Dimension 'ds'
-  -- Pass Only Elements: ['listings',]
+  -- Pass Only Elements: ['listings']
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Redshift/test_min_max_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Redshift/test_min_max_metric_time__plan0.sql
@@ -9,7 +9,7 @@ SELECT
   MIN(subq_2.metric_time__day) AS metric_time__day__min
   , MAX(subq_2.metric_time__day) AS metric_time__day__max
 FROM (
-  -- Pass Only Elements: ['metric_time__day',]
+  -- Pass Only Elements: ['metric_time__day']
   SELECT
     subq_1.metric_time__day
   FROM (

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Redshift/test_min_max_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Redshift/test_min_max_metric_time__plan0_optimized.sql
@@ -11,7 +11,7 @@ SELECT
 FROM (
   -- Read From Time Spine 'mf_time_spine'
   -- Metric Time Dimension 'ds'
-  -- Pass Only Elements: ['metric_time__day',]
+  -- Pass Only Elements: ['metric_time__day']
   SELECT
     ds AS metric_time__day
   FROM ***************************.mf_time_spine time_spine_src_28006

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Redshift/test_min_max_metric_time_week__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Redshift/test_min_max_metric_time_week__plan0.sql
@@ -9,7 +9,7 @@ SELECT
   MIN(subq_2.metric_time__week) AS metric_time__week__min
   , MAX(subq_2.metric_time__week) AS metric_time__week__max
 FROM (
-  -- Pass Only Elements: ['metric_time__week',]
+  -- Pass Only Elements: ['metric_time__week']
   SELECT
     subq_1.metric_time__week
   FROM (

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Redshift/test_min_max_metric_time_week__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Redshift/test_min_max_metric_time_week__plan0_optimized.sql
@@ -11,7 +11,7 @@ SELECT
 FROM (
   -- Read From Time Spine 'mf_time_spine'
   -- Metric Time Dimension 'ds'
-  -- Pass Only Elements: ['metric_time__week',]
+  -- Pass Only Elements: ['metric_time__week']
   SELECT
     DATE_TRUNC('week', ds) AS metric_time__week
   FROM ***************************.mf_time_spine time_spine_src_28006

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Redshift/test_min_max_only_categorical__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Redshift/test_min_max_only_categorical__plan0.sql
@@ -9,7 +9,7 @@ SELECT
   MIN(subq_1.listing__country_latest) AS listing__country_latest__min
   , MAX(subq_1.listing__country_latest) AS listing__country_latest__max
 FROM (
-  -- Pass Only Elements: ['listing__country_latest',]
+  -- Pass Only Elements: ['listing__country_latest']
   SELECT
     subq_0.listing__country_latest
   FROM (

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Redshift/test_min_max_only_categorical__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Redshift/test_min_max_only_categorical__plan0_optimized.sql
@@ -10,7 +10,7 @@ SELECT
   , MAX(listing__country_latest) AS listing__country_latest__max
 FROM (
   -- Read Elements From Semantic Model 'listings_latest'
-  -- Pass Only Elements: ['listing__country_latest',]
+  -- Pass Only Elements: ['listing__country_latest']
   SELECT
     country AS listing__country_latest
   FROM ***************************.dim_listings_latest listings_latest_src_28000

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Redshift/test_min_max_only_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Redshift/test_min_max_only_time__plan0.sql
@@ -9,7 +9,7 @@ SELECT
   MIN(subq_1.booking__paid_at__day) AS booking__paid_at__day__min
   , MAX(subq_1.booking__paid_at__day) AS booking__paid_at__day__max
 FROM (
-  -- Pass Only Elements: ['booking__paid_at__day',]
+  -- Pass Only Elements: ['booking__paid_at__day']
   SELECT
     subq_0.booking__paid_at__day
   FROM (

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Redshift/test_min_max_only_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Redshift/test_min_max_only_time__plan0_optimized.sql
@@ -10,7 +10,7 @@ SELECT
   , MAX(booking__paid_at__day) AS booking__paid_at__day__max
 FROM (
   -- Read Elements From Semantic Model 'bookings_source'
-  -- Pass Only Elements: ['booking__paid_at__day',]
+  -- Pass Only Elements: ['booking__paid_at__day']
   SELECT
     DATE_TRUNC('day', paid_at) AS booking__paid_at__day
   FROM ***************************.fct_bookings bookings_source_src_28000

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Redshift/test_min_max_only_time_quarter__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Redshift/test_min_max_only_time_quarter__plan0.sql
@@ -9,7 +9,7 @@ SELECT
   MIN(subq_1.booking__paid_at__quarter) AS booking__paid_at__quarter__min
   , MAX(subq_1.booking__paid_at__quarter) AS booking__paid_at__quarter__max
 FROM (
-  -- Pass Only Elements: ['booking__paid_at__quarter',]
+  -- Pass Only Elements: ['booking__paid_at__quarter']
   SELECT
     subq_0.booking__paid_at__quarter
   FROM (

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Redshift/test_min_max_only_time_quarter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Redshift/test_min_max_only_time_quarter__plan0_optimized.sql
@@ -10,7 +10,7 @@ SELECT
   , MAX(booking__paid_at__quarter) AS booking__paid_at__quarter__max
 FROM (
   -- Read Elements From Semantic Model 'bookings_source'
-  -- Pass Only Elements: ['booking__paid_at__quarter',]
+  -- Pass Only Elements: ['booking__paid_at__quarter']
   SELECT
     DATE_TRUNC('quarter', paid_at) AS booking__paid_at__quarter
   FROM ***************************.fct_bookings bookings_source_src_28000

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Redshift/test_multiple_metrics_no_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Redshift/test_multiple_metrics_no_dimensions__plan0.sql
@@ -15,7 +15,7 @@ FROM (
     SELECT
       SUM(subq_5.bookings) AS bookings
     FROM (
-      -- Pass Only Elements: ['bookings',]
+      -- Pass Only Elements: ['bookings']
       SELECT
         subq_4.bookings
       FROM (
@@ -328,7 +328,7 @@ CROSS JOIN (
     SELECT
       SUM(subq_11.listings) AS listings
     FROM (
-      -- Pass Only Elements: ['listings',]
+      -- Pass Only Elements: ['listings']
       SELECT
         subq_10.listings
       FROM (

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Redshift/test_multiple_metrics_no_dimensions__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Redshift/test_multiple_metrics_no_dimensions__plan0_optimized.sql
@@ -10,7 +10,7 @@ FROM (
   -- Read Elements From Semantic Model 'bookings_source'
   -- Metric Time Dimension 'ds'
   -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
-  -- Pass Only Elements: ['bookings',]
+  -- Pass Only Elements: ['bookings']
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT
@@ -22,7 +22,7 @@ CROSS JOIN (
   -- Read Elements From Semantic Model 'listings_latest'
   -- Metric Time Dimension 'ds'
   -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
-  -- Pass Only Elements: ['listings',]
+  -- Pass Only Elements: ['listings']
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Redshift/test_no_dedupe__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Redshift/test_no_dedupe__plan0.sql
@@ -181,7 +181,7 @@ FROM (
       FROM ***************************.dim_listings listings_src_26000
     ) subq_0
     CROSS JOIN (
-      -- Pass Only Elements: ['metric_time__month',]
+      -- Pass Only Elements: ['metric_time__month']
       SELECT
         subq_2.metric_time__month
       FROM (

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Redshift/test_no_dedupe_saved_query__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Redshift/test_no_dedupe_saved_query__plan0.sql
@@ -190,7 +190,7 @@ FROM (
       FROM ***************************.dim_listings_latest listings_latest_src_28000
     ) subq_0
     CROSS JOIN (
-      -- Pass Only Elements: ['metric_time__month',]
+      -- Pass Only Elements: ['metric_time__month']
       SELECT
         subq_2.metric_time__month
       FROM (

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Redshift/test_non_additive_dimension_with_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Redshift/test_non_additive_dimension_with_non_default_grain__plan0.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     SUM(subq_5.total_account_balance_first_day_of_month) AS total_account_balance_first_day_of_month
   FROM (
-    -- Pass Only Elements: ['total_account_balance_first_day_of_month',]
+    -- Pass Only Elements: ['total_account_balance_first_day_of_month']
     SELECT
       subq_4.total_account_balance_first_day_of_month
     FROM (

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Redshift/test_non_additive_dimension_with_non_default_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Redshift/test_non_additive_dimension_with_non_default_grain__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: Redshift
 ---
 -- Join on MIN(ds_month) and [] grouping by None
--- Pass Only Elements: ['total_account_balance_first_day_of_month',]
+-- Pass Only Elements: ['total_account_balance_first_day_of_month']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Redshift/test_scd_dimension_filter_without_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Redshift/test_scd_dimension_filter_without_metric_time__plan0.sql
@@ -10,7 +10,7 @@ FROM (
   SELECT
     SUM(subq_6.bookings) AS bookings
   FROM (
-    -- Pass Only Elements: ['bookings',]
+    -- Pass Only Elements: ['bookings']
     SELECT
       subq_5.bookings
     FROM (

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Redshift/test_scd_dimension_filter_without_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Redshift/test_scd_dimension_filter_without_metric_time__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_query_rendering.py
 sql_engine: Redshift
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['bookings',]
+-- Pass Only Elements: ['bookings']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Snowflake/test_distinct_values__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Snowflake/test_distinct_values__plan0.sql
@@ -8,7 +8,7 @@ sql_engine: Snowflake
 SELECT
   subq_2.listing__country_latest
 FROM (
-  -- Pass Only Elements: ['listing__country_latest',]
+  -- Pass Only Elements: ['listing__country_latest']
   SELECT
     subq_1.listing__country_latest
   FROM (

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Snowflake/test_distinct_values__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Snowflake/test_distinct_values__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: Snowflake
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['listing__country_latest',]
+-- Pass Only Elements: ['listing__country_latest']
 -- Order By ['listing__country_latest'] Limit 100
 SELECT
   listing__country_latest

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Snowflake/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Snowflake/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0.sql
@@ -19,7 +19,7 @@ FROM (
       SELECT
         SUM(subq_2.bookings) AS bookings
       FROM (
-        -- Pass Only Elements: ['bookings',]
+        -- Pass Only Elements: ['bookings']
         SELECT
           subq_1.bookings
         FROM (
@@ -229,7 +229,7 @@ FROM (
       SELECT
         SUM(subq_7.listings) AS listings
       FROM (
-        -- Pass Only Elements: ['listings',]
+        -- Pass Only Elements: ['listings']
         SELECT
           subq_6.listings
         FROM (

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Snowflake/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Snowflake/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0_optimized.sql
@@ -9,7 +9,7 @@ SELECT
 FROM (
   -- Read Elements From Semantic Model 'bookings_source'
   -- Metric Time Dimension 'ds'
-  -- Pass Only Elements: ['bookings',]
+  -- Pass Only Elements: ['bookings']
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT
@@ -19,7 +19,7 @@ FROM (
 CROSS JOIN (
   -- Read Elements From Semantic Model 'listings_latest'
   -- Metric Time Dimension 'ds'
-  -- Pass Only Elements: ['listings',]
+  -- Pass Only Elements: ['listings']
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Snowflake/test_min_max_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Snowflake/test_min_max_metric_time__plan0.sql
@@ -9,7 +9,7 @@ SELECT
   MIN(subq_2.metric_time__day) AS metric_time__day__min
   , MAX(subq_2.metric_time__day) AS metric_time__day__max
 FROM (
-  -- Pass Only Elements: ['metric_time__day',]
+  -- Pass Only Elements: ['metric_time__day']
   SELECT
     subq_1.metric_time__day
   FROM (

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Snowflake/test_min_max_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Snowflake/test_min_max_metric_time__plan0_optimized.sql
@@ -11,7 +11,7 @@ SELECT
 FROM (
   -- Read From Time Spine 'mf_time_spine'
   -- Metric Time Dimension 'ds'
-  -- Pass Only Elements: ['metric_time__day',]
+  -- Pass Only Elements: ['metric_time__day']
   SELECT
     ds AS metric_time__day
   FROM ***************************.mf_time_spine time_spine_src_28006

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Snowflake/test_min_max_metric_time_week__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Snowflake/test_min_max_metric_time_week__plan0.sql
@@ -9,7 +9,7 @@ SELECT
   MIN(subq_2.metric_time__week) AS metric_time__week__min
   , MAX(subq_2.metric_time__week) AS metric_time__week__max
 FROM (
-  -- Pass Only Elements: ['metric_time__week',]
+  -- Pass Only Elements: ['metric_time__week']
   SELECT
     subq_1.metric_time__week
   FROM (

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Snowflake/test_min_max_metric_time_week__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Snowflake/test_min_max_metric_time_week__plan0_optimized.sql
@@ -11,7 +11,7 @@ SELECT
 FROM (
   -- Read From Time Spine 'mf_time_spine'
   -- Metric Time Dimension 'ds'
-  -- Pass Only Elements: ['metric_time__week',]
+  -- Pass Only Elements: ['metric_time__week']
   SELECT
     DATE_TRUNC('week', ds) AS metric_time__week
   FROM ***************************.mf_time_spine time_spine_src_28006

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Snowflake/test_min_max_only_categorical__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Snowflake/test_min_max_only_categorical__plan0.sql
@@ -9,7 +9,7 @@ SELECT
   MIN(subq_1.listing__country_latest) AS listing__country_latest__min
   , MAX(subq_1.listing__country_latest) AS listing__country_latest__max
 FROM (
-  -- Pass Only Elements: ['listing__country_latest',]
+  -- Pass Only Elements: ['listing__country_latest']
   SELECT
     subq_0.listing__country_latest
   FROM (

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Snowflake/test_min_max_only_categorical__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Snowflake/test_min_max_only_categorical__plan0_optimized.sql
@@ -10,7 +10,7 @@ SELECT
   , MAX(listing__country_latest) AS listing__country_latest__max
 FROM (
   -- Read Elements From Semantic Model 'listings_latest'
-  -- Pass Only Elements: ['listing__country_latest',]
+  -- Pass Only Elements: ['listing__country_latest']
   SELECT
     country AS listing__country_latest
   FROM ***************************.dim_listings_latest listings_latest_src_28000

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Snowflake/test_min_max_only_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Snowflake/test_min_max_only_time__plan0.sql
@@ -9,7 +9,7 @@ SELECT
   MIN(subq_1.booking__paid_at__day) AS booking__paid_at__day__min
   , MAX(subq_1.booking__paid_at__day) AS booking__paid_at__day__max
 FROM (
-  -- Pass Only Elements: ['booking__paid_at__day',]
+  -- Pass Only Elements: ['booking__paid_at__day']
   SELECT
     subq_0.booking__paid_at__day
   FROM (

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Snowflake/test_min_max_only_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Snowflake/test_min_max_only_time__plan0_optimized.sql
@@ -10,7 +10,7 @@ SELECT
   , MAX(booking__paid_at__day) AS booking__paid_at__day__max
 FROM (
   -- Read Elements From Semantic Model 'bookings_source'
-  -- Pass Only Elements: ['booking__paid_at__day',]
+  -- Pass Only Elements: ['booking__paid_at__day']
   SELECT
     DATE_TRUNC('day', paid_at) AS booking__paid_at__day
   FROM ***************************.fct_bookings bookings_source_src_28000

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Snowflake/test_min_max_only_time_quarter__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Snowflake/test_min_max_only_time_quarter__plan0.sql
@@ -9,7 +9,7 @@ SELECT
   MIN(subq_1.booking__paid_at__quarter) AS booking__paid_at__quarter__min
   , MAX(subq_1.booking__paid_at__quarter) AS booking__paid_at__quarter__max
 FROM (
-  -- Pass Only Elements: ['booking__paid_at__quarter',]
+  -- Pass Only Elements: ['booking__paid_at__quarter']
   SELECT
     subq_0.booking__paid_at__quarter
   FROM (

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Snowflake/test_min_max_only_time_quarter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Snowflake/test_min_max_only_time_quarter__plan0_optimized.sql
@@ -10,7 +10,7 @@ SELECT
   , MAX(booking__paid_at__quarter) AS booking__paid_at__quarter__max
 FROM (
   -- Read Elements From Semantic Model 'bookings_source'
-  -- Pass Only Elements: ['booking__paid_at__quarter',]
+  -- Pass Only Elements: ['booking__paid_at__quarter']
   SELECT
     DATE_TRUNC('quarter', paid_at) AS booking__paid_at__quarter
   FROM ***************************.fct_bookings bookings_source_src_28000

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Snowflake/test_multiple_metrics_no_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Snowflake/test_multiple_metrics_no_dimensions__plan0.sql
@@ -15,7 +15,7 @@ FROM (
     SELECT
       SUM(subq_5.bookings) AS bookings
     FROM (
-      -- Pass Only Elements: ['bookings',]
+      -- Pass Only Elements: ['bookings']
       SELECT
         subq_4.bookings
       FROM (
@@ -328,7 +328,7 @@ CROSS JOIN (
     SELECT
       SUM(subq_11.listings) AS listings
     FROM (
-      -- Pass Only Elements: ['listings',]
+      -- Pass Only Elements: ['listings']
       SELECT
         subq_10.listings
       FROM (

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Snowflake/test_multiple_metrics_no_dimensions__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Snowflake/test_multiple_metrics_no_dimensions__plan0_optimized.sql
@@ -10,7 +10,7 @@ FROM (
   -- Read Elements From Semantic Model 'bookings_source'
   -- Metric Time Dimension 'ds'
   -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
-  -- Pass Only Elements: ['bookings',]
+  -- Pass Only Elements: ['bookings']
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT
@@ -22,7 +22,7 @@ CROSS JOIN (
   -- Read Elements From Semantic Model 'listings_latest'
   -- Metric Time Dimension 'ds'
   -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
-  -- Pass Only Elements: ['listings',]
+  -- Pass Only Elements: ['listings']
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Snowflake/test_no_dedupe__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Snowflake/test_no_dedupe__plan0.sql
@@ -181,7 +181,7 @@ FROM (
       FROM ***************************.dim_listings listings_src_26000
     ) subq_0
     CROSS JOIN (
-      -- Pass Only Elements: ['metric_time__month',]
+      -- Pass Only Elements: ['metric_time__month']
       SELECT
         subq_2.metric_time__month
       FROM (

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Snowflake/test_no_dedupe_saved_query__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Snowflake/test_no_dedupe_saved_query__plan0.sql
@@ -190,7 +190,7 @@ FROM (
       FROM ***************************.dim_listings_latest listings_latest_src_28000
     ) subq_0
     CROSS JOIN (
-      -- Pass Only Elements: ['metric_time__month',]
+      -- Pass Only Elements: ['metric_time__month']
       SELECT
         subq_2.metric_time__month
       FROM (

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Snowflake/test_non_additive_dimension_with_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Snowflake/test_non_additive_dimension_with_non_default_grain__plan0.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     SUM(subq_5.total_account_balance_first_day_of_month) AS total_account_balance_first_day_of_month
   FROM (
-    -- Pass Only Elements: ['total_account_balance_first_day_of_month',]
+    -- Pass Only Elements: ['total_account_balance_first_day_of_month']
     SELECT
       subq_4.total_account_balance_first_day_of_month
     FROM (

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Snowflake/test_non_additive_dimension_with_non_default_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Snowflake/test_non_additive_dimension_with_non_default_grain__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: Snowflake
 ---
 -- Join on MIN(ds_month) and [] grouping by None
--- Pass Only Elements: ['total_account_balance_first_day_of_month',]
+-- Pass Only Elements: ['total_account_balance_first_day_of_month']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Snowflake/test_scd_dimension_filter_without_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Snowflake/test_scd_dimension_filter_without_metric_time__plan0.sql
@@ -10,7 +10,7 @@ FROM (
   SELECT
     SUM(subq_6.bookings) AS bookings
   FROM (
-    -- Pass Only Elements: ['bookings',]
+    -- Pass Only Elements: ['bookings']
     SELECT
       subq_5.bookings
     FROM (

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Snowflake/test_scd_dimension_filter_without_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Snowflake/test_scd_dimension_filter_without_metric_time__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_query_rendering.py
 sql_engine: Snowflake
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['bookings',]
+-- Pass Only Elements: ['bookings']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Trino/test_distinct_values__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Trino/test_distinct_values__plan0.sql
@@ -8,7 +8,7 @@ sql_engine: Trino
 SELECT
   subq_2.listing__country_latest
 FROM (
-  -- Pass Only Elements: ['listing__country_latest',]
+  -- Pass Only Elements: ['listing__country_latest']
   SELECT
     subq_1.listing__country_latest
   FROM (

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Trino/test_distinct_values__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Trino/test_distinct_values__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: Trino
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['listing__country_latest',]
+-- Pass Only Elements: ['listing__country_latest']
 -- Order By ['listing__country_latest'] Limit 100
 SELECT
   listing__country_latest

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Trino/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Trino/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0.sql
@@ -19,7 +19,7 @@ FROM (
       SELECT
         SUM(subq_2.bookings) AS bookings
       FROM (
-        -- Pass Only Elements: ['bookings',]
+        -- Pass Only Elements: ['bookings']
         SELECT
           subq_1.bookings
         FROM (
@@ -229,7 +229,7 @@ FROM (
       SELECT
         SUM(subq_7.listings) AS listings
       FROM (
-        -- Pass Only Elements: ['listings',]
+        -- Pass Only Elements: ['listings']
         SELECT
           subq_6.listings
         FROM (

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Trino/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Trino/test_metric_with_measures_from_multiple_sources_no_dimensions__plan0_optimized.sql
@@ -9,7 +9,7 @@ SELECT
 FROM (
   -- Read Elements From Semantic Model 'bookings_source'
   -- Metric Time Dimension 'ds'
-  -- Pass Only Elements: ['bookings',]
+  -- Pass Only Elements: ['bookings']
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT
@@ -19,7 +19,7 @@ FROM (
 CROSS JOIN (
   -- Read Elements From Semantic Model 'listings_latest'
   -- Metric Time Dimension 'ds'
-  -- Pass Only Elements: ['listings',]
+  -- Pass Only Elements: ['listings']
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Trino/test_min_max_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Trino/test_min_max_metric_time__plan0.sql
@@ -9,7 +9,7 @@ SELECT
   MIN(subq_2.metric_time__day) AS metric_time__day__min
   , MAX(subq_2.metric_time__day) AS metric_time__day__max
 FROM (
-  -- Pass Only Elements: ['metric_time__day',]
+  -- Pass Only Elements: ['metric_time__day']
   SELECT
     subq_1.metric_time__day
   FROM (

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Trino/test_min_max_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Trino/test_min_max_metric_time__plan0_optimized.sql
@@ -11,7 +11,7 @@ SELECT
 FROM (
   -- Read From Time Spine 'mf_time_spine'
   -- Metric Time Dimension 'ds'
-  -- Pass Only Elements: ['metric_time__day',]
+  -- Pass Only Elements: ['metric_time__day']
   SELECT
     ds AS metric_time__day
   FROM ***************************.mf_time_spine time_spine_src_28006

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Trino/test_min_max_metric_time_week__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Trino/test_min_max_metric_time_week__plan0.sql
@@ -9,7 +9,7 @@ SELECT
   MIN(subq_2.metric_time__week) AS metric_time__week__min
   , MAX(subq_2.metric_time__week) AS metric_time__week__max
 FROM (
-  -- Pass Only Elements: ['metric_time__week',]
+  -- Pass Only Elements: ['metric_time__week']
   SELECT
     subq_1.metric_time__week
   FROM (

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Trino/test_min_max_metric_time_week__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Trino/test_min_max_metric_time_week__plan0_optimized.sql
@@ -11,7 +11,7 @@ SELECT
 FROM (
   -- Read From Time Spine 'mf_time_spine'
   -- Metric Time Dimension 'ds'
-  -- Pass Only Elements: ['metric_time__week',]
+  -- Pass Only Elements: ['metric_time__week']
   SELECT
     DATE_TRUNC('week', ds) AS metric_time__week
   FROM ***************************.mf_time_spine time_spine_src_28006

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Trino/test_min_max_only_categorical__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Trino/test_min_max_only_categorical__plan0.sql
@@ -9,7 +9,7 @@ SELECT
   MIN(subq_1.listing__country_latest) AS listing__country_latest__min
   , MAX(subq_1.listing__country_latest) AS listing__country_latest__max
 FROM (
-  -- Pass Only Elements: ['listing__country_latest',]
+  -- Pass Only Elements: ['listing__country_latest']
   SELECT
     subq_0.listing__country_latest
   FROM (

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Trino/test_min_max_only_categorical__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Trino/test_min_max_only_categorical__plan0_optimized.sql
@@ -10,7 +10,7 @@ SELECT
   , MAX(listing__country_latest) AS listing__country_latest__max
 FROM (
   -- Read Elements From Semantic Model 'listings_latest'
-  -- Pass Only Elements: ['listing__country_latest',]
+  -- Pass Only Elements: ['listing__country_latest']
   SELECT
     country AS listing__country_latest
   FROM ***************************.dim_listings_latest listings_latest_src_28000

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Trino/test_min_max_only_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Trino/test_min_max_only_time__plan0.sql
@@ -9,7 +9,7 @@ SELECT
   MIN(subq_1.booking__paid_at__day) AS booking__paid_at__day__min
   , MAX(subq_1.booking__paid_at__day) AS booking__paid_at__day__max
 FROM (
-  -- Pass Only Elements: ['booking__paid_at__day',]
+  -- Pass Only Elements: ['booking__paid_at__day']
   SELECT
     subq_0.booking__paid_at__day
   FROM (

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Trino/test_min_max_only_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Trino/test_min_max_only_time__plan0_optimized.sql
@@ -10,7 +10,7 @@ SELECT
   , MAX(booking__paid_at__day) AS booking__paid_at__day__max
 FROM (
   -- Read Elements From Semantic Model 'bookings_source'
-  -- Pass Only Elements: ['booking__paid_at__day',]
+  -- Pass Only Elements: ['booking__paid_at__day']
   SELECT
     DATE_TRUNC('day', paid_at) AS booking__paid_at__day
   FROM ***************************.fct_bookings bookings_source_src_28000

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Trino/test_min_max_only_time_quarter__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Trino/test_min_max_only_time_quarter__plan0.sql
@@ -9,7 +9,7 @@ SELECT
   MIN(subq_1.booking__paid_at__quarter) AS booking__paid_at__quarter__min
   , MAX(subq_1.booking__paid_at__quarter) AS booking__paid_at__quarter__max
 FROM (
-  -- Pass Only Elements: ['booking__paid_at__quarter',]
+  -- Pass Only Elements: ['booking__paid_at__quarter']
   SELECT
     subq_0.booking__paid_at__quarter
   FROM (

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Trino/test_min_max_only_time_quarter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Trino/test_min_max_only_time_quarter__plan0_optimized.sql
@@ -10,7 +10,7 @@ SELECT
   , MAX(booking__paid_at__quarter) AS booking__paid_at__quarter__max
 FROM (
   -- Read Elements From Semantic Model 'bookings_source'
-  -- Pass Only Elements: ['booking__paid_at__quarter',]
+  -- Pass Only Elements: ['booking__paid_at__quarter']
   SELECT
     DATE_TRUNC('quarter', paid_at) AS booking__paid_at__quarter
   FROM ***************************.fct_bookings bookings_source_src_28000

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Trino/test_multiple_metrics_no_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Trino/test_multiple_metrics_no_dimensions__plan0.sql
@@ -15,7 +15,7 @@ FROM (
     SELECT
       SUM(subq_5.bookings) AS bookings
     FROM (
-      -- Pass Only Elements: ['bookings',]
+      -- Pass Only Elements: ['bookings']
       SELECT
         subq_4.bookings
       FROM (
@@ -328,7 +328,7 @@ CROSS JOIN (
     SELECT
       SUM(subq_11.listings) AS listings
     FROM (
-      -- Pass Only Elements: ['listings',]
+      -- Pass Only Elements: ['listings']
       SELECT
         subq_10.listings
       FROM (

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Trino/test_multiple_metrics_no_dimensions__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Trino/test_multiple_metrics_no_dimensions__plan0_optimized.sql
@@ -10,7 +10,7 @@ FROM (
   -- Read Elements From Semantic Model 'bookings_source'
   -- Metric Time Dimension 'ds'
   -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
-  -- Pass Only Elements: ['bookings',]
+  -- Pass Only Elements: ['bookings']
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT
@@ -22,7 +22,7 @@ CROSS JOIN (
   -- Read Elements From Semantic Model 'listings_latest'
   -- Metric Time Dimension 'ds'
   -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
-  -- Pass Only Elements: ['listings',]
+  -- Pass Only Elements: ['listings']
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Trino/test_no_dedupe__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Trino/test_no_dedupe__plan0.sql
@@ -181,7 +181,7 @@ FROM (
       FROM ***************************.dim_listings listings_src_26000
     ) subq_0
     CROSS JOIN (
-      -- Pass Only Elements: ['metric_time__month',]
+      -- Pass Only Elements: ['metric_time__month']
       SELECT
         subq_2.metric_time__month
       FROM (

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Trino/test_no_dedupe_saved_query__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Trino/test_no_dedupe_saved_query__plan0.sql
@@ -190,7 +190,7 @@ FROM (
       FROM ***************************.dim_listings_latest listings_latest_src_28000
     ) subq_0
     CROSS JOIN (
-      -- Pass Only Elements: ['metric_time__month',]
+      -- Pass Only Elements: ['metric_time__month']
       SELECT
         subq_2.metric_time__month
       FROM (

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Trino/test_non_additive_dimension_with_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Trino/test_non_additive_dimension_with_non_default_grain__plan0.sql
@@ -12,7 +12,7 @@ FROM (
   SELECT
     SUM(subq_5.total_account_balance_first_day_of_month) AS total_account_balance_first_day_of_month
   FROM (
-    -- Pass Only Elements: ['total_account_balance_first_day_of_month',]
+    -- Pass Only Elements: ['total_account_balance_first_day_of_month']
     SELECT
       subq_4.total_account_balance_first_day_of_month
     FROM (

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Trino/test_non_additive_dimension_with_non_default_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Trino/test_non_additive_dimension_with_non_default_grain__plan0_optimized.sql
@@ -5,7 +5,7 @@ docstring:
 sql_engine: Trino
 ---
 -- Join on MIN(ds_month) and [] grouping by None
--- Pass Only Elements: ['total_account_balance_first_day_of_month',]
+-- Pass Only Elements: ['total_account_balance_first_day_of_month']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Trino/test_scd_dimension_filter_without_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Trino/test_scd_dimension_filter_without_metric_time__plan0.sql
@@ -10,7 +10,7 @@ FROM (
   SELECT
     SUM(subq_6.bookings) AS bookings
   FROM (
-    -- Pass Only Elements: ['bookings',]
+    -- Pass Only Elements: ['bookings']
     SELECT
       subq_5.bookings
     FROM (

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Trino/test_scd_dimension_filter_without_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Trino/test_scd_dimension_filter_without_metric_time__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_query_rendering.py
 sql_engine: Trino
 ---
 -- Constrain Output with WHERE
--- Pass Only Elements: ['bookings',]
+-- Pass Only Elements: ['bookings']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/BigQuery/test_join_to_time_spine_with_input_measure_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/BigQuery/test_join_to_time_spine_with_input_measure_constraint__plan0.sql
@@ -18,7 +18,7 @@ FROM (
     , subq_4.booking__is_instant AS booking__is_instant
     , subq_4.bookings AS bookings
   FROM (
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       subq_7.metric_time__day
     FROM (

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/BigQuery/test_join_to_time_spine_with_input_measure_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/BigQuery/test_join_to_time_spine_with_input_measure_constraint__plan0_optimized.sql
@@ -14,7 +14,7 @@ SELECT
   , subq_14.bookings AS instant_bookings_with_measure_filter
 FROM (
   -- Constrain Output with WHERE
-  -- Pass Only Elements: ['metric_time__day',]
+  -- Pass Only Elements: ['metric_time__day']
   SELECT
     metric_time__day
   FROM (

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/BigQuery/test_join_to_time_spine_with_queried_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/BigQuery/test_join_to_time_spine_with_queried_time_constraint__plan0.sql
@@ -19,7 +19,7 @@ FROM (
       subq_9.metric_time__day AS metric_time__day
       , subq_5.bookings AS bookings
     FROM (
-      -- Pass Only Elements: ['metric_time__day',]
+      -- Pass Only Elements: ['metric_time__day']
       SELECT
         subq_8.metric_time__day
       FROM (

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/BigQuery/test_join_to_time_spine_with_queried_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/BigQuery/test_join_to_time_spine_with_queried_time_constraint__plan0_optimized.sql
@@ -18,7 +18,7 @@ FROM (
     -- Read From Time Spine 'mf_time_spine'
     -- Change Column Aliases
     -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       ds AS metric_time__day
     FROM ***************************.mf_time_spine time_spine_src_28006

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/BigQuery/test_simple_join_to_time_spine__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/BigQuery/test_simple_join_to_time_spine__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_6.metric_time__day AS metric_time__day
     , subq_3.bookings AS bookings
   FROM (
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       subq_5.metric_time__day
     FROM (

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/BigQuery/test_simple_join_to_time_spine_with_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/BigQuery/test_simple_join_to_time_spine_with_filter__plan0.sql
@@ -14,7 +14,7 @@ FROM (
     subq_7.metric_time__day AS metric_time__day
     , subq_4.bookings AS bookings
   FROM (
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       subq_6.metric_time__day
     FROM (

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/BigQuery/test_simple_join_to_time_spine_with_queried_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/BigQuery/test_simple_join_to_time_spine_with_queried_filter__plan0.sql
@@ -22,7 +22,7 @@ FROM (
       , subq_4.booking__is_instant AS booking__is_instant
       , subq_4.bookings AS bookings
     FROM (
-      -- Pass Only Elements: ['metric_time__day',]
+      -- Pass Only Elements: ['metric_time__day']
       SELECT
         subq_6.metric_time__day
       FROM (

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Databricks/test_join_to_time_spine_with_input_measure_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Databricks/test_join_to_time_spine_with_input_measure_constraint__plan0.sql
@@ -18,7 +18,7 @@ FROM (
     , subq_4.booking__is_instant AS booking__is_instant
     , subq_4.bookings AS bookings
   FROM (
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       subq_7.metric_time__day
     FROM (

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Databricks/test_join_to_time_spine_with_input_measure_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Databricks/test_join_to_time_spine_with_input_measure_constraint__plan0_optimized.sql
@@ -14,7 +14,7 @@ SELECT
   , subq_14.bookings AS instant_bookings_with_measure_filter
 FROM (
   -- Constrain Output with WHERE
-  -- Pass Only Elements: ['metric_time__day',]
+  -- Pass Only Elements: ['metric_time__day']
   SELECT
     metric_time__day
   FROM (

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Databricks/test_join_to_time_spine_with_queried_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Databricks/test_join_to_time_spine_with_queried_time_constraint__plan0.sql
@@ -19,7 +19,7 @@ FROM (
       subq_9.metric_time__day AS metric_time__day
       , subq_5.bookings AS bookings
     FROM (
-      -- Pass Only Elements: ['metric_time__day',]
+      -- Pass Only Elements: ['metric_time__day']
       SELECT
         subq_8.metric_time__day
       FROM (

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Databricks/test_join_to_time_spine_with_queried_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Databricks/test_join_to_time_spine_with_queried_time_constraint__plan0_optimized.sql
@@ -18,7 +18,7 @@ FROM (
     -- Read From Time Spine 'mf_time_spine'
     -- Change Column Aliases
     -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       ds AS metric_time__day
     FROM ***************************.mf_time_spine time_spine_src_28006

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Databricks/test_simple_join_to_time_spine__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Databricks/test_simple_join_to_time_spine__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_6.metric_time__day AS metric_time__day
     , subq_3.bookings AS bookings
   FROM (
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       subq_5.metric_time__day
     FROM (

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Databricks/test_simple_join_to_time_spine_with_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Databricks/test_simple_join_to_time_spine_with_filter__plan0.sql
@@ -14,7 +14,7 @@ FROM (
     subq_7.metric_time__day AS metric_time__day
     , subq_4.bookings AS bookings
   FROM (
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       subq_6.metric_time__day
     FROM (

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Databricks/test_simple_join_to_time_spine_with_queried_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Databricks/test_simple_join_to_time_spine_with_queried_filter__plan0.sql
@@ -22,7 +22,7 @@ FROM (
       , subq_4.booking__is_instant AS booking__is_instant
       , subq_4.bookings AS bookings
     FROM (
-      -- Pass Only Elements: ['metric_time__day',]
+      -- Pass Only Elements: ['metric_time__day']
       SELECT
         subq_6.metric_time__day
       FROM (

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/DuckDB/test_join_to_time_spine_with_input_measure_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/DuckDB/test_join_to_time_spine_with_input_measure_constraint__plan0.sql
@@ -18,7 +18,7 @@ FROM (
     , subq_4.booking__is_instant AS booking__is_instant
     , subq_4.bookings AS bookings
   FROM (
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       subq_7.metric_time__day
     FROM (

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/DuckDB/test_join_to_time_spine_with_input_measure_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/DuckDB/test_join_to_time_spine_with_input_measure_constraint__plan0_optimized.sql
@@ -14,7 +14,7 @@ SELECT
   , subq_14.bookings AS instant_bookings_with_measure_filter
 FROM (
   -- Constrain Output with WHERE
-  -- Pass Only Elements: ['metric_time__day',]
+  -- Pass Only Elements: ['metric_time__day']
   SELECT
     metric_time__day
   FROM (

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/DuckDB/test_join_to_time_spine_with_queried_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/DuckDB/test_join_to_time_spine_with_queried_time_constraint__plan0.sql
@@ -19,7 +19,7 @@ FROM (
       subq_9.metric_time__day AS metric_time__day
       , subq_5.bookings AS bookings
     FROM (
-      -- Pass Only Elements: ['metric_time__day',]
+      -- Pass Only Elements: ['metric_time__day']
       SELECT
         subq_8.metric_time__day
       FROM (

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/DuckDB/test_join_to_time_spine_with_queried_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/DuckDB/test_join_to_time_spine_with_queried_time_constraint__plan0_optimized.sql
@@ -18,7 +18,7 @@ FROM (
     -- Read From Time Spine 'mf_time_spine'
     -- Change Column Aliases
     -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       ds AS metric_time__day
     FROM ***************************.mf_time_spine time_spine_src_28006

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/DuckDB/test_simple_join_to_time_spine__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/DuckDB/test_simple_join_to_time_spine__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_6.metric_time__day AS metric_time__day
     , subq_3.bookings AS bookings
   FROM (
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       subq_5.metric_time__day
     FROM (

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/DuckDB/test_simple_join_to_time_spine_with_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/DuckDB/test_simple_join_to_time_spine_with_filter__plan0.sql
@@ -14,7 +14,7 @@ FROM (
     subq_7.metric_time__day AS metric_time__day
     , subq_4.bookings AS bookings
   FROM (
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       subq_6.metric_time__day
     FROM (

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/DuckDB/test_simple_join_to_time_spine_with_queried_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/DuckDB/test_simple_join_to_time_spine_with_queried_filter__plan0.sql
@@ -22,7 +22,7 @@ FROM (
       , subq_4.booking__is_instant AS booking__is_instant
       , subq_4.bookings AS bookings
     FROM (
-      -- Pass Only Elements: ['metric_time__day',]
+      -- Pass Only Elements: ['metric_time__day']
       SELECT
         subq_6.metric_time__day
       FROM (

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Postgres/test_join_to_time_spine_with_input_measure_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Postgres/test_join_to_time_spine_with_input_measure_constraint__plan0.sql
@@ -18,7 +18,7 @@ FROM (
     , subq_4.booking__is_instant AS booking__is_instant
     , subq_4.bookings AS bookings
   FROM (
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       subq_7.metric_time__day
     FROM (

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Postgres/test_join_to_time_spine_with_input_measure_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Postgres/test_join_to_time_spine_with_input_measure_constraint__plan0_optimized.sql
@@ -14,7 +14,7 @@ SELECT
   , subq_14.bookings AS instant_bookings_with_measure_filter
 FROM (
   -- Constrain Output with WHERE
-  -- Pass Only Elements: ['metric_time__day',]
+  -- Pass Only Elements: ['metric_time__day']
   SELECT
     metric_time__day
   FROM (

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Postgres/test_join_to_time_spine_with_queried_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Postgres/test_join_to_time_spine_with_queried_time_constraint__plan0.sql
@@ -19,7 +19,7 @@ FROM (
       subq_9.metric_time__day AS metric_time__day
       , subq_5.bookings AS bookings
     FROM (
-      -- Pass Only Elements: ['metric_time__day',]
+      -- Pass Only Elements: ['metric_time__day']
       SELECT
         subq_8.metric_time__day
       FROM (

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Postgres/test_join_to_time_spine_with_queried_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Postgres/test_join_to_time_spine_with_queried_time_constraint__plan0_optimized.sql
@@ -18,7 +18,7 @@ FROM (
     -- Read From Time Spine 'mf_time_spine'
     -- Change Column Aliases
     -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       ds AS metric_time__day
     FROM ***************************.mf_time_spine time_spine_src_28006

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Postgres/test_simple_join_to_time_spine__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Postgres/test_simple_join_to_time_spine__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_6.metric_time__day AS metric_time__day
     , subq_3.bookings AS bookings
   FROM (
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       subq_5.metric_time__day
     FROM (

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Postgres/test_simple_join_to_time_spine_with_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Postgres/test_simple_join_to_time_spine_with_filter__plan0.sql
@@ -14,7 +14,7 @@ FROM (
     subq_7.metric_time__day AS metric_time__day
     , subq_4.bookings AS bookings
   FROM (
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       subq_6.metric_time__day
     FROM (

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Postgres/test_simple_join_to_time_spine_with_queried_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Postgres/test_simple_join_to_time_spine_with_queried_filter__plan0.sql
@@ -22,7 +22,7 @@ FROM (
       , subq_4.booking__is_instant AS booking__is_instant
       , subq_4.bookings AS bookings
     FROM (
-      -- Pass Only Elements: ['metric_time__day',]
+      -- Pass Only Elements: ['metric_time__day']
       SELECT
         subq_6.metric_time__day
       FROM (

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Redshift/test_join_to_time_spine_with_input_measure_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Redshift/test_join_to_time_spine_with_input_measure_constraint__plan0.sql
@@ -18,7 +18,7 @@ FROM (
     , subq_4.booking__is_instant AS booking__is_instant
     , subq_4.bookings AS bookings
   FROM (
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       subq_7.metric_time__day
     FROM (

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Redshift/test_join_to_time_spine_with_input_measure_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Redshift/test_join_to_time_spine_with_input_measure_constraint__plan0_optimized.sql
@@ -14,7 +14,7 @@ SELECT
   , subq_14.bookings AS instant_bookings_with_measure_filter
 FROM (
   -- Constrain Output with WHERE
-  -- Pass Only Elements: ['metric_time__day',]
+  -- Pass Only Elements: ['metric_time__day']
   SELECT
     metric_time__day
   FROM (

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Redshift/test_join_to_time_spine_with_queried_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Redshift/test_join_to_time_spine_with_queried_time_constraint__plan0.sql
@@ -19,7 +19,7 @@ FROM (
       subq_9.metric_time__day AS metric_time__day
       , subq_5.bookings AS bookings
     FROM (
-      -- Pass Only Elements: ['metric_time__day',]
+      -- Pass Only Elements: ['metric_time__day']
       SELECT
         subq_8.metric_time__day
       FROM (

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Redshift/test_join_to_time_spine_with_queried_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Redshift/test_join_to_time_spine_with_queried_time_constraint__plan0_optimized.sql
@@ -18,7 +18,7 @@ FROM (
     -- Read From Time Spine 'mf_time_spine'
     -- Change Column Aliases
     -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       ds AS metric_time__day
     FROM ***************************.mf_time_spine time_spine_src_28006

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Redshift/test_simple_join_to_time_spine__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Redshift/test_simple_join_to_time_spine__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_6.metric_time__day AS metric_time__day
     , subq_3.bookings AS bookings
   FROM (
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       subq_5.metric_time__day
     FROM (

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Redshift/test_simple_join_to_time_spine_with_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Redshift/test_simple_join_to_time_spine_with_filter__plan0.sql
@@ -14,7 +14,7 @@ FROM (
     subq_7.metric_time__day AS metric_time__day
     , subq_4.bookings AS bookings
   FROM (
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       subq_6.metric_time__day
     FROM (

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Redshift/test_simple_join_to_time_spine_with_queried_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Redshift/test_simple_join_to_time_spine_with_queried_filter__plan0.sql
@@ -22,7 +22,7 @@ FROM (
       , subq_4.booking__is_instant AS booking__is_instant
       , subq_4.bookings AS bookings
     FROM (
-      -- Pass Only Elements: ['metric_time__day',]
+      -- Pass Only Elements: ['metric_time__day']
       SELECT
         subq_6.metric_time__day
       FROM (

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Snowflake/test_join_to_time_spine_with_input_measure_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Snowflake/test_join_to_time_spine_with_input_measure_constraint__plan0.sql
@@ -18,7 +18,7 @@ FROM (
     , subq_4.booking__is_instant AS booking__is_instant
     , subq_4.bookings AS bookings
   FROM (
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       subq_7.metric_time__day
     FROM (

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Snowflake/test_join_to_time_spine_with_input_measure_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Snowflake/test_join_to_time_spine_with_input_measure_constraint__plan0_optimized.sql
@@ -14,7 +14,7 @@ SELECT
   , subq_14.bookings AS instant_bookings_with_measure_filter
 FROM (
   -- Constrain Output with WHERE
-  -- Pass Only Elements: ['metric_time__day',]
+  -- Pass Only Elements: ['metric_time__day']
   SELECT
     metric_time__day
   FROM (

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Snowflake/test_join_to_time_spine_with_queried_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Snowflake/test_join_to_time_spine_with_queried_time_constraint__plan0.sql
@@ -19,7 +19,7 @@ FROM (
       subq_9.metric_time__day AS metric_time__day
       , subq_5.bookings AS bookings
     FROM (
-      -- Pass Only Elements: ['metric_time__day',]
+      -- Pass Only Elements: ['metric_time__day']
       SELECT
         subq_8.metric_time__day
       FROM (

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Snowflake/test_join_to_time_spine_with_queried_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Snowflake/test_join_to_time_spine_with_queried_time_constraint__plan0_optimized.sql
@@ -18,7 +18,7 @@ FROM (
     -- Read From Time Spine 'mf_time_spine'
     -- Change Column Aliases
     -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       ds AS metric_time__day
     FROM ***************************.mf_time_spine time_spine_src_28006

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Snowflake/test_simple_join_to_time_spine__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Snowflake/test_simple_join_to_time_spine__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_6.metric_time__day AS metric_time__day
     , subq_3.bookings AS bookings
   FROM (
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       subq_5.metric_time__day
     FROM (

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Snowflake/test_simple_join_to_time_spine_with_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Snowflake/test_simple_join_to_time_spine_with_filter__plan0.sql
@@ -14,7 +14,7 @@ FROM (
     subq_7.metric_time__day AS metric_time__day
     , subq_4.bookings AS bookings
   FROM (
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       subq_6.metric_time__day
     FROM (

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Snowflake/test_simple_join_to_time_spine_with_queried_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Snowflake/test_simple_join_to_time_spine_with_queried_filter__plan0.sql
@@ -22,7 +22,7 @@ FROM (
       , subq_4.booking__is_instant AS booking__is_instant
       , subq_4.bookings AS bookings
     FROM (
-      -- Pass Only Elements: ['metric_time__day',]
+      -- Pass Only Elements: ['metric_time__day']
       SELECT
         subq_6.metric_time__day
       FROM (

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Trino/test_join_to_time_spine_with_input_measure_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Trino/test_join_to_time_spine_with_input_measure_constraint__plan0.sql
@@ -18,7 +18,7 @@ FROM (
     , subq_4.booking__is_instant AS booking__is_instant
     , subq_4.bookings AS bookings
   FROM (
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       subq_7.metric_time__day
     FROM (

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Trino/test_join_to_time_spine_with_input_measure_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Trino/test_join_to_time_spine_with_input_measure_constraint__plan0_optimized.sql
@@ -14,7 +14,7 @@ SELECT
   , subq_14.bookings AS instant_bookings_with_measure_filter
 FROM (
   -- Constrain Output with WHERE
-  -- Pass Only Elements: ['metric_time__day',]
+  -- Pass Only Elements: ['metric_time__day']
   SELECT
     metric_time__day
   FROM (

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Trino/test_join_to_time_spine_with_queried_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Trino/test_join_to_time_spine_with_queried_time_constraint__plan0.sql
@@ -19,7 +19,7 @@ FROM (
       subq_9.metric_time__day AS metric_time__day
       , subq_5.bookings AS bookings
     FROM (
-      -- Pass Only Elements: ['metric_time__day',]
+      -- Pass Only Elements: ['metric_time__day']
       SELECT
         subq_8.metric_time__day
       FROM (

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Trino/test_join_to_time_spine_with_queried_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Trino/test_join_to_time_spine_with_queried_time_constraint__plan0_optimized.sql
@@ -18,7 +18,7 @@ FROM (
     -- Read From Time Spine 'mf_time_spine'
     -- Change Column Aliases
     -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       ds AS metric_time__day
     FROM ***************************.mf_time_spine time_spine_src_28006

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Trino/test_simple_join_to_time_spine__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Trino/test_simple_join_to_time_spine__plan0.sql
@@ -12,7 +12,7 @@ FROM (
     subq_6.metric_time__day AS metric_time__day
     , subq_3.bookings AS bookings
   FROM (
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       subq_5.metric_time__day
     FROM (

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Trino/test_simple_join_to_time_spine_with_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Trino/test_simple_join_to_time_spine_with_filter__plan0.sql
@@ -14,7 +14,7 @@ FROM (
     subq_7.metric_time__day AS metric_time__day
     , subq_4.bookings AS bookings
   FROM (
-    -- Pass Only Elements: ['metric_time__day',]
+    -- Pass Only Elements: ['metric_time__day']
     SELECT
       subq_6.metric_time__day
     FROM (

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Trino/test_simple_join_to_time_spine_with_queried_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Trino/test_simple_join_to_time_spine_with_queried_filter__plan0.sql
@@ -22,7 +22,7 @@ FROM (
       , subq_4.booking__is_instant AS booking__is_instant
       , subq_4.bookings AS bookings
     FROM (
-      -- Pass Only Elements: ['metric_time__day',]
+      -- Pass Only Elements: ['metric_time__day']
       SELECT
         subq_6.metric_time__day
       FROM (


### PR DESCRIPTION
This PR updates the pretty-formatting of `list` objects to not include the trailing comma.