### PR TITLE
Fix error message in `no_common_items.py`

### DIFF
--- a/.changes/unreleased/Fixes-20250725-171609.yaml
+++ b/.changes/unreleased/Fixes-20250725-171609.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix error message in `no_common_items.py`
+time: 2025-07-25T17:16:09.05881-07:00
+custom:
+  Author: plypaul
+  Issue: "1795"

--- a/metricflow-semantics/metricflow_semantics/query/issues/group_by_item_resolver/no_common_items.py
+++ b/metricflow-semantics/metricflow_semantics/query/issues/group_by_item_resolver/no_common_items.py
@@ -68,13 +68,16 @@ class NoCommonItemsInParents(MetricFlowQueryResolutionIssue):
             parent_to_available_items["Matching items for: " + resolution_node.ui_description] = [
                 (spec_str if spec_str is not None else "None") for spec_str in spec_as_strs
             ]
-        return (
-            f"{last_path_item.ui_description} is built from:\n\n"
-            f"{mf_indent(last_path_item_parent_descriptions)}.\n"
-            f"However, the given input does not match to a common item that is available to those parents:\n\n"
-            f"{mf_indent(mf_pformat(parent_to_available_items, format_option=PrettyFormatDictOption(max_line_length=80)))}\n\n"
-            f"For time dimension inputs, please specify a time grain as ambiguous resolution only allows "
-            f"resolution when the parents have the same defined time gain."
+
+        return "\n\n".join(
+            (
+                f"{last_path_item.ui_description} is built from:",
+                f"{mf_indent(last_path_item_parent_descriptions)}.",
+                "However, the given input does not match to a common item that is available to those parents:",
+                f"{mf_indent(mf_pformat(parent_to_available_items, format_option=PrettyFormatDictOption(max_line_length=80)))}",
+                "For time-dimension inputs, please specify a time grain as resolution of ambiguous grains"
+                "\nis successful only when the parents have the same defined time grain.",
+            )
         )
 
     @override

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_ambiguous_entity_path.py/str/test_non_resolvable_ambiguous_entity_path_due_to_mismatch__result_0.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_ambiguous_entity_path.py/str/test_non_resolvable_ambiguous_entity_path_due_to_mismatch__result_0.txt
@@ -13,6 +13,7 @@ Error #1:
     Query(['entity_0_metric', 'entity_1_metric']) is built from:
 
       Metric('entity_0_metric'), Metric('entity_1_metric').
+
     However, the given input does not match to a common item that is available to those parents:
 
       {
@@ -22,7 +23,8 @@ Error #1:
         ],
       }
 
-    For time dimension inputs, please specify a time grain as ambiguous resolution only allows resolution when the parents have the same defined time gain.
+    For time-dimension inputs, please specify a time grain as resolution of ambiguous grains
+    is successful only when the parents have the same defined time grain.
 
   Query Input:
 


### PR DESCRIPTION
This PR fixes formatting errors in the error message generated by `no_common_items.py`.