### PR TITLE
Handle `order_output_columns_by_input_order` for filtered metrics

### DIFF
--- a/.changes/unreleased/Under the Hood-20250514-005030.yaml
+++ b/.changes/unreleased/Under the Hood-20250514-005030.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Handle `order_output_columns_by_input_order` for filtered metrics
+time: 2025-05-14T00:50:30.226465-07:00
+custom:
+  Author: plypaul
+  Issue: "1753"

--- a/metricflow/engine/metricflow_engine.py
+++ b/metricflow/engine/metricflow_engine.py
@@ -546,11 +546,12 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
             sql_client=self._sql_client,
             sql_optimization_level=mf_query_request.sql_optimization_level,
         )
+
         convert_to_execution_plan_result = _to_execution_plan_converter.convert_to_execution_plan(
             dataflow_plan=dataflow_plan,
             spec_output_order=query_spec.spec_output_order
-            if mf_query_request.order_output_columns_by_input_order
-            else (),
+            # Need to check on how the min/max case should be handled.
+            if mf_query_request.order_output_columns_by_input_order and not query_spec.min_max_only else (),
         )
         return MetricFlowExplainResult(
             query_spec=query_spec,

--- a/metricflow/plan_conversion/instance_set_transforms/select_columns.py
+++ b/metricflow/plan_conversion/instance_set_transforms/select_columns.py
@@ -13,6 +13,7 @@ from metricflow_semantics.instances import InstanceSet, InstanceSetTransform, Md
 from metricflow_semantics.mf_logging.lazy_formattable import LazyFormat
 from metricflow_semantics.specs.column_assoc import ColumnAssociationResolver
 from metricflow_semantics.specs.instance_spec import InstanceSpec
+from metricflow_semantics.specs.metric_spec import MetricSpec
 from metricflow_semantics.sql.sql_exprs import SqlColumnReference, SqlColumnReferenceExpression
 from typing_extensions import override
 
@@ -133,7 +134,12 @@ class CreateSelectColumnsForInstances(InstanceSetTransform[CreateSelectColumnsRe
             columns = self._make_sql_column_expression(metric_instance)
             for column in columns:
                 metric_cols.append(column)
-                spec_to_associated_columns[metric_instance.spec] = columns
+                metric_spec = metric_instance.spec
+                # The metric spec used in the dataflow plan contains additional attributes that are different from
+                # the metric spec provided in the query spec (e.g. includes filters), so the mapping should use the
+                # simplified form.
+                simplified_metric_spec = MetricSpec(element_name=metric_spec.element_name, alias=metric_spec.alias)
+                spec_to_associated_columns[simplified_metric_spec] = columns
 
         measure_cols = []
         for measure_instance in instance_set.measure_instances:

--- a/tests_metricflow/cli/executor_process_main_function.py
+++ b/tests_metricflow/cli/executor_process_main_function.py
@@ -238,7 +238,7 @@ class ExecutorProcessMainFunction:
     def _run_mf_cli_command(
         self,
         parameter_set: CommandParameterSet,
-        click_command: click.BaseCommand,
+        click_command: click.Command,
     ) -> IsolatedCliCommandResult:
         """Runs a MF CLI command."""
         click_result = self._mf_cli_runner.invoke(

--- a/tests_metricflow/fixtures/cli_fixtures.py
+++ b/tests_metricflow/fixtures/cli_fixtures.py
@@ -113,7 +113,7 @@ class MetricFlowCliRunner(CliRunner):
         self.project_path = project_path
         super().__init__()
 
-    def run(self, cli: click.BaseCommand, args: Optional[Sequence[str]] = None) -> Result:  # noqa: D102
+    def run(self, cli: click.Command, args: Optional[Sequence[str]] = None) -> Result:  # noqa: D102
         current_dir = os.getcwd()
         os.chdir(self.project_path)
         result = super().invoke(cli, args, obj=self.cli_context)

--- a/tests_metricflow/integration/test_configured_cases.py
+++ b/tests_metricflow/integration/test_configured_cases.py
@@ -327,6 +327,7 @@ def test_case(
             order_by_names=case.order_bys,
             min_max_only=case.min_max_only,
             apply_group_by=case.apply_group_by,
+            order_output_columns_by_input_order=True,
         )
     )
 


### PR DESCRIPTION
This PR resolves an issue where `order_output_columns_by_input_order` did not take effect as expected for metrics with filters defined. This was due to the `MetricSpec` not being the same for what was passed in vs. the one used in the dataflow plan.