### PR TITLE
Add `use_semantic_graph` flag to `SemanticManifestLookup`

### DIFF
--- a/.changes/unreleased/Under the Hood-20250807-083916.yaml
+++ b/.changes/unreleased/Under the Hood-20250807-083916.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Add `use_semantic_graph` flag to `SemanticManifestLookup`
+time: 2025-08-07T08:39:16.511789-07:00
+custom:
+  Author: plypaul
+  Issue: "1812"


### PR DESCRIPTION
This PR adds the flag `use_semantic_graph` to `SemanticManifestLookup`. Since `SemanticManifestLookup` is an input argument to `MetricFlowEngine`, this allows the flag to be used for incremental deployment.

This also updates the integration tests so that they run with and without the flag set.