### PR TITLE
Add `assert_graph_snapshot_equal` for tests

### DIFF
--- a/metricflow-semantics/tests_metricflow_semantics/experimental/graph_helpers.py
+++ b/metricflow-semantics/tests_metricflow_semantics/experimental/graph_helpers.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import logging
+from typing import Callable, Optional
+
+from _pytest.fixtures import FixtureRequest
+from metricflow_semantics.experimental.mf_graph.mf_graph import MetricflowGraph
+from metricflow_semantics.mf_logging.pretty_print import mf_pformat_dict
+from metricflow_semantics.test_helpers.snapshot_helpers import (
+    SnapshotConfiguration,
+    assert_str_snapshot_equal,
+)
+
+from tests_metricflow_semantics.experimental.mf_graph.formatting.dot_formatter import DotNotationFormatter
+
+logger = logging.getLogger(__name__)
+
+
+def assert_graph_snapshot_equal(
+    request: FixtureRequest,
+    snapshot_configuration: SnapshotConfiguration,
+    graph: MetricflowGraph,
+    snapshot_id: str = "result",
+    expectation_description: Optional[str] = None,
+    incomparable_strings_replacement_function: Optional[Callable[[str], str]] = None,
+) -> None:
+    """Generate / compare a snapshot of the graph in different formats."""
+    sorted_graph = graph.as_sorted()
+    assert_str_snapshot_equal(
+        request=request,
+        snapshot_configuration=snapshot_configuration,
+        snapshot_str=mf_pformat_dict(
+            description=None,
+            obj_dict={
+                "dot_notation": sorted_graph.format(DotNotationFormatter()),
+                "pretty_format": sorted_graph.format(),
+            },
+        ),
+        snapshot_id=snapshot_id,
+        expectation_description=expectation_description,
+        incomparable_strings_replacement_function=incomparable_strings_replacement_function,
+    )

--- a/metricflow-semantics/tests_metricflow_semantics/experimental/mf_graph/test_graph_snapshot.py
+++ b/metricflow-semantics/tests_metricflow_semantics/experimental/mf_graph/test_graph_snapshot.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import logging
+
+from _pytest.fixtures import FixtureRequest
+from metricflow_semantics.test_helpers.config_helpers import MetricFlowTestConfiguration
+
+from tests_metricflow_semantics.experimental.graph_helpers import assert_graph_snapshot_equal
+from tests_metricflow_semantics.experimental.mf_graph.flow_graph import FlowGraph
+
+logger = logging.getLogger(__name__)
+
+
+def test_graph_snapshot(
+    request: FixtureRequest, mf_test_configuration: MetricFlowTestConfiguration, flow_graph: FlowGraph
+) -> None:
+    """Check the graph snapshot."""
+    assert_graph_snapshot_equal(request=request, snapshot_configuration=mf_test_configuration, graph=flow_graph)

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_graph_snapshot.py/str/test_graph_snapshot__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_graph_snapshot.py/str/test_graph_snapshot__result.txt
@@ -1,0 +1,33 @@
+test_name: test_graph_snapshot
+test_filename: test_graph_snapshot.py
+docstring:
+  Check the graph snapshot.
+---
+dot_notation:
+  digraph {
+  	graph [name=FlowGraph]
+  	subgraph cluster_intermediate_nodes {
+  		label=intermediate_nodes
+  		a
+  		b
+  	}
+  	sink
+  	source
+  	a -> b
+  	a -> sink
+  	b -> sink
+  	source -> a
+  	source -> b
+  }
+
+pretty_format:
+  FlowGraph(
+    nodes={IntermediateNode('a'), IntermediateNode('b'), SinkNode('sink'), SourceNode('source')},
+    edges={
+      FlowEdge('a -> b'),
+      FlowEdge('a -> sink'),
+      FlowEdge('b -> sink'),
+      FlowEdge('source -> a'),
+      FlowEdge('source -> b'),
+    },
+  )


### PR DESCRIPTION
This PR adds `assert_graph_snapshot_equal` used in later graph tests.