### PR TITLE
Add a helper for writing `timeit`-based performance tests

### DIFF
--- a/.changes/unreleased/Under the Hood-20250724-212239.yaml
+++ b/.changes/unreleased/Under the Hood-20250724-212239.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Add a helper for writing `timeit`-based performance tests
+time: 2025-07-24T21:22:39.179469-07:00
+custom:
+  Author: plypaul
+  Issue: "1788"

--- a/metricflow-semantics/metricflow_semantics/experimental/test_helpers/performance_helpers.py
+++ b/metricflow-semantics/metricflow_semantics/experimental/test_helpers/performance_helpers.py
@@ -12,10 +12,10 @@ logger = logging.getLogger(__name__)
 
 
 def assert_performance_factor(
-    slow_code_setup: str,
-    slow_code_statement: str,
-    fast_code_setup: str,
-    fast_code_statement: str,
+    left_setup: str,
+    left_statement: str,
+    right_setup: str,
+    right_statement: str,
     min_performance_factor: float,
 ) -> None:
     """Using `timeit`, check that the fast code is faster than the slow code by the given factor.
@@ -29,13 +29,13 @@ def assert_performance_factor(
             # `autorange()` runs the given code multiple times until 0.2s is spent.
             gc.collect()
             iteration_count, total_time = timeit.Timer(
-                timer=time.thread_time, setup=slow_code_setup, stmt=slow_code_statement
+                timer=time.thread_time, setup=left_setup, stmt=left_statement
             ).autorange()
             average_slow_code_runtime = total_time / iteration_count
 
             gc.collect()
             iteration_count, total_time = timeit.Timer(
-                timer=time.thread_time, setup=fast_code_setup, stmt=fast_code_statement
+                timer=time.thread_time, setup=right_setup, stmt=right_statement
             ).autorange()
             average_fast_code_runtime = total_time / iteration_count
 
@@ -43,10 +43,10 @@ def assert_performance_factor(
             raise RuntimeError(
                 LazyFormat(
                     "Got an exception with the given code",
-                    slow_code_setup=slow_code_setup,
-                    slow_code_statement=slow_code_statement,
-                    fast_code_setup=fast_code_setup,
-                    fast_code_statement=fast_code_statement,
+                    slow_code_setup=left_setup,
+                    slow_code_statement=left_statement,
+                    fast_code_setup=right_setup,
+                    fast_code_statement=right_statement,
                 )
             ) from e
 

--- a/metricflow-semantics/metricflow_semantics/experimental/test_helpers/performance_helpers.py
+++ b/metricflow-semantics/metricflow_semantics/experimental/test_helpers/performance_helpers.py
@@ -18,7 +18,7 @@ def assert_performance_factor(
     right_statement: str,
     min_performance_factor: float,
 ) -> None:
-    """Using `timeit`, check that the fast code is faster than the slow code by the given factor.
+    """Using `timeit`, check that the right statement is faster than the left statement by the given factor.
 
     See `timeit` for definitions of `setup` and `statement`.
     """
@@ -31,32 +31,32 @@ def assert_performance_factor(
             iteration_count, total_time = timeit.Timer(
                 timer=time.thread_time, setup=left_setup, stmt=left_statement
             ).autorange()
-            average_slow_code_runtime = total_time / iteration_count
+            average_left_code_runtime = total_time / iteration_count
 
             gc.collect()
             iteration_count, total_time = timeit.Timer(
                 timer=time.thread_time, setup=right_setup, stmt=right_statement
             ).autorange()
-            average_fast_code_runtime = total_time / iteration_count
+            average_right_code_runtime = total_time / iteration_count
 
         except Exception as e:
             raise RuntimeError(
                 LazyFormat(
-                    "Got an exception with the given code",
-                    slow_code_setup=left_setup,
-                    slow_code_statement=left_statement,
-                    fast_code_setup=right_setup,
-                    fast_code_statement=right_statement,
+                    "Got an exception with the executed statements.",
+                    left_setup=left_setup,
+                    left_statement=left_statement,
+                    right_setup=right_setup,
+                    right_statement=right_statement,
                 )
             ) from e
 
-        performance_factor = average_slow_code_runtime / average_fast_code_runtime
+        performance_factor = average_left_code_runtime / average_right_code_runtime
 
         logger.debug(
             LazyFormat(
-                "Compared performance of slow code and fast code",
-                slow_code_runtime=lambda: datetime.timedelta(seconds=average_slow_code_runtime),
-                fast_code_runtime=lambda: datetime.timedelta(seconds=average_fast_code_runtime),
+                "Compared performance of left and right statements.",
+                left_statement_runtime=lambda: datetime.timedelta(seconds=average_left_code_runtime),
+                right_statement_runtime=lambda: datetime.timedelta(seconds=average_right_code_runtime),
                 performance_factor=lambda: f"{performance_factor:.2f}",
                 expected_min_performance_factor=lambda: f"{min_performance_factor:.2f}",
             )

--- a/metricflow-semantics/metricflow_semantics/experimental/test_helpers/performance_helpers.py
+++ b/metricflow-semantics/metricflow_semantics/experimental/test_helpers/performance_helpers.py
@@ -5,6 +5,8 @@ import gc
 import logging
 import time
 import timeit
+from abc import ABC, abstractmethod
+from io import StringIO
 
 from metricflow_semantics.mf_logging.lazy_formattable import LazyFormat
 
@@ -84,3 +86,122 @@ def assert_performance_factor(
                 )
             )
             time.sleep(sleep_time)
+
+
+class BenchmarkFunction(ABC):
+    """Closure to encapsulate the setup code and the benchmarked code.
+
+    This closure is helpful for authoring tests as the arguments to the `timeit` calls are strings of code
+    snippets. Those strings are annoying to author as the IDE inspections don't work / mypy does not do type checks in
+    strings. In addition, all imports must be specifically included in the code snippet.
+
+    Using the closure, there's no need to add additional imports as this can make references to objects in the
+    caller's frame.
+
+    This is a WIP - there may be other approaches and there may be implications to measuring code performance. One
+    issue that is known is that this is not suitable for checking fast snippets as due to the overhead in the
+    method call.
+
+    The `__init__` method of implementing classes should have no parameters.
+    """
+
+    @abstractmethod
+    def run(self) -> None:
+        """This should contain the code to run in the benchmark."""
+        raise NotImplementedError
+
+
+class PerformanceBenchmark:
+    """Helper to benchmark execution performance using `timeit`."""
+
+    @staticmethod
+    def assert_function_performance(
+        left_function_class: type[BenchmarkFunction],
+        right_function_class: type[BenchmarkFunction],
+        min_performance_factor: float,
+    ) -> None:
+        """Assert that the right function is `min_performance_factor` times faster than the left function.
+
+        As there is an overhead to calling a function in a class, this is not suitable to fast functions.
+        """
+        attempt_count = 3
+        sleep_time = 1.0
+        # 50 microseconds.
+        min_function_runtime = 50e-6
+        left_timer = timeit.Timer(
+            timer=time.thread_time,
+            setup="left_function = left_function_class()",
+            stmt="left_function.run()",
+            globals={"left_function_class": left_function_class},
+        )
+        right_timer = timeit.Timer(
+            timer=time.thread_time,
+            setup="right_function = right_function_class()",
+            stmt="right_function.run()",
+            globals={"right_function_class": right_function_class},
+        )
+
+        for i in range(attempt_count):
+            left_function_runtime = PerformanceBenchmark._call_with_exception_handling(left_timer)
+            right_function_runtime = PerformanceBenchmark._call_with_exception_handling(right_timer)
+
+            if any(runtime < min_function_runtime for runtime in (left_function_runtime, right_function_runtime)):
+                raise RuntimeError(
+                    LazyFormat(
+                        "The runtime of at least one of the provided functions is too short."
+                        " This means that the runtime will include the function-call overhead as a significant"
+                        " component",
+                        left_function_runtime=lambda: datetime.timedelta(seconds=left_function_runtime),
+                        right_function_runtime=lambda: datetime.timedelta(seconds=right_function_runtime),
+                        min_function_runtime=min_function_runtime,
+                    )
+                )
+
+            performance_factor = left_function_runtime / right_function_runtime
+
+            logger.debug(
+                LazyFormat(
+                    "Compared performance of left and right functions.",
+                    left_function_runtime=lambda: datetime.timedelta(seconds=left_function_runtime),
+                    right_function_runtime=lambda: datetime.timedelta(seconds=right_function_runtime),
+                    performance_factor=lambda: f"{performance_factor:.2f}",
+                    expected_min_performance_factor=lambda: f"{min_performance_factor:.2f}",
+                )
+            )
+
+            if performance_factor > min_performance_factor:
+                return
+
+            if i == attempt_count - 1:
+                raise AssertionError(
+                    LazyFormat(
+                        "The performance factor is lower than the minimum expected.",
+                        expected_min_performance_factor=min_performance_factor,
+                        actual_performance_factor=lambda: f"{performance_factor:.2f}",
+                        attempt_count=attempt_count,
+                    )
+                )
+            else:
+                logger.debug(
+                    LazyFormat(
+                        "Since performance is lower than expected, sleeping and retrying in case it's a fluke",
+                        sleep_time=lambda: f"{sleep_time:.2f}s",
+                        attempt_num=i + 1,
+                        attempt_count=attempt_count,
+                    )
+                )
+                time.sleep(sleep_time)
+
+    @staticmethod
+    def _call_with_exception_handling(timer: timeit.Timer) -> float:
+        """Wraps the call to `timeit` to include the stack trace as the one raised by `timeit` does not."""
+        gc.collect()
+        try:
+            return timer.timeit(number=1)
+        except Exception as e:
+            with StringIO() as fp:
+                timer.print_exc(fp)
+                # noinspection PyUnresolvedReferences
+                raise RuntimeError(
+                    LazyFormat("Got an exception while executing timed code.", exception=fp.getvalue())
+                ) from e

--- a/metricflow-semantics/tests_metricflow_semantics/experimental/collection_helpers/test_fast_frozen_dataclass.py
+++ b/metricflow-semantics/tests_metricflow_semantics/experimental/collection_helpers/test_fast_frozen_dataclass.py
@@ -26,10 +26,10 @@ def setup_statement() -> str:
 def test_hash(setup_statement: str) -> None:
     """Test that `fast_frozen_dataclass` is faster for repeated hashing."""
     assert_performance_factor(
-        slow_code_setup=setup_statement,
-        slow_code_statement="hash(left)",
-        fast_code_setup=setup_statement,
-        fast_code_statement="hash(fast_left)",
+        left_setup=setup_statement,
+        left_statement="hash(left)",
+        right_setup=setup_statement,
+        right_statement="hash(fast_left)",
         min_performance_factor=10,
     )
 
@@ -37,10 +37,10 @@ def test_hash(setup_statement: str) -> None:
 def test_in_set(setup_statement: str) -> None:
     """Test that `fast_frozen_dataclass` is faster for repeated set-inclusion checks."""
     assert_performance_factor(
-        slow_code_setup=setup_statement,
-        slow_code_statement="left in item_group_set",
-        fast_code_setup=setup_statement,
-        fast_code_statement="fast_left in fast_item_group_set",
+        left_setup=setup_statement,
+        left_statement="left in item_group_set",
+        right_setup=setup_statement,
+        right_statement="fast_left in fast_item_group_set",
         min_performance_factor=10,
     )
 
@@ -48,10 +48,10 @@ def test_in_set(setup_statement: str) -> None:
 def test_in_dict(setup_statement: str) -> None:
     """Test that `fast_frozen_dataclass` is faster for repeated dict-inclusion checks."""
     assert_performance_factor(
-        slow_code_setup=setup_statement,
-        slow_code_statement="left in item_group_dict",
-        fast_code_setup=setup_statement,
-        fast_code_statement="fast_left in fast_item_group_dict",
+        left_setup=setup_statement,
+        left_statement="left in item_group_dict",
+        right_setup=setup_statement,
+        right_statement="fast_left in fast_item_group_dict",
         min_performance_factor=10,
     )
 
@@ -59,10 +59,10 @@ def test_in_dict(setup_statement: str) -> None:
 def test_create(setup_statement: str) -> None:
     """Test that `fast_frozen_dataclass` is faster to create."""
     assert_performance_factor(
-        slow_code_setup=setup_statement,
-        slow_code_statement="create_group('left')",
-        fast_code_setup=setup_statement,
-        fast_code_statement="create_fast_group('left')",
+        left_setup=setup_statement,
+        left_statement="create_group('left')",
+        right_setup=setup_statement,
+        right_statement="create_fast_group('left')",
         min_performance_factor=1.5,
     )
 
@@ -70,10 +70,10 @@ def test_create(setup_statement: str) -> None:
 def test_equals(setup_statement: str) -> None:
     """Test that `fast_frozen_dataclass` has similar equals performance."""
     assert_performance_factor(
-        slow_code_setup=setup_statement,
-        slow_code_statement="left == right",
-        fast_code_setup=setup_statement,
-        fast_code_statement="fast_left == fast_right",
+        left_setup=setup_statement,
+        left_statement="left == right",
+        right_setup=setup_statement,
+        right_statement="fast_left == fast_right",
         # Usually close to 1, but using 0.8 for reduced test flakiness.
         min_performance_factor=0.8,
     )
@@ -82,10 +82,10 @@ def test_equals(setup_statement: str) -> None:
 def test_field_access(setup_statement: str) -> None:
     """Test that `fast_frozen_dataclass` has similar field access performance."""
     assert_performance_factor(
-        slow_code_setup=setup_statement,
-        slow_code_statement="left.item_group_field_0.item_field_0",
-        fast_code_setup=setup_statement,
-        fast_code_statement="fast_left.item_group_field_0.item_field_0",
+        left_setup=setup_statement,
+        left_statement="left.item_group_field_0.item_field_0",
+        right_setup=setup_statement,
+        right_statement="fast_left.item_group_field_0.item_field_0",
         # Usually close to 1, but using 0.8 for reduced test flakiness.
         min_performance_factor=0.8,
     )
@@ -94,10 +94,10 @@ def test_field_access(setup_statement: str) -> None:
 def test_lt(setup_statement: str) -> None:
     """Test that `fast_frozen_dataclass` has similar `<` performance."""
     assert_performance_factor(
-        slow_code_setup=setup_statement,
-        slow_code_statement="left < right",
-        fast_code_setup=setup_statement,
-        fast_code_statement="fast_left < fast_right",
+        left_setup=setup_statement,
+        left_statement="left < right",
+        right_setup=setup_statement,
+        right_statement="fast_left < fast_right",
         # Usually close to 1, but using 0.8 for reduced test flakiness.
         min_performance_factor=0.8,
     )

--- a/metricflow-semantics/tests_metricflow_semantics/experimental/collection_helpers/test_singleton.py
+++ b/metricflow-semantics/tests_metricflow_semantics/experimental/collection_helpers/test_singleton.py
@@ -34,7 +34,7 @@ def test_set_equals(setup_statement: str) -> None:
     """Tests performance of set comparison using singletons."""
     size = 4
     assert_performance_factor(
-        slow_code_setup=mf_newline_join(
+        left_setup=mf_newline_join(
             setup_statement,
             mf_dedent(
                 f"""
@@ -43,8 +43,8 @@ def test_set_equals(setup_statement: str) -> None:
                 """
             ),
         ),
-        slow_code_statement="left == right",
-        fast_code_setup=mf_newline_join(
+        left_statement="left == right",
+        right_setup=mf_newline_join(
             setup_statement,
             mf_dedent(
                 f"""
@@ -53,7 +53,7 @@ def test_set_equals(setup_statement: str) -> None:
                 """
             ),
         ),
-        fast_code_statement="left == right",
+        right_statement="left == right",
         min_performance_factor=25.0,
     )
 
@@ -62,16 +62,16 @@ def test_set_in(setup_statement: str) -> None:
     """Tests performance of set inclusion checks."""
     size = 10
     assert_performance_factor(
-        slow_code_setup=mf_newline_join(
+        left_setup=mf_newline_join(
             setup_statement,
             f"id_set = create_id_set({size})",
         ),
-        slow_code_statement="FIRST_ID in id_set",
-        fast_code_setup=mf_newline_join(
+        left_statement="FIRST_ID in id_set",
+        right_setup=mf_newline_join(
             setup_statement,
             f"singleton_id_set = create_singleton_id_set({size})",
         ),
-        fast_code_statement="FIRST_SINGLETON_ID in singleton_id_set",
+        right_statement="FIRST_SINGLETON_ID in singleton_id_set",
         min_performance_factor=5.0,
     )
 
@@ -80,7 +80,7 @@ def test_tuple_equals(setup_statement: str) -> None:
     """Tests performance of tuple comparisons."""
     size = 4
     assert_performance_factor(
-        slow_code_setup=mf_newline_join(
+        left_setup=mf_newline_join(
             setup_statement,
             mf_dedent(
                 f"""
@@ -89,8 +89,8 @@ def test_tuple_equals(setup_statement: str) -> None:
                 """
             ),
         ),
-        slow_code_statement="left == right",
-        fast_code_setup=mf_newline_join(
+        left_statement="left == right",
+        right_setup=mf_newline_join(
             setup_statement,
             mf_dedent(
                 f"""
@@ -99,7 +99,7 @@ def test_tuple_equals(setup_statement: str) -> None:
                 """
             ),
         ),
-        fast_code_statement="left == right",
+        right_statement="left == right",
         min_performance_factor=50.0,
     )
 
@@ -112,8 +112,8 @@ def test_create_new(setup_statement: str) -> None:
     size = 1000
     setup_statement = mf_newline_join(setup_statement, "import random")
     assert_performance_factor(
-        slow_code_setup=setup_statement,
-        slow_code_statement=mf_dedent(
+        left_setup=setup_statement,
+        left_statement=mf_dedent(
             f"""
             start_index = random.randint(0, 1_000_000_000_000)
             for i in range(start_index, start_index + {size}):
@@ -123,8 +123,8 @@ def test_create_new(setup_statement: str) -> None:
                 )
             """
         ),
-        fast_code_setup=setup_statement,
-        fast_code_statement=mf_dedent(
+        right_setup=setup_statement,
+        right_statement=mf_dedent(
             f"""
             start_index = random.randint(0, 1_000_000_000_000)
             for i in range(start_index, start_index + {size}):
@@ -151,8 +151,8 @@ def test_create_existing(setup_statement: str) -> None:
         """
     )
     assert_performance_factor(
-        slow_code_setup=setup_statement,
-        slow_code_statement=mf_dedent(
+        left_setup=setup_statement,
+        left_statement=mf_dedent(
             f"""
             for _ in range({size}):
                 CompositeId(
@@ -161,7 +161,7 @@ def test_create_existing(setup_statement: str) -> None:
                 )
             """
         ),
-        fast_code_setup=mf_newline_join(setup_statement, get_singleton_statement),
-        fast_code_statement=get_singleton_statement,
+        right_setup=mf_newline_join(setup_statement, get_singleton_statement),
+        right_statement=get_singleton_statement,
         min_performance_factor=0.25,
     )

--- a/metricflow-semantics/tests_metricflow_semantics/test_benchmark.py
+++ b/metricflow-semantics/tests_metricflow_semantics/test_benchmark.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import logging
+from abc import ABC
+
+from metricflow_semantics.experimental.test_helpers.performance_helpers import BenchmarkFunction, PerformanceBenchmark
+
+logger = logging.getLogger(__name__)
+
+
+def test_assert_performance_factor() -> None:
+    """Using `assert_function_performance`, check that a function that does 1/2 the work shows 2x performance.
+
+    The left function adds 20,000 strings to a set while the right function adds 10,000 strings to a set.
+    """
+
+    class _AddStringsToSetFunction(BenchmarkFunction, ABC):
+        def __init__(self, string_count: int) -> None:
+            self._string_count = string_count
+
+        def run(self) -> None:
+            items: set[str] = set()
+            for i in range(self._string_count):
+                items.add(str(i))
+
+    class _LeftFunction(_AddStringsToSetFunction):
+        def __init__(self) -> None:
+            super().__init__(20_000)
+
+    class _RightFunction(_AddStringsToSetFunction):
+        def __init__(self) -> None:
+            super().__init__(10_000)
+
+    PerformanceBenchmark.assert_function_performance(
+        left_function_class=_LeftFunction,
+        right_function_class=_RightFunction,
+        min_performance_factor=2,
+    )


### PR DESCRIPTION
This PR adds a helper that makes it easier to write tests that compare performance of function calls using `timeit`. The issue with `timeit` is that the arguments are strings of code snippets. Those strings are annoying to write as the IDE inspections don't work / `mypy` does not do type checks. In addition, all required imports must be included in the code snippets.

The helper provides a closure that can be written normally and is instantiated in the `timeit` statement. Please view by commit as there were some renames that are included.

The helper is a WIP so this PR does not migrate existing performance tests.