### PR TITLE
Add semantic-graph node classes

### DIFF
--- a/.changes/unreleased/Under the Hood-20250724-212448.yaml
+++ b/.changes/unreleased/Under the Hood-20250724-212448.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Add semantic-graph node classes
+time: 2025-07-24T21:24:48.723416-07:00
+custom:
+  Author: plypaul
+  Issue: "1791"

--- a/metricflow-semantics/metricflow_semantics/experimental/semantic_graph/attribute_resolution/attribute_recipe_step.py
+++ b/metricflow-semantics/metricflow_semantics/experimental/semantic_graph/attribute_resolution/attribute_recipe_step.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import logging
+from abc import ABC
+from functools import cached_property
+from typing import Optional
+
+from dbt_semantic_interfaces.type_enums import DatePart, TimeGranularity
+from typing_extensions import override
+
+from metricflow_semantics.collection_helpers.mf_type_aliases import AnyLengthTuple
+from metricflow_semantics.dag.mf_dag import DisplayedProperty
+from metricflow_semantics.experimental.dataclass_helpers import fast_frozen_dataclass
+from metricflow_semantics.experimental.mf_graph.comparable import Comparable, ComparisonKey
+from metricflow_semantics.experimental.mf_graph.graph_element import HasDisplayedProperty
+from metricflow_semantics.experimental.semantic_graph.model_id import SemanticModelId
+from metricflow_semantics.model.linkable_element_property import LinkableElementProperty
+from metricflow_semantics.model.semantics.linkable_element import LinkableElementType
+from metricflow_semantics.time.granularity import ExpandedTimeGranularity
+
+logger = logging.getLogger(__name__)
+
+
+@fast_frozen_dataclass(order=False)
+class AttributeRecipeStep(HasDisplayedProperty, Comparable):
+    """A step that should be added to the `AttributeRecipe`.
+
+    A path from a metric / measure node to an attribute node in the semantic graph describes the computation that is
+    required to generate the corresponding query. The computation is represented by a `AttributeRecipe`.
+
+    The nodes / edges in the path specify additions to the recipe. For example, an edge from one entity node to
+    another entity node would specify a step to join to a semantic model.
+
+    Currently, the recipe stores aggregated properties, and each step generally adds or sets some of those
+    properties. However, the recipe can be updated to include more context so that it can be used in the
+    `DataflowPlanBuilder`.
+    """
+
+    # Adds an element to the dunder name. For example, the edge from the `user` entity node to the
+    # `country_latest` attribute node would add the `country_latest` element.
+    add_dunder_name_element: Optional[str] = None
+    # Adds a property that describes that attribute. For example, the metric-time entity node would add the
+    # `METRIC_TIME` property.
+    add_properties: Optional[AnyLengthTuple[LinkableElementProperty]] = None
+    add_model_join: Optional[SemanticModelId] = None
+    add_entity_link: Optional[str] = None
+
+    # Set the element type. For example. visiting a time-dimension entity node would set this to `TIME_DIMENSION`.
+    set_element_type: Optional[LinkableElementType] = None
+    # To handle the case where time dimensions have a defined grain, the minimum time grain can be set to limit the
+    # attribute nodes accessible later in the path.
+    set_min_time_grain: Optional[TimeGranularity] = None
+    # With `set_min_time_grain`, `set_time_grain_access` can be used to check for valid paths. e.g. the node associated
+    # with a time dimension with a `month` defined grain can block access to edges that specify access to `day`.
+    set_time_grain_access: Optional[ExpandedTimeGranularity] = None
+    set_date_part_access: Optional[DatePart] = None
+    # Some edges prevent access of date part attributes (e.g. cumulative metrics)
+    set_deny_date_part: Optional[bool] = None
+
+    @override
+    @property
+    def comparison_key(self) -> ComparisonKey:
+        return (
+            self.add_dunder_name_element,
+            self.add_properties,
+            self.add_model_join,
+            self.set_min_time_grain.value if self.set_min_time_grain is not None else None,
+            self.set_element_type,
+            self.add_entity_link,
+            self.set_time_grain_access,
+            self.set_date_part_access.to_int() if self.set_date_part_access is not None else None,
+            self.set_deny_date_part,
+        )
+
+    @override
+    @cached_property
+    def displayed_properties(self) -> AnyLengthTuple[DisplayedProperty]:
+        properties = list(super().displayed_properties)
+
+        if self.add_dunder_name_element is not None:
+            properties.append(
+                DisplayedProperty("add_name", self.add_dunder_name_element),
+            )
+        for linkable_element_property_addition in self.add_properties or ():
+            properties.append(DisplayedProperty("add_prop", linkable_element_property_addition.name))
+        if self.add_model_join is not None:
+            properties.append(DisplayedProperty("add_model_join", self.add_model_join.model_name))
+        if self.set_min_time_grain is not None:
+            properties.append(DisplayedProperty("set_min_grain", self.set_min_time_grain.name))
+        if self.set_element_type is not None:
+            properties.append(DisplayedProperty("add_type", self.set_element_type.name))
+        if self.add_entity_link is not None:
+            properties.append(DisplayedProperty("add_entity_link", self.add_entity_link))
+        if self.set_time_grain_access is not None:
+            properties.append(DisplayedProperty("set_time_grain", self.set_time_grain_access.name))
+        if self.set_date_part_access is not None:
+            properties.append(DisplayedProperty("set_date_part", self.set_date_part_access.name))
+        if self.set_deny_date_part is not None:
+            properties.append(DisplayedProperty("set_deny_date_part", self.set_deny_date_part))
+        return tuple(properties)
+
+
+class AttributeRecipeStepProvider(HasDisplayedProperty, ABC):
+    """Interface for a class that provides a step that can be appended to a recipe."""
+
+    @cached_property
+    def recipe_step_to_append(self) -> AttributeRecipeStep:  # noqa: D102
+        return AttributeRecipeStep()

--- a/metricflow-semantics/metricflow_semantics/experimental/semantic_graph/nodes/attribute_nodes.py
+++ b/metricflow-semantics/metricflow_semantics/experimental/semantic_graph/nodes/attribute_nodes.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+from abc import ABC
+from functools import cached_property
+
+from dbt_semantic_interfaces.type_enums import DatePart, TimeGranularity
+from typing_extensions import override
+
+from metricflow_semantics.experimental.mf_graph.comparable import ComparisonKey
+from metricflow_semantics.experimental.mf_graph.formatting.dot_attributes import (
+    DotColor,
+    DotNodeAttributeSet,
+)
+from metricflow_semantics.experimental.mf_graph.graph_labeling import MetricflowGraphLabel
+from metricflow_semantics.experimental.mf_graph.node_descriptor import MetricflowGraphNodeDescriptor
+from metricflow_semantics.experimental.ordered_set import FrozenOrderedSet, OrderedSet
+from metricflow_semantics.experimental.semantic_graph.attribute_resolution.attribute_recipe_step import (
+    AttributeRecipeStep,
+)
+from metricflow_semantics.experimental.semantic_graph.nodes.node_labels import (
+    GroupByAttributeLabel,
+    KeyAttributeLabel,
+    TimeClusterLabel,
+)
+from metricflow_semantics.experimental.semantic_graph.sg_constant import ClusterNameFactory
+from metricflow_semantics.experimental.semantic_graph.sg_interfaces import SemanticGraphNode
+from metricflow_semantics.experimental.singleton_decorator import singleton_dataclass
+from metricflow_semantics.model.linkable_element_property import LinkableElementProperty
+from metricflow_semantics.model.semantics.linkable_element import LinkableElementType
+from metricflow_semantics.naming.linkable_spec_name import StructuredLinkableSpecName
+from metricflow_semantics.time.granularity import ExpandedTimeGranularity
+
+
+@singleton_dataclass(order=False)
+class AttributeNode(SemanticGraphNode, ABC):
+    """ABC for attribute nodes. See `SemanticGraph` for additional context on usage."""
+
+    attribute_name: str
+
+    @cached_property
+    @override
+    def comparison_key(self) -> ComparisonKey:
+        return (self.attribute_name,)
+
+    @cached_property
+    @override
+    def node_descriptor(self) -> MetricflowGraphNodeDescriptor:
+        return MetricflowGraphNodeDescriptor.get_instance(node_name=f"{self.__class__.__name__}({self.attribute_name})")
+
+    @override
+    def as_dot_node(self, include_graphical_attributes: bool) -> DotNodeAttributeSet:
+        dot_node = super(AttributeNode, self).as_dot_node(include_graphical_attributes)
+        if include_graphical_attributes:
+            dot_node = dot_node.with_attributes(color=DotColor.SALMON_PINK)
+        return dot_node
+
+    @cached_property
+    @override
+    def labels(self) -> OrderedSet[MetricflowGraphLabel]:
+        return FrozenOrderedSet((GroupByAttributeLabel(),))
+
+    @cached_property
+    @override
+    def recipe_step_to_append(self) -> AttributeRecipeStep:
+        return AttributeRecipeStep(
+            add_dunder_name_element=self.attribute_name,
+        )
+
+
+@singleton_dataclass(order=False)
+class TimeAttributeNode(AttributeNode):
+    """An attribute node that corresponds to the different time grains available for querying time dimensions.
+
+    e.g. the graph would contain instances for `day`, `dow`, `month`...
+    """
+
+    element_property_additions: FrozenOrderedSet[LinkableElementProperty]
+
+    @staticmethod
+    def get_instance_for_time_grain(time_grain: TimeGranularity) -> TimeAttributeNode:  # noqa: D102
+        return TimeAttributeNode(
+            attribute_name=time_grain.value,
+            element_property_additions=FrozenOrderedSet(),
+        )
+
+    @staticmethod
+    def get_instance_for_date_part(date_part: DatePart) -> TimeAttributeNode:  # noqa: D102
+        return TimeAttributeNode(
+            attribute_name=StructuredLinkableSpecName.date_part_suffix(date_part),
+            element_property_additions=FrozenOrderedSet((LinkableElementProperty.DATE_PART,)),
+        )
+
+    @staticmethod
+    def get_instance_for_expanded_time_grain(  # noqa: D102
+        expanded_time_grain: ExpandedTimeGranularity,
+    ) -> TimeAttributeNode:
+        return TimeAttributeNode(
+            attribute_name=expanded_time_grain.name,
+            element_property_additions=FrozenOrderedSet((LinkableElementProperty.DERIVED_TIME_GRANULARITY,)),
+        )
+
+    @cached_property
+    @override
+    def node_descriptor(self) -> MetricflowGraphNodeDescriptor:
+        return MetricflowGraphNodeDescriptor.get_instance(
+            node_name=f"TimeAttribute({self.attribute_name})",
+            cluster_name=ClusterNameFactory.TIME,
+        )
+
+    @cached_property
+    @override
+    def labels(self) -> OrderedSet[MetricflowGraphLabel]:
+        return super(TimeAttributeNode, self).labels.union((TimeClusterLabel.get_instance(),))
+
+
+@singleton_dataclass(order=False)
+class KeyAttributeNode(AttributeNode):
+    """Represents the attribute corresponding to the value of a configured entity.
+
+    In the current MF interface, a "query for an entity" means a query for the column values associated with the
+    configured entity in a semantic model. To avoid confusion between entities in the semantic graph and entities
+    configured in semantic models, "query for an entity" is phrased as "query for an entity key" in the semantic graph
+    module.
+
+    Consider using the phrase `entity value` instead.
+    """
+
+    @staticmethod
+    def get_instance(entity_name: str) -> KeyAttributeNode:  # noqa: D102
+        return KeyAttributeNode(attribute_name=entity_name)
+
+    @property
+    @override
+    def node_descriptor(self) -> MetricflowGraphNodeDescriptor:
+        return MetricflowGraphNodeDescriptor.get_instance(
+            node_name=f"KeyAttribute({self.attribute_name})",
+            cluster_name=ClusterNameFactory.KEY,
+        )
+
+    @cached_property
+    @override
+    def recipe_step_to_append(self) -> AttributeRecipeStep:
+        return AttributeRecipeStep(
+            add_dunder_name_element=self.attribute_name,
+            add_properties=(LinkableElementProperty.ENTITY,),
+            set_element_type=LinkableElementType.ENTITY,
+        )
+
+    @cached_property
+    @override
+    def labels(self) -> OrderedSet[MetricflowGraphLabel]:
+        return super(KeyAttributeNode, self).labels.union((KeyAttributeLabel.get_instance(),))
+
+
+@singleton_dataclass(order=False)
+class CategoricalDimensionAttributeNode(AttributeNode):
+    """Represents a dimension in a semantic model with `DimensionType.CATEGORICAL`."""
+
+    @property
+    @override
+    def node_descriptor(self) -> MetricflowGraphNodeDescriptor:
+        return MetricflowGraphNodeDescriptor.get_instance(
+            node_name=f"Dimension({self.attribute_name})", cluster_name=ClusterNameFactory.DIMENSION
+        )
+
+    @property
+    @override
+    def recipe_step_to_append(self) -> AttributeRecipeStep:
+        return AttributeRecipeStep(
+            add_dunder_name_element=self.attribute_name,
+            set_element_type=LinkableElementType.DIMENSION,
+        )

--- a/metricflow-semantics/metricflow_semantics/experimental/semantic_graph/nodes/entity_nodes.py
+++ b/metricflow-semantics/metricflow_semantics/experimental/semantic_graph/nodes/entity_nodes.py
@@ -1,0 +1,383 @@
+from __future__ import annotations
+
+import logging
+from abc import ABC
+from functools import cached_property
+
+from dbt_semantic_interfaces.naming.keywords import METRIC_TIME_ELEMENT_NAME
+from typing_extensions import override
+
+from metricflow_semantics.experimental.mf_graph.comparable import ComparisonKey
+from metricflow_semantics.experimental.mf_graph.formatting.dot_attributes import (
+    DotColor,
+    DotNodeAttributeSet,
+)
+from metricflow_semantics.experimental.mf_graph.graph_labeling import MetricflowGraphLabel
+from metricflow_semantics.experimental.mf_graph.node_descriptor import MetricflowGraphNodeDescriptor
+from metricflow_semantics.experimental.ordered_set import FrozenOrderedSet, OrderedSet
+from metricflow_semantics.experimental.semantic_graph.attribute_resolution.attribute_recipe_step import (
+    AttributeRecipeStep,
+)
+from metricflow_semantics.experimental.semantic_graph.model_id import SemanticModelId
+from metricflow_semantics.experimental.semantic_graph.nodes.node_labels import (
+    BaseMetricLabel,
+    ConfiguredEntityLabel,
+    DerivedMetricLabel,
+    JoinedModelLabel,
+    LocalModelLabel,
+    MeasureLabel,
+    MetricLabel,
+    MetricTimeLabel,
+    TimeClusterLabel,
+    TimeDimensionLabel,
+)
+from metricflow_semantics.experimental.semantic_graph.sg_constant import ClusterNameFactory
+from metricflow_semantics.experimental.semantic_graph.sg_interfaces import SemanticGraphNode
+from metricflow_semantics.experimental.singleton_decorator import singleton_dataclass
+from metricflow_semantics.model.linkable_element_property import LinkableElementProperty
+from metricflow_semantics.model.semantics.linkable_element import LinkableElementType
+
+logger = logging.getLogger(__name__)
+
+
+@singleton_dataclass(order=False)
+class ConfiguredEntityNode(SemanticGraphNode):
+    """Represents an `entity` element as configured in a semantic model / manifest.
+
+    This node is named "configured" to avoid confusion between entities in the semantic manifest and entities in the
+    semantic graph.
+    """
+
+    entity_name: str
+    model_id: SemanticModelId
+
+    @staticmethod
+    def get_instance(entity_name: str, model_id: SemanticModelId) -> ConfiguredEntityNode:  # noqa: D102
+        return ConfiguredEntityNode(
+            entity_name=entity_name,
+            model_id=model_id,
+        )
+
+    @cached_property
+    @override
+    def comparison_key(self) -> ComparisonKey:
+        return (self.entity_name, self.model_id)
+
+    @override
+    def as_dot_node(self, include_graphical_attributes: bool) -> DotNodeAttributeSet:
+        dot_node = super(ConfiguredEntityNode, self).as_dot_node(include_graphical_attributes)
+        if include_graphical_attributes:
+            dot_node = dot_node.with_attributes(color=DotColor.CORNFLOWER_BLUE)
+        return dot_node
+
+    @cached_property
+    @override
+    def node_descriptor(self) -> MetricflowGraphNodeDescriptor:
+        return MetricflowGraphNodeDescriptor.get_instance(
+            node_name=f"{self.model_id}.{self.entity_name}",
+            cluster_name=ClusterNameFactory.CONFIGURED_ENTITY,
+        )
+
+    @cached_property
+    @override
+    def labels(self) -> OrderedSet[MetricflowGraphLabel]:
+        return FrozenOrderedSet((ConfiguredEntityLabel.get_instance(),))
+
+    @cached_property
+    @override
+    def recipe_step_to_append(self) -> AttributeRecipeStep:
+        return AttributeRecipeStep(
+            add_entity_link=self.entity_name,
+            add_dunder_name_element=self.entity_name,
+        )
+
+
+@singleton_dataclass(order=False)
+class JoinedModelNode(SemanticGraphNode):
+    """An entity that represents the attributes accessible from a semantic model when the name includes an entity link.
+
+    In the query interface, the description for a group-by item (e.g. with the dunder name, `listing__country_latest`
+    `listing` is the entity link).
+
+    An entity link often means a join between semantic models, but not always. For example, dimensions
+    can be queried with the associated primary entity name as the entity link even when the query does not require
+    joining semantic models.
+
+    To capture this behavior, semantic models are represented with 2 seperate nodes.
+    """
+
+    model_id: SemanticModelId
+
+    @staticmethod
+    def get_instance(model_id: SemanticModelId) -> JoinedModelNode:  # noqa: D102
+        return JoinedModelNode(model_id=model_id)
+
+    @cached_property
+    @override
+    def node_descriptor(self) -> MetricflowGraphNodeDescriptor:
+        return MetricflowGraphNodeDescriptor.get_instance(
+            node_name=f"JoinedModel({self.model_id})",
+            cluster_name=ClusterNameFactory.get_name_for_model(self.model_id),
+        )
+
+    @cached_property
+    @override
+    def comparison_key(self) -> ComparisonKey:
+        return self.model_id.comparison_key
+
+    @cached_property
+    @override
+    def labels(self) -> OrderedSet[MetricflowGraphLabel]:
+        return FrozenOrderedSet((JoinedModelLabel.get_instance(),))
+
+
+@singleton_dataclass(order=False)
+class LocalModelNode(SemanticGraphNode):
+    """An entity that represents the attributes accessible from a semantic model without entity links.
+
+    Also see `JoinedModelNode`.
+    """
+
+    model_id: SemanticModelId
+
+    @staticmethod
+    def get_instance(model_id: SemanticModelId) -> LocalModelNode:  # noqa: D102
+        return LocalModelNode(model_id=model_id)
+
+    @cached_property
+    @override
+    def node_descriptor(self) -> MetricflowGraphNodeDescriptor:
+        return MetricflowGraphNodeDescriptor.get_instance(
+            node_name=f"LocalModel({self.model_id})",
+            cluster_name=ClusterNameFactory.get_name_for_model(self.model_id),
+        )
+
+    @cached_property
+    @override
+    def comparison_key(self) -> ComparisonKey:
+        return self.model_id.comparison_key
+
+    @cached_property
+    @override
+    def labels(self) -> OrderedSet[MetricflowGraphLabel]:
+        return FrozenOrderedSet((LocalModelLabel.get_instance(),))
+
+    @cached_property
+    @override
+    def recipe_step_to_append(self) -> AttributeRecipeStep:
+        return AttributeRecipeStep(add_model_join=self.model_id)
+
+
+@singleton_dataclass(order=False)
+class TimeDimensionNode(SemanticGraphNode):
+    """An entity representing a time dimension configured in a semantic model.
+
+    In the semantic graph, time dimensions are represented as entities that are related to the time entity. The time
+    entity has edges to the different queryable grain-related attributes (e.g. `day`, `month`).
+    """
+
+    dimension_name: str
+
+    @staticmethod
+    def get_instance(dimension_name: str) -> TimeDimensionNode:  # noqa: D102
+        return TimeDimensionNode(dimension_name=dimension_name)
+
+    @cached_property
+    @override
+    def node_descriptor(self) -> MetricflowGraphNodeDescriptor:
+        return MetricflowGraphNodeDescriptor.get_instance(
+            node_name=f"TimeDimension({self.dimension_name})",
+            cluster_name=ClusterNameFactory.TIME_DIMENSION,
+        )
+
+    @cached_property
+    @override
+    def comparison_key(self) -> ComparisonKey:
+        return (self.dimension_name,)
+
+    @cached_property
+    @override
+    def recipe_step_to_append(self) -> AttributeRecipeStep:
+        return AttributeRecipeStep(
+            add_dunder_name_element=self.dimension_name,
+            set_element_type=LinkableElementType.TIME_DIMENSION,
+        )
+
+
+@singleton_dataclass(order=False)
+class MetricTimeNode(SemanticGraphNode):
+    """An entity that represents `metric_time`."""
+
+    @staticmethod
+    def get_instance() -> MetricTimeNode:  # noqa: D102
+        return MetricTimeNode()
+
+    @cached_property
+    @override
+    def node_descriptor(self) -> MetricflowGraphNodeDescriptor:
+        return MetricflowGraphNodeDescriptor.get_instance(
+            node_name="MetricTime",
+            cluster_name=ClusterNameFactory.TIME_DIMENSION,
+        )
+
+    @cached_property
+    @override
+    def comparison_key(self) -> ComparisonKey:
+        return ()
+
+    @cached_property
+    @override
+    def labels(self) -> OrderedSet[MetricflowGraphLabel]:
+        return FrozenOrderedSet((MetricTimeLabel.get_instance(), TimeDimensionLabel.get_instance()))
+
+    @cached_property
+    @override
+    def recipe_step_to_append(self) -> AttributeRecipeStep:
+        return AttributeRecipeStep(
+            add_dunder_name_element=METRIC_TIME_ELEMENT_NAME,
+            add_properties=(LinkableElementProperty.METRIC_TIME,),
+            set_element_type=LinkableElementType.TIME_DIMENSION,
+        )
+
+
+@singleton_dataclass(order=False)
+class TimeNode(SemanticGraphNode):
+    """An entity representing time.
+
+    Other entities related to time (time dimensions, metric time) have an edge to this node.
+    """
+
+    @staticmethod
+    def get_instance() -> TimeNode:  # noqa: D102
+        return TimeNode()
+
+    @cached_property
+    @override
+    def node_descriptor(self) -> MetricflowGraphNodeDescriptor:
+        return MetricflowGraphNodeDescriptor.get_instance(
+            node_name="TimeEntity",
+            cluster_name=ClusterNameFactory.TIME,
+        )
+
+    @cached_property
+    @override
+    def comparison_key(self) -> ComparisonKey:
+        return ()
+
+    @cached_property
+    @override
+    def labels(self) -> OrderedSet[MetricflowGraphLabel]:
+        return FrozenOrderedSet((TimeClusterLabel.get_instance(),))
+
+
+@singleton_dataclass(order=False)
+class MetricNode(SemanticGraphNode, ABC):
+    """ABC for nodes that represent a metric."""
+
+    metric_name: str
+
+    @cached_property
+    @override
+    def comparison_key(self) -> ComparisonKey:
+        return (self.metric_name,)
+
+    @cached_property
+    @override
+    def labels(self) -> OrderedSet[MetricflowGraphLabel]:
+        return FrozenOrderedSet((MetricLabel.get_instance(), MetricLabel.get_instance(self.metric_name)))
+
+    @cached_property
+    @override
+    def recipe_step_to_append(self) -> AttributeRecipeStep:
+        return AttributeRecipeStep(
+            add_dunder_name_element=self.metric_name,
+        )
+
+
+@singleton_dataclass(order=False)
+class BaseMetricNode(MetricNode):
+    """Represents a metric without successors to other metric nodes.
+
+    All non-derived metrics are represented by this node.
+    """
+
+    @staticmethod
+    def get_instance(metric_name: str) -> BaseMetricNode:  # noqa: D102
+        return BaseMetricNode(metric_name=metric_name)
+
+    @cached_property
+    @override
+    def node_descriptor(self) -> MetricflowGraphNodeDescriptor:
+        return MetricflowGraphNodeDescriptor.get_instance(
+            node_name=f"BaseMetric({self.metric_name})", cluster_name=ClusterNameFactory.METRIC
+        )
+
+    @cached_property
+    @override
+    def labels(self) -> OrderedSet[MetricflowGraphLabel]:
+        return super(BaseMetricNode, self).labels.union((BaseMetricLabel.get_instance(),))
+
+
+@singleton_dataclass(order=False)
+class DerivedMetricNode(MetricNode):
+    """Represents derived metrics."""
+
+    @staticmethod
+    def get_instance(metric_name: str) -> DerivedMetricNode:  # noqa: D102
+        return DerivedMetricNode(metric_name=metric_name)
+
+    @cached_property
+    @override
+    def node_descriptor(self) -> MetricflowGraphNodeDescriptor:
+        return MetricflowGraphNodeDescriptor.get_instance(
+            node_name=f"DerivedMetric({self.metric_name})", cluster_name=ClusterNameFactory.METRIC
+        )
+
+    @cached_property
+    @override
+    def labels(self) -> OrderedSet[MetricflowGraphLabel]:
+        return super(DerivedMetricNode, self).labels.union((DerivedMetricLabel.get_instance(),))
+
+
+@singleton_dataclass(order=False)
+class MeasureNode(SemanticGraphNode):
+    """Represents measures.
+
+    * Currently modeled as an entity since it's not a leaf node.
+    * The successors of this node include `LocalModelNode`, `JoinedModelNode`, and `MetricTimeNode`.
+    """
+
+    measure_name: str
+    source_model_id: SemanticModelId
+
+    @staticmethod
+    def get_instance(measure_name: str, source_model_id: SemanticModelId) -> MeasureNode:  # noqa: D102
+        return MeasureNode(
+            measure_name=measure_name,
+            source_model_id=source_model_id,
+        )
+
+    @cached_property
+    @override
+    def node_descriptor(self) -> MetricflowGraphNodeDescriptor:
+        return MetricflowGraphNodeDescriptor.get_instance(
+            node_name=f"Measure({self.measure_name})",
+            cluster_name=ClusterNameFactory.get_name_for_model(self.source_model_id),
+        )
+
+    @override
+    def as_dot_node(self, include_graphical_attributes: bool) -> DotNodeAttributeSet:
+        dot_node = super(SemanticGraphNode, self).as_dot_node(include_graphical_attributes)
+        if include_graphical_attributes:
+            dot_node = dot_node.with_attributes(color=DotColor.LIME_GREEN)
+        return dot_node
+
+    @cached_property
+    @override
+    def labels(self) -> FrozenOrderedSet[MetricflowGraphLabel]:
+        return FrozenOrderedSet((MeasureLabel(measure_name=None), MeasureLabel(measure_name=self.measure_name)))
+
+    @cached_property
+    @override
+    def comparison_key(self) -> ComparisonKey:
+        return (self.measure_name,)

--- a/metricflow-semantics/metricflow_semantics/experimental/semantic_graph/nodes/node_labels.py
+++ b/metricflow-semantics/metricflow_semantics/experimental/semantic_graph/nodes/node_labels.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from metricflow_semantics.experimental.mf_graph.graph_labeling import MetricflowGraphLabel
+from metricflow_semantics.experimental.singleton_decorator import singleton_dataclass
+
+logger = logging.getLogger(__name__)
+
+
+@singleton_dataclass()
+class MeasureLabel(MetricflowGraphLabel):
+    """Used to label measure nodes.
+
+    `measure_name = None` is a label applied to all measure nodes.
+    """
+
+    measure_name: Optional[str]
+
+    @staticmethod
+    def get_instance(measure_name: Optional[str] = None) -> MeasureLabel:  # noqa: D102
+        return MeasureLabel(measure_name=measure_name)
+
+
+@singleton_dataclass()
+class GroupByAttributeLabel(MetricflowGraphLabel):
+    """Label for any attribute node that can be used in the group-by argument of an MF query."""
+
+    @staticmethod
+    def get_instance() -> GroupByAttributeLabel:  # noqa: D102
+        return GroupByAttributeLabel()
+
+
+@singleton_dataclass()
+class ConfiguredEntityLabel(MetricflowGraphLabel):
+    """Label for nodes that correspond to entities configured in a semantic model."""
+
+    @staticmethod
+    def get_instance() -> ConfiguredEntityLabel:  # noqa: D102
+        return ConfiguredEntityLabel()
+
+
+@singleton_dataclass()
+class TimeDimensionLabel(MetricflowGraphLabel):
+    """Label for time dimension nodes."""
+
+    @staticmethod
+    def get_instance() -> TimeDimensionLabel:  # noqa: D102
+        return TimeDimensionLabel()
+
+
+@singleton_dataclass()
+class TimeClusterLabel(MetricflowGraphLabel):
+    """Label for nodes that should be clustered together in the `time` section when visualizing the graph."""
+
+    @staticmethod
+    def get_instance() -> TimeClusterLabel:  # noqa: D102
+        return TimeClusterLabel()
+
+
+@singleton_dataclass()
+class MetricTimeLabel(MetricflowGraphLabel):
+    """Label for the node that represents metric-time."""
+
+    @staticmethod
+    def get_instance() -> MetricTimeLabel:  # noqa: D102
+        return MetricTimeLabel()
+
+
+@singleton_dataclass()
+class MetricLabel(MetricflowGraphLabel):
+    """Label for the node that corresponds to a configured metric in the semantic manifest.
+
+    `metric_name = None` is a label applied to all metric nodes.
+    """
+
+    metric_name: Optional[str]
+
+    @staticmethod
+    def get_instance(metric_name: Optional[str] = None) -> MetricLabel:  # noqa: D102
+        return MetricLabel(metric_name=metric_name)
+
+
+@singleton_dataclass()
+class BaseMetricLabel(MetricflowGraphLabel):
+    """Label for nodes that represent a non-derived metric."""
+
+    @staticmethod
+    def get_instance() -> BaseMetricLabel:  # noqa: D102
+        return BaseMetricLabel()
+
+
+@singleton_dataclass()
+class DerivedMetricLabel(MetricflowGraphLabel):
+    """Label for nodes that represent a derived metric."""
+
+    @staticmethod
+    def get_instance() -> DerivedMetricLabel:  # noqa: D102
+        return DerivedMetricLabel()
+
+
+@singleton_dataclass()
+class JoinedModelLabel(MetricflowGraphLabel):
+    """Label for nodes that represent a joined semantic model.
+
+    See `JoinedModelNode`.
+    """
+
+    @staticmethod
+    def get_instance() -> JoinedModelLabel:  # noqa: D102
+        return JoinedModelLabel()
+
+
+@singleton_dataclass()
+class LocalModelLabel(MetricflowGraphLabel):
+    """Label for nodes that represent a local semantic model.
+
+    See `LocalModelNode`.
+    """
+
+    @staticmethod
+    def get_instance() -> LocalModelLabel:  # noqa: D102
+        return LocalModelLabel()
+
+
+@singleton_dataclass()
+class KeyAttributeLabel(MetricflowGraphLabel):
+    """Label for nodes that correspond to the entity-key attribute nodes."""
+
+    @staticmethod
+    def get_instance() -> KeyAttributeLabel:  # noqa: D102
+        return KeyAttributeLabel()

--- a/metricflow-semantics/metricflow_semantics/experimental/semantic_graph/sg_constant.py
+++ b/metricflow-semantics/metricflow_semantics/experimental/semantic_graph/sg_constant.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import logging
+from typing import Final, final
+
+from typing_extensions import override
+
+from metricflow_semantics.experimental.semantic_graph.model_id import SemanticModelId
+from metricflow_semantics.mf_logging.lazy_formattable import LazyFormat
+
+logger = logging.getLogger(__name__)
+
+
+@final
+class ClusterNameFactory:
+    """Creates cluster names for the semantic graph.
+
+    * Currently, the cluster name is only used to group related nodes in the semantic graph for visualizations.
+    * Clusters / subgraphs could be later used to improve semantic-graph traversal.
+    * Additional refinement is pending (e.g. switch to subgraphs, use `ClusterId`).
+    """
+
+    TIME: Final[str] = "time"
+    KEY: Final[str] = "key"
+    CONFIGURED_ENTITY: Final[str] = "configured_entity"
+    DIMENSION: Final[str] = "dimension"
+    METRIC: Final[str] = "metric"
+    TIME_DIMENSION: Final[str] = "time_dimension"
+
+    @override
+    def __init__(self) -> None:
+        """Can't override `__new__` as that results in a type-check error."""
+        raise TypeError(LazyFormat("Class should not be instantiated", cls=self.__class__))
+
+    @staticmethod
+    def get_name_for_configured_entity(entity_name: str, model_id: SemanticModelId) -> str:  # noqa: D102
+        return f"{model_id}.{entity_name}"
+
+    @staticmethod
+    def get_name_for_model(model_id: SemanticModelId) -> str:  # noqa: D102
+        """Return the cluster name that should be used to group nodes associated with a specific semantic model."""
+        return model_id.model_name

--- a/metricflow-semantics/metricflow_semantics/experimental/semantic_graph/sg_interfaces.py
+++ b/metricflow-semantics/metricflow_semantics/experimental/semantic_graph/sg_interfaces.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import logging
+from abc import ABC
+from collections import defaultdict
+from dataclasses import dataclass
+
+from typing_extensions import Optional, override
+
+from metricflow_semantics.collection_helpers.mf_type_aliases import AnyLengthTuple
+from metricflow_semantics.collection_helpers.syntactic_sugar import mf_flatten
+from metricflow_semantics.dag.mf_dag import DisplayedProperty
+from metricflow_semantics.experimental.mf_graph.formatting.dot_attributes import DotGraphAttributeSet
+from metricflow_semantics.experimental.mf_graph.graph_id import MetricflowGraphId, SequentialGraphId
+from metricflow_semantics.experimental.mf_graph.graph_labeling import MetricflowGraphLabel
+from metricflow_semantics.experimental.mf_graph.mf_graph import (
+    MetricflowGraph,
+    MetricflowGraphEdge,
+    MetricflowGraphNode,
+)
+from metricflow_semantics.experimental.mf_graph.mutable_graph import MutableGraph
+from metricflow_semantics.experimental.ordered_set import MutableOrderedSet
+from metricflow_semantics.experimental.semantic_graph.attribute_resolution.attribute_recipe_step import (
+    AttributeRecipeStepProvider,
+)
+from metricflow_semantics.mf_logging.pretty_formattable import MetricFlowPrettyFormattable
+from metricflow_semantics.mf_logging.pretty_formatter import PrettyFormatContext
+
+logger = logging.getLogger(__name__)
+
+
+class SemanticGraphNode(MetricflowGraphNode, AttributeRecipeStepProvider, MetricFlowPrettyFormattable, ABC):
+    """A node in the semantic graph.
+
+    At the top level, the semantic graph has two types of nodes: entity nodes and attribute nodes. Entity nodes have
+    other entity nodes or attribute nodes as successors while attribute nodes do not have any successors (leaf nodes).
+
+    The entity nodes in the semantic graph are not directly mapped from entities configured in the semantic manifest.
+    The one that corresponds to an entity in the manifest are instances of `ConfiguredEntityNode`. However, there
+    are other entity nodes that model other relationships. For example, `metric_time` is represented by the
+    metric-time entity node, and there is a time-entity node that relates time dimensions and metric time. to the
+    various time grains (the time grains (e.g. `day`, `year`) map to attribute nodes).
+
+    Please see the subclasses for more details.
+    """
+
+    @override
+    def pretty_format(self, format_context: PrettyFormatContext) -> Optional[str]:
+        return self.node_descriptor.node_name
+
+    @property
+    @override
+    def displayed_properties(self) -> AnyLengthTuple[DisplayedProperty]:
+        properties: list[DisplayedProperty] = list(super().displayed_properties)
+        if self.recipe_step_to_append is not None:
+            properties.extend(self.recipe_step_to_append.displayed_properties)
+        properties.extend(DisplayedProperty("label", label) for label in self.labels)
+        return tuple(properties)
+
+    @property
+    def dunder_name_element(self) -> Optional[str]:
+        """This node's associated dunder-name element in the query interface.
+
+        Not all nodes in the semantic graph have a direct relationship to the dunder name, but many do. e.g. the
+        metric time entity corresponds to the 'metric_time' dunder-name element.
+        """
+        return self.recipe_step_to_append.add_dunder_name_element
+
+
+class SemanticGraphEdge(MetricflowGraphEdge[SemanticGraphNode], AttributeRecipeStepProvider, ABC):
+    """An edge in the semantic graph.
+
+    Currently, the edges in the semantic graph represent entity relationships also describes how a related attribute
+    can be computed from the relationship (see `AttributeRecipe`).
+
+    For example, if a semantic model contains the `listings` foreign entity and another semantic model contains the
+    `listings` primary entity, there would be a path from the node representing the first semantic model to the 2nd
+    semantic model (via a configured-entity node for `listings`). The path's edges includes a recipe step that
+    describes a join between the two semantic models.
+    """
+
+    @override
+    def pretty_format(self, format_context: PrettyFormatContext) -> Optional[str]:
+        formatter = format_context.formatter
+        return formatter.pretty_format_object_by_parts(
+            class_name=self.__class__.__name__,
+            field_mapping={
+                "tail_node": self._tail_node,
+                "head_node": self._head_node,
+            },
+        )
+
+    @property
+    @override
+    def displayed_properties(self) -> AnyLengthTuple[DisplayedProperty]:
+        properties: list[DisplayedProperty] = list(super().displayed_properties)
+        if self.recipe_step_to_append is not None:
+            properties.extend(self.recipe_step_to_append.displayed_properties)
+
+        return tuple(properties)
+
+
+class SemanticGraph(MetricflowGraph[SemanticGraphNode, SemanticGraphEdge], ABC):
+    """A read-only interface for a semantic graph based on `MetricflowGraph`.
+
+    Also see `SemanticGraphNode` and `SemanticGraphEdge`.
+
+    The semantic graph helps to model entity relationships that are defined in the semantic manifest and encodes
+    context on how attributes for entities can be queried (e.g. by joining semantic models).
+
+    Currently, the edges in the graph are oriented so that a path from a metric node to an attribute node describes
+    the query required to compute that metric. However, additional edge types can be added to better model associative
+    entity relationships.
+
+    Note: Some changes obviated the inverse graph, and it needs to be either refined or removed.
+    """
+
+    @override
+    def as_dot_graph(self, include_graphical_attributes: bool) -> DotGraphAttributeSet:
+        return (
+            super()
+            .as_dot_graph(include_graphical_attributes=include_graphical_attributes)
+            .with_attributes(
+                dot_kwargs={
+                    "rankdir": "LR",
+                }
+                if include_graphical_attributes
+                else {}
+            )
+        )
+
+    def nodes_with_labels(self, *labels: MetricflowGraphLabel) -> MutableOrderedSet[SemanticGraphNode]:
+        """Return nodes in the graph with any of the given labels."""
+        return MutableOrderedSet(mf_flatten(self.nodes_with_label(label) for label in labels))
+
+
+@dataclass
+class MutableSemanticGraph(MutableGraph[SemanticGraphNode, SemanticGraphEdge], SemanticGraph):
+    """A mutable implementation of `SemanticGraph` for building graphs."""
+
+    @classmethod
+    def create(cls, graph_id: Optional[MetricflowGraphId] = None) -> MutableSemanticGraph:  # noqa: D102
+        return MutableSemanticGraph(
+            _graph_id=graph_id or SequentialGraphId.create(),
+            _nodes=MutableOrderedSet(),
+            _edges=MutableOrderedSet(),
+            _tail_node_to_edges=defaultdict(MutableOrderedSet),
+            _head_node_to_edges=defaultdict(MutableOrderedSet),
+            _label_to_nodes=defaultdict(MutableOrderedSet),
+            _label_to_edges=defaultdict(MutableOrderedSet),
+            _node_to_predecessor_nodes=defaultdict(MutableOrderedSet),
+            _node_to_successor_nodes=defaultdict(MutableOrderedSet),
+        )
+
+    @override
+    def intersection(self, other: MetricflowGraph[SemanticGraphNode, SemanticGraphEdge]) -> MutableSemanticGraph:
+        intersection_graph = MutableSemanticGraph.create(graph_id=self.graph_id)
+        self.add_edges(self._intersect_edges(other))
+        return intersection_graph
+
+    @override
+    def inverse(self) -> MutableSemanticGraph:
+        inverse_graph = MutableSemanticGraph.create()
+        for edge in self.edges:
+            inverse_graph.add_edge(edge.inverse)
+        return inverse_graph
+
+    @override
+    def as_sorted(self) -> MutableSemanticGraph:
+        updated_graph = MutableSemanticGraph.create(graph_id=self.graph_id)
+        for node in sorted(self._nodes):
+            updated_graph.add_node(node)
+
+        for edge in sorted(self._edges):
+            updated_graph.add_edge(edge)
+
+        return updated_graph

--- a/metricflow-semantics/metricflow_semantics/experimental/semantic_graph/sg_interfaces.py
+++ b/metricflow-semantics/metricflow_semantics/experimental/semantic_graph/sg_interfaces.py
@@ -38,7 +38,7 @@ class SemanticGraphNode(MetricflowGraphNode, AttributeRecipeStepProvider, Metric
     The entity nodes in the semantic graph are not directly mapped from entities configured in the semantic manifest.
     The one that corresponds to an entity in the manifest are instances of `ConfiguredEntityNode`. However, there
     are other entity nodes that model other relationships. For example, `metric_time` is represented by the
-    metric-time entity node, and there is a time-entity node that relates time dimensions and metric time. to the
+    metric-time entity node, and there is a time-entity node that relates time dimensions and metric time to the
     various time grains (the time grains (e.g. `day`, `year`) map to attribute nodes).
 
     Please see the subclasses for more details.
@@ -70,11 +70,11 @@ class SemanticGraphNode(MetricflowGraphNode, AttributeRecipeStepProvider, Metric
 class SemanticGraphEdge(MetricflowGraphEdge[SemanticGraphNode], AttributeRecipeStepProvider, ABC):
     """An edge in the semantic graph.
 
-    Currently, the edges in the semantic graph represent entity relationships also describes how a related attribute
+    Currently, the edges in the semantic graph represent entity relationships and also describe how a related attribute
     can be computed from the relationship (see `AttributeRecipe`).
 
     For example, if a semantic model contains the `listings` foreign entity and another semantic model contains the
-    `listings` primary entity, there would be a path from the node representing the first semantic model to the 2nd
+    `listings` primary entity, there would be a path from the node representing the first semantic model to the second
     semantic model (via a configured-entity node for `listings`). The path's edges includes a recipe step that
     describes a join between the two semantic models.
     """
@@ -106,7 +106,7 @@ class SemanticGraph(MetricflowGraph[SemanticGraphNode, SemanticGraphEdge], ABC):
     Also see `SemanticGraphNode` and `SemanticGraphEdge`.
 
     The semantic graph helps to model entity relationships that are defined in the semantic manifest and encodes
-    context on how attributes for entities can be queried (e.g. by joining semantic models).
+    context on how attributes for entities can be computed (e.g. by joining semantic models).
 
     Currently, the edges in the graph are oriented so that a path from a metric node to an attribute node describes
     the query required to compute that metric. However, additional edge types can be added to better model associative


### PR DESCRIPTION
This PR adds the set of nodes used in the semantic graph. Docstrings are in the process of refinement, but there should be enough context in there for review.