### PR TITLE
Add test to check the error message for empty queries

### DIFF
--- a/.changes/unreleased/Under the Hood-20250429-144932.yaml
+++ b/.changes/unreleased/Under the Hood-20250429-144932.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Add test to check the error message for empty queries
+time: 2025-04-29T14:49:32.258539-07:00
+custom:
+  Author: plypaul
+  Issue: "1739"

--- a/metricflow-semantics/tests_metricflow_semantics/query/conftest.py
+++ b/metricflow-semantics/tests_metricflow_semantics/query/conftest.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import textwrap
+from typing import List
+
+import pytest
+from dbt_semantic_interfaces.parsing.dir_to_model import parse_yaml_files_to_validation_ready_semantic_manifest
+from dbt_semantic_interfaces.parsing.objects import YamlConfigFile
+from dbt_semantic_interfaces.protocols import SemanticManifest
+from dbt_semantic_interfaces.validations.semantic_manifest_validator import SemanticManifestValidator
+from metricflow_semantics.model.semantic_manifest_lookup import SemanticManifestLookup
+from metricflow_semantics.query.query_parser import MetricFlowQueryParser
+from metricflow_semantics.test_helpers.example_project_configuration import (
+    EXAMPLE_PROJECT_CONFIGURATION_YAML_CONFIG_FILE,
+)
+
+BOOKINGS_YAML = textwrap.dedent(
+    """\
+    semantic_model:
+      name: bookings_source
+
+      node_relation:
+        schema_name: some_schema
+        alias: bookings_source_table
+
+      defaults:
+        agg_time_dimension: ds
+
+      measures:
+        - name: bookings
+          expr: "1"
+          agg: sum
+          create_metric: true
+
+      dimensions:
+        - name: is_instant
+          type: categorical
+        - name: ds
+          type: time
+          type_params:
+            time_granularity: day
+
+      primary_entity: booking
+
+      entities:
+        - name: listing
+          type: foreign
+          expr: listing_id
+    """
+)
+
+
+@pytest.fixture(scope="session")
+def bookings_query_parser() -> MetricFlowQueryParser:  # noqa
+    bookings_yaml_file = YamlConfigFile(filepath="inline_for_test_1", contents=BOOKINGS_YAML)
+    return query_parser_from_yaml([EXAMPLE_PROJECT_CONFIGURATION_YAML_CONFIG_FILE, bookings_yaml_file])
+
+
+def query_parser_from_yaml(yaml_contents: List[YamlConfigFile]) -> MetricFlowQueryParser:
+    """Given yaml files, return a query parser using default source nodes, resolvers and time spine source."""
+    semantic_manifest = parse_yaml_files_to_validation_ready_semantic_manifest(
+        yaml_contents, apply_transformations=True
+    ).semantic_manifest
+    semantic_manifest_lookup = SemanticManifestLookup(semantic_manifest)
+    SemanticManifestValidator[SemanticManifest]().checked_validations(semantic_manifest)
+    return MetricFlowQueryParser(
+        semantic_manifest_lookup=semantic_manifest_lookup,
+    )

--- a/metricflow-semantics/tests_metricflow_semantics/query/errors/test_messages.py
+++ b/metricflow-semantics/tests_metricflow_semantics/query/errors/test_messages.py
@@ -1,0 +1,80 @@
+"""Test cases that check error messages raised during query parsing.
+
+TODO: These tests may be better parameterized.
+"""
+from __future__ import annotations
+
+from typing import Optional, Sequence
+
+import pytest
+from _pytest.fixtures import FixtureRequest
+from metricflow_semantics.query.query_parser import MetricFlowQueryParser
+from metricflow_semantics.test_helpers.config_helpers import MetricFlowTestConfiguration
+from metricflow_semantics.test_helpers.snapshot_helpers import assert_str_snapshot_equal
+
+
+def _check_error_message(
+    request: FixtureRequest,
+    mf_test_configuration: MetricFlowTestConfiguration,
+    query_parser: MetricFlowQueryParser,
+    metric_names: Optional[Sequence[str]] = None,
+    group_by_names: Optional[Sequence[str]] = None,
+    where_constraint_strs: Optional[Sequence[str]] = None,
+) -> None:
+    with pytest.raises(Exception) as e:
+        query_parser.parse_and_validate_query(
+            metric_names=metric_names,
+            group_by_names=group_by_names,
+            where_constraint_strs=where_constraint_strs,
+        )
+    assert_str_snapshot_equal(
+        request=request,
+        mf_test_configuration=mf_test_configuration,
+        snapshot_id="result",
+        snapshot_str=str(e.value),
+    )
+
+
+def test_empty_query(
+    request: FixtureRequest,
+    mf_test_configuration: MetricFlowTestConfiguration,
+    bookings_query_parser: MetricFlowQueryParser,
+) -> None:
+    """Test the error message for an empty query."""
+    _check_error_message(
+        request=request,
+        mf_test_configuration=mf_test_configuration,
+        query_parser=bookings_query_parser,
+    )
+
+
+def test_invalid_where_filter(
+    request: FixtureRequest,
+    mf_test_configuration: MetricFlowTestConfiguration,
+    bookings_query_parser: MetricFlowQueryParser,
+) -> None:
+    """Test the error message for an invalid where-filter."""
+    _check_error_message(
+        request=request,
+        mf_test_configuration=mf_test_configuration,
+        query_parser=bookings_query_parser,
+        metric_names=["bookings"],
+        group_by_names=["metric_time__day"],
+        where_constraint_strs=["{{ Dimension('booking__invalid_dim') }} = '1'"],
+    )
+
+
+def test_long_invalid_metric(
+    request: FixtureRequest,
+    mf_test_configuration: MetricFlowTestConfiguration,
+    bookings_query_parser: MetricFlowQueryParser,
+) -> None:
+    """Test the error message for an empty query."""
+    _check_error_message(
+        request=request,
+        mf_test_configuration=mf_test_configuration,
+        query_parser=bookings_query_parser,
+        metric_names=["bookings", "long_invalid_metric_name" + "_" * 50],
+        group_by_names=["metric_time__day"],
+        where_constraint_strs=["{{ Dimension('booking__invalid_dim') }} = '1'"],
+    )

--- a/metricflow-semantics/tests_metricflow_semantics/query/test_query_parser.py
+++ b/metricflow-semantics/tests_metricflow_semantics/query/test_query_parser.py
@@ -2,18 +2,14 @@ from __future__ import annotations
 
 import logging
 import textwrap
-from typing import List
 
 import pytest
 from _pytest.fixtures import FixtureRequest
 from dbt_semantic_interfaces.implementations.semantic_manifest import PydanticSemanticManifest
-from dbt_semantic_interfaces.parsing.dir_to_model import parse_yaml_files_to_validation_ready_semantic_manifest
 from dbt_semantic_interfaces.parsing.objects import YamlConfigFile
-from dbt_semantic_interfaces.protocols import SemanticManifest
 from dbt_semantic_interfaces.references import EntityReference
 from dbt_semantic_interfaces.test_utils import as_datetime
 from dbt_semantic_interfaces.type_enums.date_part import DatePart
-from dbt_semantic_interfaces.validations.semantic_manifest_validator import SemanticManifestValidator
 from metricflow_semantics.model.semantic_manifest_lookup import SemanticManifestLookup
 from metricflow_semantics.query.query_exceptions import InvalidQueryException
 from metricflow_semantics.query.query_parser import MetricFlowQueryParser
@@ -31,44 +27,9 @@ from metricflow_semantics.test_helpers.example_project_configuration import (
 from metricflow_semantics.test_helpers.metric_time_dimension import MTD
 from metricflow_semantics.test_helpers.snapshot_helpers import assert_object_snapshot_equal
 
+from tests_metricflow_semantics.query.conftest import BOOKINGS_YAML, query_parser_from_yaml
+
 logger = logging.getLogger(__name__)
-
-
-BOOKINGS_YAML = textwrap.dedent(
-    """\
-    semantic_model:
-      name: bookings_source
-
-      node_relation:
-        schema_name: some_schema
-        alias: bookings_source_table
-
-      defaults:
-        agg_time_dimension: ds
-
-      measures:
-        - name: bookings
-          expr: "1"
-          agg: sum
-          create_metric: true
-
-      dimensions:
-        - name: is_instant
-          type: categorical
-        - name: ds
-          type: time
-          type_params:
-            time_granularity: day
-
-      primary_entity: booking
-
-      entities:
-        - name: listing
-          type: foreign
-          expr: listing_id
-    """
-)
-
 
 REVENUE_YAML = textwrap.dedent(
     """\
@@ -177,12 +138,6 @@ METRICS_YAML = textwrap.dedent(
             alias: revenue_last_7_days
     """
 )
-
-
-@pytest.fixture
-def bookings_query_parser() -> MetricFlowQueryParser:  # noqa
-    bookings_yaml_file = YamlConfigFile(filepath="inline_for_test_1", contents=BOOKINGS_YAML)
-    return query_parser_from_yaml([EXAMPLE_PROJECT_CONFIGURATION_YAML_CONFIG_FILE, bookings_yaml_file])
 
 
 @pytest.fixture
@@ -600,18 +555,6 @@ def test_offset_metric_with_diff_agg_time_dims_error() -> None:  # noqa: D103
             metric_names=["monthly_revenue_last_7_days"],
             group_by_names=["revenue___ds"],
         )
-
-
-def query_parser_from_yaml(yaml_contents: List[YamlConfigFile]) -> MetricFlowQueryParser:
-    """Given yaml files, return a query parser using default source nodes, resolvers and time spine source."""
-    semantic_manifest = parse_yaml_files_to_validation_ready_semantic_manifest(
-        yaml_contents, apply_transformations=True
-    ).semantic_manifest
-    semantic_manifest_lookup = SemanticManifestLookup(semantic_manifest)
-    SemanticManifestValidator[SemanticManifest]().checked_validations(semantic_manifest)
-    return MetricFlowQueryParser(
-        semantic_manifest_lookup=semantic_manifest_lookup,
-    )
 
 
 def test_invalid_group_by_metric(bookings_query_parser: MetricFlowQueryParser) -> None:

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_messages.py/str/test_empty_query__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_messages.py/str/test_empty_query__result.txt
@@ -1,0 +1,19 @@
+test_name: test_empty_query
+test_filename: test_messages.py
+docstring:
+  Test the error message for an empty query.
+---
+Got error(s) during query resolution.
+
+Error #1:
+  Message:
+
+    There are no metrics or group by items requested in the query.
+
+  Query Input:
+
+    Query([], []
+
+  Issue Location:
+
+    [Resolve Query([])]

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_messages.py/str/test_invalid_where_filter__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_messages.py/str/test_invalid_where_filter__result.txt
@@ -1,0 +1,44 @@
+test_name: test_invalid_where_filter
+test_filename: test_messages.py
+docstring:
+  Test the error message for an invalid where-filter.
+---
+Got error(s) during query resolution.
+
+Error #1:
+  Message:
+
+    The given input does not match any of the available group-by-items for
+    Measure('bookings'). Common issues are:
+
+      * Incorrect names.
+      * No valid join paths exist from the measure to the group-by-item.
+        (fan-out join support is pending).
+      * There are multiple matching join paths.
+        (disambiguation support is pending).
+
+    Suggestions:
+      [
+        "Dimension('booking__is_instant')",
+        "TimeDimension('booking__ds', 'day')",
+        "Entity('booking__listing')",
+        "TimeDimension('metric_time', 'day')",
+        "Metric('bookings', group_by=['listing'])",
+        "Entity('listing')",
+      ]
+
+  Query Input:
+
+    WhereFilter(
+      ["{{ Dimension('booking__invalid_dim') }} = '1'"]
+    )
+    Filter Path:
+      [Resolve Query(['bookings'])]
+    Object Builder Input:
+      Dimension('booking__invalid_dim')
+
+  Issue Location:
+
+    [Resolve Query(['bookings'])]
+      -> [Resolve Metric('bookings')]
+        -> [Resolve Measure('bookings')]

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_messages.py/str/test_long_invalid_metric__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_messages.py/str/test_long_invalid_metric__result.txt
@@ -1,0 +1,22 @@
+test_name: test_long_invalid_metric
+test_filename: test_messages.py
+docstring:
+  Test the error message for an empty query.
+---
+Got error(s) during query resolution.
+
+Error #1:
+  Message:
+
+    The given input does not exactly match any known metrics.
+
+    Suggestions:
+      ['bookings']
+
+  Query Input:
+
+    long_invalid_metric_name__________________________________________________
+
+  Issue Location:
+
+    [Resolve Query(['bookings', 'long_invalid_metric_name__________________________________________________'])]


### PR DESCRIPTION
This PR sets up tests for query error messages and adds a test to check the output of an empty query (no metrics, no group-by items). It shows there are some typos as the output includes `Query([], []`. This will be resolved in a later PR.