### PR TITLE
Add `OrderedEnum`

### DIFF
--- a/metricflow-semantics/metricflow_semantics/experimental/orderd_enum.py
+++ b/metricflow-semantics/metricflow_semantics/experimental/orderd_enum.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import functools
+from enum import Enum
+
+from metricflow_semantics.experimental.comparison_helpers import ComparisonOtherType
+
+
+@functools.total_ordering
+class OrderedEnum(Enum):
+    """An `Enum` that can be sorted by definition order.
+
+    * This is useful dataclasses that have enums as fields as the default `Enum` isn't sortable.
+    * Considering using the `OrderedEnum` from `aenum`.
+    """
+
+    @classmethod
+    @functools.cache
+    def _enum_to_index(cls) -> dict[OrderedEnum, int]:
+        return {member: i for i, member in enumerate(cls)}
+
+    def __lt__(self, other: ComparisonOtherType) -> bool:  # noqa: D105
+        if type(other) is not type(self):
+            return NotImplemented
+        enum_to_index = self._enum_to_index()
+
+        return enum_to_index[self] < enum_to_index[other]

--- a/metricflow-semantics/tests_metricflow_semantics/experimental/test_ordered_enum.py
+++ b/metricflow-semantics/tests_metricflow_semantics/experimental/test_ordered_enum.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from metricflow_semantics.experimental.orderd_enum import OrderedEnum
+
+
+class Alphabet(OrderedEnum):  # noqa: D101
+    A = "a"
+    B = "b"
+    C = "c"
+
+
+def test_ordered_enum() -> None:  # noqa: D103
+    assert sorted([Alphabet.C, Alphabet.B, Alphabet.A]) == [Alphabet.A, Alphabet.B, Alphabet.C]
+    assert tuple(Alphabet) == (Alphabet.A, Alphabet.B, Alphabet.C)


### PR DESCRIPTION
This PR adds an `Enum` base class that can be ordered for consistency in tests. The `OrderedEnum` from `aenum` was considered but favoring this as the implementation is short and avoids adding a dependency.