### PR TITLE
Add ordered set classes

### DIFF
--- a/metricflow-semantics/metricflow_semantics/collection_helpers/mf_type_aliases.py
+++ b/metricflow-semantics/metricflow_semantics/collection_helpers/mf_type_aliases.py
@@ -2,8 +2,13 @@ from __future__ import annotations
 
 from typing import TypeVar
 
+T = TypeVar("T")
+T_co = TypeVar("T_co", covariant=True)
 T1 = TypeVar("T1")
 T2 = TypeVar("T2")
+
+T1_co = TypeVar("T1_co", covariant=True)
+T2_co = TypeVar("T2_co", covariant=True)
 
 # A pair of objects.
 Pair = tuple[T1, T2]

--- a/metricflow-semantics/metricflow_semantics/collection_helpers/mf_type_aliases.py
+++ b/metricflow-semantics/metricflow_semantics/collection_helpers/mf_type_aliases.py
@@ -1,14 +1,19 @@
 from __future__ import annotations
 
-from typing import TypeVar
+from typing import Hashable, TypeVar
 
 T = TypeVar("T")
 T_co = TypeVar("T_co", covariant=True)
+
 T1 = TypeVar("T1")
 T2 = TypeVar("T2")
 
 T1_co = TypeVar("T1_co", covariant=True)
 T2_co = TypeVar("T2_co", covariant=True)
+
+
+HashableT = TypeVar("HashableT", bound=Hashable)
+HashableT_co = TypeVar("HashableT_co", bound=Hashable, covariant=True)
 
 # A pair of objects.
 Pair = tuple[T1, T2]

--- a/metricflow-semantics/metricflow_semantics/experimental/comparison_helpers.py
+++ b/metricflow-semantics/metricflow_semantics/experimental/comparison_helpers.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+
+class SupportsLessThan(Protocol):
+    """Protocol describing an object that supports `<`.
+
+    This should be replaced with an already-available implementation.
+    """
+
+    def __lt__(self, other: ComparisonOtherType) -> bool:
+        """Standard Python `<` comparison."""
+        ...
+
+
+# Type used to annotate the `other` argument in standard comparison methods like `__lt__`.
+# Helpful to reduce the need to put `# type: ignore` in many places.
+ComparisonOtherType = Any  # type: ignore

--- a/metricflow-semantics/metricflow_semantics/experimental/ordered_set.py
+++ b/metricflow-semantics/metricflow_semantics/experimental/ordered_set.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from collections.abc import Hashable, MutableSet, Set
+from functools import cached_property
+from typing import Generic, Iterable, Iterator, Optional, TypeVar
+
+from typing_extensions import Self, override
+
+from metricflow_semantics.collection_helpers.mf_type_aliases import HashableT, HashableT_co
+from metricflow_semantics.experimental.comparison_helpers import ComparisonOtherType
+
+logger = logging.getLogger(__name__)
+
+OrderedSetT = TypeVar("OrderedSetT", bound="OrderedSet", covariant=True)
+
+
+class OrderedSet(Generic[HashableT_co], Set[HashableT_co], ABC):
+    """Set where the iteration order is the insertion order.
+
+    * Having a consistent iteration order is helpful for ensuring consistency in tests and snapshot generation without
+      sorting.
+    * Since this is meant to be used for consistency in iteration, eq / hash behavior does not depend on order.
+    * Considering using the `ordered-set` package instead, but it would add a dependency and this implementation is
+      short.
+    """
+
+    def __init__(
+        self,
+        iterable: Optional[Iterable[HashableT_co]] = None,
+        _set_as_dict: Optional[dict[HashableT_co, None]] = None,
+    ) -> None:
+        """Initializer.
+
+        Args:
+            iterable: Create the set using the given iterable.
+            _set_as_dict: For internal use - create a copy of this and use it for the internal representation.
+        """
+        self._set_as_dict = _set_as_dict.copy() if _set_as_dict is not None else {}
+        if iterable is not None:
+            self._set_as_dict.update({item: None for item in iterable})
+
+    def intersection(self, other: Iterable[HashableT_co]) -> Self:  # noqa: D102
+        other_set = set(other)
+        return self.__class__(item for item in self if item in other_set)
+
+    def union(self, other: Iterable[HashableT_co]) -> Self:  # noqa: D102
+        return self.__class__(tuple(self._set_as_dict.keys()) + tuple(other))
+
+    @override
+    def __contains__(self, obj: ComparisonOtherType) -> bool:
+        return obj in self._set_as_dict
+
+    @override
+    def __len__(self) -> int:
+        return len(self._set_as_dict)
+
+    @override
+    def __iter__(self) -> Iterator[HashableT_co]:
+        return iter(self._set_as_dict)
+
+    @override
+    def __str__(self) -> str:
+        return "{" + ", ".join(str(item) for item in self) + "}"
+
+    @abstractmethod
+    def as_mutable(self) -> MutableOrderedSet[HashableT_co]:  # noqa: D102
+        raise NotImplementedError
+
+    @abstractmethod
+    def as_frozen(self) -> FrozenOrderedSet[HashableT_co]:  # noqa: D102
+        raise NotImplementedError
+
+
+class FrozenOrderedSet(Generic[HashableT_co], OrderedSet[HashableT_co], Hashable):
+    """A frozen version of `OrderedSet` that can be hashed."""
+
+    @cached_property
+    def _cached_hash_value(self) -> int:
+        return hash(frozenset(self._set_as_dict.keys()))
+
+    @override
+    def __hash__(self) -> int:
+        return self._cached_hash_value
+
+    @override
+    def as_mutable(self) -> MutableOrderedSet[HashableT_co]:
+        return MutableOrderedSet(self)
+
+    @override
+    def as_frozen(self) -> FrozenOrderedSet[HashableT_co]:
+        return self
+
+    @override
+    def union(self, other: Iterable[HashableT_co]) -> Self:  # noqa: D102
+        return super().union(other)
+
+
+class MutableOrderedSet(Generic[HashableT], OrderedSet[HashableT], MutableSet[HashableT]):
+    """An ordered set that can be modified."""
+
+    def update(self, *iterables: Iterable[HashableT]) -> None:  # noqa: D102
+        for iterable in iterables:
+            for item in iterable:
+                self._set_as_dict[item] = None
+
+    @override
+    def add(self, value: HashableT) -> None:
+        self._set_as_dict[value] = None
+
+    @override
+    def discard(self, value: HashableT) -> None:
+        self._set_as_dict.pop(value, None)
+
+    @override
+    def as_mutable(self) -> MutableOrderedSet[HashableT]:
+        return self
+
+    @override
+    def as_frozen(self) -> FrozenOrderedSet[HashableT]:
+        return FrozenOrderedSet(self)
+
+    @override
+    def union(self, other: Iterable[HashableT]) -> Self:  # noqa: D102
+        return super().union(other)
+
+    def copy(self) -> MutableOrderedSet[HashableT]:
+        """Return a copy of this set."""
+        return MutableOrderedSet(iterable=None, _set_as_dict=self._set_as_dict.copy())

--- a/metricflow-semantics/tests_metricflow_semantics/experimental/test_ordered_set.py
+++ b/metricflow-semantics/tests_metricflow_semantics/experimental/test_ordered_set.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import logging
+
+from metricflow_semantics.experimental.ordered_set import FrozenOrderedSet, MutableOrderedSet
+
+logger = logging.getLogger(__name__)
+
+
+def test_create() -> None:  # noqa: D103
+    example_set = MutableOrderedSet((1, 2, 3, 2, 1))
+    assert tuple(example_set) == (1, 2, 3)
+    assert len(example_set) == 3
+    assert 2 in example_set and 4 not in example_set
+
+
+def test_equality() -> None:  # noqa: D103
+    a = MutableOrderedSet((1, 2, 3))
+    b = MutableOrderedSet((3, 2, 1))
+    assert a == b
+    assert tuple(a) == (1, 2, 3)
+    assert tuple(b) == (3, 2, 1)
+
+
+def test_intersection() -> None:  # noqa: D103
+    left = MutableOrderedSet((1, 2, 3))
+    right = {1, 2}
+    result = left.intersection(right)
+    assert isinstance(result, MutableOrderedSet)
+    assert tuple(result) == (1, 2)  # order from *left* operand
+
+
+def test_union() -> None:  # noqa: D103
+    left = MutableOrderedSet((1, 2))
+    right = [3, 2]
+    assert tuple(left.union(right)) == (1, 2, 3)
+
+
+def test_operators() -> None:  # noqa: D103
+    left = MutableOrderedSet((1, 2, 3))
+    right = MutableOrderedSet((1, 3, 4))
+
+    assert tuple(left - right) == (2,)
+    assert tuple(left | right) == (1, 2, 3, 4)
+
+
+def test_mutation() -> None:  # noqa: D103
+    example_set = MutableOrderedSet[int]()
+    example_set.add(1)
+    example_set.update((2, 3), [4])
+    assert tuple(example_set) == (1, 2, 3, 4)
+
+    example_set.discard(3)
+    assert tuple(example_set) == (1, 2, 4)
+
+    example_set.discard(0)
+    assert tuple(example_set) == (1, 2, 4)
+
+
+def test_eq() -> None:  # noqa: D103
+    assert MutableOrderedSet((1,)) == FrozenOrderedSet((1,))

--- a/metricflow-semantics/tests_metricflow_semantics/mf_logging/test_pretty_print.py
+++ b/metricflow-semantics/tests_metricflow_semantics/mf_logging/test_pretty_print.py
@@ -8,6 +8,7 @@ from typing import Optional
 
 from dbt_semantic_interfaces.implementations.elements.dimension import PydanticDimension
 from dbt_semantic_interfaces.type_enums import DimensionType
+from metricflow_semantics.experimental.ordered_set import FrozenOrderedSet
 from metricflow_semantics.helpers.string_helpers import mf_dedent, mf_indent
 from metricflow_semantics.mf_logging.pretty_formattable import MetricFlowPrettyFormattable
 from metricflow_semantics.mf_logging.pretty_formatter import (
@@ -218,3 +219,8 @@ def test_path() -> None:
     It should be represented as `/a/b/c` instead of  `PosixPath("/a/b/c")`.
     """
     assert mf_pformat(Path("/a/b/c")) == "/a/b/c"
+
+
+def test_ordered_set() -> None:  # noqa: D103
+    ordered_set = FrozenOrderedSet((3, 2, 1))
+    assert mf_pformat(ordered_set) == "{3, 2, 1}"


### PR DESCRIPTION
This PR adds ordered set classes to provide consistency in tests. The `ordered-set` package provides similar functionality, but favoring this as the implementation is short and would avoid adding a dependency.