### PR TITLE
Add semantic-graph-based resolver for group-by metrics

### DIFF
--- a/.changes/unreleased/Under the Hood-20250805-164525.yaml
+++ b/.changes/unreleased/Under the Hood-20250805-164525.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Add semantic-graph-based resolver for group-by metrics
+time: 2025-08-05T16:45:25.983688-07:00
+custom:
+  Author: plypaul
+  Issue: "1807"

--- a/metricflow-semantics/metricflow_semantics/experimental/semantic_graph/attribute_resolution/annotated_spec_linkable_element_set.py
+++ b/metricflow-semantics/metricflow_semantics/experimental/semantic_graph/attribute_resolution/annotated_spec_linkable_element_set.py
@@ -13,6 +13,7 @@ from metricflow_semantics.collection_helpers.mf_type_aliases import AnyLengthTup
 from metricflow_semantics.collection_helpers.syntactic_sugar import mf_flatten
 from metricflow_semantics.experimental.dataclass_helpers import fast_frozen_dataclass
 from metricflow_semantics.experimental.ordered_set import FrozenOrderedSet, MutableOrderedSet
+from metricflow_semantics.experimental.semantic_graph.trie_resolver.dunder_name_trie import DunderNameTrie
 from metricflow_semantics.model.semantics.element_filter import LinkableElementFilter
 from metricflow_semantics.model.semantics.linkable_element_set_base import AnnotatedSpec, BaseLinkableElementSet
 from metricflow_semantics.specs.instance_spec import InstanceSpec, LinkableInstanceSpec
@@ -45,6 +46,19 @@ class AnnotatedSpecLinkableElementSet(BaseLinkableElementSet, SerializableDatacl
 
         return AnnotatedSpecLinkableElementSet(
             annotated_specs=tuple(dunder_name_to_annotated_spec.values()),
+        )
+
+    @staticmethod
+    def create_from_trie(*dunder_name_tries: DunderNameTrie) -> AnnotatedSpecLinkableElementSet:  # noqa: D102
+        return AnnotatedSpecLinkableElementSet(
+            annotated_specs=tuple(
+                annotated_spec
+                for annotated_spec in mf_flatten(
+                    AnnotatedSpec.create_from_indexed_dunder_name(indexed_dunder_name, descriptor)
+                    for trie in dunder_name_tries
+                    for indexed_dunder_name, descriptor in trie.name_items()
+                )
+            )
         )
 
     @staticmethod

--- a/metricflow-semantics/metricflow_semantics/experimental/semantic_graph/trie_resolver/entity_key_resolver.py
+++ b/metricflow-semantics/metricflow_semantics/experimental/semantic_graph/trie_resolver/entity_key_resolver.py
@@ -1,0 +1,238 @@
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+from collections.abc import Mapping
+from typing import Set
+
+from metricflow_semantics.collection_helpers.mf_type_aliases import AnyLengthTuple
+from metricflow_semantics.experimental.dataclass_helpers import fast_frozen_dataclass
+from metricflow_semantics.experimental.semantic_graph.attribute_resolution.attribute_recipe import (
+    AttributeRecipe,
+    IndexedDunderName,
+)
+from metricflow_semantics.experimental.semantic_graph.attribute_resolution.recipe_writer_weight import (
+    AttributeRecipeWriterWeightFunction,
+)
+from metricflow_semantics.experimental.semantic_graph.nodes.node_labels import (
+    ConfiguredEntityLabel,
+    JoinedModelLabel,
+    KeyAttributeLabel,
+    LocalModelLabel,
+)
+from metricflow_semantics.experimental.semantic_graph.sg_interfaces import SemanticGraph, SemanticGraphNode
+from metricflow_semantics.experimental.semantic_graph.trie_resolver.dunder_name_descriptor import DunderNameDescriptor
+from metricflow_semantics.experimental.semantic_graph.trie_resolver.dunder_name_trie import (
+    DunderNameTrie,
+    MutableDunderNameTrie,
+)
+from metricflow_semantics.mf_logging.lazy_formattable import LazyFormat
+from metricflow_semantics.model.semantics.linkable_element import LinkableElementType
+from metricflow_semantics.model.semantics.semantic_model_join_evaluator import MAX_JOIN_HOPS
+
+logger = logging.getLogger(__name__)
+
+
+DunderNameTuple = AnyLengthTuple[str]
+
+
+class EntityKeyTrieResolver:
+    """A resolver to figure out the possible group-by items that are entity-keys.
+
+     i.e. the available items when the user wants to `query for an entity`.
+
+    For example, the `bookings` metric could be queried by the following entity keys (if you include entity links):
+
+        booking
+        host
+        guest
+        booking__listing
+        listing__user
+        ...
+
+    The entity-key trie represents all possible group-by items that represent an entity key.
+
+    The entity-key trie is needed to resolve the available group-by metrics for a query. Group-by metrics
+    are modeled as a join using a subquery where the group-by item is the entity key. e.g. for the query (`bookings` by
+    `listing__views` ), the query (`bookings` by `listing`) is joined with the subquery (`views` by `listing`) on
+    the entity key.
+    """
+
+    def __init__(self, semantic_graph: SemanticGraph) -> None:  # noqa: D107
+        self._verbose_debug_logs = False
+        self._semantic_graph = semantic_graph
+
+    def resolve_entity_key_trie_mapping(self) -> Mapping[SemanticGraphNode, DunderNameTrie]:
+        """Returns a mapping from the local-model to the associated entity-key trie.
+
+        This is returned as single mapping because to resolve the group-by metrics for any measure, you need them all
+        anyway.
+        """
+        local_model_nodes = self._semantic_graph.nodes_with_labels(LocalModelLabel.get_instance())
+        key_attribute_nodes = self._semantic_graph.nodes_with_labels(KeyAttributeLabel.get_instance())
+        joined_model_nodes = self._semantic_graph.nodes_with_labels(JoinedModelLabel.get_instance())
+        configured_entity_nodes = self._semantic_graph.nodes_with_labels(ConfiguredEntityLabel.get_instance())
+
+        allowed_nodes: Set[SemanticGraphNode] = set()
+        allowed_nodes.update(local_model_nodes, key_attribute_nodes, joined_model_nodes, configured_entity_nodes)
+
+        source_nodes = local_model_nodes
+        target_nodes = key_attribute_nodes
+        max_entity_links = MAX_JOIN_HOPS
+
+        if self._verbose_debug_logs:
+            logger.debug(
+                LazyFormat(
+                    "Starting path-finding for key queries",
+                    source_nodes=source_nodes,
+                    target_nodes=target_nodes,
+                    allowed_nodes=allowed_nodes,
+                )
+            )
+
+        # We're looking to find all possible paths from the local-model nodes (the source nodes) to the entity-key
+        # nodes (the target nodes).
+        # To do this efficiently, this uses a method similar to Dijkstra's algorithm. For each node, we maintain
+        # a lookup that records the next possible node on paths that lead to entity-key nodes. By starting from the
+        # target nodes (instead of the source nodes), we can ensure that by the end of the exploration, the lookup
+        # only contains valid paths from source nodes to target nodes.
+        semantic_graph = self._semantic_graph
+        notifications_to_process: dict[SemanticGraphNode, list[_FoundPathToNodeNotification]] = defaultdict(list)
+        initial_recipe = AttributeRecipe()
+
+        # Since we're starting at the target node and going backwards, initially populate the lookup for the target
+        # nodes.
+        for node in target_nodes:
+            recipe_at_node = initial_recipe.push_step(node.recipe_step_to_append)
+            for edge_from_predecessor in semantic_graph.edges_with_head_node(node):
+                predecessor_node = edge_from_predecessor.tail_node
+                recipe_at_predecessor_node = recipe_at_node.push_steps(
+                    edge_from_predecessor.recipe_step_to_append,
+                    edge_from_predecessor.tail_node.recipe_step_to_append,
+                )
+                notification = _FoundPathToNodeNotification(next_node=node, recipe=recipe_at_predecessor_node)
+
+                if self._verbose_debug_logs:
+                    logger.debug(
+                        LazyFormat(
+                            "Adding initial notification",
+                            predecessor_node=predecessor_node,
+                            notification=notification,
+                        )
+                    )
+                notifications_to_process[predecessor_node].append(notification)
+
+        found_path_to_node_notifications: dict[SemanticGraphNode, list[_FoundPathToNodeNotification]] = defaultdict(
+            list
+        )
+
+        # At each step, explore the predecessors of the nodes that were discovered in the previous step. Repeat until.
+        # there are no more new nodes / new paths discovered.
+        step_index = 0
+        while len(notifications_to_process) > 0:
+            if self._verbose_debug_logs:
+                logger.debug(
+                    LazyFormat(
+                        "Processing step", step_index=step_index, notifications_to_process=notifications_to_process
+                    )
+                )
+
+            next_notifications_to_process: dict[SemanticGraphNode, list[_FoundPathToNodeNotification]] = defaultdict(
+                list
+            )
+
+            for current_node, found_new_path_notifications in notifications_to_process.items():
+                if current_node in source_nodes:
+                    found_path_to_node_notifications[current_node].extend(found_new_path_notifications)
+                    continue
+
+                for new_path_notification in found_new_path_notifications:
+                    recipe_at_current_node = new_path_notification.recipe
+
+                    for edge_from_predecessor in semantic_graph.edges_with_head_node(current_node):
+                        predecessor_node = edge_from_predecessor.tail_node
+
+                        tail_node_step = edge_from_predecessor.tail_node.recipe_step_to_append
+                        edge_step = edge_from_predecessor.recipe_step_to_append
+
+                        if AttributeRecipeWriterWeightFunction.repeated_dunder_name_elements(
+                            recipe=recipe_at_current_node, step=tail_node_step, other_step=edge_step
+                        ) or AttributeRecipeWriterWeightFunction.repeated_model_join(
+                            recipe=recipe_at_current_node, step=tail_node_step, other_step=edge_step
+                        ):
+                            continue
+
+                        next_entity_link_count = (
+                            len(recipe_at_current_node.entity_link_names)
+                            + (1 if tail_node_step.add_entity_link else 0)
+                            + (1 if edge_step.add_entity_link else 0)
+                        )
+
+                        if next_entity_link_count > max_entity_links:
+                            continue
+
+                        # Handle a special case where entities can be queried by an entity link prefix in the same
+                        # semantic model, but not when a part of a join.
+                        next_model_count = (
+                            len(recipe_at_current_node.joined_model_ids)
+                            + (1 if tail_node_step.add_model_join else 0)
+                            + (1 if edge_step.add_model_join else 0)
+                        )
+                        if next_model_count > 1 and next_entity_link_count > (next_model_count - 1):
+                            continue
+
+                        recipe_at_predecessor = recipe_at_current_node.push_steps(
+                            edge_from_predecessor.recipe_step_to_append,
+                            edge_from_predecessor.tail_node.recipe_step_to_append,
+                        )
+
+                        notification = _FoundPathToNodeNotification(
+                            next_node=current_node, recipe=recipe_at_predecessor
+                        )
+                        if self._verbose_debug_logs:
+                            logger.debug(
+                                LazyFormat(
+                                    "Adding notification",
+                                    predecessor_node=predecessor_node,
+                                    notification=notification,
+                                )
+                            )
+                        next_notifications_to_process[predecessor_node].append(notification)
+            notifications_to_process = next_notifications_to_process
+            step_index += 1
+
+        # Once the above loop has finished, the lookup can be used to figure out the possible path (encoded in the
+        # recipe).
+        source_node_to_trie: dict[SemanticGraphNode, MutableDunderNameTrie] = defaultdict(MutableDunderNameTrie)
+        for source_node, notifications in found_path_to_node_notifications.items():
+            items_to_add: list[tuple[IndexedDunderName, DunderNameDescriptor]] = []
+            for notification in notifications:
+                recipe = notification.recipe
+                indexed_dunder_name = recipe.indexed_dunder_name
+                last_model_id = recipe.last_model_id
+                items_to_add.append(
+                    (
+                        indexed_dunder_name,
+                        DunderNameDescriptor(
+                            element_type=LinkableElementType.ENTITY,
+                            time_grain=None,
+                            date_part=None,
+                            element_properties=(),
+                            origin_model_ids=(last_model_id,) if last_model_id else (),
+                            derived_from_model_ids=notification.recipe.joined_model_ids,
+                            entity_key_queries_for_group_by_metric=(),
+                        ),
+                    )
+                )
+
+            source_node_to_trie[source_node].add_name_items(items_to_add)
+
+        return {source_node: source_node_to_trie[source_node] for source_node in source_nodes}
+
+
+@fast_frozen_dataclass()
+class _FoundPathToNodeNotification:
+    """The value for the keys in the dict that maps a node to the next node in the path (to a target node)."""
+
+    next_node: SemanticGraphNode
+    recipe: AttributeRecipe

--- a/metricflow-semantics/metricflow_semantics/experimental/semantic_graph/trie_resolver/group_by_metric_resolver.py
+++ b/metricflow-semantics/metricflow_semantics/experimental/semantic_graph/trie_resolver/group_by_metric_resolver.py
@@ -1,0 +1,491 @@
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+from collections.abc import Set
+from functools import cached_property
+from typing import Mapping, Optional
+
+from typing_extensions import override
+
+from metricflow_semantics.experimental.metricflow_exception import MetricflowInternalError
+from metricflow_semantics.experimental.mf_graph.path_finding.pathfinder import MetricflowPathfinder
+from metricflow_semantics.experimental.mf_graph.path_finding.traversal_profile_differ import TraversalProfileDiffer
+from metricflow_semantics.experimental.ordered_set import FrozenOrderedSet, MutableOrderedSet, OrderedSet
+from metricflow_semantics.experimental.semantic_graph.attribute_resolution.attribute_recipe import IndexedDunderName
+from metricflow_semantics.experimental.semantic_graph.attribute_resolution.recipe_writer_path import (
+    AttributeRecipeWriterPath,
+)
+from metricflow_semantics.experimental.semantic_graph.edges.edge_labels import (
+    DenyEntityKeyQueryResolutionLabel,
+    DenyVisibleAttributesLabel,
+)
+from metricflow_semantics.experimental.semantic_graph.model_id import SemanticModelId
+from metricflow_semantics.experimental.semantic_graph.nodes.entity_nodes import MetricTimeNode
+from metricflow_semantics.experimental.semantic_graph.nodes.node_labels import (
+    BaseMetricLabel,
+    ConfiguredEntityLabel,
+    JoinedModelLabel,
+    LocalModelLabel,
+    MeasureLabel,
+    MetricLabel,
+)
+from metricflow_semantics.experimental.semantic_graph.sg_interfaces import (
+    SemanticGraph,
+    SemanticGraphEdge,
+    SemanticGraphNode,
+)
+from metricflow_semantics.experimental.semantic_graph.trie_resolver.dunder_name_descriptor import (
+    DunderNameDescriptor,
+    EntityKeyQueryForGroupByMetric,
+)
+from metricflow_semantics.experimental.semantic_graph.trie_resolver.dunder_name_trie import (
+    DunderNameTrie,
+    MutableDunderNameTrie,
+)
+from metricflow_semantics.experimental.semantic_graph.trie_resolver.dunder_name_trie_resolver import (
+    DunderNameTrieResolver,
+    TrieResolutionResult,
+)
+from metricflow_semantics.experimental.semantic_graph.trie_resolver.entity_key_resolver import (
+    EntityKeyTrieResolver,
+)
+from metricflow_semantics.helpers.performance_helpers import ExecutionTimer
+from metricflow_semantics.mf_logging.lazy_formattable import LazyFormat
+from metricflow_semantics.mf_logging.runtime import log_block_runtime
+from metricflow_semantics.model.linkable_element_property import LinkableElementProperty
+from metricflow_semantics.model.semantics.element_filter import LinkableElementFilter
+from metricflow_semantics.model.semantics.linkable_element import LinkableElementType
+
+logger = logging.getLogger(__name__)
+
+
+class GroupByMetricTrieResolver(DunderNameTrieResolver):
+    """Resolves the group-by metrics that are available for the given measures / metrics.
+
+    Group-by metrics are handled separately to break out the resolution of all available group-by items into smaller
+    pieces.
+    """
+
+    def __init__(  # noqa: D107
+        self,
+        semantic_graph: SemanticGraph,
+        path_finder: MetricflowPathfinder[SemanticGraphNode, SemanticGraphEdge, AttributeRecipeWriterPath],
+    ) -> None:
+        super().__init__(semantic_graph=semantic_graph, path_finder=path_finder)
+        self._local_model_nodes = semantic_graph.nodes_with_labels(self._local_model_label)
+        self._key_attribute_nodes = semantic_graph.nodes_with_labels(self._entity_key_attribute_label)
+        self._node_allow_set = self._local_model_nodes.union(
+            self._key_attribute_nodes,
+            self._semantic_graph.nodes_with_labels(
+                JoinedModelLabel.get_instance(),
+                ConfiguredEntityLabel.get_instance(),
+            ),
+        )
+        self._metric_nodes = semantic_graph.nodes_with_labels(MetricLabel.get_instance())
+        self._measure_nodes = semantic_graph.nodes_with_labels(MeasureLabel.get_instance())
+        self._base_metric_nodes = semantic_graph.nodes_with_labels(BaseMetricLabel.get_instance())
+        self._nodes_in_path_from_metric_nodes_to_local_model_nodes = semantic_graph.nodes_with_labels(
+            MetricLabel.get_instance(),
+            MeasureLabel.get_instance(),
+            LocalModelLabel.get_instance(),
+        )
+        self._metric_time_node = MetricTimeNode.get_instance()
+
+        self._group_by_metric_element_properties = (
+            LinkableElementProperty.JOINED,
+            LinkableElementProperty.METRIC,
+        )
+
+        self._verbose_debug_logs = False
+
+    @override
+    def resolve_trie(
+        self, source_nodes: OrderedSet[SemanticGraphNode], element_filter: Optional[LinkableElementFilter]
+    ) -> TrieResolutionResult:
+        execution_timer = ExecutionTimer()
+        pathfinder_counter_set_differ = TraversalProfileDiffer(self._path_finder)
+
+        with execution_timer, pathfinder_counter_set_differ:
+            trie_result = self._resolve_trie(source_nodes=source_nodes, element_filter=element_filter)
+
+        return TrieResolutionResult(
+            execution_time=execution_timer.execution_time,
+            traversal_profile=pathfinder_counter_set_differ.profile_delta,
+            dunder_name_trie=trie_result,
+        )
+
+    @cached_property
+    def _metric_name_to_entity_key_trie(self) -> Mapping[str, DunderNameTrie]:
+        return _MetricNameToEntityKeyTrieGenerator(
+            semantic_graph=self._semantic_graph,
+            path_finder=self._path_finder,
+            model_node_to_entity_key_trie=self._model_node_to_entity_key_trie,
+        ).generate()
+
+    @cached_property
+    def _entity_key_name_to_metric_names(self) -> Mapping[str, OrderedSet[str]]:
+        entity_key_name_to_metric_names: dict[str, MutableOrderedSet[str]] = defaultdict(MutableOrderedSet)
+        for metric_name, entity_key_trie in self._metric_name_to_entity_key_trie.items():
+            for indexed_name, _ in entity_key_trie.name_items():
+                entity_key_name_to_metric_names[indexed_name[-1]].add(metric_name)
+
+        return entity_key_name_to_metric_names
+
+    def _resolve_trie(
+        self,
+        source_nodes: OrderedSet[SemanticGraphNode],
+        element_filter: Optional[LinkableElementFilter],
+    ) -> DunderNameTrie:
+        trie_to_update = MutableDunderNameTrie()
+
+        # Find all required local-model nodes.
+        metric_names_allow_set: Optional[Set[str]] = None
+
+        if element_filter is not None:
+            metric_names_allow_set = element_filter.element_names
+            # Group-by metrics always have these properties, so return an empty set if the filter doesn't allow them.
+            if not element_filter.allow(
+                element_name=None, element_properties=(LinkableElementProperty.METRIC, LinkableElementProperty.JOINED)
+            ):
+                logger.debug(
+                    LazyFormat(
+                        "Skipping resolution due to the element filter",
+                        class_name=self.__class__.__name__,
+                        element_filter=element_filter,
+                    )
+                )
+                return trie_to_update
+
+        find_descendants_result = self._path_finder.find_descendants(
+            graph=self._semantic_graph,
+            source_nodes=source_nodes,
+            target_nodes=self._local_model_nodes,
+            node_allow_set=self._node_allow_set,
+            deny_labels={self._deny_visible_attributes_label},
+        )
+        reachable_local_model_nodes = tuple(find_descendants_result.reachable_target_nodes)
+        if self._verbose_debug_logs:
+            logger.debug(
+                LazyFormat(
+                    "Found local-model nodes for source nodes.",
+                    source_nodes=source_nodes,
+                    reachable_local_model_nodes=reachable_local_model_nodes,
+                )
+            )
+
+        if len(reachable_local_model_nodes) == 0:
+            raise MetricflowInternalError(
+                LazyFormat(
+                    "No local-model nodes were found to be reachable from the given source nodes.",
+                    source_nodes=source_nodes,
+                    local_model_nodes=self._local_model_nodes,
+                )
+            )
+
+        # Figure out which entity-key queries are possible given the local-model nodes.
+        entity_key_trie: DunderNameTrie = MutableDunderNameTrie.intersection_merge_common(
+            tuple(
+                self._model_node_to_entity_key_trie[reachable_local_model_node]
+                for reachable_local_model_node in reachable_local_model_nodes
+            )
+        )
+        # `entity_key_trie` contains all entity-keys like `booking__listing__user`. But we only want `booking`,
+        # so use 1 as the max length.
+        collected_entity_key_names: list[str] = []
+        collected_derived_from_model_ids: list[SemanticModelId] = []
+
+        for indexed_dunder_name, descriptor in entity_key_trie.name_items(max_length=1):
+            if len(indexed_dunder_name) != 1:
+                raise MetricflowInternalError(
+                    LazyFormat(
+                        "The indexed dunder name should have only contained 1 element.",
+                        indexed_dunder_name=indexed_dunder_name,
+                    )
+                )
+            collected_entity_key_names.append(indexed_dunder_name[0])
+            collected_derived_from_model_ids.extend(descriptor.derived_from_model_ids)
+
+        entity_key_names = FrozenOrderedSet(collected_entity_key_names)
+        derived_from_model_ids = FrozenOrderedSet(collected_derived_from_model_ids)
+
+        for entity_key_name in entity_key_names:
+            metric_names = self._entity_key_name_to_metric_names[entity_key_name]
+            if metric_names is None:
+                logger.warning(
+                    LazyFormat(
+                        "Valid group-by metrics for the given entity-key name not found. this may occur"
+                        " when a given entity is not accessible from any metric (known case is related to conversion"
+                        " measures)",
+                        entity_key_name=entity_key_name,
+                        known_key_names=list(self._entity_key_name_to_metric_names.keys()),
+                    )
+                )
+            trie_for_entity = trie_to_update.next_name_element_to_trie[entity_key_name]
+
+            items_to_add_to_trie: list[tuple[IndexedDunderName, DunderNameDescriptor]] = []
+
+            for metric_name in metric_names:
+                if metric_names_allow_set is not None and metric_name not in metric_names_allow_set:
+                    continue
+                entity_key_queries: list[EntityKeyQueryForGroupByMetric] = []
+                for indexed_dunder_name, descriptor in self._metric_name_to_entity_key_trie[metric_name].name_items():
+                    if indexed_dunder_name[-1] != entity_key_name:
+                        continue
+                    entity_key_queries.append(
+                        EntityKeyQueryForGroupByMetric(
+                            entity_key_query=indexed_dunder_name,
+                            derived_from_model_ids=descriptor.derived_from_model_ids,
+                        )
+                    )
+                descriptor = DunderNameDescriptor(
+                    element_type=LinkableElementType.METRIC,
+                    time_grain=None,
+                    date_part=None,
+                    element_properties=self._group_by_metric_element_properties,
+                    origin_model_ids=self._virtual_semantic_model_ids,
+                    derived_from_model_ids=tuple(derived_from_model_ids),
+                    entity_key_queries_for_group_by_metric=tuple(entity_key_queries),
+                )
+                items_to_add_to_trie.append(((metric_name,), descriptor))
+            trie_for_entity.add_name_items(items_to_add_to_trie)
+
+        return trie_to_update
+
+    @cached_property
+    def _model_node_to_entity_key_trie(self) -> Mapping[SemanticGraphNode, DunderNameTrie]:
+        with log_block_runtime("Resolve key queries"):
+            # resolver = KeyQueryResolver()
+            # resolver_result = resolver.find_key_query_groups(self._current_graph)
+
+            resolver = EntityKeyTrieResolver(self._semantic_graph)
+            resolver_result = resolver.resolve_entity_key_trie_mapping()
+            if self._verbose_debug_logs:
+                logger.debug(
+                    LazyFormat(
+                        "Resolved entity-key trie",
+                        resolver_result=resolver_result,
+                    )
+                )
+
+            return resolver_result
+
+
+class _MetricNameToEntityKeyTrieGenerator:
+    def __init__(
+        self,
+        semantic_graph: SemanticGraph,
+        path_finder: MetricflowPathfinder[SemanticGraphNode, SemanticGraphEdge, AttributeRecipeWriterPath],
+        model_node_to_entity_key_trie: Mapping[SemanticGraphNode, DunderNameTrie],
+    ) -> None:
+        self._current_graph = semantic_graph
+        self._path_finder = path_finder
+        self._metric_node_to_entity_key_trie: dict[SemanticGraphNode, MutableDunderNameTrie] = {}
+        metric_nodes = semantic_graph.nodes_with_labels(MetricLabel.get_instance())
+        self._metric_nodes_in_current_graph = metric_nodes
+        self._verbose_debug_logs = False
+        self._model_node_to_entity_key_trie = model_node_to_entity_key_trie
+
+    def _get_entity_key_trie_for_metric_node(
+        self,
+        metric_node: SemanticGraphNode,
+        _metric_nodes_in_definition_path: Set[SemanticGraphNode] = frozenset(),
+    ) -> MutableDunderNameTrie:
+        entity_key_trie = self._metric_node_to_entity_key_trie.get(metric_node)
+        if entity_key_trie is not None:
+            return entity_key_trie
+
+        if metric_node in _metric_nodes_in_definition_path:
+            raise RuntimeError(
+                LazyFormat(
+                    "Recursive metric definition detected",
+                    metric_node=metric_node,
+                    metric_nodes_in_definition_path=_metric_nodes_in_definition_path,
+                )
+            )
+
+        if metric_node not in self._metric_nodes_in_current_graph:
+            raise RuntimeError(
+                LazyFormat(
+                    "Traversal reached a non-metric node",
+                    current_node=metric_node,
+                    metric_nodes=self._metric_nodes_in_current_graph,
+                    metric_nodes_in_definition_path=_metric_nodes_in_definition_path,
+                )
+            )
+
+        current_graph = self._current_graph
+
+        deny_label = DenyEntityKeyQueryResolutionLabel.get_instance()
+        parent_metric_nodes: MutableOrderedSet[SemanticGraphNode] = MutableOrderedSet()
+        for edge_to_successor in current_graph.edges_with_tail_node(metric_node):
+            parent_metric_node = edge_to_successor.head_node
+            if deny_label in edge_to_successor.labels or deny_label in edge_to_successor.head_node.labels:
+                parent_metric_nodes = MutableOrderedSet()
+                break
+            else:
+                parent_metric_nodes.add(parent_metric_node)
+
+        if len(parent_metric_nodes) == 0:
+            result = MutableDunderNameTrie()
+            self._metric_node_to_entity_key_trie[metric_node] = result
+            return result
+
+        key_query_sets_to_intersect: list[MutableDunderNameTrie] = []
+        for parent_metric_node in parent_metric_nodes:
+            if parent_metric_node not in self._metric_node_to_entity_key_trie:
+                self._get_entity_key_trie_for_metric_node(
+                    metric_node=parent_metric_node,
+                    _metric_nodes_in_definition_path=_metric_nodes_in_definition_path | {metric_node},
+                )
+            key_query_sets_to_intersect.append(self._metric_node_to_entity_key_trie[parent_metric_node])
+
+        dunder_name_trie = MutableDunderNameTrie.intersection_merge_common(key_query_sets_to_intersect)
+        self._metric_node_to_entity_key_trie[metric_node] = dunder_name_trie
+
+        return dunder_name_trie
+
+    def generate(self) -> Mapping[str, MutableDunderNameTrie]:
+        """This return a mapping from the metric name, to a trie representing the valid entity-key queries for that metric.
+
+        The descriptors for the trie include context on the semantic models required to query the entity key for the
+        given metric.
+        """
+        current_graph = self._current_graph
+        path_finder = self._path_finder
+
+        base_metric_label = BaseMetricLabel.get_instance()
+        base_metric_nodes = current_graph.nodes_with_labels(base_metric_label)
+
+        if len(base_metric_nodes) == 0:
+            raise RuntimeError(
+                LazyFormat(
+                    "Did not find any base metric nodes. This indicates an error in graph construction.",
+                    base_metric_nodes=base_metric_nodes,
+                    label=base_metric_label,
+                )
+            )
+
+        if self._verbose_debug_logs:
+            logger.debug(
+                LazyFormat(
+                    "Found base-metric nodes",
+                    base_metric_nodes=base_metric_nodes,
+                )
+            )
+
+        self._metric_node_to_entity_key_trie = {}
+
+        local_model_nodes = current_graph.nodes_with_labels(LocalModelLabel.get_instance())
+        measure_nodes = current_graph.nodes_with_labels(MeasureLabel.get_instance())
+
+        allowed_nodes_for_walking_from_metrics_to_models: MutableOrderedSet[SemanticGraphNode] = MutableOrderedSet(
+            local_model_nodes
+        )
+        allowed_nodes_for_walking_from_metrics_to_models.update(self._metric_nodes_in_current_graph)
+        allowed_nodes_for_walking_from_metrics_to_models.update(measure_nodes)
+
+        if self._verbose_debug_logs:
+            logger.debug(
+                LazyFormat(
+                    "Finding entity key queries for base metric nodes",
+                    base_metric_nodes=base_metric_nodes,
+                    local_model_nodes=local_model_nodes,
+                    allowed_nodes_for_walking_from_metrics_to_models=allowed_nodes_for_walking_from_metrics_to_models,
+                )
+            )
+
+        deny_labels = {
+            # For conversion metrics, the conversion measure is effectively hidden and is not used to generate the
+            # available group-by items for a metric.
+            DenyEntityKeyQueryResolutionLabel.get_instance(),
+            # For metrics that require metric time to be in a query, it's not possible to query just the entity keys.
+            DenyVisibleAttributesLabel.get_instance(),
+        }
+
+        # For each base metric, generate the set of possible entity-key queries. These will be used to generate the
+        # set of possible entity-key queries for derived metrics.
+        for base_metric_node in base_metric_nodes:
+            base_metric_node_set = FrozenOrderedSet((base_metric_node,))
+
+            result = path_finder.find_descendants(
+                graph=current_graph,
+                source_nodes=base_metric_node_set,
+                target_nodes=local_model_nodes,
+                node_allow_set=allowed_nodes_for_walking_from_metrics_to_models,
+                deny_labels=deny_labels,
+            )
+            visible_source_model_nodes = result.reachable_target_nodes
+
+            if self._verbose_debug_logs:
+                logger.debug(
+                    LazyFormat(
+                        "Found model nodes containing the measures for the given metric. Those model nodes"
+                        " will be used for generating the available group-by items.",
+                        base_metric_node=base_metric_node,
+                        visible_source_model_nodes=visible_source_model_nodes,
+                    )
+                )
+
+            if len(visible_source_model_nodes) == 0:
+                # Entity-key attributes can't be queried for cumulative metrics (as described by the deny labels),
+                # so set an empty result.
+                self._metric_node_to_entity_key_trie[base_metric_node] = MutableDunderNameTrie()
+                continue
+
+            entity_key_trie_intersection_list: list[DunderNameTrie] = []
+            for source_model_node in visible_source_model_nodes:
+                entity_key_trie_intersection_list.append(self._model_node_to_entity_key_trie[source_model_node])
+
+            # Figure out the models that a metric depends on.
+            result = path_finder.find_descendants(
+                graph=current_graph,
+                source_nodes=base_metric_node_set,
+                target_nodes=local_model_nodes,
+                node_allow_set=allowed_nodes_for_walking_from_metrics_to_models,
+            )
+            source_model_nodes = result.reachable_target_nodes
+            if self._verbose_debug_logs:
+                logger.debug(
+                    LazyFormat(
+                        "Found model nodes containing the measures for the given metric. Those model nodes"
+                        " will be used for generating the available group-by items.",
+                        base_metric_node=base_metric_node,
+                        visible_source_model_nodes=visible_source_model_nodes,
+                    )
+                )
+
+            common_source_model_ids: MutableOrderedSet[SemanticModelId] = MutableOrderedSet()
+            for model_node in source_model_nodes - visible_source_model_nodes:
+                model_id = model_node.recipe_step_to_append.add_model_join
+                assert model_id is not None, LazyFormat(
+                    "A found node is expected to be a model node, but the recipe step does not include the"
+                    " associated model ID. The search may be incorrect and found the wrong node.",
+                    model_id=model_id,
+                    model_node=model_node,
+                )
+                common_source_model_ids.add(model_id)
+
+            dunder_name_trie = MutableDunderNameTrie.intersection_merge_common(entity_key_trie_intersection_list)
+
+            dunder_name_trie.update_derived_from_model_ids(
+                tuple(common_source_model_ids),
+            )
+            self._metric_node_to_entity_key_trie[base_metric_node] = dunder_name_trie
+
+        metric_name_to_entity_key_trie: dict[str, MutableDunderNameTrie] = {}
+
+        for metric_node in self._metric_nodes_in_current_graph:
+            entity_key_trie = self._get_entity_key_trie_for_metric_node(metric_node)
+            metric_name = metric_node.dunder_name_element
+            if metric_name is None:
+                raise RuntimeError(
+                    LazyFormat(
+                        "Expected a metric node to have a name",
+                        metric_node=metric_node,
+                    )
+                )
+
+            metric_name_to_entity_key_trie[metric_name] = entity_key_trie
+
+        return metric_name_to_entity_key_trie

--- a/metricflow-semantics/tests_metricflow_semantics/experimental/semantic_graph/trie_resolver/test_group_by_metric_trie_resolver.py
+++ b/metricflow-semantics/tests_metricflow_semantics/experimental/semantic_graph/trie_resolver/test_group_by_metric_trie_resolver.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import logging
+
+from _pytest.fixtures import FixtureRequest
+from dbt_semantic_interfaces.protocols import SemanticManifest
+from metricflow_semantics.experimental.dsi.manifest_object_lookup import ManifestObjectLookup
+from metricflow_semantics.experimental.mf_graph.path_finding.pathfinder import MetricflowPathfinder
+from metricflow_semantics.experimental.ordered_set import FrozenOrderedSet
+from metricflow_semantics.experimental.semantic_graph.attribute_resolution.annotated_spec_linkable_element_set import (
+    AnnotatedSpecLinkableElementSet,
+)
+from metricflow_semantics.experimental.semantic_graph.attribute_resolution.recipe_writer_path import (
+    RecipeWriterPathfinder,
+)
+from metricflow_semantics.experimental.semantic_graph.builder.graph_builder import SemanticGraphBuilder
+from metricflow_semantics.experimental.semantic_graph.nodes.node_labels import MeasureLabel
+from metricflow_semantics.experimental.semantic_graph.trie_resolver.group_by_metric_resolver import (
+    GroupByMetricTrieResolver,
+)
+from metricflow_semantics.test_helpers.config_helpers import MetricFlowTestConfiguration
+from metricflow_semantics.test_helpers.snapshot_helpers import assert_object_snapshot_equal
+
+logger = logging.getLogger(__name__)
+
+
+def test_measure(  # noqa: D103
+    request: FixtureRequest,
+    mf_test_configuration: MetricFlowTestConfiguration,
+    sg_05_derived_metric_manifest: SemanticManifest,
+) -> None:
+    semantic_graph = SemanticGraphBuilder(ManifestObjectLookup(sg_05_derived_metric_manifest)).build()
+    pathfinder: RecipeWriterPathfinder = MetricflowPathfinder()
+    resolver = GroupByMetricTrieResolver(semantic_graph=semantic_graph, path_finder=pathfinder)
+    measure_node = semantic_graph.node_with_label(MeasureLabel.get_instance("booking_count"))
+    result = resolver.resolve_trie(source_nodes=FrozenOrderedSet((measure_node,)), element_filter=None)
+
+    assert_object_snapshot_equal(
+        request=request,
+        snapshot_configuration=mf_test_configuration,
+        obj=AnnotatedSpecLinkableElementSet.create_from_trie(result.dunder_name_trie),
+    )

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_group_by_metric_trie_resolver.py/AnnotatedSpecLinkableElementSet/test_measure__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_group_by_metric_trie_resolver.py/AnnotatedSpecLinkableElementSet/test_measure__result.txt
@@ -1,0 +1,43 @@
+test_name: test_measure
+test_filename: test_group_by_metric_trie_resolver.py
+---
+AnnotatedSpecLinkableElementSet(
+  annotated_specs=(
+    AnnotatedSpec(
+      element_type=METRIC,
+      element_name='bookings',
+      entity_link_names=('booking',),
+      metric_subquery_entity_link_names=('booking',),
+      element_properties=(JOINED, METRIC),
+      origin_semantic_model_names=('__VIRTUAL__',),
+      derived_from_semantic_model_names=('bookings_source',),
+    ),
+    AnnotatedSpec(
+      element_type=METRIC,
+      element_name='views',
+      entity_link_names=('booking',),
+      metric_subquery_entity_link_names=('booking',),
+      element_properties=(JOINED, METRIC),
+      origin_semantic_model_names=('__VIRTUAL__',),
+      derived_from_semantic_model_names=('bookings_source', 'views_source'),
+    ),
+    AnnotatedSpec(
+      element_type=METRIC,
+      element_name='views',
+      entity_link_names=('booking',),
+      metric_subquery_entity_link_names=('view', 'booking'),
+      element_properties=(JOINED, METRIC),
+      origin_semantic_model_names=('__VIRTUAL__',),
+      derived_from_semantic_model_names=('bookings_source', 'views_source'),
+    ),
+    AnnotatedSpec(
+      element_type=METRIC,
+      element_name='bookings_per_view',
+      entity_link_names=('booking',),
+      metric_subquery_entity_link_names=('booking',),
+      element_properties=(JOINED, METRIC),
+      origin_semantic_model_names=('__VIRTUAL__',),
+      derived_from_semantic_model_names=('bookings_source', 'views_source'),
+    ),
+  ),
+)


### PR DESCRIPTION
Related to https://github.com/dbt-labs/metricflow/pull/1806 - this PR adds a semantic-graph-based resolver to resolve group-by metrics.