### PR TITLE
Add trie-like data structure for dunder names

### DIFF
--- a/.changes/unreleased/Under the Hood-20250805-163012.yaml
+++ b/.changes/unreleased/Under the Hood-20250805-163012.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Add trie-like data structure for dunder names
+time: 2025-08-05T16:30:12.771303-07:00
+custom:
+  Author: plypaul
+  Issue: "1805"

--- a/metricflow-semantics/metricflow_semantics/collection_helpers/dictionaries.py
+++ b/metricflow-semantics/metricflow_semantics/collection_helpers/dictionaries.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping, Set
+from typing import Sequence
+
+from metricflow_semantics.collection_helpers.mf_type_aliases import KeyT
+
+logger = logging.getLogger(__name__)
+
+
+def mf_common_keys(dicts: Sequence[Mapping[KeyT, object]]) -> Set[KeyT]:
+    """Returns the set of keys that are common to all dictionaries."""
+    if not dicts:
+        return set()
+
+    first_dict = dicts[0]
+    return set(first_dict).intersection(*[other_dict for other_dict in dicts[1:]])

--- a/metricflow-semantics/metricflow_semantics/experimental/semantic_graph/trie_resolver/dunder_name_descriptor.py
+++ b/metricflow-semantics/metricflow_semantics/experimental/semantic_graph/trie_resolver/dunder_name_descriptor.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from dbt_semantic_interfaces.type_enums import DatePart
+
+from metricflow_semantics.collection_helpers.mf_type_aliases import AnyLengthTuple
+from metricflow_semantics.experimental.dataclass_helpers import fast_frozen_dataclass
+from metricflow_semantics.experimental.semantic_graph.attribute_resolution.attribute_recipe import IndexedDunderName
+from metricflow_semantics.experimental.semantic_graph.model_id import SemanticModelId
+from metricflow_semantics.model.linkable_element_property import LinkableElementProperty
+from metricflow_semantics.model.semantics.linkable_element import LinkableElementType
+from metricflow_semantics.time.granularity import ExpandedTimeGranularity
+
+logger = logging.getLogger(__name__)
+
+
+@fast_frozen_dataclass()
+class EntityKeyQueryForGroupByMetric:
+    """Represents a possible entity-key query for group-by metric.
+
+    e.g for the `bookings_source` semantic model, `booking__listing` is a possible entity-key query.
+    """
+
+    entity_key_query: IndexedDunderName
+    derived_from_model_ids: AnyLengthTuple[SemanticModelId]
+
+
+@fast_frozen_dataclass()
+class DunderNameDescriptor:
+    """A descriptor used in `DunderNameTrie` that can be used to build a `AnnotatedSpec` later.
+
+    The fields here are analogous to the ones in `AnnotatedSpec`.
+
+    These descriptors are used in trie-based data structures that describe the available group-by items for a metric (
+    see `DunderNameTrie`). In these structures, the dunder name maps to this descriptor.
+
+    Some consolidation is needed between similar descriptor types.
+    """
+
+    element_type: LinkableElementType
+    time_grain: Optional[ExpandedTimeGranularity]
+    date_part: Optional[DatePart]
+
+    element_properties: AnyLengthTuple[LinkableElementProperty]
+    origin_model_ids: AnyLengthTuple[SemanticModelId]
+    derived_from_model_ids: AnyLengthTuple[SemanticModelId]
+    entity_key_queries_for_group_by_metric: AnyLengthTuple[EntityKeyQueryForGroupByMetric]
+
+    def merge(self, other: DunderNameDescriptor) -> DunderNameDescriptor:
+        """Combine the properties of this with the other descriptor.
+
+        To generate the trie for a metric from the corresponding trie for the constituent measures, there
+        needs to be a mechanism for combining them to reflect properties like `derived_from_model_ids`.
+
+        For example, a metric like `bookings_per_view` would be based on the `booking` measure (in the
+        `booking_source` model) and the `views` measure (in the `views_source` model). Combining the trie from each
+        model should result in descriptors that include both `views_source` and `bookings_source`.
+        """
+        # Fields like `element_type` and `time_grain` should be the same for both descriptors if there were no bugs
+        # with the construction of the trie. Considering adding a check.
+        return DunderNameDescriptor(
+            element_type=self.element_type,
+            time_grain=self.time_grain,
+            date_part=self.date_part,
+            element_properties=self.element_properties + other.element_properties,
+            origin_model_ids=self.origin_model_ids + other.origin_model_ids,
+            derived_from_model_ids=self.derived_from_model_ids + other.derived_from_model_ids,
+            entity_key_queries_for_group_by_metric=self.entity_key_queries_for_group_by_metric,
+        )
+
+    def merge_derived_from_model_ids(
+        self, derived_from_model_ids: AnyLengthTuple[SemanticModelId]
+    ) -> DunderNameDescriptor:
+        """Return a new descriptor that is a copy of this but with additional `derived_from_model_ids`."""
+        return DunderNameDescriptor(
+            element_type=self.element_type,
+            time_grain=self.time_grain,
+            date_part=self.date_part,
+            element_properties=self.element_properties,
+            origin_model_ids=self.origin_model_ids,
+            derived_from_model_ids=self.derived_from_model_ids + derived_from_model_ids,
+            entity_key_queries_for_group_by_metric=self.entity_key_queries_for_group_by_metric,
+        )
+
+    def is_mergeable(self, other: DunderNameDescriptor) -> bool:
+        """Returns True if this descriptor can form a union with another descriptor."""
+        return (
+            self.element_type is other.element_type
+            and self.time_grain == other.time_grain
+            and self.date_part is other.date_part
+            and self.entity_key_queries_for_group_by_metric == other.entity_key_queries_for_group_by_metric
+        )

--- a/metricflow-semantics/metricflow_semantics/experimental/semantic_graph/trie_resolver/dunder_name_trie.py
+++ b/metricflow-semantics/metricflow_semantics/experimental/semantic_graph/trie_resolver/dunder_name_trie.py
@@ -1,0 +1,350 @@
+from __future__ import annotations
+
+import dataclasses
+import logging
+from abc import ABC, abstractmethod
+from collections import defaultdict
+from collections.abc import Mapping
+from dataclasses import dataclass
+from functools import cached_property
+from typing import Iterable, Optional, Sequence
+
+from dbt_semantic_interfaces.naming.keywords import DUNDER
+from typing_extensions import Self, override
+
+from metricflow_semantics.collection_helpers.dictionaries import mf_common_keys
+from metricflow_semantics.collection_helpers.mf_type_aliases import AnyLengthTuple
+from metricflow_semantics.experimental.metricflow_exception import MetricflowInternalError
+from metricflow_semantics.experimental.semantic_graph.attribute_resolution.attribute_recipe import IndexedDunderName
+from metricflow_semantics.experimental.semantic_graph.model_id import SemanticModelId
+from metricflow_semantics.experimental.semantic_graph.trie_resolver.dunder_name_descriptor import DunderNameDescriptor
+from metricflow_semantics.mf_logging.lazy_formattable import LazyFormat
+
+logger = logging.getLogger(__name__)
+
+
+class DunderNameTrie(ABC):
+    """A read-only interface for a trie-based data structure that stores dunder names and associated properties.
+
+    Unlike a typical trie that is based on individual characters, this is based on the names that are joined with `__`.
+    For example, the trie that contains
+
+        listing__user
+        listing__country
+
+    would be represented as:
+
+        listing -> user
+                -> country
+
+    The trie helps to simplify union / intersection operations that are done to generate the list of available group-by
+    items for a query.
+
+    There's currently a mutable implementation, but a frozen one may be added if it turns out to be useful.
+    """
+
+    @abstractmethod
+    def name_items(self, max_length: Optional[int] = None) -> Sequence[tuple[IndexedDunderName, DunderNameDescriptor]]:
+        """Return a sequence of tuples that represent all dunder names that are represented by this trie.
+
+        The first item is the indexed dunder-name (e.g. ("listing", "country")) and the second is the descriptor
+        associated with that name.
+        """
+        raise NotImplementedError
+
+    def dunder_names(self) -> Sequence[str]:
+        """Return the dunder names that are represented by this trie (e.g. ["listing__country", ...]).
+
+        This is mainly used for tests / debugging.
+        """
+        return tuple(DUNDER.join(indexed_dunder_name) for indexed_dunder_name, _ in self.name_items())
+
+    @classmethod
+    @abstractmethod
+    def union_merge_common(cls, trie_sequence: Sequence[Self]) -> Self:
+        """Union names from a sequence of tries, and merge the descriptors for common names."""
+        raise NotImplementedError
+
+    @classmethod
+    @abstractmethod
+    def union_exclude_common(cls, trie_sequence: Sequence[Self]) -> Self:
+        """Union names from a sequence of tries, but remove the common ones.
+
+        In this operation, non-unique names are discarded. This is to represent ambiguous join paths which are not
+        allowed in the query interface.
+        """
+        raise NotImplementedError
+
+    @classmethod
+    @abstractmethod
+    def intersection_merge_common(cls, trie_sequence: Sequence[Self]) -> Self:
+        """Intersect names from a sequence of tries, and merge the descriptors for common names.
+
+        In an intersection operation, names that do not exist in all tries are discarded. This represents the
+        requirement that, for a derived metric, a group-by name must be available for each of the input metrics
+        (similar situation for a query of multiple metrics).
+        """
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def name_element_to_descriptor(self) -> Mapping[str, DunderNameDescriptor]:
+        """Return a mapping of the name elements in this trie to the descriptor.
+
+        For example, this would return `{"listing": Descriptor(...)}` for a trie that stored `listing` and
+        `listing__country`. See `name_element_to_next_trie` for retrieval of the `country` element.
+        """
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def next_name_element_to_trie(self) -> Mapping[str, MutableDunderNameTrie]:
+        """Return a mapping from the next name element to the associated trie.
+
+        For example, a trie that represents `listing` and `listing__country` would return
+        `{"listing": DunderNameTrie(...)}`.
+        """
+        raise NotImplementedError
+
+    def mutable_copy(self) -> MutableDunderNameTrie:
+        """Return a mutable copy of this trie. Child tries are copied as well.
+
+        Descriptors don't need to be copied as they are immutable.
+        """
+        return MutableDunderNameTrie(
+            name_element_to_descriptor_dict=dict(self.name_element_to_descriptor),
+            name_element_to_next_trie_dict={
+                name_element: next_trie.mutable_copy()
+                for name_element, next_trie in self.next_name_element_to_trie.items()
+            },
+        )
+
+
+@dataclass
+class MutableDunderNameTrie(DunderNameTrie):
+    """A mutable implementation of `DunderNameTrie`."""
+
+    name_element_to_descriptor_dict: dict[str, DunderNameDescriptor] = dataclasses.field(default_factory=dict)
+    name_element_to_next_trie_dict: dict[str, MutableDunderNameTrie] = dataclasses.field(
+        default_factory=lambda: defaultdict(MutableDunderNameTrie)
+    )
+
+    @classmethod
+    @override
+    def union_merge_common(cls, trie_sequence: Sequence[DunderNameTrie]) -> MutableDunderNameTrie:
+        if len(trie_sequence) == 0:
+            return MutableDunderNameTrie()
+        elif len(trie_sequence) == 1:
+            return trie_sequence[0].mutable_copy()
+
+        new_name_element_to_descriptors: dict[str, DunderNameDescriptor] = {}
+        for trie in trie_sequence:
+            for name_element, descriptor in trie.name_element_to_descriptor.items():
+                previous_descriptor = new_name_element_to_descriptors.get(name_element)
+                if previous_descriptor is None:
+                    new_name_element_to_descriptors[name_element] = descriptor
+                else:
+                    new_name_element_to_descriptors[name_element] = previous_descriptor.merge(descriptor)
+
+        next_name_element_to_tries_for_union: dict[str, list[MutableDunderNameTrie]] = defaultdict(list)
+        for trie in trie_sequence:
+            for name_element, next_trie in trie.next_name_element_to_trie.items():
+                next_name_element_to_tries_for_union[name_element].append(next_trie)
+
+        new_name_element_to_next_trie: dict[str, MutableDunderNameTrie] = {}
+        for name_element, next_tries in next_name_element_to_tries_for_union.items():
+            new_name_element_to_next_trie[name_element] = MutableDunderNameTrie.union_merge_common(next_tries)
+
+        return MutableDunderNameTrie(
+            name_element_to_descriptor_dict=new_name_element_to_descriptors,
+            name_element_to_next_trie_dict=new_name_element_to_next_trie,
+        )
+
+    @classmethod
+    @override
+    def union_exclude_common(cls, trie_sequence: Sequence[DunderNameTrie]) -> MutableDunderNameTrie:
+        if len(trie_sequence) == 0:
+            return MutableDunderNameTrie()
+        elif len(trie_sequence) == 1:
+            return trie_sequence[0].mutable_copy()
+
+        common_name_elements_for_descriptors = mf_common_keys(
+            tuple(trie.name_element_to_descriptor for trie in trie_sequence)
+        )
+
+        new_name_element_to_descriptors: dict[str, DunderNameDescriptor] = {
+            name_element: descriptor
+            for trie in trie_sequence
+            for name_element, descriptor in trie.name_element_to_descriptor.items()
+            # if name_element not in new_ambiguous_name_elements
+            if name_element not in common_name_elements_for_descriptors
+        }
+
+        next_name_element_to_tries_for_union: dict[str, list[MutableDunderNameTrie]] = defaultdict(list)
+        for trie in trie_sequence:
+            for name_element, next_trie in trie.next_name_element_to_trie.items():
+                next_name_element_to_tries_for_union[name_element].append(next_trie)
+
+        new_name_element_to_next_trie: dict[str, MutableDunderNameTrie] = {}
+        for name_element, next_tries in next_name_element_to_tries_for_union.items():
+            new_name_element_to_next_trie[name_element] = MutableDunderNameTrie.union_exclude_common(next_tries)
+
+        return MutableDunderNameTrie(
+            name_element_to_descriptor_dict=new_name_element_to_descriptors,
+            name_element_to_next_trie_dict=new_name_element_to_next_trie,
+        )
+
+    @classmethod
+    @override
+    def intersection_merge_common(cls, trie_sequence: Sequence[DunderNameTrie]) -> MutableDunderNameTrie:
+        if len(trie_sequence) == 0:
+            return MutableDunderNameTrie()
+        elif len(trie_sequence) == 1:
+            return trie_sequence[0].mutable_copy()
+
+        left_trie = trie_sequence[0]
+        other_tries = trie_sequence[1:]
+
+        intersected_name_elements_for_descriptors = mf_common_keys(
+            tuple(trie.name_element_to_descriptor for trie in trie_sequence)
+        )
+
+        new_element_name_to_descriptor: dict[str, DunderNameDescriptor] = {
+            name_element: left_trie.name_element_to_descriptor[name_element]
+            for name_element in intersected_name_elements_for_descriptors
+        }
+
+        for trie in other_tries:
+            for name_element in intersected_name_elements_for_descriptors:
+                new_element_name_to_descriptor[name_element] = new_element_name_to_descriptor[name_element].merge(
+                    trie.name_element_to_descriptor[name_element]
+                )
+
+        intersected_name_elements_for_next_tries = mf_common_keys(
+            tuple(trie.next_name_element_to_trie for trie in trie_sequence)
+        )
+
+        name_element_to_next_tries: dict[str, list[MutableDunderNameTrie]] = defaultdict(list)
+        for trie in trie_sequence:
+            for name_element, next_trie in trie.next_name_element_to_trie.items():
+                if name_element not in intersected_name_elements_for_next_tries:
+                    continue
+                name_element_to_next_tries[name_element].append(next_trie)
+
+        new_name_element_to_next_trie = {
+            name_element: MutableDunderNameTrie.intersection_merge_common(next_tries)
+            for name_element, next_tries in name_element_to_next_tries.items()
+        }
+
+        return MutableDunderNameTrie(
+            name_element_to_descriptor_dict=new_element_name_to_descriptor,
+            name_element_to_next_trie_dict=new_name_element_to_next_trie,
+        )
+
+    @cached_property
+    @override
+    def name_element_to_descriptor(self) -> Mapping[str, DunderNameDescriptor]:
+        return self.name_element_to_descriptor_dict
+
+    @cached_property
+    @override
+    def next_name_element_to_trie(self) -> Mapping[str, MutableDunderNameTrie]:
+        return self.name_element_to_next_trie_dict
+
+    def update_derived_from_model_ids(self, derived_from_model_ids: AnyLengthTuple[SemanticModelId]) -> None:
+        """Update the descriptor for all represented names to include additional `derived_from_model_ids`."""
+        self.name_element_to_descriptor_dict.update(
+            {
+                name_element: descriptor.merge_derived_from_model_ids(derived_from_model_ids)
+                for name_element, descriptor in self.name_element_to_descriptor_dict.items()
+            }
+        )
+        for _, next_trie in self.name_element_to_next_trie_dict.items():
+            next_trie.update_derived_from_model_ids(derived_from_model_ids)
+
+    def add_name_items(self, items: Iterable[tuple[IndexedDunderName, DunderNameDescriptor]]) -> None:
+        """Build out this trie by adding individual names."""
+        # Mapping from the path to the leaf trie to the common name elements.
+        # e.g. for items
+        #
+        #       `listing__country`,
+        #       `listing__country`,
+        #       `listing__country__region`
+        #
+        # This should contain:
+        # {
+        #     (`listing`,): {
+        #         "country",
+        #     },
+        # }
+        trie_path_to_common_names: dict[IndexedDunderName, set[str]] = defaultdict(set)
+        for indexed_dunder_name, descriptor in items:
+            name_element_count = len(indexed_dunder_name)
+            if name_element_count == 0:
+                raise MetricflowInternalError(
+                    LazyFormat(
+                        "There must at least be one name element.",
+                        name_element_list=indexed_dunder_name,
+                    )
+                )
+            leaf_trie_path = indexed_dunder_name[:-1]
+
+            # Traverse the trie tree to find the leaf trie.
+            current_trie = self
+            for name_element_index in range(name_element_count):
+                current_name_element = indexed_dunder_name[name_element_index]
+
+                # At the leaf.
+                if name_element_index == name_element_count - 1:
+                    name_element_to_descriptor = current_trie.name_element_to_descriptor_dict
+                    current_descriptor = name_element_to_descriptor.get(current_name_element)
+
+                    # If there are multiple names given, they are considered ambiguous.
+                    # Ambiguous names should be removed.
+                    if current_name_element in trie_path_to_common_names[leaf_trie_path]:
+                        continue
+
+                    if current_descriptor is None:
+                        name_element_to_descriptor[current_name_element] = descriptor
+                        continue
+
+                    del name_element_to_descriptor[current_name_element]
+                    trie_path_to_common_names[leaf_trie_path].add(current_name_element)
+                    continue
+
+                next_trie = current_trie.name_element_to_next_trie_dict[current_name_element]
+                current_trie.name_element_to_next_trie_dict[current_name_element] = next_trie
+
+                current_trie = next_trie
+
+    @override
+    def name_items(self, max_length: Optional[int] = None) -> Sequence[tuple[IndexedDunderName, DunderNameDescriptor]]:
+        item_collector: list[tuple[IndexedDunderName, DunderNameDescriptor]] = []
+        self._collect_name_items(
+            name_element_prefix=(), item_collector=item_collector, current_element_index=0, max_element_count=max_length
+        )
+        return item_collector
+
+    def _collect_name_items(
+        self,
+        name_element_prefix: IndexedDunderName,
+        item_collector: list[tuple[IndexedDunderName, DunderNameDescriptor]],
+        current_element_index: int,
+        max_element_count: Optional[int],
+    ) -> None:
+        """Recursive helper method to add names represented in the trie to `item_collector`.
+
+        If `max_element_count` is set, names with more elements than the given value are not included.
+        """
+        if max_element_count is not None and current_element_index + 1 > max_element_count:
+            return
+
+        item_collector.extend(
+            (name_element_prefix + (name_element,), descriptor)
+            for name_element, descriptor in self.name_element_to_descriptor_dict.items()
+        )
+
+        for name_element, next_node in self.name_element_to_next_trie_dict.items():
+            next_node._collect_name_items(
+                name_element_prefix + (name_element,), item_collector, current_element_index + 1, max_element_count
+            )

--- a/metricflow-semantics/tests_metricflow_semantics/experimental/test_dunder_name_trie.py
+++ b/metricflow-semantics/tests_metricflow_semantics/experimental/test_dunder_name_trie.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import logging
+
+from _pytest.fixtures import FixtureRequest
+from metricflow_semantics.experimental.semantic_graph.attribute_resolution.attribute_recipe import IndexedDunderName
+from metricflow_semantics.experimental.semantic_graph.trie_resolver.dunder_name_descriptor import DunderNameDescriptor
+from metricflow_semantics.experimental.semantic_graph.trie_resolver.dunder_name_trie import (
+    MutableDunderNameTrie,
+)
+from metricflow_semantics.helpers.string_helpers import mf_dedent
+from metricflow_semantics.model.semantics.linkable_element import LinkableElementType
+from metricflow_semantics.test_helpers.config_helpers import MetricFlowTestConfiguration
+from metricflow_semantics.test_helpers.snapshot_helpers import (
+    assert_object_snapshot_equal,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def test_add_items(request: FixtureRequest, mf_test_configuration: MetricFlowTestConfiguration) -> None:  # noqa: D103
+    indexed_dunder_names: list[IndexedDunderName] = [
+        ("listing",),
+        ("listing", "user"),
+        ("booking", "host"),
+        ("booking", "view"),
+        ("booking", "host", "country"),
+        ("ambiguous",),
+        ("ambiguous",),
+    ]
+
+    dunder_name_trie = MutableDunderNameTrie()
+    descriptor = DunderNameDescriptor(
+        element_type=LinkableElementType.ENTITY,
+        time_grain=None,
+        date_part=None,
+        element_properties=(),
+        derived_from_model_ids=(),
+        origin_model_ids=(),
+        entity_key_queries_for_group_by_metric=(),
+    )
+    dunder_name_trie.add_name_items(((indexed_dunder_name, descriptor) for indexed_dunder_name in indexed_dunder_names))
+
+    indexed_names = [name for name, _ in dunder_name_trie.name_items()]
+
+    assert_object_snapshot_equal(
+        request=request,
+        snapshot_configuration=mf_test_configuration,
+        obj={"names_after_removing_ambiguous_names": indexed_names, "trie": dunder_name_trie},
+        expectation_description=mf_dedent(
+            """
+            `ambiguous` should not show up since the union operation removes common items.
+            """
+        ),
+    )
+
+
+def test_union() -> None:  # noqa: D103
+    descriptor = DunderNameDescriptor(
+        element_type=LinkableElementType.DIMENSION,
+        time_grain=None,
+        date_part=None,
+        element_properties=(),
+        derived_from_model_ids=(),
+        origin_model_ids=(),
+        entity_key_queries_for_group_by_metric=(),
+    )
+
+    left_trie = MutableDunderNameTrie()
+    left_trie.add_name_items(
+        [
+            (("listing", "user"), descriptor),
+            (("booking",), descriptor),
+            (("listing",), descriptor),
+        ]
+    )
+
+    right_trie = MutableDunderNameTrie()
+    right_trie.add_name_items(
+        [
+            (("listing", "user"), descriptor),
+            (("booking",), descriptor),
+            (("listing", "country"), descriptor),
+        ]
+    )
+    assert MutableDunderNameTrie.union_exclude_common([left_trie, right_trie]).dunder_names() == (
+        "listing",
+        "listing__country",
+    )
+
+
+def test_intersection() -> None:  # noqa: D103
+    descriptor = DunderNameDescriptor(
+        element_type=LinkableElementType.DIMENSION,
+        time_grain=None,
+        date_part=None,
+        element_properties=(),
+        derived_from_model_ids=(),
+        origin_model_ids=(),
+        entity_key_queries_for_group_by_metric=(),
+    )
+
+    left_trie = MutableDunderNameTrie()
+    left_trie.add_name_items(
+        [
+            (("booking",), descriptor),
+            (("listing", "user"), descriptor),
+            (("listing", "country"), descriptor),
+        ]
+    )
+
+    right_trie = MutableDunderNameTrie()
+    right_trie.add_name_items(
+        [
+            (("booking",), descriptor),
+            (("listing", "user"), descriptor),
+            (("listing",), descriptor),
+        ]
+    )
+    assert MutableDunderNameTrie.intersection_merge_common([left_trie, right_trie]).dunder_names() == (
+        "booking",
+        "listing__user",
+    )

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_dunder_name_trie.py/dict/test_add_items__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_dunder_name_trie.py/dict/test_add_items__result.txt
@@ -1,0 +1,45 @@
+test_name: test_add_items
+test_filename: test_dunder_name_trie.py
+expectation_description:
+  `ambiguous` should not show up since the union operation removes common items.
+---
+{
+  'names_after_removing_ambiguous_names': [
+    ('listing',),
+    ('listing', 'user'),
+    ('booking', 'host'),
+    ('booking', 'view'),
+    ('booking', 'host', 'country'),
+  ],
+  'trie': MutableDunderNameTrie(
+    name_element_to_descriptor_dict={'listing': DunderNameDescriptor(element_type=ENTITY)},
+    name_element_to_next_trie_dict={
+      'listing': MutableDunderNameTrie(
+        name_element_to_descriptor_dict={
+          'user': DunderNameDescriptor(
+            element_type=ENTITY,
+          ),
+        },
+      ),
+      'booking': MutableDunderNameTrie(
+        name_element_to_descriptor_dict={
+          'host': DunderNameDescriptor(
+            element_type=ENTITY,
+          ),
+          'view': DunderNameDescriptor(
+            element_type=ENTITY,
+          ),
+        },
+        name_element_to_next_trie_dict={
+          'host': MutableDunderNameTrie(
+            name_element_to_descriptor_dict={
+              'country': DunderNameDescriptor(
+                element_type=ENTITY,
+              ),
+            },
+          ),
+        },
+      ),
+    },
+  ),
+}


### PR DESCRIPTION
This PR adds a trie-like data structure for dunder names to simplify the union / intersection operations that are required for group-by item resolution