### PR TITLE
Ensure lowercase agg_time_dimension

### DIFF
--- a/.changes/unreleased/Fixes-20250624-131026.yaml
+++ b/.changes/unreleased/Fixes-20250624-131026.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Ensure agg_time_dimension is lowercased
+time: 2025-06-24T13:10:26.024907-07:00
+custom:
+  Author: courtneyholcomb
+  Issue: "1773"

--- a/metricflow-semantics/metricflow_semantics/model/semantics/semantic_model_lookup.py
+++ b/metricflow-semantics/metricflow_semantics/model/semantics/semantic_model_lookup.py
@@ -124,6 +124,8 @@ class SemanticModelLookup:
         for measure in semantic_model.measures:
             self._measure_index[measure.reference] = semantic_model
             agg_time_dimension_reference = semantic_model.checked_agg_time_dimension_for_measure(measure.reference)
+            # Ensure agg_time_dimension is lowercased - this transformation was not enforced on earlier manifests
+            agg_time_dimension_reference = TimeDimensionReference(agg_time_dimension_reference.element_name.lower())
 
             matching_dimensions = tuple(
                 dimension

--- a/metricflow-semantics/requirements-files/requirements.txt
+++ b/metricflow-semantics/requirements-files/requirements.txt
@@ -1,7 +1,7 @@
 # Always support a range of production DSI versions capped at the next breaking version in metricflow-semantics.
 # This allows us to sync new, non-breaking changes to dbt-core without getting a version mismatch in dbt-mantle,
 # which depends on a specific commit of DSI.
-dbt-semantic-interfaces>=0.8.3, <0.9.0
+dbt-semantic-interfaces>=0.8.4, <0.9.0
 graphviz>=0.18.2, <0.21
 python-dateutil>=2.9.0, <2.10.0
 rapidfuzz>=3.0, <4.0

--- a/requirements-files/requirements.txt
+++ b/requirements-files/requirements.txt
@@ -1,5 +1,5 @@
 Jinja2>=3.1.6, <3.7.0
-dbt-semantic-interfaces==0.8.3
+dbt-semantic-interfaces==0.8.4
 more-itertools>=8.10.0, <10.2.0
 pydantic>=1.10.0, <3.0
 tabulate>=0.8.9

--- a/tests_metricflow/snapshots/test_manifest_generator.py/PydanticSemanticManifest/test_manifest_generator__result.txt
+++ b/tests_metricflow/snapshots/test_manifest_generator.py/PydanticSemanticManifest/test_manifest_generator__result.txt
@@ -120,7 +120,7 @@ PydanticSemanticManifest(
     dsi_package_version=PydanticSemanticVersion(
       major_version='0',
       minor_version='8',
-      patch_version='3',
+      patch_version='4',
     ),
     time_spines=[
       PydanticTimeSpine(


### PR DESCRIPTION
Pair to [this PR](https://github.com/dbt-labs/dbt-semantic-interfaces/pull/379). Fixes an issue where we can't find the `agg_time_dimension` in the semantic model because it's uppercased in one place and lowercased in the other.