### PR TITLE
Allow including derived time grains in list_group_bys

### DIFF
--- a/metricflow/engine/metricflow_engine.py
+++ b/metricflow/engine/metricflow_engine.py
@@ -698,7 +698,7 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
                     )
                 dimensions.append(dimension)
 
-        return sorted(dimensions, key=lambda x: x.default_search_and_sort_attribute)
+        return sorted(set(dimensions), key=lambda x: x.default_search_and_sort_attribute)
 
     @log_call(module_name=__name__, telemetry_reporter=_telemetry_reporter)
     def list_dimensions(self, metric_names: Optional[List[str]] = None) -> List[Dimension]:
@@ -718,7 +718,7 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
                     )
                     dimensions.append(dimension)
 
-        return sorted(dimensions, key=lambda x: x.default_search_and_sort_attribute)
+        return sorted(set(dimensions), key=lambda x: x.default_search_and_sort_attribute)
 
     def entities_for_metrics(self, metric_names: List[str]) -> List[Entity]:  # noqa: D102
         linkable_element_set = self._semantic_manifest_lookup.metric_lookup.linkable_elements_for_metrics(
@@ -729,7 +729,7 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
         )
 
         entities = self._filter_linkable_entities(linkable_element_set=linkable_element_set)
-        return sorted(entities, key=lambda x: x.default_search_and_sort_attribute)
+        return sorted(set(entities), key=lambda x: x.default_search_and_sort_attribute)
 
     def _filter_linkable_entities(self, linkable_element_set: LinkableElementSet) -> List[Entity]:
         entities: List[Entity] = []
@@ -843,7 +843,7 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
         else:
             # TODO: better support for querying entities without metrics; include entities here at that time
             group_bys = self.list_dimensions()
-        return sorted(group_bys, key=lambda x: x.default_search_and_sort_attribute)
+        return sorted(set(group_bys), key=lambda x: x.default_search_and_sort_attribute)
 
     def group_by_exists(self, structured_name: StructuredLinkableSpecName) -> bool:
         """Check if a group by exists in the semantic manifest by its element name."""

--- a/tests_metricflow/snapshots/test_mf_engine.py/list/test_list_dimensions_for_metrics_for_multiple_metrics__result0.txt
+++ b/tests_metricflow/snapshots/test_mf_engine.py/list/test_list_dimensions_for_metrics_for_multiple_metrics__result0.txt
@@ -5,15 +5,9 @@ docstring:
 ---
 [
   'listing__capacity_latest',
-  'listing__capacity_latest',
-  'listing__country_latest',
   'listing__country_latest',
   'listing__created_at',
-  'listing__created_at',
-  'listing__ds',
   'listing__ds',
   'listing__is_lux_latest',
-  'listing__is_lux_latest',
-  'metric_time__day',
   'metric_time__day',
 ]


### PR DESCRIPTION
1. Allow including derived time grains in `list_group_bys` - This is used for a pretty niche feature in our API that allows you to list all group by names for a given metric. See [here](https://github.com/dbt-labs/metricflow-server/pull/1498) for how it's used.
2. Dedupe group bys exposed in `MFEngine`. There might be duplicates here due to differences between the `LinkableDimension/Entity` and `Dimension/Entity` objects. Ultimately this is because of different join paths used to reach the group by from different metrics.