### PR TITLE
feat: Add mf list saved-queries

### DIFF
--- a/dbt-metricflow/dbt_metricflow/cli/main.py
+++ b/dbt-metricflow/dbt_metricflow/cli/main.py
@@ -618,6 +618,28 @@ def validate_configs(
     if merged_results.has_blocking_issues:
         exit(1)
 
+@list_command_group.command()
+@pass_config
+@exception_handler
+@log_call(module_name=__name__, telemetry_reporter=_telemetry_reporter)
+def saved_queries(cfg: CLIConfiguration) -> None:
+    """List all saved queries in the project."""
+    if not cfg.is_setup:
+        cfg.setup()
+    spinner = Halo(text="🔍 Looking for all available saved queries...", spinner="dots")
+    spinner.start()
+
+    saved_queries = cfg.mf.list_saved_queries()
+
+    if not saved_queries:
+        spinner.fail("No saved queries found.")
+        return
+
+    spinner.succeed(f"🌱 We've found {len(saved_queries)} saved queries.")
+    click.echo('The list below shows saved queries with their descriptions:')
+    for sq in saved_queries:
+        description = sq.description if sq.description else "No description provided"
+        click.echo(f"• {click.style(sq.name, bold=True, fg='green')}: {description}")
 
 if __name__ == "__main__":
     cli()

--- a/tests_metricflow/cli/executor_process_main_function.py
+++ b/tests_metricflow/cli/executor_process_main_function.py
@@ -23,6 +23,7 @@ from dbt_metricflow.cli.main import (
     list_command_group,
     metrics,
     query,
+    saved_queries,
     tutorial,
     validate_configs,
 )
@@ -216,6 +217,11 @@ class ExecutorProcessMainFunction:
             return self._run_mf_cli_command(
                 parameter_set=parameter_set,
                 click_command=metrics,
+            )
+        elif parameter_set.command_enum is IsolatedCliCommandEnum.MF_SAVED_QUERIES:
+            return self._run_mf_cli_command(
+                parameter_set=parameter_set,
+                click_command=saved_queries,
             )
         elif parameter_set.command_enum is IsolatedCliCommandEnum.MF_QUERY:
             return self._run_mf_cli_command(

--- a/tests_metricflow/cli/isolated_cli_command_interface.py
+++ b/tests_metricflow/cli/isolated_cli_command_interface.py
@@ -25,6 +25,7 @@ class IsolatedCliCommandEnum(Enum):
     MF_METRICS = "mf_metrics"
     MF_LIST = "mf_list"
     MF_QUERY = "mf_query"
+    MF_SAVED_QUERIES = "mf_saved_queries"
     MF_TUTORIAL = "mf_tutorial"
     MF_VALIDATE_CONFIGS = "mf_validate_configs"
 

--- a/tests_metricflow/cli/test_cli.py
+++ b/tests_metricflow/cli/test_cli.py
@@ -204,6 +204,20 @@ def test_list_entities(  # noqa: D103
 
 
 @pytest.mark.slow
+def test_list_saved_queries( # noqa: D103
+    request: FixtureRequest,
+    mf_test_configuration: MetricFlowTestConfiguration,
+    cli_runner: IsolatedCliCommandRunner,
+) -> None:
+    run_and_check_cli_command(
+        request=request,
+        mf_test_configuration=mf_test_configuration,
+        cli_runner=cli_runner,
+        command_enum=IsolatedCliCommandEnum.MF_SAVED_QUERIES,
+        args=[],
+)
+
+@pytest.mark.slow
 def test_saved_query(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,

--- a/tests_metricflow/snapshots/test_cli.py/str/test_list_saved_queries__result.txt
+++ b/tests_metricflow/snapshots/test_cli.py/str/test_list_saved_queries__result.txt
@@ -1,0 +1,6 @@
+test_name: test_list_saved_queries
+test_filename: test_cli.py
+---
+The list below shows saved queries with their descriptions:
+• core_transaction_metrics: Important transaction metrics.
+• cumulative_transaction_metrics: Cumulative metrics related to transactions.


### PR DESCRIPTION
## Summary

This PR introduces a new CLI command mf list saved-queries that allows users to list all saved queries in their MetricFlow project along with their descriptions.

## Changes Made

- CLI Command Implementation: Added saved_queries command to the list command group in dbt_metricflow/cli/main.py
    - Displays saved query names and descriptions in a user-friendly format
    - Includes loading spinner and success/error messaging
    - Handles cases where no saved queries are found

- Test Infrastructure Updates:
    - Extended ExecutorProcessMainFunction to support the new command
    - Added MF_SAVED_QUERIES to IsolatedCliCommandEnum
    - Created comprehensive test case test_list_saved_queries with snapshot verification

- Test Coverage: Added snapshot test to ensure consistent output formatting

## Usage

```bash
mf list saved-queries

🌱 We've found 2 saved queries.
The list below shows saved queries with their descriptions:
• my_saved_query: A sample saved query for testing
• another_query: No description provided
```