### PR TITLE
Add `pretty_format_object_by_parts()` to pretty formatter

### DIFF
--- a/.changes/unreleased/Under the Hood-20250429-143615.yaml
+++ b/.changes/unreleased/Under the Hood-20250429-143615.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Add `pretty_format_object_by_parts()` to pretty formatter
+time: 2025-04-29T14:36:15.205691-07:00
+custom:
+  Author: plypaul
+  Issue: "1738"

--- a/metricflow-semantics/metricflow_semantics/mf_logging/pretty_formatter.py
+++ b/metricflow-semantics/metricflow_semantics/mf_logging/pretty_formatter.py
@@ -225,6 +225,17 @@ class MetricFlowPrettyFormatter:
 
         return mf_indent("\n".join(result_lines), indent_prefix=self._format_option.indent_prefix)
 
+    def pretty_format_object_by_parts(self, class_name: str, field_mapping: Mapping) -> str:
+        """Return the string representation given class name and a mapping of the field names to field values."""
+        return self._handle_mapping_like_obj(
+            mapping=field_mapping,
+            left_enclose_str=class_name + "(",
+            key_value_seperator="=",
+            right_enclose_str=")",
+            is_dataclass_like_object=True,
+            remaining_line_length=self._format_option.max_line_length,
+        )
+
     def _handle_mapping_like_obj(
         self,
         mapping: Mapping,

--- a/metricflow-semantics/tests_metricflow_semantics/mf_logging/test_pretty_print.py
+++ b/metricflow-semantics/tests_metricflow_semantics/mf_logging/test_pretty_print.py
@@ -9,7 +9,11 @@ from dbt_semantic_interfaces.implementations.elements.dimension import PydanticD
 from dbt_semantic_interfaces.type_enums import DimensionType
 from metricflow_semantics.helpers.string_helpers import mf_dedent, mf_indent
 from metricflow_semantics.mf_logging.pretty_formattable import MetricFlowPrettyFormattable
-from metricflow_semantics.mf_logging.pretty_formatter import PrettyFormatContext, PrettyFormatOption
+from metricflow_semantics.mf_logging.pretty_formatter import (
+    MetricFlowPrettyFormatter,
+    PrettyFormatContext,
+    PrettyFormatOption,
+)
 from metricflow_semantics.mf_logging.pretty_print import PrettyFormatDictOption, mf_pformat
 from metricflow_semantics.test_helpers.metric_time_dimension import MTD_SPEC_DAY
 from typing_extensions import override
@@ -196,4 +200,11 @@ def test_include_underscore_prefix_option() -> None:  # noqa: D103
             format_option=PrettyFormatOption(include_underscore_prefix_fields=True),
         )
         == "_ExampleDataclass(field_0=1, _hidden_field=2)"
+    )
+
+
+def test_format_object_by_parts() -> None:  # noqa: D103
+    formatter = MetricFlowPrettyFormatter(PrettyFormatOption())
+    assert "_ExampleDataclass(field_0=1)" == formatter.pretty_format_object_by_parts(
+        class_name="_ExampleDataclass", field_mapping={"field_0": 1}
     )


### PR DESCRIPTION
This PR adds `MetricFlowPrettyFormatter.pretty_format_object_by_parts()`, which is useful for custom formatting when implementing `MetricFlowPrettyFormattable`.