### PR TITLE
Add `include_underscore_prefix_fields` option to `mf_pformat`

### DIFF
--- a/.changes/unreleased/Under the Hood-20250425-183020.yaml
+++ b/.changes/unreleased/Under the Hood-20250425-183020.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Add `include_underscore_prefix_fields` option to `mf_pformat`
+time: 2025-04-25T18:30:20.541633-07:00
+custom:
+  Author: plypaul
+  Issue: "1736"

--- a/metricflow-semantics/metricflow_semantics/mf_logging/pretty_formatter.py
+++ b/metricflow-semantics/metricflow_semantics/mf_logging/pretty_formatter.py
@@ -266,6 +266,9 @@ class MetricFlowPrettyFormatter:
                 if (isinstance(value, Sized) and len(value) > 0) or (not isinstance(value, Sized))
             }
 
+        if is_dataclass_like_object and not self._format_option.include_underscore_prefix_fields:
+            mapping = {key: value for key, value in mapping.items() if not key.startswith("_")}
+
         if len(mapping) == 0:
             return f"{left_enclose_str}{right_enclose_str}"
 
@@ -412,6 +415,7 @@ class PrettyFormatOption:
     include_object_field_names: bool = True
     include_none_object_fields: bool = False
     include_empty_object_fields: bool = False
+    include_underscore_prefix_fields: bool = False
 
     def with_max_line_length(self, max_line_length: Optional[int]) -> PrettyFormatOption:
         """Return a copy of self but with a new value for `max_line_length`."""

--- a/metricflow-semantics/metricflow_semantics/mf_logging/pretty_formatter.py
+++ b/metricflow-semantics/metricflow_semantics/mf_logging/pretty_formatter.py
@@ -256,18 +256,17 @@ class MetricFlowPrettyFormatter:
             A string representation of the mapping. e.g. "{'a'=[1, 2]}" or "Foo(a=[1, 2])".
         """
         # Skip key / values depending on the pretty-print configuration.
-        if is_dataclass_like_object and not self._format_option.include_none_object_fields:
-            mapping = {key: value for key, value in mapping.items() if value is not None}
-
-        if is_dataclass_like_object and not self._format_option.include_empty_object_fields:
-            mapping = {
-                key: value
-                for key, value in mapping.items()
-                if (isinstance(value, Sized) and len(value) > 0) or (not isinstance(value, Sized))
-            }
-
-        if is_dataclass_like_object and not self._format_option.include_underscore_prefix_fields:
-            mapping = {key: value for key, value in mapping.items() if not key.startswith("_")}
+        if is_dataclass_like_object:
+            new_mapping = {}
+            for key, value in mapping.items():
+                if not self._format_option.include_none_object_fields and value is None:
+                    continue
+                if not self._format_option.include_empty_object_fields and isinstance(value, Sized) and len(value) == 0:
+                    continue
+                if not self._format_option.include_underscore_prefix_fields and key.startswith("_"):
+                    continue
+                new_mapping[key] = value
+            mapping = new_mapping
 
         if len(mapping) == 0:
             return f"{left_enclose_str}{right_enclose_str}"

--- a/metricflow-semantics/metricflow_semantics/mf_logging/pretty_formatter.py
+++ b/metricflow-semantics/metricflow_semantics/mf_logging/pretty_formatter.py
@@ -134,20 +134,19 @@ class MetricFlowPrettyFormatter:
             of the mapping-like object.
         """
         # See if the string representation can fit on one line. e.g. "'a': [1, 2]"
-        if remaining_line_length is None or remaining_line_length > 0:
-            result_items_without_limit: List[str] = []
-            if is_dataclass_like_object and self._format_option.include_object_field_names:
-                result_items_without_limit.append(str(key))
-            else:
-                result_items_without_limit.append(self._handle_any_obj(key, remaining_line_length=None))
-            result_items_without_limit.append(key_value_seperator)
-            result_items_without_limit.append(self._handle_any_obj(value, remaining_line_length=None))
+        result_items_without_limit: List[str] = []
+        if is_dataclass_like_object and self._format_option.include_object_field_names:
+            result_items_without_limit.append(str(key))
+        else:
+            result_items_without_limit.append(self._handle_any_obj(key, remaining_line_length=None))
+        result_items_without_limit.append(key_value_seperator)
+        result_items_without_limit.append(self._handle_any_obj(value, remaining_line_length=None))
 
-            result_without_limit = mf_indent(
-                "".join(result_items_without_limit), indent_prefix=self._format_option.indent_prefix
-            )
-            if remaining_line_length is None or len(result_without_limit) <= remaining_line_length:
-                return result_without_limit
+        result_without_limit = mf_indent(
+            "".join(result_items_without_limit), indent_prefix=self._format_option.indent_prefix
+        )
+        if remaining_line_length is None or len(result_without_limit) <= remaining_line_length:
+            return result_without_limit
 
         # The string representation can't fit on one line - use multiple. e.g.
         """

--- a/metricflow-semantics/metricflow_semantics/mf_logging/pretty_formatter.py
+++ b/metricflow-semantics/metricflow_semantics/mf_logging/pretty_formatter.py
@@ -148,7 +148,7 @@ class MetricFlowPrettyFormatter:
         if remaining_line_length is None or len(result_without_limit) <= remaining_line_length:
             return result_without_limit
 
-        # The string representation can't fit on one line - use multiple. e.g.
+        # The string representation can't fit on one line - use multiple lines. e.g.
         """
         'key':
           [1, 2, 3, 4]

--- a/metricflow-semantics/tests_metricflow_semantics/mf_logging/test_pretty_print.py
+++ b/metricflow-semantics/tests_metricflow_semantics/mf_logging/test_pretty_print.py
@@ -175,3 +175,25 @@ def test_custom_pretty_print() -> None:
             return format_context.formatter.pretty_format({"field_0": f"{self.field_0:.2f}"})
 
     assert mf_pformat(_ExampleDataclass(1.2345)) == "{'field_0': '1.23'}"
+
+
+def test_include_underscore_prefix_option() -> None:  # noqa: D103
+    @dataclass(frozen=True)
+    class _ExampleDataclass:
+        field_0: int
+        _hidden_field: int
+
+    assert (
+        mf_pformat(
+            _ExampleDataclass(field_0=1, _hidden_field=2),
+            format_option=PrettyFormatOption(include_underscore_prefix_fields=False),
+        )
+        == "_ExampleDataclass(field_0=1)"
+    )
+    assert (
+        mf_pformat(
+            _ExampleDataclass(field_0=1, _hidden_field=2),
+            format_option=PrettyFormatOption(include_underscore_prefix_fields=True),
+        )
+        == "_ExampleDataclass(field_0=1, _hidden_field=2)"
+    )


### PR DESCRIPTION
This PR adds the `include_underscore_prefix_fields` to `mf_pformat` to handle private fields.