### PR TITLE
Fix ambiguity error for time dimensions in Dimension Jinja block

### DIFF
--- a/.changes/unreleased/Fixes-20250620-153226.yaml
+++ b/.changes/unreleased/Fixes-20250620-153226.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix ambiguity error for time dimensions in Dimension Jinja block
+time: 2025-06-20T15:32:26.019251-07:00
+custom:
+  Author: courtneyholcomb
+  Issue: "1772"

--- a/metricflow-semantics/metricflow_semantics/specs/patterns/typed_patterns.py
+++ b/metricflow-semantics/metricflow_semantics/specs/patterns/typed_patterns.py
@@ -47,6 +47,7 @@ class DimensionPattern(EntityLinkPattern):
                 fields_to_compare=(
                     ParameterSetField.ELEMENT_NAME,
                     ParameterSetField.ENTITY_LINKS,
+                    ParameterSetField.DATE_PART,
                 ),
                 element_name=dimension_call_parameter_set.dimension_reference.element_name,
                 entity_links=dimension_call_parameter_set.entity_path,

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_parse_and_validate_where_constraint_dims__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_parse_and_validate_where_constraint_dims__result.txt
@@ -94,6 +94,7 @@ ParseQueryResult(
           spec_pattern=DimensionPattern(
             parameter_set=SpecPatternParameterSet(
               fields_to_compare=(
+                DATE_PART,
                 ELEMENT_NAME,
                 ENTITY_LINKS,
               ),

--- a/metricflow-semantics/tests_metricflow_semantics/specs/patterns/test_typed_patterns.py
+++ b/metricflow-semantics/tests_metricflow_semantics/specs/patterns/test_typed_patterns.py
@@ -85,11 +85,6 @@ def test_dimension_pattern(specs: Sequence[LinkableInstanceSpec]) -> None:  # no
             entity_links=(EntityReference("booking"), EntityReference("listing")),
             time_granularity=ExpandedTimeGranularity.from_time_granularity(TimeGranularity.DAY),
         ),
-        TimeDimensionSpec(
-            element_name="common_name",
-            entity_links=(EntityReference("booking"), EntityReference("listing")),
-            date_part=DatePart.MONTH,
-        ),
     )
 
 

--- a/tests_metricflow/integration/test_cases/itest_constraints.yaml
+++ b/tests_metricflow/integration/test_cases/itest_constraints.yaml
@@ -7,7 +7,7 @@ integration_test:
   group_bys: ["metric_time", "booking__is_instant"]
   where_filter: '{{ render_dimension_template("booking__is_instant") }}'
   check_query: |
-    SELECT  SUM(booking_value) AS booking_value
+    SELECT SUM(booking_value) AS booking_value
       , is_instant AS booking__is_instant
       , ds AS metric_time__day
     FROM  {{ source_schema }}.fct_bookings
@@ -286,3 +286,15 @@ integration_test:
     ) subq_4
     ON ts = subq_4.metric_time__hour
     WHERE {{ render_time_constraint("ts", "2020-01-01 02:00:00", "2020-01-03 05:59:59") }}
+---
+integration_test:
+  name: test_metric_time_in_dimension_jinja
+  description: Query a metric with metric_time in the Dimension object of the where filter
+  model: SIMPLE_MODEL
+  metrics: ["booking_value"]
+  where_filter: '{{ render_dimension_template("metric_time") }} = {{ cast_to_ts("2020-01-01") }}'
+  check_query: |
+    SELECT
+      SUM(booking_value) AS booking_value
+    FROM {{ source_schema }}.fct_bookings
+    WHERE ds = '2020-01-01'


### PR DESCRIPTION
We've been seeing an error that looks like this when querying a time dimension with no grain in a Dimension Jinja block:
![image](https://github.com/user-attachments/assets/7ce6f444-0673-4984-ae80-8b3a5b9ee265)
This PR fixes that.