### PR TITLE
Add subgraph generator for categorical dimensions

### DIFF
--- a/.changes/unreleased/Under the Hood-20250730-204027.yaml
+++ b/.changes/unreleased/Under the Hood-20250730-204027.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Add subgraph generator for categorical dimensions
+time: 2025-07-30T20:40:27.416138-07:00
+custom:
+  Author: plypaul
+  Issue: "1799"

--- a/metricflow-semantics/metricflow_semantics/experimental/semantic_graph/builder/categorical_dimension_subgraph.py
+++ b/metricflow-semantics/metricflow_semantics/experimental/semantic_graph/builder/categorical_dimension_subgraph.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import logging
+
+from dbt_semantic_interfaces.enum_extension import assert_values_exhausted
+from dbt_semantic_interfaces.type_enums import DimensionType
+from typing_extensions import override
+
+from metricflow_semantics.experimental.dsi.model_object_lookup import (
+    ModelObjectLookup,
+)
+from metricflow_semantics.experimental.semantic_graph.builder.subgraph_generator import (
+    SemanticSubgraphGenerator,
+)
+from metricflow_semantics.experimental.semantic_graph.edges.sg_edges import EntityAttributeEdge
+from metricflow_semantics.experimental.semantic_graph.model_id import SemanticModelId
+from metricflow_semantics.experimental.semantic_graph.nodes.attribute_nodes import (
+    AttributeNode,
+    CategoricalDimensionAttributeNode,
+)
+from metricflow_semantics.experimental.semantic_graph.nodes.entity_nodes import (
+    JoinedModelNode,
+)
+from metricflow_semantics.experimental.semantic_graph.sg_interfaces import (
+    SemanticGraphEdge,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class CategoricalDimensionSubgraphGenerator(SemanticSubgraphGenerator):
+    """Generator that adds edges for categorical dimensions.
+
+    This generator add edges from the joined-model nodes to the relevant categorical-dimension nodes.
+    """
+
+    @override
+    def add_edges_for_manifest(self, edge_list: list[SemanticGraphEdge]) -> None:
+        for lookup in self._manifest_object_lookup.model_object_lookups:
+            self._add_edges_for_model(lookup, edge_list)
+
+    def _get_nodes_for_categorical_dimensions(self, lookup: ModelObjectLookup) -> list[AttributeNode]:
+        attribute_nodes: list[AttributeNode] = []
+
+        for dimension in lookup.semantic_model.dimensions:
+            if dimension.type is DimensionType.CATEGORICAL:
+                attribute_nodes.append(CategoricalDimensionAttributeNode.get_instance(dimension.name))
+            elif dimension.type is DimensionType.TIME:
+                pass
+            else:
+                assert_values_exhausted(dimension.type)
+
+        return attribute_nodes
+
+    def _add_edges_for_model(self, lookup: ModelObjectLookup, edge_list: list[SemanticGraphEdge]) -> None:
+        model_id = SemanticModelId.get_instance(model_name=lookup.semantic_model.name)
+        semantic_model_node = JoinedModelNode.get_instance(model_id)
+        edge_list.extend(
+            [
+                EntityAttributeEdge.create(
+                    tail_node=semantic_model_node,
+                    head_node=attribute_node,
+                )
+                for attribute_node in self._get_nodes_for_categorical_dimensions(lookup)
+            ]
+        )

--- a/metricflow-semantics/tests_metricflow_semantics/experimental/semantic_graph/builder/test_subgraph_2_categorical_dimension.py
+++ b/metricflow-semantics/tests_metricflow_semantics/experimental/semantic_graph/builder/test_subgraph_2_categorical_dimension.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import logging
+
+from _pytest.fixtures import FixtureRequest
+from dbt_semantic_interfaces.protocols import SemanticManifest
+from metricflow_semantics.experimental.semantic_graph.builder.categorical_dimension_subgraph import (
+    CategoricalDimensionSubgraphGenerator,
+)
+from metricflow_semantics.helpers.string_helpers import mf_dedent
+from metricflow_semantics.test_helpers.config_helpers import MetricFlowTestConfiguration
+
+from tests_metricflow_semantics.experimental.semantic_graph.builder.subgraph_test_helpers import (
+    check_graph_build,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def test_single_join_manifest(
+    request: FixtureRequest,
+    mf_test_configuration: MetricFlowTestConfiguration,
+    sg_02_single_join_manifest: SemanticManifest,
+) -> None:
+    """Test generation of the categorical-dimension subgraph using the single-join manifest."""
+    check_graph_build(
+        request=request,
+        mf_test_configuration=mf_test_configuration,
+        semantic_manifest=sg_02_single_join_manifest,
+        subgraph_generators=[
+            CategoricalDimensionSubgraphGenerator,
+        ],
+        expectation_description=mf_dedent(
+            """
+            The graph should show an edge to the categorical dimension.
+            """
+        ),
+    )

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_subgraph_2_categorical_dimension.py/str/test_single_join_manifest__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_subgraph_2_categorical_dimension.py/str/test_single_join_manifest__result.txt
@@ -1,0 +1,26 @@
+test_name: test_single_join_manifest
+test_filename: test_subgraph_2_categorical_dimension.py
+docstring:
+  Test generation of the categorical-dimension subgraph using the single-join manifest.
+expectation_description:
+  The graph should show an edge to the categorical dimension.
+---
+dot_notation:
+  digraph {
+  	graph [name=MutableSemanticGraph]
+  	subgraph cluster_dimension {
+  		label=dimension
+  		"Dimension(country_latest)"
+  	}
+  	subgraph cluster_listings_source {
+  		label=listings_source
+  		"JoinedModel(listings_source)"
+  	}
+  	"JoinedModel(listings_source)" -> "Dimension(country_latest)"
+  }
+
+pretty_format:
+  MutableSemanticGraph(
+    nodes={Dimension(country_latest), JoinedModel(listings_source)},
+    edges={EntityAttributeEdge(tail_node=JoinedModel(listings_source), head_node=Dimension(country_latest))},
+  )


### PR DESCRIPTION
This PR adds a subgraph generator for the semantic graph to handle categorical dimensions.