### PR TITLE
Use `output` from the `click` invocation to check test results

### DIFF
--- a/.changes/unreleased/Under the Hood-20250513-220750.yaml
+++ b/.changes/unreleased/Under the Hood-20250513-220750.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Use `output` from the `click` invocation to check test results
+time: 2025-05-13T22:07:50.460496-07:00
+custom:
+  Author: plypaul
+  Issue: "1749"

--- a/tests_metricflow/cli/cli_test_helpers.py
+++ b/tests_metricflow/cli/cli_test_helpers.py
@@ -46,7 +46,7 @@ def run_and_check_cli_command(
         ).evaluated_value
 
     # Replace incomparable values in snapshots with `***`.
-    snapshot_str = result.stdout
+    snapshot_str = result.output
     for prefix in (
         CLIString.LOG_FILE_PREFIX,
         CLIString.ARTIFACT_PATH,

--- a/tests_metricflow/cli/executor_process_main_function.py
+++ b/tests_metricflow/cli/executor_process_main_function.py
@@ -101,7 +101,7 @@ class ExecutorProcessMainFunction:
             output_queue.put(
                 IsolatedCliCommandResult(
                     exit_code=1,
-                    stdout=log_file_contents,
+                    output=log_file_contents,
                     formatted_exception=formatted_exception,
                     executor_process_log_path=self._starting_parameter_set.log_file_path,
                 )
@@ -109,7 +109,7 @@ class ExecutorProcessMainFunction:
 
     @contextmanager
     def _redirect_output_to_file(self, log_file_path: Path) -> Iterator[TextIO]:
-        """Provides a context manager the redirects stdout, stderr, and logging output to the given file.
+        """Provides a context manager the redirects output, stderr, and logging output to the given file.
 
         Useful for debugging as without the log file, the output is invisible. This method is not thread safe due to
         mutation of global state (i.e. logging configuration, `redirect_*`).
@@ -128,7 +128,7 @@ class ExecutorProcessMainFunction:
             try:
                 root_logger.addHandler(logging_handler)
                 if self._output_logging_check_lines:
-                    print("Capturing `stdout` into this file.")
+                    print("Capturing `output` into this file.")
                     print("Capturing `stderr` into this file.", file=sys.stderr)
                     logger.log(
                         level=self._log_level,
@@ -183,7 +183,7 @@ class ExecutorProcessMainFunction:
             )
             return IsolatedCliCommandResult(
                 exit_code=0 if dbt_build_result.success else 1,
-                stdout="",
+                output="",
                 formatted_exception=formatted_exception,
                 executor_process_log_path=self._starting_parameter_set.log_file_path,
             )
@@ -252,7 +252,7 @@ class ExecutorProcessMainFunction:
         )
         return IsolatedCliCommandResult(
             exit_code=click_result.exit_code,
-            stdout=click_result.output,
+            output=click_result.output,
             formatted_exception=formatted_exception,
             executor_process_log_path=self._starting_parameter_set.log_file_path,
         )

--- a/tests_metricflow/cli/executor_process_main_function.py
+++ b/tests_metricflow/cli/executor_process_main_function.py
@@ -252,7 +252,7 @@ class ExecutorProcessMainFunction:
         )
         return IsolatedCliCommandResult(
             exit_code=click_result.exit_code,
-            stdout=click_result.stdout,
+            stdout=click_result.output,
             formatted_exception=formatted_exception,
             executor_process_log_path=self._starting_parameter_set.log_file_path,
         )

--- a/tests_metricflow/cli/isolated_cli_command_interface.py
+++ b/tests_metricflow/cli/isolated_cli_command_interface.py
@@ -44,7 +44,7 @@ class IsolatedCliCommandResult:
     """
 
     exit_code: int
-    stdout: str
+    output: str
     # Pass as the formatted version as it's unclear if there would be problems pickling some exception types.
     formatted_exception: Optional[str]
     executor_process_log_path: Path
@@ -55,7 +55,7 @@ class IsolatedCliCommandResult:
             LazyFormat(
                 "Isolated CLI command failed",
                 exit_code=self.exit_code,
-                stdout=self.stdout,
+                output=self.output,
                 formatted_exception=self.formatted_exception,
                 executor_process_log_path=str(self.executor_process_log_path),
             )

--- a/tests_metricflow/cli/test_isolated_command_runner.py
+++ b/tests_metricflow/cli/test_isolated_command_runner.py
@@ -54,7 +54,7 @@ def test_isolated_query(
             request=request,
             mf_test_configuration=mf_test_configuration,
             snapshot_id="result",
-            snapshot_str=result.stdout,
+            snapshot_str=result.output,
             expectation_description="A table showing the `transactions` metric.",
         )
 
@@ -86,7 +86,7 @@ def test_multiple_queries(
                 ],
             )
             result.raise_exception_on_failure()
-            result_dict["transactions_query"] = result.stdout
+            result_dict["transactions_query"] = result.output
             result = cli_runner.run_command(
                 command_enum=command_enum,
                 command_args=[
@@ -95,7 +95,7 @@ def test_multiple_queries(
                 ],
             )
             result.raise_exception_on_failure()
-            result_dict["quick_buy_transactions_query"] = result.stdout
+            result_dict["quick_buy_transactions_query"] = result.output
 
         assert_str_snapshot_equal(
             request=request,
@@ -153,6 +153,6 @@ def test_environment_variables(
             request=request,
             mf_test_configuration=mf_test_configuration,
             snapshot_id="result",
-            snapshot_str=result.stdout,
+            snapshot_str=result.output,
             expectation_description="A table showing the `transactions` metric.",
         )


### PR DESCRIPTION
There were some recent CI test failures that may be the result of inconsistent or updated behavior from the `Click` dependency. The output of CLI commands was previously checked with the `stdout` field, but that field is now returning an empty value in the error case. This PR updates the test framework to use the `output` field that combines both `stdout` and `stderr`.