### PR TITLE
Update error handling for `simple_dimensions_for_metrics`

### DIFF
--- a/.changes/unreleased/Under the Hood-20250811-180206.yaml
+++ b/.changes/unreleased/Under the Hood-20250811-180206.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Update error handling for `simple_dimensions_for_metrics`
+time: 2025-08-11T18:02:06.615091-07:00
+custom:
+  Author: plypaul
+  Issue: "1816"

--- a/metricflow-semantics/metricflow_semantics/errors/error_classes.py
+++ b/metricflow-semantics/metricflow_semantics/errors/error_classes.py
@@ -69,7 +69,7 @@ class SqlBindParametersNotSupportedError(Exception):
     """Raised when a SqlClient that does not have support for bind parameters receives a non-empty set of params."""
 
 
-class UnknownMetricLinkingError(InformativeUserError):
+class UnknownMetricError(InformativeUserError):
     """Raised during linking when a user attempts to use a metric that isn't specified."""
 
 

--- a/metricflow-semantics/metricflow_semantics/errors/error_classes.py
+++ b/metricflow-semantics/metricflow_semantics/errors/error_classes.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import textwrap
+from collections.abc import Sequence
 from typing import Dict, Optional
 
 
@@ -70,7 +71,16 @@ class SqlBindParametersNotSupportedError(Exception):
 
 
 class UnknownMetricError(InformativeUserError):
-    """Raised during linking when a user attempts to use a metric that isn't specified."""
+    """Raised when user input contains metric names that are not known."""
+
+    def __init__(self, metric_names: Sequence[str]) -> None:  # noqa: D107
+        name_count = len(metric_names)
+        if name_count == 0:
+            raise RuntimeError(f"Can't create an {self.__class__.__name__} without metric names")
+        elif name_count == 1:
+            super().__init__(f"Unknown metric: {repr(metric_names[0])}")
+        else:
+            super().__init__(f"Unknown metrics: {list(metric_names)}")
 
 
 class InvalidQuerySyntax(InformativeUserError):

--- a/metricflow-semantics/metricflow_semantics/model/semantics/linkable_spec_index_builder.py
+++ b/metricflow-semantics/metricflow_semantics/model/semantics/linkable_spec_index_builder.py
@@ -22,7 +22,7 @@ from dbt_semantic_interfaces.type_enums.date_part import DatePart
 from dbt_semantic_interfaces.type_enums.time_granularity import TimeGranularity
 from dbt_semantic_interfaces.validations.unique_valid_name import MetricFlowReservedKeywords
 
-from metricflow_semantics.errors.error_classes import UnknownMetricLinkingError
+from metricflow_semantics.errors.error_classes import UnknownMetricError
 from metricflow_semantics.mf_logging.lazy_formattable import LazyFormat
 from metricflow_semantics.mf_logging.pretty_print import mf_pformat
 from metricflow_semantics.model.linkable_element_property import LinkableElementProperty
@@ -700,7 +700,7 @@ class LinkableSpecIndexBuilder:
         for metric_reference in metric_references:
             element_sets = self._linkable_spec_index.metric_to_linkable_element_sets.get(metric_reference.element_name)
             if not element_sets:
-                raise UnknownMetricLinkingError(
+                raise UnknownMetricError(
                     LazyFormat(
                         "Did not find a non-empty element set for the given metric",
                         metric_reference=metric_reference,

--- a/metricflow-semantics/metricflow_semantics/model/semantics/linkable_spec_resolver.py
+++ b/metricflow-semantics/metricflow_semantics/model/semantics/linkable_spec_resolver.py
@@ -19,7 +19,7 @@ from dbt_semantic_interfaces.type_enums.date_part import DatePart
 from dbt_semantic_interfaces.type_enums.time_granularity import TimeGranularity
 from typing_extensions import override
 
-from metricflow_semantics.errors.error_classes import UnknownMetricLinkingError
+from metricflow_semantics.errors.error_classes import UnknownMetricError
 from metricflow_semantics.mf_logging.lazy_formattable import LazyFormat
 from metricflow_semantics.model.linkable_element_property import LinkableElementProperty
 from metricflow_semantics.model.semantics.element_filter import LinkableElementFilter
@@ -327,7 +327,7 @@ class LegacyLinkableSpecResolver(LinkableSpecResolver):
         for metric_reference in metric_references:
             element_sets = self._linkable_spec_index.metric_to_linkable_element_sets.get(metric_reference.element_name)
             if not element_sets:
-                raise UnknownMetricLinkingError(f"Unknown metric: {metric_reference} in element set")
+                raise UnknownMetricError(f"Unknown metric: {metric_reference} in element set")
 
             # Using .only_unique_path_keys to exclude ambiguous elements where there are multiple join paths to get
             # a dimension / entity.

--- a/metricflow-semantics/metricflow_semantics/model/semantics/metric_lookup.py
+++ b/metricflow-semantics/metricflow_semantics/model/semantics/metric_lookup.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 import time
-from typing import Dict, Optional, Sequence, Set, Tuple
+from typing import Dict, Iterable, Optional, Sequence, Set, Tuple
 
 from dbt_semantic_interfaces.enum_extension import assert_values_exhausted
 from dbt_semantic_interfaces.protocols.metric import Metric, MetricInputMeasure, MetricType
@@ -12,6 +12,7 @@ from dbt_semantic_interfaces.type_enums.time_granularity import TimeGranularity
 
 from metricflow_semantics.collection_helpers.lru_cache import LruCache
 from metricflow_semantics.errors.error_classes import DuplicateMetricError, MetricNotFoundError, NonExistentMeasureError
+from metricflow_semantics.experimental.ordered_set import FrozenOrderedSet
 from metricflow_semantics.mf_logging.lazy_formattable import LazyFormat
 from metricflow_semantics.model.linkable_element_property import LinkableElementProperty
 from metricflow_semantics.model.semantics.element_filter import LinkableElementFilter
@@ -199,7 +200,7 @@ class MetricLookup:
         self._linkable_elements_for_metrics_cache.set(cache_key, result)
         return result
 
-    def get_metrics(self, metric_references: Sequence[MetricReference]) -> Sequence[Metric]:  # noqa: D102
+    def get_metrics(self, metric_references: Iterable[MetricReference]) -> Sequence[Metric]:  # noqa: D102
         res = []
         for metric_reference in metric_references:
             if metric_reference not in self._metrics:
@@ -211,8 +212,8 @@ class MetricLookup:
         return res
 
     @property
-    def metric_references(self) -> Sequence[MetricReference]:  # noqa: D102
-        return sorted(self._metrics.keys())
+    def metric_references(self) -> FrozenOrderedSet[MetricReference]:  # noqa: D102
+        return FrozenOrderedSet(sorted(self._metrics.keys()))
 
     def get_metric(self, metric_reference: MetricReference) -> Metric:  # noqa: D102
         if metric_reference not in self._metrics:

--- a/tests_metricflow/engine/test_errors.py
+++ b/tests_metricflow/engine/test_errors.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+
+import pytest
+from _pytest.fixtures import FixtureRequest
+from metricflow_semantics.test_helpers.config_helpers import MetricFlowTestConfiguration
+
+from tests_metricflow.fixtures.manifest_fixtures import MetricFlowEngineTestFixture, SemanticManifestSetup
+from tests_metricflow.snapshot_utils import assert_object_snapshot_equal
+
+logger = logging.getLogger(__name__)
+
+
+def test_simple_dimensions_for_metrics_with_invalid_metric(
+    request: FixtureRequest,
+    mf_test_configuration: MetricFlowTestConfiguration,
+    mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
+) -> None:
+    """Check the exception raised when invalid metric names are provided to `simple_dimensions_for_metrics`."""
+    mf_engine = mf_engine_test_fixture_mapping[SemanticManifestSetup.SIMPLE_MANIFEST].metricflow_engine
+
+    with pytest.raises(Exception) as exception_info_for_one_invalid_metric:
+        mf_engine.simple_dimensions_for_metrics(["invalid_metric"])
+
+    with pytest.raises(Exception) as exception_info_for_multiple_invalid_metrics:
+        mf_engine.simple_dimensions_for_metrics(["invalid_metric_0", "invalid_metric_1"])
+
+    assert_object_snapshot_equal(
+        request=request,
+        mf_test_configuration=mf_test_configuration,
+        obj={
+            "one_invalid_metric": exception_info_for_one_invalid_metric.value,
+            "multiple_invalid_metrics": exception_info_for_multiple_invalid_metrics.value,
+        },
+    )

--- a/tests_metricflow/snapshot_utils.py
+++ b/tests_metricflow/snapshot_utils.py
@@ -70,8 +70,8 @@ def assert_dataflow_plan_text_equal(  # noqa: D103
 def assert_object_snapshot_equal(  # type: ignore[misc]
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
-    obj_id: str,
     obj: Any,
+    obj_id: str = "result",
     sql_client: Optional[SqlClient] = None,
     expectation_description: Optional[str] = None,
 ) -> None:

--- a/tests_metricflow/snapshots/test_errors.py/dict/test_simple_dimensions_for_metrics_with_invalid_metric__result.txt
+++ b/tests_metricflow/snapshots/test_errors.py/dict/test_simple_dimensions_for_metrics_with_invalid_metric__result.txt
@@ -1,0 +1,9 @@
+test_name: test_simple_dimensions_for_metrics_with_invalid_metric
+test_filename: test_errors.py
+docstring:
+  Check the exception raised when invalid metric names are provided to `simple_dimensions_for_metrics`.
+---
+{
+  'one_invalid_metric': UnknownMetricError("Unknown metric: 'invalid_metric'"),
+  'multiple_invalid_metrics': UnknownMetricError("Unknown metrics: ['invalid_metric_0', 'invalid_metric_1']"),
+}


### PR DESCRIPTION
This PR updates error handling for `simple_dimensions_for_metrics` to return an error that is decoupled from the underlying implementations in `metric_lookup`.