### PR TITLE
Add handling of `Path` objects in `mf_pformat()`

### DIFF
--- a/.changes/unreleased/Under the Hood-20250514-101429.yaml
+++ b/.changes/unreleased/Under the Hood-20250514-101429.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Add handling of `Path` objects in `mf_pformat()`
+time: 2025-05-14T10:14:29.168893-07:00
+custom:
+  Author: plypaul
+  Issue: "1752"

--- a/metricflow-semantics/metricflow_semantics/mf_logging/pretty_formatter.py
+++ b/metricflow-semantics/metricflow_semantics/mf_logging/pretty_formatter.py
@@ -4,6 +4,7 @@ import pprint
 from collections.abc import Sequence, Set
 from dataclasses import fields, is_dataclass
 from enum import Enum
+from pathlib import Path
 from typing import Any, List, Mapping, Optional, Sized, Union
 
 from metricflow_semantics.experimental.dataclass_helpers import fast_frozen_dataclass
@@ -393,6 +394,9 @@ class MetricFlowPrettyFormatter:
                 # Fall back to built-in pretty-print in case the dict method can't be called. e.g. requires arguments.
                 # Consider logging a warning.
                 pass
+
+        if isinstance(obj, Path):
+            return str(obj)
 
         # Any other object that's not handled.
         return self._handle_using_pprint(obj, remaining_line_length=remaining_line_length)

--- a/metricflow-semantics/tests_metricflow_semantics/mf_logging/test_pretty_print.py
+++ b/metricflow-semantics/tests_metricflow_semantics/mf_logging/test_pretty_print.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import textwrap
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Optional
 
 from dbt_semantic_interfaces.implementations.elements.dimension import PydanticDimension
@@ -209,3 +210,11 @@ def test_format_object_by_parts() -> None:  # noqa: D103
     assert "_ExampleDataclass(field_0=1)" == formatter.pretty_format_object_by_parts(
         class_name="_ExampleDataclass", field_mapping={"field_0": 1}
     )
+
+
+def test_path() -> None:
+    """Test formatting of `Path` objects.
+
+    It should be represented as `/a/b/c` instead of  `PosixPath("/a/b/c")`.
+    """
+    assert mf_pformat(Path("/a/b/c")) == "/a/b/c"


### PR DESCRIPTION
This PR updates the handling of `pathlib.Path` objects so that they are presented more cleanly in logs.