### PR TITLE
Add subgraph generator for configured-entity keys

### DIFF
--- a/.changes/unreleased/Under the Hood-20250730-204837.yaml
+++ b/.changes/unreleased/Under the Hood-20250730-204837.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Add subgraph generator for configured-entity keys
+time: 2025-07-30T20:48:37.855004-07:00
+custom:
+  Author: plypaul
+  Issue: "1800"

--- a/metricflow-semantics/metricflow_semantics/experimental/semantic_graph/builder/entity_key_subgraph.py
+++ b/metricflow-semantics/metricflow_semantics/experimental/semantic_graph/builder/entity_key_subgraph.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import logging
+
+from typing_extensions import override
+
+from metricflow_semantics.experimental.dsi.model_object_lookup import (
+    ModelObjectLookup,
+)
+from metricflow_semantics.experimental.semantic_graph.builder.subgraph_generator import (
+    SemanticSubgraphGenerator,
+)
+from metricflow_semantics.experimental.semantic_graph.edges.sg_edges import EntityAttributeEdge
+from metricflow_semantics.experimental.semantic_graph.model_id import SemanticModelId
+from metricflow_semantics.experimental.semantic_graph.nodes.attribute_nodes import (
+    KeyAttributeNode,
+)
+from metricflow_semantics.experimental.semantic_graph.nodes.entity_nodes import (
+    JoinedModelNode,
+    LocalModelNode,
+)
+from metricflow_semantics.experimental.semantic_graph.sg_interfaces import (
+    SemanticGraphEdge,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class EntityKeySubgraphGenerator(SemanticSubgraphGenerator):
+    """Generator that adds edges for entity-key attributes.
+
+    Each entity defined in a semantic model maps to an entity-key attribute node as the name of the entity can be used
+    to query the respective values.
+    """
+
+    @override
+    def add_edges_for_manifest(self, edge_list: list[SemanticGraphEdge]) -> None:
+        for lookup in self._manifest_object_lookup.model_object_lookups:
+            self._add_edges_for_model(lookup, edge_list)
+
+    def _add_edges_for_model(self, lookup: ModelObjectLookup, edge_list: list[SemanticGraphEdge]) -> None:
+        model_id = SemanticModelId.get_instance(model_name=lookup.semantic_model.name)
+        semantic_model_node = JoinedModelNode.get_instance(model_id)
+        local_semantic_model_node = LocalModelNode.get_instance(model_id)
+
+        key_attribute_nodes = [KeyAttributeNode.get_instance(entity.name) for entity in lookup.semantic_model.entities]
+        edge_list.extend(
+            [
+                EntityAttributeEdge.create(
+                    tail_node=semantic_model_node,
+                    head_node=key_attribute_node,
+                )
+                for key_attribute_node in key_attribute_nodes
+            ]
+        )
+        edge_list.extend(
+            [
+                EntityAttributeEdge.create(
+                    tail_node=local_semantic_model_node,
+                    head_node=key_attribute_node,
+                )
+                for key_attribute_node in key_attribute_nodes
+            ]
+        )

--- a/metricflow-semantics/tests_metricflow_semantics/experimental/semantic_graph/builder/test_subgraph_3_entity_key.py
+++ b/metricflow-semantics/tests_metricflow_semantics/experimental/semantic_graph/builder/test_subgraph_3_entity_key.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import logging
+
+from _pytest.fixtures import FixtureRequest
+from dbt_semantic_interfaces.protocols import SemanticManifest
+from metricflow_semantics.experimental.semantic_graph.builder.entity_join_subgraph import EntityJoinSubgraphGenerator
+from metricflow_semantics.experimental.semantic_graph.builder.entity_key_subgraph import EntityKeySubgraphGenerator
+from metricflow_semantics.helpers.string_helpers import mf_dedent
+from metricflow_semantics.test_helpers.config_helpers import MetricFlowTestConfiguration
+
+from tests_metricflow_semantics.experimental.semantic_graph.builder.subgraph_test_helpers import (
+    check_graph_build,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def test_minimal_manifest(
+    request: FixtureRequest,
+    mf_test_configuration: MetricFlowTestConfiguration,
+    sg_00_minimal_manifest: SemanticManifest,
+) -> None:
+    """Test generation of the entity-key subgraph using the minimal manifest.
+
+    The `EntityJoinSubgraphGenerator` is included in the graphs to show how the keys relate to the configured entities.
+    """
+    check_graph_build(
+        request=request,
+        mf_test_configuration=mf_test_configuration,
+        semantic_manifest=sg_00_minimal_manifest,
+        subgraph_generators=[
+            EntityJoinSubgraphGenerator,
+            EntityKeySubgraphGenerator,
+        ],
+        expectation_description=mf_dedent(
+            """
+            The graph should show an edge to the primary entity.
+            """
+        ),
+    )

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_subgraph_3_entity_key.py/str/test_minimal_manifest__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_subgraph_3_entity_key.py/str/test_minimal_manifest__result.txt
@@ -1,0 +1,41 @@
+test_name: test_minimal_manifest
+test_filename: test_subgraph_3_entity_key.py
+docstring:
+  Test generation of the entity-key subgraph using the minimal manifest.
+
+      The `EntityJoinSubgraphGenerator` is included in the graphs to show how the keys relate to the configured entities.
+expectation_description:
+  The graph should show an edge to the primary entity.
+---
+dot_notation:
+  digraph {
+  	graph [name=MutableSemanticGraph]
+  	subgraph cluster_key {
+  		label=key
+  		"KeyAttribute(booking)"
+  	}
+  	subgraph cluster_configured_entity {
+  		label=configured_entity
+  		"bookings_source.booking"
+  	}
+  	subgraph cluster_bookings_source {
+  		label=bookings_source
+  		"JoinedModel(bookings_source)"
+  		"LocalModel(bookings_source)"
+  	}
+  	"JoinedModel(bookings_source)" -> "KeyAttribute(booking)"
+  	"LocalModel(bookings_source)" -> "KeyAttribute(booking)"
+  	"bookings_source.booking" -> "JoinedModel(bookings_source)"
+  	"LocalModel(bookings_source)" -> "bookings_source.booking"
+  }
+
+pretty_format:
+  MutableSemanticGraph(
+    nodes={KeyAttribute(booking), bookings_source.booking, JoinedModel(bookings_source), LocalModel(bookings_source)},
+    edges={
+      EntityAttributeEdge(tail_node=JoinedModel(bookings_source), head_node=KeyAttribute(booking)),
+      EntityAttributeEdge(tail_node=LocalModel(bookings_source), head_node=KeyAttribute(booking)),
+      EntityRelationshipEdge(tail_node=bookings_source.booking, head_node=JoinedModel(bookings_source)),
+      EntityRelationshipEdge(tail_node=LocalModel(bookings_source), head_node=bookings_source.booking),
+    },
+  )


### PR DESCRIPTION
This PR adds a subgraph generator to model queries for configured-entity keys. In the context of the query interface, this is related to "querying for an entity".