### PR TITLE
Fix exception propagation in SQL generation

### DIFF
--- a/.changes/unreleased/Fixes-20250503-102521.yaml
+++ b/.changes/unreleased/Fixes-20250503-102521.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix exception propagation in SQL generation
+time: 2025-05-03T10:25:21.517493-07:00
+custom:
+  Author: plypaul
+  Issue: "1747"

--- a/metricflow-semantics/metricflow_semantics/test_helpers/mock_helpers.py
+++ b/metricflow-semantics/metricflow_semantics/test_helpers/mock_helpers.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from typing import Callable
+
+
+def mf_function_patch_target(method: Callable) -> str:
+    """Helper to get the target for a patch.
+
+    Useful so that we don't have strings that reference classes that don't get properly updated during refactoring in
+    the IDE.
+
+    Example:
+        with patch(get_patch_target(DataflowToSqlPlanConverter.convert_using_specifics)):
+            ...
+
+    Annotating with `Callable` as `FunctionType` does not seem to work as expected in `mypy`.
+    """
+    # noinspection PyUnresolvedReferences
+    return f"{method.__module__}.{method.__qualname__}"

--- a/metricflow/plan_conversion/to_sql_plan/dataflow_to_sql.py
+++ b/metricflow/plan_conversion/to_sql_plan/dataflow_to_sql.py
@@ -133,7 +133,7 @@ class DataflowToSqlPlanConverter:
                 return result
 
             except Exception as e:
-                if optimization_level is optimization_levels_to_attempt[-1]:
+                if attempted_optimization_level is optimization_levels_to_attempt[-1]:
                     logger.error(
                         "Exhausted attempts to generate the SQL without exceptions."
                         " Propagating the most recent exception."

--- a/tests_metricflow/plan_conversion/dataflow_to_sql/test_exception_retry.py
+++ b/tests_metricflow/plan_conversion/dataflow_to_sql/test_exception_retry.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import logging
+from typing import Mapping
+from unittest.mock import patch
+
+import pytest
+from metricflow_semantics.dag.mf_dag import DagId
+from metricflow_semantics.test_helpers.config_helpers import MetricFlowTestConfiguration
+from metricflow_semantics.test_helpers.mock_helpers import mf_function_patch_target
+
+from metricflow.plan_conversion.to_sql_plan.dataflow_to_sql import DataflowToSqlPlanConverter
+from metricflow.protocols.sql_client import SqlClient
+from tests_metricflow.fixtures.manifest_fixtures import MetricFlowEngineTestFixture, SemanticManifestSetup
+
+logger = logging.getLogger(__name__)
+
+
+def test_retry_exception_propagation(
+    caplog: pytest.LogCaptureFixture,
+    mf_test_configuration: MetricFlowTestConfiguration,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
+    mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
+    sql_client: SqlClient,
+) -> None:
+    """Test that exceptions are propagated by the retry handler in `DataflowToSqlPlanConverter`."""
+    source_node = mf_engine_test_fixture_mapping[SemanticManifestSetup.SIMPLE_MANIFEST].read_node_mapping[
+        "bookings_source"
+    ]
+
+    # noinspection PyTypeChecker
+    patch_target = mf_function_patch_target(DataflowToSqlPlanConverter.convert_using_specifics)
+    with (
+        pytest.raises(RuntimeError) as result,
+        patch(patch_target) as method_raising_exception,
+        # Test exception is going to generate error logs and won't be useful, so disable them.
+        caplog.at_level(logging.FATAL),
+    ):
+        error_message = "Error raised from patch"
+        method_raising_exception.side_effect = RuntimeError(error_message)
+        dataflow_to_sql_converter.convert_to_sql_plan(
+            sql_engine_type=sql_client.sql_engine_type,
+            sql_query_plan_id=DagId.from_str("plan0"),
+            dataflow_plan_node=source_node,
+        )
+
+    assert str(result.value) == error_message


### PR DESCRIPTION
This PR fixes an issue with a retry mechanism when generating SQL. Due to the bug, the underlying exception was not propagated up when retries were exhausted.