### PR TITLE
Add semantic-graph edge classes

### DIFF
--- a/.changes/unreleased/Under the Hood-20250725-170903.yaml
+++ b/.changes/unreleased/Under the Hood-20250725-170903.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Add semantic-graph edge classes
+time: 2025-07-25T17:09:03.122067-07:00
+custom:
+  Author: plypaul
+  Issue: "1794"

--- a/metricflow-semantics/metricflow_semantics/experimental/semantic_graph/edges/edge_labels.py
+++ b/metricflow-semantics/metricflow_semantics/experimental/semantic_graph/edges/edge_labels.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import logging
+
+from metricflow_semantics.experimental.dataclass_helpers import fast_frozen_dataclass
+from metricflow_semantics.experimental.mf_graph.graph_labeling import MetricflowGraphLabel
+from metricflow_semantics.experimental.singleton import Singleton
+
+logger = logging.getLogger(__name__)
+
+
+@fast_frozen_dataclass()
+class CumulativeMeasureLabel(MetricflowGraphLabel, Singleton):
+    """Label for an edge from a cumulative metric node to a measure node.
+
+    This label is helpful for addressing special cases with cumulative metrics (e.g. ability to query by date part).
+    """
+
+    @classmethod
+    def get_instance(cls) -> CumulativeMeasureLabel:  # noqa: D102
+        return cls._get_instance()
+
+
+@fast_frozen_dataclass()
+class DenyDatePartLabel(MetricflowGraphLabel, Singleton):
+    """Label for edges that, when added to a path, should not allow querying of the date part."""
+
+    @classmethod
+    def get_instance(cls) -> DenyDatePartLabel:  # noqa: D102
+        return cls._get_instance()
+
+
+@fast_frozen_dataclass()
+class DenyEntityKeyQueryResolutionLabel(MetricflowGraphLabel, Singleton):
+    """Label for edges that, when added to a path, should not allow querying of only the entity-key attributes.
+
+    e.g. for time-offset metrics, the successor edges have this label as those metrics must be queried with
+    `metric_time` and it is not possible to query the metric only for entity-key attributes.
+    """
+
+    @classmethod
+    def get_instance(cls) -> DenyEntityKeyQueryResolutionLabel:  # noqa: D102
+        return cls._get_instance()
+
+
+@fast_frozen_dataclass()
+class ConversionMeasureLabel(MetricflowGraphLabel, Singleton):
+    """Label for successor edges from a conversion metric to the conversion measure node."""
+
+    @classmethod
+    def get_instance(cls) -> ConversionMeasureLabel:  # noqa: D102
+        return cls._get_instance()
+
+
+@fast_frozen_dataclass()
+class DenyVisibleAttributesLabel(MetricflowGraphLabel, Singleton):
+    """Label for edges that, when added to a path, should not affect visibility of group-by items.
+
+    e.g. for conversion metrics, the edge from the conversion-metric node to the conversion-measure node is given this
+    label as the conversion measure does not affect the available group-by items for the metric.
+    """
+
+    @classmethod
+    def get_instance(cls) -> DenyVisibleAttributesLabel:  # noqa: D102
+        return cls._get_instance()

--- a/metricflow-semantics/metricflow_semantics/experimental/semantic_graph/edges/sg_edges.py
+++ b/metricflow-semantics/metricflow_semantics/experimental/semantic_graph/edges/sg_edges.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+import logging
+from functools import cached_property
+from typing import Optional
+
+from typing_extensions import override
+
+from metricflow_semantics.experimental.dataclass_helpers import fast_frozen_dataclass
+from metricflow_semantics.experimental.mf_graph.comparable import ComparisonKey
+from metricflow_semantics.experimental.mf_graph.graph_labeling import MetricflowGraphLabel
+from metricflow_semantics.experimental.ordered_set import FrozenOrderedSet, OrderedSet
+from metricflow_semantics.experimental.semantic_graph.attribute_resolution.attribute_recipe_step import (
+    AttributeRecipeStep,
+)
+from metricflow_semantics.experimental.semantic_graph.model_id import SemanticModelId
+from metricflow_semantics.experimental.semantic_graph.sg_interfaces import SemanticGraphEdge, SemanticGraphNode
+from metricflow_semantics.mf_logging.pretty_formatter import PrettyFormatContext
+
+logger = logging.getLogger(__name__)
+
+
+@fast_frozen_dataclass(order=False)
+class JoinToModelEdge(SemanticGraphEdge):
+    """Edge that describes joining a model on the right side."""
+
+    right_model_id: SemanticModelId
+
+    @staticmethod
+    def create(  # noqa: D102
+        tail_node: SemanticGraphNode,
+        head_node: SemanticGraphNode,
+        right_model_id: SemanticModelId,
+    ) -> JoinToModelEdge:
+        return JoinToModelEdge(
+            tail_node=tail_node,
+            head_node=head_node,
+            right_model_id=right_model_id,
+        )
+
+    @cached_property
+    @override
+    def comparison_key(self) -> ComparisonKey:
+        return (self.tail_node, self.head_node, self.right_model_id)
+
+    @cached_property
+    @override
+    def inverse(self) -> JoinToModelEdge:
+        return JoinToModelEdge.create(
+            tail_node=self.tail_node,
+            head_node=self.head_node,
+            right_model_id=self.right_model_id,
+        )
+
+    @cached_property
+    @override
+    def recipe_step_to_append(self) -> AttributeRecipeStep:
+        return AttributeRecipeStep(add_model_join=self.right_model_id)
+
+
+_EMPTY_LABEL_SET: FrozenOrderedSet[MetricflowGraphLabel] = FrozenOrderedSet()
+_EMPTY_RECIPE_STEP = AttributeRecipeStep()
+
+
+@fast_frozen_dataclass(order=False)
+class MetricDefinitionEdge(SemanticGraphEdge):
+    """An edge that points from a metric to the inputs for the metric."""
+
+    additional_labels: FrozenOrderedSet[MetricflowGraphLabel]
+    _recipe_step: AttributeRecipeStep
+
+    @staticmethod
+    def create(  # noqa: D102
+        tail_node: SemanticGraphNode,
+        head_node: SemanticGraphNode,
+        additional_labels: Optional[FrozenOrderedSet[MetricflowGraphLabel]] = None,
+        recipe_step: Optional[AttributeRecipeStep] = None,
+    ) -> MetricDefinitionEdge:
+        return MetricDefinitionEdge(
+            tail_node=tail_node,
+            head_node=head_node,
+            additional_labels=additional_labels if additional_labels is not None else _EMPTY_LABEL_SET,
+            _recipe_step=recipe_step if recipe_step is not None else _EMPTY_RECIPE_STEP,
+        )
+
+    @cached_property
+    @override
+    def comparison_key(self) -> ComparisonKey:
+        return (
+            self.tail_node,
+            self.head_node,
+        )
+
+    @cached_property
+    @override
+    def inverse(self) -> MetricDefinitionEdge:
+        return MetricDefinitionEdge.create(
+            tail_node=self.head_node,
+            head_node=self.tail_node,
+        )
+
+    @cached_property
+    @override
+    def recipe_step_to_append(self) -> AttributeRecipeStep:
+        return self._recipe_step
+
+    @override
+    def pretty_format(self, format_context: PrettyFormatContext) -> Optional[str]:
+        formatter = format_context.formatter
+        return formatter.pretty_format_object_by_parts(
+            class_name=self.__class__.__name__,
+            field_mapping={
+                "tail_node": self.tail_node,
+                "head_node": self.head_node,
+                "labels": self.labels,
+                "recipe_step": self.recipe_step_to_append,
+            },
+        )
+
+    @cached_property
+    @override
+    def labels(self) -> OrderedSet[MetricflowGraphLabel]:
+        return FrozenOrderedSet(self.additional_labels)
+
+
+@fast_frozen_dataclass(order=False)
+class EntityRelationshipEdge(SemanticGraphEdge):
+    """Represents a relationship between entity nodes."""
+
+    _recipe_update: AttributeRecipeStep
+
+    @staticmethod
+    def create(  # noqa: D102
+        tail_node: SemanticGraphNode,
+        head_node: SemanticGraphNode,
+        recipe_update: AttributeRecipeStep = _EMPTY_RECIPE_STEP,
+    ) -> EntityRelationshipEdge:
+        return EntityRelationshipEdge(
+            tail_node=tail_node,
+            head_node=head_node,
+            _recipe_update=recipe_update,
+        )
+
+    @cached_property
+    @override
+    def comparison_key(self) -> ComparisonKey:
+        return (self.tail_node, self.head_node, self._recipe_update)
+
+    @cached_property
+    @override
+    def inverse(self) -> EntityRelationshipEdge:
+        return EntityRelationshipEdge.create(
+            tail_node=self.head_node,
+            head_node=self.tail_node,
+            recipe_update=self._recipe_update,
+        )
+
+    @cached_property
+    @override
+    def recipe_step_to_append(self) -> AttributeRecipeStep:
+        return self._recipe_update
+
+
+@fast_frozen_dataclass(order=False)
+class EntityAttributeEdge(SemanticGraphEdge):
+    """Edge from entity nodes to attribute nodes."""
+
+    _recipe_step: AttributeRecipeStep
+
+    @staticmethod
+    def create(  # noqa: D102
+        tail_node: SemanticGraphNode,
+        head_node: SemanticGraphNode,
+        recipe_step: Optional[AttributeRecipeStep] = None,
+    ) -> EntityAttributeEdge:
+        return EntityAttributeEdge(
+            tail_node=tail_node,
+            head_node=head_node,
+            _recipe_step=recipe_step or _EMPTY_RECIPE_STEP,
+        )
+
+    @cached_property
+    @override
+    def comparison_key(self) -> ComparisonKey:
+        return (self.tail_node, self.head_node, self._recipe_step)
+
+    @cached_property
+    @override
+    def inverse(self) -> EntityAttributeEdge:
+        return EntityAttributeEdge.create(
+            tail_node=self.head_node,
+            head_node=self.tail_node,
+            recipe_step=self._recipe_step,
+        )
+
+    @cached_property
+    @override
+    def recipe_step_to_append(self) -> AttributeRecipeStep:
+        return self._recipe_step


### PR DESCRIPTION
Related to https://github.com/dbt-labs/metricflow/pull/1791, this add the classes for edges in the semantic graph.