### PR TITLE
Update `SequentialIdGenerator` to support async methods

### DIFF
--- a/.changes/unreleased/Under the Hood-20250429-154609.yaml
+++ b/.changes/unreleased/Under the Hood-20250429-154609.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Update `SequentialIdGenerator` to support async methods
+time: 2025-04-29T15:46:09.063545-07:00
+custom:
+  Author: plypaul
+  Issue: "1741"

--- a/metricflow-semantics/metricflow_semantics/collection_helpers/mf_type_aliases.py
+++ b/metricflow-semantics/metricflow_semantics/collection_helpers/mf_type_aliases.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from typing import TypeVar
+
+T1 = TypeVar("T1")
+T2 = TypeVar("T2")
+
+# A pair of objects.
+Pair = tuple[T1, T2]
+
+# A tuple of any length. Faster to auto-complete than typing out `, ...`
+AnyLengthTuple = tuple[T1, ...]
+
+# A tuple of items in a mapping. Each item is a tuple of the form `(key, value)`
+# These are useful for type-annotating immutable dataclasses where a mapping is stored as a tuple.
+KeyT = TypeVar("KeyT")
+ValueT = TypeVar("ValueT")
+MappingItem = tuple[KeyT, ValueT]
+MappingItemsTuple = tuple[tuple[KeyT, ValueT], ...]

--- a/metricflow-semantics/metricflow_semantics/helpers/mapping_helpers.py
+++ b/metricflow-semantics/metricflow_semantics/helpers/mapping_helpers.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+from typing import Iterable, TypeVar
+
+from metricflow_semantics.collection_helpers.mf_type_aliases import (
+    KeyT,
+    MappingItemsTuple,
+    Pair,
+    ValueT,
+)
+
+logger = logging.getLogger(__name__)
+
+
+T1 = TypeVar("T1")
+T2 = TypeVar("T2")
+
+
+def mf_mapping_to_items(mapping: Mapping[KeyT, ValueT]) -> MappingItemsTuple[KeyT, ValueT]:
+    """Converts the items in a mapping to tuples."""
+    return tuple((key, value) for key, value in mapping.items())
+
+
+def mf_items_to_dict(items: Iterable[Pair[KeyT, ValueT]]) -> dict[KeyT, ValueT]:
+    """Convert mapping items represented as tuples to a dict."""
+    return {key: value for key, value in items}

--- a/metricflow-semantics/tests_metricflow_semantics/dag/test_sequential_id_generator.py
+++ b/metricflow-semantics/tests_metricflow_semantics/dag/test_sequential_id_generator.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import asyncio
+import concurrent.futures
+import logging
+import time
+
+from metricflow_semantics.dag.id_prefix import DynamicIdPrefix
+from metricflow_semantics.dag.sequential_id import SequentialIdGenerator
+from metricflow_semantics.mf_logging.lazy_formattable import LazyFormat
+
+logger = logging.getLogger(__name__)
+
+_ID_PREFIX = "test_id_prefix"
+
+
+def test_sequential_id_generator_in_threads() -> None:
+    """Test generating IDs in multiple threads."""
+
+    def _check_id_task(task_id: str, sleep_time: float) -> None:
+        for i in range(10):
+            time.sleep(sleep_time)
+            generated_id = SequentialIdGenerator.create_next_id(DynamicIdPrefix(_ID_PREFIX))
+            logger.debug(LazyFormat("Generated ID", task_id=task_id, i=i, generated_id=generated_id.str_value))
+
+            assert generated_id.str_value == str(f"{_ID_PREFIX}_{i}")
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+        futures = (
+            executor.submit(_check_id_task, "task_0", 0.001),
+            executor.submit(_check_id_task, "task_1", 0.0015),
+        )
+        # This will raise the exception that was raised in the task.
+        for future in futures:
+            future.result()
+
+
+def test_sequential_id_generator_in_async_tasks() -> None:
+    """Test generating IDs in multiple async tasks."""
+    # Since other tests / fixtures could have generated IDs in the main thread, reset ID generation.
+
+    with SequentialIdGenerator.id_number_space(0):
+
+        async def _check_id_task(task_id: str, sleep_time: float) -> None:
+            for i in range(10):
+                generated_id = SequentialIdGenerator.create_next_id(DynamicIdPrefix(_ID_PREFIX))
+                logger.debug(LazyFormat("Generated ID", task_id=task_id, i=i, generated_id=generated_id.str_value))
+                assert generated_id.str_value == str(f"{_ID_PREFIX}_{i}")
+                await asyncio.sleep(sleep_time)
+
+        async def main() -> None:
+            await asyncio.gather(
+                _check_id_task("task_0", 0.001),
+                _check_id_task("task_1", 0.0015),
+            )
+
+        asyncio.run(main())


### PR DESCRIPTION
This PR updates `SequentialIdGenerator` to properly handle calls from async methods. Previously, `SequentialIdGenerator` used thread-local objects, but in async methods, different contexts are run from a single thread.