### PR TITLE
Update `SelectColumnSet` fields to tuples

### DIFF
--- a/.changes/unreleased/Under the Hood-20250505-155239.yaml
+++ b/.changes/unreleased/Under the Hood-20250505-155239.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Update `SelectColumnSet` fields to tuples
+time: 2025-05-05T15:52:39.55792-07:00
+custom:
+  Author: plypaul
+  Issue: "1744"

--- a/metricflow/plan_conversion/instance_converters.py
+++ b/metricflow/plan_conversion/instance_converters.py
@@ -99,7 +99,7 @@ class CreateSelectColumnsForInstances(InstanceSetTransform[SelectColumnSet]):
         group_by_metric_cols = list(
             chain.from_iterable([self._make_sql_column_expression(x) for x in instance_set.group_by_metric_instances])
         )
-        return SelectColumnSet(
+        return SelectColumnSet.create(
             metric_columns=metric_cols,
             measure_columns=measure_cols,
             dimension_columns=dimension_cols,
@@ -255,7 +255,7 @@ class CreateSelectColumnsWithMeasuresAggregated(CreateSelectColumnsForInstances)
         group_by_metric_cols = list(
             chain.from_iterable([self._make_sql_column_expression(x) for x in instance_set.group_by_metric_instances])
         )
-        return SelectColumnSet(
+        return SelectColumnSet.create(
             metric_columns=metric_cols,
             measure_columns=measure_cols,
             dimension_columns=dimension_cols,
@@ -805,7 +805,7 @@ class CreateSelectColumnForCombineOutputNode(InstanceSetTransform[SelectColumnSe
         return select_columns
 
     def transform(self, instance_set: InstanceSet) -> SelectColumnSet:  # noqa: D102
-        return SelectColumnSet(
+        return SelectColumnSet.create(
             metric_columns=self._create_select_columns_for_metrics(instance_set.metric_instances),
             measure_columns=self._create_select_columns_for_measures(instance_set.measure_instances),
         )
@@ -950,7 +950,7 @@ def create_simple_select_columns_for_instance_sets(
 
     Used in cases where you join multiple tables and need to render select columns to access all of those.
     """
-    column_set = SelectColumnSet()
+    column_set = SelectColumnSet.create()
     for table_alias, instance_set in table_alias_to_instance_set.items():
         column_set = column_set.merge(
             instance_set.transform(

--- a/metricflow/plan_conversion/select_column_gen.py
+++ b/metricflow/plan_conversion/select_column_gen.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass, field
-from typing import Iterable, List, Tuple
+from dataclasses import dataclass
+from typing import Iterable, Tuple
 
 from metricflow_semantics.collection_helpers.merger import Mergeable
+from metricflow_semantics.collection_helpers.mf_type_aliases import AnyLengthTuple
 from typing_extensions import override
 
 from metricflow.sql.sql_plan import SqlSelectColumn
@@ -14,15 +15,18 @@ logger = logging.getLogger(__name__)
 
 @dataclass(frozen=True)
 class SelectColumnSet(Mergeable):
-    """A set of SQL select columns that represent the different instance types in a data set."""
+    """A set of SQL select columns that represent the different instance types in a data set.
 
-    metric_columns: List[SqlSelectColumn] = field(default_factory=list)
-    measure_columns: List[SqlSelectColumn] = field(default_factory=list)
-    dimension_columns: List[SqlSelectColumn] = field(default_factory=list)
-    time_dimension_columns: List[SqlSelectColumn] = field(default_factory=list)
-    entity_columns: List[SqlSelectColumn] = field(default_factory=list)
-    group_by_metric_columns: List[SqlSelectColumn] = field(default_factory=list)
-    metadata_columns: List[SqlSelectColumn] = field(default_factory=list)
+    TODO: Evaluate using a single field instead of one for every instance type.
+    """
+
+    metric_columns: AnyLengthTuple[SqlSelectColumn]
+    measure_columns: AnyLengthTuple[SqlSelectColumn]
+    dimension_columns: AnyLengthTuple[SqlSelectColumn]
+    time_dimension_columns: AnyLengthTuple[SqlSelectColumn]
+    entity_columns: AnyLengthTuple[SqlSelectColumn]
+    group_by_metric_columns: AnyLengthTuple[SqlSelectColumn]
+    metadata_columns: AnyLengthTuple[SqlSelectColumn]
 
     @staticmethod
     def create(  # noqa: D102
@@ -35,13 +39,13 @@ class SelectColumnSet(Mergeable):
         metadata_columns: Iterable[SqlSelectColumn] = (),
     ) -> SelectColumnSet:
         return SelectColumnSet(
-            metric_columns=list(metric_columns),
-            measure_columns=list(measure_columns),
-            dimension_columns=list(dimension_columns),
-            time_dimension_columns=list(time_dimension_columns),
-            entity_columns=list(entity_columns),
-            group_by_metric_columns=list(group_by_metric_columns),
-            metadata_columns=list(metadata_columns),
+            metric_columns=tuple(metric_columns),
+            measure_columns=tuple(measure_columns),
+            dimension_columns=tuple(dimension_columns),
+            time_dimension_columns=tuple(time_dimension_columns),
+            entity_columns=tuple(entity_columns),
+            group_by_metric_columns=tuple(group_by_metric_columns),
+            metadata_columns=tuple(metadata_columns),
         )
 
     @override
@@ -60,7 +64,7 @@ class SelectColumnSet(Mergeable):
     @classmethod
     @override
     def empty_instance(cls) -> SelectColumnSet:
-        return SelectColumnSet()
+        return SelectColumnSet.create()
 
     def as_tuple(self) -> Tuple[SqlSelectColumn, ...]:
         """Return all select columns as a tuple."""

--- a/metricflow/plan_conversion/select_column_gen.py
+++ b/metricflow/plan_conversion/select_column_gen.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
-from typing import List, Tuple
+from typing import Iterable, List, Tuple
 
 from metricflow_semantics.collection_helpers.merger import Mergeable
 from typing_extensions import override
@@ -24,10 +24,30 @@ class SelectColumnSet(Mergeable):
     group_by_metric_columns: List[SqlSelectColumn] = field(default_factory=list)
     metadata_columns: List[SqlSelectColumn] = field(default_factory=list)
 
+    @staticmethod
+    def create(  # noqa: D102
+        metric_columns: Iterable[SqlSelectColumn] = (),
+        measure_columns: Iterable[SqlSelectColumn] = (),
+        dimension_columns: Iterable[SqlSelectColumn] = (),
+        time_dimension_columns: Iterable[SqlSelectColumn] = (),
+        entity_columns: Iterable[SqlSelectColumn] = (),
+        group_by_metric_columns: Iterable[SqlSelectColumn] = (),
+        metadata_columns: Iterable[SqlSelectColumn] = (),
+    ) -> SelectColumnSet:
+        return SelectColumnSet(
+            metric_columns=list(metric_columns),
+            measure_columns=list(measure_columns),
+            dimension_columns=list(dimension_columns),
+            time_dimension_columns=list(time_dimension_columns),
+            entity_columns=list(entity_columns),
+            group_by_metric_columns=list(group_by_metric_columns),
+            metadata_columns=list(metadata_columns),
+        )
+
     @override
     def merge(self, other_set: SelectColumnSet) -> SelectColumnSet:
         """Combine the select columns by type."""
-        return SelectColumnSet(
+        return SelectColumnSet.create(
             metric_columns=self.metric_columns + other_set.metric_columns,
             measure_columns=self.measure_columns + other_set.measure_columns,
             dimension_columns=self.dimension_columns + other_set.dimension_columns,
@@ -57,7 +77,7 @@ class SelectColumnSet(Mergeable):
 
     def without_measure_columns(self) -> SelectColumnSet:
         """Returns this but with the measure columns removed."""
-        return SelectColumnSet(
+        return SelectColumnSet.create(
             metric_columns=self.metric_columns,
             dimension_columns=self.dimension_columns,
             time_dimension_columns=self.time_dimension_columns,

--- a/metricflow/plan_conversion/select_column_gen.py
+++ b/metricflow/plan_conversion/select_column_gen.py
@@ -4,13 +4,16 @@ import logging
 from dataclasses import dataclass, field
 from typing import List, Tuple
 
+from metricflow_semantics.collection_helpers.merger import Mergeable
+from typing_extensions import override
+
 from metricflow.sql.sql_plan import SqlSelectColumn
 
 logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
-class SelectColumnSet:
+class SelectColumnSet(Mergeable):
     """A set of SQL select columns that represent the different instance types in a data set."""
 
     metric_columns: List[SqlSelectColumn] = field(default_factory=list)
@@ -21,6 +24,7 @@ class SelectColumnSet:
     group_by_metric_columns: List[SqlSelectColumn] = field(default_factory=list)
     metadata_columns: List[SqlSelectColumn] = field(default_factory=list)
 
+    @override
     def merge(self, other_set: SelectColumnSet) -> SelectColumnSet:
         """Combine the select columns by type."""
         return SelectColumnSet(
@@ -32,6 +36,11 @@ class SelectColumnSet:
             group_by_metric_columns=self.group_by_metric_columns + other_set.group_by_metric_columns,
             metadata_columns=self.metadata_columns + other_set.metadata_columns,
         )
+
+    @classmethod
+    @override
+    def empty_instance(cls) -> SelectColumnSet:
+        return SelectColumnSet()
 
     def as_tuple(self) -> Tuple[SqlSelectColumn, ...]:
         """Return all select columns as a tuple."""

--- a/metricflow/plan_conversion/spec_transforms.py
+++ b/metricflow/plan_conversion/spec_transforms.py
@@ -64,7 +64,7 @@ class CreateSelectCoalescedColumnsForLinkableSpecs(InstanceSpecSetTransform[Sele
                 )
             )
 
-        return SelectColumnSet(
+        return SelectColumnSet.create(
             dimension_columns=dimension_columns,
             time_dimension_columns=time_dimension_columns,
             entity_columns=entity_columns,

--- a/metricflow/plan_conversion/to_sql_plan/dataflow_to_subquery.py
+++ b/metricflow/plan_conversion/to_sql_plan/dataflow_to_subquery.py
@@ -725,7 +725,7 @@ class DataflowNodeToSqlSubqueryVisitor(DataflowPlanNodeVisitor[SqlDataSet]):
         output_instance_set = output_instance_set.transform(transform_func)
 
         combined_select_column_set = non_metric_select_column_set.merge(
-            SelectColumnSet(metric_columns=metric_select_columns)
+            SelectColumnSet.create(metric_columns=metric_select_columns)
         )
 
         return SqlDataSet(
@@ -980,7 +980,7 @@ class DataflowNodeToSqlSubqueryVisitor(DataflowPlanNodeVisitor[SqlDataSet]):
         output_instance_set = InstanceSet.merge([x.data_set.instance_set for x in parent_data_sets])
         output_instance_set = output_instance_set.transform(ChangeAssociatedColumns(self._column_association_resolver))
 
-        aggregated_select_columns = SelectColumnSet()
+        aggregated_select_columns = SelectColumnSet.create()
         for table_alias, instance_set in table_alias_to_instance_set.items():
             aggregated_select_columns = aggregated_select_columns.merge(
                 instance_set.transform(


### PR DESCRIPTION
This PR updates the fields in `SelectColumnSet` to be tuples as the dataclass is supposed to be immutable. In addition, the `.create()` factory method was added to make it easier to create an instance with an additional field added in a later PR.