### PR TITLE
Rename `mf_test_configuration` -> `snapshot_configuration`

### DIFF
--- a/metricflow-semantics/metricflow_semantics/test_helpers/snapshot_helpers.py
+++ b/metricflow-semantics/metricflow_semantics/test_helpers/snapshot_helpers.py
@@ -44,7 +44,7 @@ class SnapshotConfiguration:
 
 def assert_snapshot_text_equal(
     request: _pytest.fixtures.FixtureRequest,
-    mf_test_configuration: SnapshotConfiguration,
+    snapshot_configuration: SnapshotConfiguration,
     group_id: str,
     snapshot_id: str,
     snapshot_text: str,
@@ -61,7 +61,7 @@ def assert_snapshot_text_equal(
         str(
             snapshot_path_prefix(
                 request=request,
-                snapshot_configuration=mf_test_configuration,
+                snapshot_configuration=snapshot_configuration,
                 snapshot_group=group_id,
                 snapshot_id=snapshot_id,
                 additional_sub_directories=additional_sub_directories_for_snapshots,
@@ -98,7 +98,7 @@ def assert_snapshot_text_equal(
         snapshot_text = snapshot_text + "\n"
 
     # If we are in overwrite mode, create / overwrite the snapshot file.:
-    if mf_test_configuration.overwrite_snapshots:
+    if snapshot_configuration.overwrite_snapshots:
         # Create parent directory for the plan text files.
         os.makedirs(os.path.dirname(file_path), exist_ok=True)
         with open(file_path, "w") as snapshot_text_file:
@@ -111,8 +111,8 @@ def assert_snapshot_text_equal(
             f"to see what's new."
         )
 
-    if mf_test_configuration.display_snapshots:
-        if not mf_test_configuration.overwrite_snapshots:
+    if snapshot_configuration.display_snapshots:
+        if not snapshot_configuration.overwrite_snapshots:
             logger.warning(
                 LazyFormat(lambda: f"Not overwriting snapshots, so displaying existing snapshot at {file_path}")
             )
@@ -251,7 +251,7 @@ PlanT = TypeVar("PlanT", bound=MetricFlowDag)
 
 def assert_plan_snapshot_text_equal(
     request: FixtureRequest,
-    mf_test_configuration: SnapshotConfiguration,
+    snapshot_configuration: SnapshotConfiguration,
     plan: PlanT,
     plan_snapshot_text: str,
     plan_snapshot_file_extension: str = ".xml",
@@ -273,7 +273,7 @@ def assert_plan_snapshot_text_equal(
     """
     assert_snapshot_text_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=snapshot_configuration,
         group_id=plan.__class__.__name__,
         snapshot_id=str(plan.dag_id),
         snapshot_text=plan_snapshot_text,
@@ -287,7 +287,7 @@ def assert_plan_snapshot_text_equal(
 
 def assert_linkable_element_set_snapshot_equal(  # noqa: D103
     request: FixtureRequest,
-    mf_test_configuration: SnapshotConfiguration,
+    snapshot_configuration: SnapshotConfiguration,
     set_id: str,
     linkable_element_set: LinkableElementSet,
     expectation_description: Optional[str] = None,
@@ -358,7 +358,7 @@ def assert_linkable_element_set_snapshot_equal(  # noqa: D103
 
     assert_str_snapshot_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=snapshot_configuration,
         snapshot_id=set_id,
         snapshot_str=tabulate.tabulate(headers=headers, tabular_data=sorted(rows)),
         expectation_description=expectation_description,
@@ -367,14 +367,14 @@ def assert_linkable_element_set_snapshot_equal(  # noqa: D103
 
 def assert_spec_set_snapshot_equal(  # noqa: D103
     request: FixtureRequest,
-    mf_test_configuration: SnapshotConfiguration,
+    snapshot_configuration: SnapshotConfiguration,
     set_id: str,
     spec_set: InstanceSpecSet,
     expectation_description: Optional[str] = None,
 ) -> None:
     assert_object_snapshot_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=snapshot_configuration,
         obj_id=set_id,
         obj=sorted(spec.qualified_name for spec in spec_set.all_specs),
         expectation_description=expectation_description,
@@ -383,7 +383,7 @@ def assert_spec_set_snapshot_equal(  # noqa: D103
 
 def assert_linkable_spec_set_snapshot_equal(  # noqa: D103
     request: FixtureRequest,
-    mf_test_configuration: SnapshotConfiguration,
+    snapshot_configuration: SnapshotConfiguration,
     set_id: str,
     spec_set: LinkableSpecSet,
     expectation_description: Optional[str] = None,
@@ -391,7 +391,7 @@ def assert_linkable_spec_set_snapshot_equal(  # noqa: D103
     naming_scheme = ObjectBuilderNamingScheme()
     assert_snapshot_text_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=snapshot_configuration,
         group_id=spec_set.__class__.__name__,
         snapshot_id=set_id,
         snapshot_text=mf_pformat(sorted(naming_scheme.input_str(spec) for spec in spec_set.as_tuple)),
@@ -403,7 +403,7 @@ def assert_linkable_spec_set_snapshot_equal(  # noqa: D103
 
 def assert_object_snapshot_equal(  # type: ignore[misc]
     request: FixtureRequest,
-    mf_test_configuration: SnapshotConfiguration,
+    snapshot_configuration: SnapshotConfiguration,
     obj: Any,
     obj_id: str = "result",
     expectation_description: Optional[str] = None,
@@ -411,7 +411,7 @@ def assert_object_snapshot_equal(  # type: ignore[misc]
     """For tests to compare large objects, this can be used to snapshot a text representation of the object."""
     assert_snapshot_text_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=snapshot_configuration,
         group_id=obj.__class__.__name__,
         snapshot_id=obj_id,
         snapshot_text=mf_pformat(obj),
@@ -422,7 +422,7 @@ def assert_object_snapshot_equal(  # type: ignore[misc]
 
 def assert_str_snapshot_equal(  # noqa: D103
     request: FixtureRequest,
-    mf_test_configuration: SnapshotConfiguration,
+    snapshot_configuration: SnapshotConfiguration,
     snapshot_id: str,
     snapshot_str: str,
     expectation_description: Optional[str] = None,
@@ -431,7 +431,7 @@ def assert_str_snapshot_equal(  # noqa: D103
     """Write / compare a string snapshot."""
     assert_snapshot_text_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=snapshot_configuration,
         group_id=snapshot_str.__class__.__name__,
         snapshot_id=snapshot_id,
         snapshot_text=snapshot_str,

--- a/metricflow-semantics/tests_metricflow_semantics/model/semantics/test_dimension_lookup.py
+++ b/metricflow-semantics/tests_metricflow_semantics/model/semantics/test_dimension_lookup.py
@@ -36,5 +36,5 @@ def test_get_invariant(
         for dimension_reference in sorted_dimension_references
     }
     assert_object_snapshot_equal(
-        request=request, mf_test_configuration=mf_test_configuration, obj_id="obj_0", obj=result
+        request=request, snapshot_configuration=mf_test_configuration, obj_id="obj_0", obj=result
     )

--- a/metricflow-semantics/tests_metricflow_semantics/model/semantics/test_linkable_spec_resolver.py
+++ b/metricflow-semantics/tests_metricflow_semantics/model/semantics/test_linkable_spec_resolver.py
@@ -75,7 +75,7 @@ def test_all_properties(  # noqa: D103
 ) -> None:
     assert_linkable_element_set_snapshot_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         set_id="result0",
         linkable_element_set=simple_model_spec_resolver.get_linkable_elements_for_metrics(
             metric_references=[MetricReference(element_name="bookings"), MetricReference(element_name="views")],
@@ -93,7 +93,7 @@ def test_one_property(  # noqa: D103
 ) -> None:
     assert_linkable_element_set_snapshot_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         set_id="result0",
         linkable_element_set=simple_model_spec_resolver.get_linkable_elements_for_metrics(
             metric_references=[MetricReference(element_name="bookings"), MetricReference(element_name="views")],
@@ -111,7 +111,7 @@ def test_metric_time_property_for_cumulative_metric(  # noqa: D103
 ) -> None:
     assert_linkable_element_set_snapshot_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         set_id="result0",
         linkable_element_set=simple_model_spec_resolver.get_linkable_elements_for_metrics(
             metric_references=[MetricReference(element_name="trailing_2_months_revenue")],
@@ -129,7 +129,7 @@ def test_metric_time_property_for_derived_metrics(  # noqa: D103
 ) -> None:
     assert_linkable_element_set_snapshot_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         set_id="result0",
         linkable_element_set=simple_model_spec_resolver.get_linkable_elements_for_metrics(
             metric_references=[MetricReference(element_name="bookings_per_view")],
@@ -147,7 +147,7 @@ def test_cyclic_join_manifest(  # noqa: D103
 ) -> None:
     assert_linkable_element_set_snapshot_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         set_id="result0",
         linkable_element_set=cyclic_join_manifest_spec_resolver.get_linkable_elements_for_metrics(
             metric_references=[MetricReference(element_name="listings")],
@@ -166,7 +166,7 @@ def test_create_linkable_element_set_from_join_path(  # noqa: D103
 ) -> None:
     assert_linkable_element_set_snapshot_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         set_id="result0",
         linkable_element_set=simple_model_spec_resolver.create_linkable_element_set_from_join_path(
             join_path=SemanticModelJoinPath.from_single_element(
@@ -185,7 +185,7 @@ def test_create_linkable_element_set_from_join_path_multi_hop(  # noqa: D103
 ) -> None:
     assert_linkable_element_set_snapshot_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         set_id="result0",
         linkable_element_set=simple_model_spec_resolver.create_linkable_element_set_from_join_path(
             SemanticModelJoinPath(
@@ -227,7 +227,7 @@ def test_linkable_element_set_as_spec_set(
     )
     assert_spec_set_snapshot_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         set_id="set0",
         spec_set=linkable_spec_set,
     )

--- a/metricflow-semantics/tests_metricflow_semantics/model/semantics/test_measure_lookup.py
+++ b/metricflow-semantics/tests_metricflow_semantics/model/semantics/test_measure_lookup.py
@@ -32,5 +32,5 @@ def test_measure_properties(
         measure_name: measure_lookup.get_properties(MeasureReference(measure_name)) for measure_name in measure_names
     }
     assert_object_snapshot_equal(
-        request=request, mf_test_configuration=mf_test_configuration, obj_id="obj_0", obj=result
+        request=request, snapshot_configuration=mf_test_configuration, obj_id="obj_0", obj=result
     )

--- a/metricflow-semantics/tests_metricflow_semantics/model/test_semantic_model_container.py
+++ b/metricflow-semantics/tests_metricflow_semantics/model/test_semantic_model_container.py
@@ -67,7 +67,7 @@ def test_get_names(  # noqa: D103
 ) -> None:
     assert_object_snapshot_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         obj_id="result0",
         obj={
             "dimension_references": sorted([d.element_name for d in semantic_model_lookup.get_dimension_references()]),
@@ -90,7 +90,7 @@ def test_local_linked_elements_for_metric(  # noqa: D103
     sorted_specs = sorted(linkable_elements.specs, key=lambda x: x.qualified_name)
     assert_object_snapshot_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         obj_id="result0",
         obj=tuple(spec.qualified_name for spec in sorted_specs),
     )
@@ -107,7 +107,7 @@ def test_linkable_elements_for_metrics(  # noqa: D103
 ) -> None:
     assert_linkable_element_set_snapshot_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         set_id="result0",
         linkable_element_set=metric_lookup.linkable_elements_for_metrics(
             (MetricReference(element_name="views"),),
@@ -131,7 +131,7 @@ def test_linkable_elements_for_measure(
     """Tests extracting linkable elements for a given measure input."""
     assert_linkable_element_set_snapshot_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         set_id="result0",
         linkable_element_set=metric_lookup.linkable_elements_for_measure(
             measure_reference=MeasureReference(element_name="listings"),
@@ -147,7 +147,7 @@ def test_linkable_elements_for_measure_multi_hop_model(
     """Tests extracting linkable elements for a given measure input."""
     assert_linkable_element_set_snapshot_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         set_id="result0",
         linkable_element_set=multi_hop_metric_lookup.linkable_elements_for_measure(
             measure_reference=MeasureReference(element_name="txn_count"),
@@ -167,7 +167,7 @@ def test_linkable_elements_for_no_metrics_query(
     sorted_specs = sorted(linkable_elements.specs, key=lambda x: x.qualified_name)
     assert_object_snapshot_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         obj_id="result0",
         obj=tuple(spec.qualified_name for spec in sorted_specs),
     )
@@ -182,7 +182,7 @@ def test_linkable_set_for_common_dimensions_in_different_models(
     """
     assert_linkable_element_set_snapshot_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         set_id="result0",
         linkable_element_set=metric_lookup.linkable_elements_for_metrics(
             (MetricReference(element_name="bookings_per_view"),),

--- a/metricflow-semantics/tests_metricflow_semantics/query/errors/test_messages.py
+++ b/metricflow-semantics/tests_metricflow_semantics/query/errors/test_messages.py
@@ -29,7 +29,7 @@ def _check_error_message(
         )
     assert_str_snapshot_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         snapshot_id="result",
         snapshot_str=str(e.value),
     )

--- a/metricflow-semantics/tests_metricflow_semantics/query/group_by_item/filter_spec_resolution/test_spec_lookup.py
+++ b/metricflow-semantics/tests_metricflow_semantics/query/group_by_item/filter_spec_resolution/test_spec_lookup.py
@@ -47,7 +47,7 @@ def assert_spec_lookup_snapshot_equal(  # noqa: D103
 ) -> None:
     assert_str_snapshot_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         snapshot_id="result",
         snapshot_str=mf_pformat(spec_lookup, format_option=PrettyFormatDictOption(include_none_object_fields=False)),
     )

--- a/metricflow-semantics/tests_metricflow_semantics/query/group_by_item/resolution_dag/test_resolution_dags.py
+++ b/metricflow-semantics/tests_metricflow_semantics/query/group_by_item/resolution_dag/test_resolution_dags.py
@@ -27,7 +27,7 @@ def test_snapshot(
     resolution_dag = resolution_dags[AmbiguousResolutionQueryId(dag_case_id)]
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         plan=resolution_dag,
         plan_snapshot_text=resolution_dag.structure_text(),
     )

--- a/metricflow-semantics/tests_metricflow_semantics/query/group_by_item/test_available_group_by_items.py
+++ b/metricflow-semantics/tests_metricflow_semantics/query/group_by_item/test_available_group_by_items.py
@@ -34,7 +34,7 @@ def test_available_group_by_items(  # noqa: D103
     result = group_by_item_resolver.resolve_available_items()
     assert_linkable_spec_set_snapshot_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         set_id="set0",
         spec_set=LinkableSpecSet.create_from_specs(result.specs),
     )

--- a/metricflow-semantics/tests_metricflow_semantics/query/group_by_item/test_matching_item_for_filters.py
+++ b/metricflow-semantics/tests_metricflow_semantics/query/group_by_item/test_matching_item_for_filters.py
@@ -52,7 +52,7 @@ def test_ambiguous_metric_time_in_query_filter(  # noqa: D103
 
     assert_object_snapshot_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         obj_id="result",
         obj=result,
     )

--- a/metricflow-semantics/tests_metricflow_semantics/query/group_by_item/test_matching_item_for_querying.py
+++ b/metricflow-semantics/tests_metricflow_semantics/query/group_by_item/test_matching_item_for_querying.py
@@ -90,7 +90,7 @@ def test_unavailable_group_by_item_in_derived_metric_parent(
 
     assert_object_snapshot_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         obj_id="result",
         obj=result,
     )
@@ -119,7 +119,7 @@ def test_invalid_group_by_item(  # noqa: D103
 
     assert_object_snapshot_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         obj_id="result",
         obj=result,
     )
@@ -149,5 +149,5 @@ def test_missing_parent_for_metric(
     result = group_by_item_resolver.resolve_available_items(metric_node)
 
     assert_object_snapshot_equal(
-        request=request, mf_test_configuration=mf_test_configuration, obj_id="result", obj=result
+        request=request, snapshot_configuration=mf_test_configuration, obj_id="result", obj=result
     )

--- a/metricflow-semantics/tests_metricflow_semantics/query/test_ambiguous_entity_path.py
+++ b/metricflow-semantics/tests_metricflow_semantics/query/test_ambiguous_entity_path.py
@@ -32,7 +32,7 @@ def test_resolvable_ambiguous_entity_path(  # noqa: D103
 
     assert_object_snapshot_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         obj_id="result_0",
         obj=query_spec,
     )
@@ -51,7 +51,7 @@ def test_ambiguous_entity_path_resolves_to_shortest_entity_path_item(
 
     assert_object_snapshot_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         obj_id="result_0",
         obj=query_spec,
     )
@@ -74,7 +74,7 @@ def test_non_resolvable_ambiguous_entity_path_due_to_multiple_matches(
 
     assert_str_snapshot_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         snapshot_id="result_0",
         snapshot_str=str(e.value),
     )
@@ -97,7 +97,7 @@ def test_non_resolvable_ambiguous_entity_path_due_to_mismatch(
 
     assert_str_snapshot_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         snapshot_id="result_0",
         snapshot_str=str(e.value),
     )

--- a/metricflow-semantics/tests_metricflow_semantics/query/test_conversion_metrics.py
+++ b/metricflow-semantics/tests_metricflow_semantics/query/test_conversion_metrics.py
@@ -26,6 +26,6 @@ def test_conversion_rate_with_constant_properties(  # noqa: D103
 
     assert_object_snapshot_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         obj=result,
     )

--- a/metricflow-semantics/tests_metricflow_semantics/query/test_metric_time_granularity.py
+++ b/metricflow-semantics/tests_metricflow_semantics/query/test_metric_time_granularity.py
@@ -33,7 +33,7 @@ def test_simple_metric_with_explicit_time_granularity(  # noqa: D103
 
     assert_object_snapshot_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         obj_id="result_0",
         obj=query_spec,
     )
@@ -52,7 +52,7 @@ def test_simple_metric_without_explicit_time_granularity(
 
     assert_object_snapshot_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         obj_id="result_0",
         obj=query_spec,
     )
@@ -71,7 +71,7 @@ def test_derived_metric_with_explicit_time_granularity(
 
     assert_object_snapshot_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         obj_id="result_0",
         obj=query_spec,
     )
@@ -93,7 +93,7 @@ def test_derived_metric_without_explicit_time_granularity(
 
     assert_object_snapshot_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         obj_id="result_0",
         obj=query_spec,
     )
@@ -110,7 +110,7 @@ def test_non_metric_time_ignores_default_granularity(  # noqa: D103
 
     assert_object_snapshot_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         obj_id="result_0",
         obj=query_spec,
     )
@@ -128,7 +128,7 @@ def test_simple_metric_with_defined_metric_time_filter(
 
     assert_object_snapshot_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         obj_id="result_0",
         obj=query_spec,
     )
@@ -146,7 +146,7 @@ def test_derived_metric_with_defined_metric_time_filter(
 
     assert_object_snapshot_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         obj_id="result_0",
         obj=query_spec,
     )
@@ -168,7 +168,7 @@ def test_derived_metric_with_defined_metric_time_filter_on_input_metric(
 
     assert_object_snapshot_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         obj_id="result_0",
         obj=query_spec,
     )

--- a/metricflow-semantics/tests_metricflow_semantics/query/test_query_parser.py
+++ b/metricflow-semantics/tests_metricflow_semantics/query/test_query_parser.py
@@ -162,7 +162,7 @@ def test_query_parser(  # noqa: D103
         group_by_names=["booking__is_instant", "listing", MTD],
         order_by_names=[MTD, "-bookings"],
     )
-    assert_object_snapshot_equal(request=request, mf_test_configuration=mf_test_configuration, obj=result)
+    assert_object_snapshot_equal(request=request, snapshot_configuration=mf_test_configuration, obj=result)
 
 
 def test_query_parser_case_insensitivity_with_names(  # noqa: D103
@@ -175,7 +175,7 @@ def test_query_parser_case_insensitivity_with_names(  # noqa: D103
         group_by_names=["BOOKING__IS_INSTANT", "LISTING", MTD.upper()],
         order_by_names=[MTD.upper(), "-BOOKINGS"],
     )
-    assert_object_snapshot_equal(request=request, mf_test_configuration=mf_test_configuration, obj=result)
+    assert_object_snapshot_equal(request=request, snapshot_configuration=mf_test_configuration, obj=result)
 
 
 def test_query_parser_case_insensitivity_with_parameter_objects(  # noqa: D103
@@ -194,7 +194,7 @@ def test_query_parser_case_insensitivity_with_parameter_objects(  # noqa: D103
         OrderByParameter(order_by=MetricParameter("BOOKINGS"), descending=True),
     )
     result = bookings_query_parser.parse_and_validate_query(metrics=[metric], group_by=group_by, order_by=order_by)
-    assert_object_snapshot_equal(request=request, mf_test_configuration=mf_test_configuration, obj=result)
+    assert_object_snapshot_equal(request=request, snapshot_configuration=mf_test_configuration, obj=result)
 
 
 def test_query_parser_invalid_group_by(bookings_query_parser: MetricFlowQueryParser) -> None:  # noqa: D103
@@ -218,7 +218,7 @@ def test_query_parser_with_object_params(  # noqa: D103
         OrderByParameter(order_by=MetricParameter("bookings"), descending=True),
     )
     result = bookings_query_parser.parse_and_validate_query(metrics=[metric], group_by=group_by, order_by=order_by)
-    assert_object_snapshot_equal(request=request, mf_test_configuration=mf_test_configuration, obj=result)
+    assert_object_snapshot_equal(request=request, snapshot_configuration=mf_test_configuration, obj=result)
 
 
 def test_order_by_granularity_conversion(
@@ -240,7 +240,7 @@ def test_order_by_granularity_conversion(
     result = query_parser.parse_and_validate_query(
         metric_names=["bookings", "revenue"], group_by_names=[MTD], order_by_names=[f"-{MTD}"]
     )
-    assert_object_snapshot_equal(request=request, mf_test_configuration=mf_test_configuration, obj=result)
+    assert_object_snapshot_equal(request=request, snapshot_configuration=mf_test_configuration, obj=result)
 
 
 def test_order_by_granularity_no_conversion(  # noqa: D103
@@ -251,7 +251,7 @@ def test_order_by_granularity_no_conversion(  # noqa: D103
     result = bookings_query_parser.parse_and_validate_query(
         metric_names=["bookings"], group_by_names=[MTD], order_by_names=[MTD]
     )
-    assert_object_snapshot_equal(request=request, mf_test_configuration=mf_test_configuration, obj=result)
+    assert_object_snapshot_equal(request=request, snapshot_configuration=mf_test_configuration, obj=result)
 
 
 def test_time_range_constraint_conversion(
@@ -273,7 +273,7 @@ def test_time_range_constraint_conversion(
         time_constraint_start=as_datetime("2020-01-15"),
         time_constraint_end=as_datetime("2020-02-15"),
     )
-    assert_object_snapshot_equal(request=request, mf_test_configuration=mf_test_configuration, obj=result)
+    assert_object_snapshot_equal(request=request, snapshot_configuration=mf_test_configuration, obj=result)
 
 
 def test_parse_and_validate_where_constraint_dims(
@@ -308,7 +308,7 @@ def test_parse_and_validate_where_constraint_dims(
         time_constraint_end=as_datetime("2020-02-15"),
         where_constraint_strs=["{{ Dimension('booking__is_instant') }} = '1'"],
     )
-    assert_object_snapshot_equal(request=request, mf_test_configuration=mf_test_configuration, obj=result)
+    assert_object_snapshot_equal(request=request, snapshot_configuration=mf_test_configuration, obj=result)
     assert (
         DimensionSpec(element_name="is_instant", entity_links=(EntityReference("booking"),))
         not in result.query_spec.dimension_specs
@@ -417,7 +417,7 @@ def test_cumulative_metric_agg_time_dimension_name_validation(
     result = query_parser.parse_and_validate_query(
         metric_names=["revenue_cumulative"], group_by_names=["revenue_instance__ds"]
     )
-    assert_object_snapshot_equal(request=request, mf_test_configuration=mf_test_configuration, obj=result)
+    assert_object_snapshot_equal(request=request, snapshot_configuration=mf_test_configuration, obj=result)
 
 
 def test_derived_metric_query_parsing(
@@ -481,7 +481,7 @@ def test_derived_metric_with_offset_parsing(
         metric_names=["revenue_growth_2_weeks"],
         group_by_names=[MTD],
     )
-    assert_object_snapshot_equal(request=request, mf_test_configuration=mf_test_configuration, obj=result)
+    assert_object_snapshot_equal(request=request, snapshot_configuration=mf_test_configuration, obj=result)
 
 
 def test_date_part_parsing(

--- a/metricflow-semantics/tests_metricflow_semantics/query/test_suggestions.py
+++ b/metricflow-semantics/tests_metricflow_semantics/query/test_suggestions.py
@@ -38,7 +38,7 @@ def test_suggestions_for_group_by_item(  # noqa: D103
 
     assert_str_snapshot_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         snapshot_id="result_0",
         snapshot_str=str(e.value),
     )
@@ -54,7 +54,7 @@ def test_suggestions_for_metric(  # noqa: D103
 
     assert_str_snapshot_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         snapshot_id="result_0",
         snapshot_str=str(e.value),
     )
@@ -70,7 +70,7 @@ def test_suggestions_for_multiple_metrics(  # noqa: D103
 
     assert_str_snapshot_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         snapshot_id="result_0",
         snapshot_str=str(e.value),
     )
@@ -105,7 +105,7 @@ def test_suggestions_for_defined_where_filter(  # noqa: D103
 
     assert_str_snapshot_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         snapshot_id="result_0",
         snapshot_str=str(e.value),
     )
@@ -157,7 +157,7 @@ def test_suggestions_for_defined_filters_in_multi_metric_query(
 
     assert_str_snapshot_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         snapshot_id="result_0",
         snapshot_str=str(e.value),
     )

--- a/metricflow-semantics/tests_metricflow_semantics/test_snapshot.py
+++ b/metricflow-semantics/tests_metricflow_semantics/test_snapshot.py
@@ -12,7 +12,7 @@ def test_expectation_description(
     """Tests having a description of the expectation in a snapshot."""
     assert_str_snapshot_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         snapshot_id="result",
         snapshot_str="1 + 1 = 2",
         expectation_description="The snapshot should show the 2 as the result.",

--- a/metricflow-semantics/tests_metricflow_semantics/time/test_time_adjuster.py
+++ b/metricflow-semantics/tests_metricflow_semantics/time/test_time_adjuster.py
@@ -68,7 +68,7 @@ def test_start_and_end_periods(  # noqa: D103
             )
     assert_str_snapshot_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         snapshot_id="results",
         snapshot_str=tabulate.tabulate(rows, headers=["Date", "Grain", "Period Start", "Period End"]),
     )

--- a/tests_metricflow/dataflow/builder/test_cyclic_join.py
+++ b/tests_metricflow/dataflow/builder/test_cyclic_join.py
@@ -47,7 +47,7 @@ def test_cyclic_join(
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )

--- a/tests_metricflow/dataflow/builder/test_dataflow_plan_builder.py
+++ b/tests_metricflow/dataflow/builder/test_dataflow_plan_builder.py
@@ -58,7 +58,7 @@ def test_simple_plan(
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
@@ -91,7 +91,7 @@ def test_primary_entity_dimension(
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
@@ -128,7 +128,7 @@ def test_joined_plan(
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
@@ -166,7 +166,7 @@ def test_order_by_plan(
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
@@ -195,7 +195,7 @@ def test_limit_rows_plan(
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
@@ -229,7 +229,7 @@ def test_multiple_metrics_plan(
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
@@ -263,7 +263,7 @@ def test_single_semantic_model_ratio_metrics_plan(
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
@@ -297,7 +297,7 @@ def test_multi_semantic_model_ratio_metrics_plan(
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
@@ -333,7 +333,7 @@ def test_multihop_join_plan(
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
@@ -363,7 +363,7 @@ def test_where_constrained_plan(
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
@@ -392,7 +392,7 @@ def test_where_constrained_plan_time_dimension(
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
@@ -422,7 +422,7 @@ def test_where_constrained_with_common_linkable_plan(
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
@@ -474,7 +474,7 @@ def test_cumulative_metric_with_window(
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
@@ -502,7 +502,7 @@ def test_cumulative_metric_no_window_or_grain_with_metric_time(  # noqa: D103
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
@@ -530,7 +530,7 @@ def test_cumulative_metric_no_window_or_grain_without_metric_time(  # noqa: D103
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
@@ -561,7 +561,7 @@ def test_distinct_values_plan(
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
@@ -591,7 +591,7 @@ def test_distinct_values_plan_with_join(
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
@@ -619,7 +619,7 @@ def test_measure_constraint_plan(
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
@@ -647,7 +647,7 @@ def test_measure_constraint_with_reused_measure_plan(
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
@@ -678,7 +678,7 @@ def test_common_semantic_model(
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
@@ -706,7 +706,7 @@ def test_derived_metric_offset_window(
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
@@ -734,7 +734,7 @@ def test_derived_metric_offset_to_grain(
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
@@ -760,7 +760,7 @@ def test_derived_metric_offset_with_granularity(  # noqa: D103
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
@@ -787,7 +787,7 @@ def test_derived_offset_cumulative_metric(  # noqa: D103
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
@@ -813,7 +813,7 @@ def test_join_to_time_spine_with_metric_time(  # noqa: D103
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
@@ -839,7 +839,7 @@ def test_join_to_time_spine_derived_metric(  # noqa: D103
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
@@ -871,7 +871,7 @@ def test_join_to_time_spine_with_non_metric_time(  # noqa: D103
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
@@ -894,7 +894,7 @@ def test_dont_join_to_time_spine_if_no_time_dimension_requested(  # noqa: D103
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
@@ -920,7 +920,7 @@ def test_nested_derived_metric_with_outer_offset(  # noqa: D103
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
@@ -949,7 +949,7 @@ def test_min_max_only_categorical(
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
@@ -982,7 +982,7 @@ def test_min_max_only_time(
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
@@ -1005,7 +1005,7 @@ def test_metric_time_only(  # noqa: D103
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
@@ -1028,7 +1028,7 @@ def test_metric_time_quarter(  # noqa: D103
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
@@ -1057,7 +1057,7 @@ def test_metric_time_with_other_dimensions(  # noqa: D103
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
@@ -1086,7 +1086,7 @@ def test_dimensions_with_time_constraint(  # noqa: D103
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
@@ -1119,7 +1119,7 @@ def test_min_max_only_time_year(
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
@@ -1146,7 +1146,7 @@ def test_min_max_metric_time(
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
@@ -1173,7 +1173,7 @@ def test_min_max_metric_time_week(
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
@@ -1206,7 +1206,7 @@ def test_join_to_time_spine_with_filters(
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
@@ -1237,7 +1237,7 @@ def test_offset_window_metric_filter_and_query_have_different_granularities(
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
@@ -1268,7 +1268,7 @@ def test_offset_to_grain_metric_filter_and_query_have_different_granularities(
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
@@ -1295,7 +1295,7 @@ def test_metric_in_query_where_filter(
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
@@ -1322,7 +1322,7 @@ def test_metric_in_metric_where_filter(
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
@@ -1374,7 +1374,7 @@ def test_cumulative_metric_with_non_default_grain(
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
@@ -1401,7 +1401,7 @@ def test_derived_cumulative_metric_with_non_default_grain(
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )

--- a/tests_metricflow/dataflow/builder/test_node_data_set.py
+++ b/tests_metricflow/dataflow/builder/test_node_data_set.py
@@ -120,7 +120,7 @@ def test_joined_node_data_set(
 
     assert_spec_set_snapshot_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         set_id="result0",
         spec_set=join_node_output_data_set.instance_set.spec_set,
     )

--- a/tests_metricflow/dataflow/optimizer/source_scan/test_cm_branch_combiner.py
+++ b/tests_metricflow/dataflow/optimizer/source_scan/test_cm_branch_combiner.py
@@ -49,7 +49,7 @@ def test_read_sql_source_combination(
     dataflow_plan = make_dataflow_plan(result.combined_branch)
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
@@ -87,7 +87,7 @@ def test_filter_combination(
     dataflow_plan = make_dataflow_plan(result.combined_branch)
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )

--- a/tests_metricflow/dataflow/optimizer/source_scan/test_source_scan_optimizer.py
+++ b/tests_metricflow/dataflow/optimizer/source_scan/test_source_scan_optimizer.py
@@ -138,7 +138,7 @@ def check_optimization(  # noqa: D103
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
@@ -157,7 +157,7 @@ def check_optimization(  # noqa: D103
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         plan=optimized_dataflow_plan,
         plan_snapshot_text=optimized_dataflow_plan.structure_text(),
     )

--- a/tests_metricflow/dataflow/optimizer/test_predicate_pushdown_optimizer.py
+++ b/tests_metricflow/dataflow/optimizer/test_predicate_pushdown_optimizer.py
@@ -184,7 +184,7 @@ def _check_optimization(
     for plan in (dataflow_plan, optimized_plan):
         assert_plan_snapshot_text_equal(
             request=request,
-            mf_test_configuration=mf_test_configuration,
+            snapshot_configuration=mf_test_configuration,
             plan=plan,
             plan_snapshot_text=plan.structure_text(),
         )

--- a/tests_metricflow/dataset/test_convert_semantic_model.py
+++ b/tests_metricflow/dataset/test_convert_semantic_model.py
@@ -30,7 +30,7 @@ def test_convert_table_semantic_model_without_measures(
 
     assert_spec_set_snapshot_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         set_id="result0",
         spec_set=users_data_set.instance_set.spec_set,
     )
@@ -62,7 +62,7 @@ def test_convert_table_semantic_model_with_measures(
 
     assert_spec_set_snapshot_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         set_id="result0",
         spec_set=id_verifications_data_set.instance_set.spec_set,
     )

--- a/tests_metricflow/performance/test_manifest_generator.py
+++ b/tests_metricflow/performance/test_manifest_generator.py
@@ -35,7 +35,7 @@ def test_manifest_generator(  # noqa: D103
     manifest = generator.generate_manifest()
     assert_object_snapshot_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         obj=manifest,
     )
 

--- a/tests_metricflow/plan_conversion/dataflow_to_sql/test_cte_sql.py
+++ b/tests_metricflow/plan_conversion/dataflow_to_sql/test_cte_sql.py
@@ -71,7 +71,7 @@ def convert_and_check(
 
     assert_str_snapshot_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         snapshot_id="result",
         snapshot_str="\n".join(lines),
         incomparable_strings_replacement_function=make_schema_replacement_function(

--- a/tests_metricflow/plan_conversion/test_dataflow_to_sql_plan.py
+++ b/tests_metricflow/plan_conversion/test_dataflow_to_sql_plan.py
@@ -543,7 +543,7 @@ def test_compute_metrics_node_simple_expr(
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )

--- a/tests_metricflow/snapshot_utils.py
+++ b/tests_metricflow/snapshot_utils.py
@@ -37,7 +37,7 @@ def assert_execution_plan_text_equal(  # noqa: D103
 ) -> None:
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         plan=execution_plan,
         plan_snapshot_text=execution_plan.structure_text(),
         incomparable_strings_replacement_function=make_schema_replacement_function(
@@ -58,7 +58,7 @@ def assert_dataflow_plan_text_equal(  # noqa: D103
 ) -> None:
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
         incomparable_strings_replacement_function=replace_dataset_id_hash,
@@ -81,7 +81,7 @@ def assert_object_snapshot_equal(  # type: ignore[misc]
 
     assert_snapshot_text_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         group_id=obj.__class__.__name__,
         snapshot_id=obj_id,
         snapshot_text=mf_pformat(obj),
@@ -105,7 +105,7 @@ def assert_sql_snapshot_equal(
 
     assert_snapshot_text_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         group_id=sql.__class__.__name__,
         snapshot_id=snapshot_id,
         snapshot_text=sql,
@@ -134,7 +134,7 @@ def assert_str_snapshot_equal(  # type: ignore[misc]
 
     assert_snapshot_text_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         group_id=snapshot_str.__class__.__name__,
         snapshot_id=snapshot_id,
         snapshot_text=snapshot_str,

--- a/tests_metricflow/sql/compare_sql_plan.py
+++ b/tests_metricflow/sql/compare_sql_plan.py
@@ -31,7 +31,7 @@ def assert_default_rendered_sql_equal(
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         plan=sql_query_plan,
         plan_snapshot_text=rendered_sql,
         plan_snapshot_file_extension=".sql",
@@ -73,7 +73,7 @@ def assert_rendered_sql_from_plan_equal(
     sql_engine = sql_client.sql_engine_type
     assert_snapshot_text_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         group_id=sql_query_plan.__class__.__name__,
         snapshot_id=sql_query_plan.dag_id.id_str,
         snapshot_text=rendered_sql,
@@ -94,7 +94,7 @@ def assert_sql_plan_text_equal(  # noqa: D103
 ) -> None:
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         plan=sql_query_plan,
         plan_snapshot_text=sql_query_plan.structure_text(),
         incomparable_strings_replacement_function=make_schema_replacement_function(

--- a/tests_metricflow/sql/optimizer/check_optimizer.py
+++ b/tests_metricflow/sql/optimizer/check_optimizer.py
@@ -58,7 +58,7 @@ def assert_optimizer_result_snapshot_equal(
     )
     assert_str_snapshot_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         snapshot_id="result",
         snapshot_str=snapshot_str,
         expectation_description=expectation_description,

--- a/tests_metricflow/sql/test_common_dataflow_branches.py
+++ b/tests_metricflow/sql/test_common_dataflow_branches.py
@@ -45,7 +45,7 @@ def test_shared_metric_query(
 
     assert_str_snapshot_equal(
         request=request,
-        mf_test_configuration=mf_test_configuration,
+        snapshot_configuration=mf_test_configuration,
         snapshot_id="result",
         snapshot_str=mf_pformat_dict(
             obj_dict=obj_dict,


### PR DESCRIPTION
This PR renames the `mf_test_configuration` argument in the snapshot helper functions to make it more sensible when those methods are used in other contexts.