### PR TITLE
Add subgraph generator for modeling joins

### DIFF
--- a/.changes/unreleased/Under the Hood-20250730-203401.yaml
+++ b/.changes/unreleased/Under the Hood-20250730-203401.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Add subgraph generator for modeling joins
+time: 2025-07-30T20:34:01.01371-07:00
+custom:
+  Author: plypaul
+  Issue: "1798"

--- a/metricflow-semantics/metricflow_semantics/experimental/dsi/join_lookup.py
+++ b/metricflow-semantics/metricflow_semantics/experimental/dsi/join_lookup.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+from collections.abc import Mapping, Set
+from functools import cached_property
+
+from dbt_semantic_interfaces.type_enums import EntityType
+from typing_extensions import override
+
+from metricflow_semantics.experimental.dataclass_helpers import fast_frozen_dataclass
+from metricflow_semantics.experimental.dsi.manifest_object_lookup import ManifestObjectLookup
+from metricflow_semantics.experimental.ordered_set import FrozenOrderedSet, MutableOrderedSet, OrderedSet
+from metricflow_semantics.experimental.semantic_graph.model_id import SemanticModelId
+from metricflow_semantics.mf_logging.lazy_formattable import LazyFormat
+
+logger = logging.getLogger(__name__)
+
+
+@fast_frozen_dataclass()
+class EntityJoinType:
+    """Describe a type of join between semantic models where entities are of the listed types."""
+
+    left_entity_type: EntityType
+    right_entity_type: EntityType
+
+
+@fast_frozen_dataclass()
+class JoinModelOnRightDescriptor:
+    """How to join one semantic model onto another, using a specific entity and join type."""
+
+    entity_name: str
+    join_type: EntityJoinType
+
+
+class SemanticModelJoinLookup:
+    """Lookup for valid joins between semantic models.
+
+    * This is a simplified / refactored version of the `SemanticModelJoinEvaluator` with no significant logic changes.
+    * Migrating `SemanticModelJoinEvaluator` to this one will be done after the semantic graph is fully in place to
+      ensure that we have a reference path to compare results in case of differences during rollout.
+    """
+
+    _VALID_ENTITY_JOINS: Set[EntityJoinType] = {
+        EntityJoinType(left_entity_type=EntityType.PRIMARY, right_entity_type=EntityType.NATURAL),
+        EntityJoinType(left_entity_type=EntityType.PRIMARY, right_entity_type=EntityType.PRIMARY),
+        EntityJoinType(left_entity_type=EntityType.PRIMARY, right_entity_type=EntityType.UNIQUE),
+        EntityJoinType(left_entity_type=EntityType.UNIQUE, right_entity_type=EntityType.NATURAL),
+        EntityJoinType(left_entity_type=EntityType.UNIQUE, right_entity_type=EntityType.PRIMARY),
+        EntityJoinType(left_entity_type=EntityType.UNIQUE, right_entity_type=EntityType.UNIQUE),
+        EntityJoinType(left_entity_type=EntityType.FOREIGN, right_entity_type=EntityType.NATURAL),
+        EntityJoinType(left_entity_type=EntityType.FOREIGN, right_entity_type=EntityType.PRIMARY),
+        EntityJoinType(left_entity_type=EntityType.FOREIGN, right_entity_type=EntityType.UNIQUE),
+        EntityJoinType(left_entity_type=EntityType.NATURAL, right_entity_type=EntityType.PRIMARY),
+        EntityJoinType(left_entity_type=EntityType.NATURAL, right_entity_type=EntityType.UNIQUE),
+    }
+
+    _INVALID_ENTITY_JOINS: Set[EntityJoinType] = {
+        EntityJoinType(left_entity_type=EntityType.PRIMARY, right_entity_type=EntityType.FOREIGN),
+        EntityJoinType(left_entity_type=EntityType.UNIQUE, right_entity_type=EntityType.FOREIGN),
+        EntityJoinType(left_entity_type=EntityType.FOREIGN, right_entity_type=EntityType.FOREIGN),
+        EntityJoinType(left_entity_type=EntityType.NATURAL, right_entity_type=EntityType.FOREIGN),
+        # Natural -> Natural joins are not allowed due to hidden fanout or missing value concerns with
+        # multiple validity windows in play
+        EntityJoinType(left_entity_type=EntityType.NATURAL, right_entity_type=EntityType.NATURAL),
+    }
+
+    @override
+    def __init__(self, manifest_object_lookup: ManifestObjectLookup) -> None:
+        self._model_id_to_lookup = manifest_object_lookup.model_id_to_lookup
+        self._entity_name_to_model_lookups = manifest_object_lookup.entity_name_to_model_lookups
+        self._entity_name_to_model_ids = manifest_object_lookup.entity_name_to_model_ids
+
+    @cached_property
+    def valid_join_to_entity_types(self) -> OrderedSet[EntityType]:
+        """Returns the valid entity types that can be on the right side of a join."""
+        return FrozenOrderedSet(
+            join_type.right_entity_type for join_type in SemanticModelJoinLookup._VALID_ENTITY_JOINS
+        )
+
+    @cached_property
+    def _model_id_to_has_validity_dimensions(self) -> Mapping[SemanticModelId, bool]:
+        return {
+            model_id: lookup.semantic_model.has_validity_dimensions
+            for model_id, lookup in self._model_id_to_lookup.items()
+        }
+
+    def get_join_model_on_right_descriptors(
+        self, left_model_id: SemanticModelId
+    ) -> Mapping[SemanticModelId, OrderedSet[JoinModelOnRightDescriptor]]:
+        """Return descriptors for semantic models that can be joined to `left_model_id`.
+
+        The returned dict maps the ID of the semantic model on the right to the entities in the corresponding model
+        that can be used as a join key.
+        """
+        right_model_id_to_join_descriptors: dict[
+            SemanticModelId, MutableOrderedSet[JoinModelOnRightDescriptor]
+        ] = defaultdict(MutableOrderedSet)
+        left_model_lookup = self._model_id_to_lookup[left_model_id]
+        left_model = left_model_lookup.semantic_model
+        left_model_has_validity_dimensions = self._model_id_to_has_validity_dimensions[left_model_id]
+        for entity in left_model_lookup.semantic_model.entities:
+            left_entity_name = entity.name
+            left_entity_type = entity.type
+            other_model_lookups_with_same_entity_name = self._entity_name_to_model_ids[left_entity_name]
+            for right_model_id in other_model_lookups_with_same_entity_name:
+                right_model_lookup = self._model_id_to_lookup[right_model_id]
+                right_model = right_model_lookup.semantic_model
+                right_entity_type = right_model_lookup.entity_lookup.entity_name_to_type[left_entity_name]
+                right_model_has_validity_dimension = self._model_id_to_has_validity_dimensions[right_model_id]
+
+                join_type = EntityJoinType(
+                    left_entity_type=left_entity_type,
+                    right_entity_type=right_entity_type,
+                )
+
+                if join_type in SemanticModelJoinLookup._VALID_ENTITY_JOINS:
+                    pass
+                elif join_type in SemanticModelJoinLookup._INVALID_ENTITY_JOINS:
+                    continue
+                else:
+                    raise ValueError(
+                        LazyFormat(
+                            "Unknown join type.",
+                            join_type=join_type,
+                            left_entity_name=left_entity_name,
+                            left_model=left_model,
+                            right_model=right_model,
+                        )
+                    )
+
+                if left_model_has_validity_dimensions and right_model_has_validity_dimension:
+                    # We cannot join two semantic models with validity dimensions due to concerns with unexpected fanout
+                    # due to the key structure of these semantic models. Applying multi-stage validity window filters can
+                    # also lead to unexpected removal of interim join keys. Note this will need to be updated if we enable
+                    # measures in such semantic models, since those will need to be converted to a different type of semantic model
+                    # to support measure computation.
+                    continue
+
+                if right_entity_type is EntityType.NATURAL and not right_model_has_validity_dimension:
+                    # There is no way to refine this to a single row per key, so we cannot support this join
+                    continue
+
+                right_model_id_to_join_descriptors[right_model_id].add(
+                    JoinModelOnRightDescriptor(
+                        entity_name=left_entity_name,
+                        join_type=join_type,
+                    )
+                )
+        return right_model_id_to_join_descriptors

--- a/metricflow-semantics/metricflow_semantics/experimental/semantic_graph/builder/entity_join_subgraph.py
+++ b/metricflow-semantics/metricflow_semantics/experimental/semantic_graph/builder/entity_join_subgraph.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import logging
+
+from typing_extensions import override
+
+from metricflow_semantics.experimental.dsi.join_lookup import SemanticModelJoinLookup
+from metricflow_semantics.experimental.dsi.manifest_object_lookup import ManifestObjectLookup
+from metricflow_semantics.experimental.dsi.model_object_lookup import (
+    ModelObjectLookup,
+)
+from metricflow_semantics.experimental.semantic_graph.builder.subgraph_generator import (
+    SemanticSubgraphGenerator,
+)
+from metricflow_semantics.experimental.semantic_graph.edges.sg_edges import (
+    EntityRelationshipEdge,
+    JoinToModelEdge,
+)
+from metricflow_semantics.experimental.semantic_graph.model_id import SemanticModelId
+from metricflow_semantics.experimental.semantic_graph.nodes.entity_nodes import (
+    ConfiguredEntityNode,
+    JoinedModelNode,
+    LocalModelNode,
+)
+from metricflow_semantics.experimental.semantic_graph.sg_interfaces import (
+    SemanticGraphEdge,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class EntityJoinSubgraphGenerator(SemanticSubgraphGenerator):
+    """Generator for the subgraph that represents the joins that are possible between semantic models.
+
+    Following the current query interface, joins between semantic models are modeled as a path from a model node
+    to a configured-entity node, and then to another model node.
+
+    Also see `LocalModelNode` and `JoinedModelNode` for context on why two different nodes are required
+    for each semantic model.
+    """
+
+    @override
+    def __init__(self, manifest_object_lookup: ManifestObjectLookup) -> None:
+        super().__init__(manifest_object_lookup)
+        self._verbose_debug_logs = True
+        self._join_lookup = SemanticModelJoinLookup(manifest_object_lookup)
+
+    @override
+    def add_edges_for_manifest(self, edge_list: list[SemanticGraphEdge]) -> None:
+        for lookup in self._manifest_object_lookup.model_object_lookups:
+            self._add_edges_for_model(lookup, edge_list)
+
+    def _add_edges_for_model(self, lookup: ModelObjectLookup, edge_list: list[SemanticGraphEdge]) -> None:
+        left_model_id = SemanticModelId.get_instance(lookup.semantic_model.name)
+        left_joined_model_node = JoinedModelNode.get_instance(left_model_id)
+        left_local_model_node = LocalModelNode.get_instance(left_model_id)
+
+        left_model = lookup.semantic_model
+
+        # Add edges from the left model to the configured entities that can be reached by joining other semantic
+        # models.
+        #
+        # e.g.
+        #
+        #   JoinedModel(bookings_source) -> ConfiguredEntity(listings_source.listings)
+        #
+        for right_model_id, join_descriptors in self._join_lookup.get_join_model_on_right_descriptors(
+            left_model_id=left_model_id
+        ).items():
+            # Joining a semantic model to itself is currently not allowed.
+            if right_model_id == left_model_id:
+                continue
+
+            # For all possible entities in the semantic model on the right.
+            for join_descriptor in join_descriptors:
+                right_entity_node = ConfiguredEntityNode.get_instance(
+                    entity_name=join_descriptor.entity_name,
+                    model_id=right_model_id,
+                )
+                # Add an edge from the joined-model node to the configured-entity node.
+                edge_list.append(
+                    JoinToModelEdge.create(
+                        tail_node=left_joined_model_node,
+                        head_node=right_entity_node,
+                        right_model_id=right_model_id,
+                    )
+                )
+                # Add an edge from the local-model node to the configured-entity node.
+                edge_list.append(
+                    JoinToModelEdge.create(
+                        tail_node=left_local_model_node,
+                        head_node=right_entity_node,
+                        right_model_id=right_model_id,
+                    )
+                )
+
+        # * The above loop created outgoing edges from the model node to the configured entity nodes.
+        # * When this method is run with other models, it will do the same.
+        # * From the configured-entity node, we need to add edges from the configured entity node to the model node so
+        # * that there is a path from one model node to another.
+        #
+        # e.g.
+        #   The previous loop added:
+        #
+        #       JoinedModel(bookings_source) -> ConfiguredEntity(listings_source.listings)
+        #
+        #   The following loop adds:
+        #
+        #       ConfiguredEntity(listings_source.listings) -> JoinedModel(listings_source)
+        #
+        # Combining those edges, we now have a path between the model nodes:
+        #
+        #   JoinedModel(bookings_source) -> ConfiguredEntity(listings_source.listings) -> JoinedModel(listings_source)
+        #
+        # In addition, we need to model the ability to query dimensions with an entity link, even if there's no actual
+        # join. e.g. from `listings_source`, the `country_latest` dimension is accessed with `listing__country_latest`
+        # but there is no join involved.
+        #
+        # This behavior can be modeled by adding the following edges.
+        #
+        #   LocalModel(listings_source) -> ConfiguredEntity(listing_source) -> JoinedModel(listings_source)
+        valid_join_to_entity_types = self._join_lookup.valid_join_to_entity_types
+        for entity in left_model.entities:
+            if entity.type in valid_join_to_entity_types:
+                entity_node = ConfiguredEntityNode.get_instance(
+                    entity_name=entity.name,
+                    model_id=left_model_id,
+                )
+                edge_list.append(
+                    EntityRelationshipEdge.create(
+                        tail_node=entity_node,
+                        head_node=left_joined_model_node,
+                    )
+                )
+
+                edge_list.append(
+                    EntityRelationshipEdge.create(
+                        tail_node=left_local_model_node,
+                        head_node=entity_node,
+                    )
+                )
+
+        # For semantic models with dimensions but no primary key, the `primary_entity` field is specified
+        # as a virtual primary entity. In that case, the entity does not show up as an entity in
+        # SemanticModel.entities, so add relevant edges.
+        primary_entity_field_name = lookup.semantic_model.primary_entity
+        if primary_entity_field_name is not None:
+            primary_entity_node = ConfiguredEntityNode.get_instance(
+                entity_name=primary_entity_field_name,
+                model_id=left_model_id,
+            )
+            edge_list.append(
+                EntityRelationshipEdge.create(
+                    tail_node=left_local_model_node,
+                    head_node=primary_entity_node,
+                )
+            )
+            edge_list.append(
+                EntityRelationshipEdge.create(
+                    tail_node=primary_entity_node,
+                    head_node=left_joined_model_node,
+                )
+            )
+            # Since there's no join key, `primary_entity_node` is not accessible via a join from another model.
+            # Consequently, no other edges are needed.

--- a/metricflow-semantics/tests_metricflow_semantics/experimental/mf_graph/formatting/mf_to_graphical_dot.py
+++ b/metricflow-semantics/tests_metricflow_semantics/experimental/mf_graph/formatting/mf_to_graphical_dot.py
@@ -75,7 +75,6 @@ class GraphicalDotConversionArgumentSet(DotConversionArgumentSet):
         "splines": "false",
         "bgcolor": DotColor.DARK_GRAY.value,
         "ranksep": "1.0",
-        # "nodesep": "1.0",
     }
 
     # Default attributes for DOT nodes.

--- a/metricflow-semantics/tests_metricflow_semantics/experimental/semantic_graph/builder/test_subgraph_1_entity_join.py
+++ b/metricflow-semantics/tests_metricflow_semantics/experimental/semantic_graph/builder/test_subgraph_1_entity_join.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import logging
+
+from _pytest.fixtures import FixtureRequest
+from dbt_semantic_interfaces.protocols import SemanticManifest
+from metricflow_semantics.experimental.semantic_graph.builder.entity_join_subgraph import EntityJoinSubgraphGenerator
+from metricflow_semantics.experimental.semantic_graph.builder.measure_subgraph import MeasureSubgraphGenerator
+from metricflow_semantics.helpers.string_helpers import mf_dedent
+from metricflow_semantics.test_helpers.config_helpers import MetricFlowTestConfiguration
+
+from tests_metricflow_semantics.experimental.semantic_graph.builder.subgraph_test_helpers import (
+    check_graph_build,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def test_minimal_manifest(  # noqa: D103
+    request: FixtureRequest,
+    mf_test_configuration: MetricFlowTestConfiguration,
+    sg_00_minimal_manifest: SemanticManifest,
+) -> None:
+    """Test generation of the subgraph that describes joins / entity-link using the minimal manifest."""
+    check_graph_build(
+        request=request,
+        mf_test_configuration=mf_test_configuration,
+        semantic_manifest=sg_00_minimal_manifest,
+        subgraph_generators=[MeasureSubgraphGenerator, EntityJoinSubgraphGenerator],
+        expectation_description=mf_dedent(
+            """
+            The minimal manifest only has a single primary entity and no joins are possible.
+            """
+        ),
+    )
+
+
+def test_single_join_manifest(  # noqa: D103
+    request: FixtureRequest,
+    mf_test_configuration: MetricFlowTestConfiguration,
+    sg_02_single_join_manifest: SemanticManifest,
+) -> None:
+    """Test generation of the subgraph that describes joins / entity-link using the single-join manifest."""
+    check_graph_build(
+        request=request,
+        mf_test_configuration=mf_test_configuration,
+        semantic_manifest=sg_02_single_join_manifest,
+        subgraph_generators=[MeasureSubgraphGenerator, EntityJoinSubgraphGenerator],
+        expectation_description=mf_dedent(
+            """
+            The single-join manifest has one model with the `listing` foreign entity and another model with the
+            corresponding primary entity.
+            """
+        ),
+    )

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_subgraph_1_entity_join.py/str/test_minimal_manifest__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_subgraph_1_entity_join.py/str/test_minimal_manifest__result.txt
@@ -1,0 +1,46 @@
+test_name: test_minimal_manifest
+test_filename: test_subgraph_1_entity_join.py
+docstring:
+  Test generation of the subgraph that describes joins / entity-link using the minimal manifest.
+expectation_description:
+  The minimal manifest only has a single primary entity and no joins are possible.
+---
+dot_notation:
+  digraph {
+  	graph [name=MutableSemanticGraph]
+  	subgraph cluster_configured_entity {
+  		label=configured_entity
+  		"bookings_source.booking"
+  	}
+  	subgraph cluster_bookings_source {
+  		label=bookings_source
+  		"JoinedModel(bookings_source)"
+  		"LocalModel(bookings_source)"
+  		"Measure(booking_count)"
+  	}
+  	subgraph cluster_time_dimension {
+  		label=time_dimension
+  		MetricTime
+  	}
+  	"bookings_source.booking" -> "JoinedModel(bookings_source)"
+  	"LocalModel(bookings_source)" -> "bookings_source.booking"
+  	"Measure(booking_count)" -> "LocalModel(bookings_source)"
+  	"Measure(booking_count)" -> MetricTime
+  }
+
+pretty_format:
+  MutableSemanticGraph(
+    nodes={
+      bookings_source.booking,
+      JoinedModel(bookings_source),
+      LocalModel(bookings_source),
+      Measure(booking_count),
+      MetricTime,
+    },
+    edges={
+      EntityRelationshipEdge(tail_node=bookings_source.booking, head_node=JoinedModel(bookings_source)),
+      EntityRelationshipEdge(tail_node=LocalModel(bookings_source), head_node=bookings_source.booking),
+      EntityRelationshipEdge(tail_node=Measure(booking_count), head_node=LocalModel(bookings_source)),
+      EntityRelationshipEdge(tail_node=Measure(booking_count), head_node=MetricTime),
+    },
+  )

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_subgraph_1_entity_join.py/str/test_single_join_manifest__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_subgraph_1_entity_join.py/str/test_single_join_manifest__result.txt
@@ -1,0 +1,64 @@
+test_name: test_single_join_manifest
+test_filename: test_subgraph_1_entity_join.py
+docstring:
+  Test generation of the subgraph that describes joins / entity-link using the single-join manifest.
+expectation_description:
+  The single-join manifest has one model with the `listing` foreign entity and another model with the
+  corresponding primary entity.
+---
+dot_notation:
+  digraph {
+  	graph [name=MutableSemanticGraph]
+  	subgraph cluster_configured_entity {
+  		label=configured_entity
+  		"bookings_source.booking"
+  		"listings_source.listing"
+  	}
+  	subgraph cluster_bookings_source {
+  		label=bookings_source
+  		"JoinedModel(bookings_source)"
+  		"LocalModel(bookings_source)"
+  		"Measure(booking_count)"
+  	}
+  	subgraph cluster_listings_source {
+  		label=listings_source
+  		"JoinedModel(listings_source)"
+  		"LocalModel(listings_source)"
+  	}
+  	subgraph cluster_time_dimension {
+  		label=time_dimension
+  		MetricTime
+  	}
+  	"bookings_source.booking" -> "JoinedModel(bookings_source)"
+  	"listings_source.listing" -> "JoinedModel(listings_source)"
+  	"LocalModel(bookings_source)" -> "bookings_source.booking"
+  	"LocalModel(listings_source)" -> "listings_source.listing"
+  	"Measure(booking_count)" -> "LocalModel(bookings_source)"
+  	"Measure(booking_count)" -> MetricTime
+  	"JoinedModel(bookings_source)" -> "listings_source.listing"
+  	"LocalModel(bookings_source)" -> "listings_source.listing"
+  }
+
+pretty_format:
+  MutableSemanticGraph(
+    nodes={
+      bookings_source.booking,
+      listings_source.listing,
+      JoinedModel(bookings_source),
+      JoinedModel(listings_source),
+      LocalModel(bookings_source),
+      LocalModel(listings_source),
+      Measure(booking_count),
+      MetricTime,
+    },
+    edges={
+      EntityRelationshipEdge(tail_node=bookings_source.booking, head_node=JoinedModel(bookings_source)),
+      EntityRelationshipEdge(tail_node=listings_source.listing, head_node=JoinedModel(listings_source)),
+      EntityRelationshipEdge(tail_node=LocalModel(bookings_source), head_node=bookings_source.booking),
+      EntityRelationshipEdge(tail_node=LocalModel(listings_source), head_node=listings_source.listing),
+      EntityRelationshipEdge(tail_node=Measure(booking_count), head_node=LocalModel(bookings_source)),
+      EntityRelationshipEdge(tail_node=Measure(booking_count), head_node=MetricTime),
+      JoinToModelEdge(tail_node=JoinedModel(bookings_source), head_node=listings_source.listing),
+      JoinToModelEdge(tail_node=LocalModel(bookings_source), head_node=listings_source.listing),
+    },
+  )


### PR DESCRIPTION
This PR adds `EntityJoinSubgraphGenerator`, which generates the edges to model joins between semantic models via configured entities.