### PR TITLE
Minor fixes for semantic manifests in test cases

### DIFF
--- a/metricflow-semantics/metricflow_semantics/test_helpers/semantic_manifest_yamls/multi_hop_join_manifest/customer_other_data.yaml
+++ b/metricflow-semantics/metricflow_semantics/test_helpers/semantic_manifest_yamls/multi_hop_join_manifest/customer_other_data.yaml
@@ -7,9 +7,21 @@ semantic_model:
     schema_name: $source_schema
     alias: customer_other_data
 
+  defaults:
+    agg_time_dimension: acquired_ds
+
+  measures:
+    - name: customers_with_other_data
+      expr: 1
+      agg: sum
+
   dimensions:
     - name: country
       type: categorical
+    - name: acquired_ds
+      type: time
+      type_params:
+        time_granularity: day
 
   entities:
     - name: customer_id

--- a/metricflow-semantics/metricflow_semantics/test_helpers/semantic_manifest_yamls/multi_hop_join_manifest/metrics.yaml
+++ b/metricflow-semantics/metricflow_semantics/test_helpers/semantic_manifest_yamls/multi_hop_join_manifest/metrics.yaml
@@ -1,0 +1,8 @@
+---
+metric:
+  name: paraguayan_customers
+  type: SIMPLE
+  type_params:
+    measure: customers_with_other_data
+  filter: |
+    {{ Dimension('customer_id__country') }} = 'paraguay'

--- a/metricflow-semantics/metricflow_semantics/test_helpers/semantic_manifest_yamls/simple_manifest/semantic_models/bookings_source.yaml
+++ b/metricflow-semantics/metricflow_semantics/test_helpers/semantic_manifest_yamls/simple_manifest/semantic_models/bookings_source.yaml
@@ -19,6 +19,7 @@ semantic_model:
       agg: sum_boolean
     - name: booking_value
       agg: sum
+      create_metric: true
     - name: max_booking_value
       agg: max
       expr: booking_value

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_semantic_model_container.py/str/test_linkable_elements_for_measure_multi_hop_model__result0.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_semantic_model_container.py/str/test_linkable_elements_for_measure_multi_hop_model__result0.txt
@@ -3,38 +3,50 @@ test_filename: test_semantic_model_container.py
 docstring:
   Tests extracting linkable elements for a given measure input.
 ---
-Dunder Name                                      Metric-Subquery Entity-Links    Type            Properties                            Derived-From Semantic Models
------------------------------------------------  ------------------------------  --------------  ------------------------------------  ---------------------------------------------------
-account_id                                                                       ENTITY          ENTITY,LOCAL                          account_month_txns
-account_id__account_month                                                        DIMENSION       LOCAL                                 account_month_txns
-account_id__customer_id                                                          ENTITY          ENTITY,JOINED                         account_month_txns,bridge_table
-account_id__customer_id__country                                                 DIMENSION       JOINED,MULTI_HOP                      account_month_txns,bridge_table,customer_other_data
-account_id__customer_id__customer_atomic_weight                                  DIMENSION       JOINED,MULTI_HOP                      account_month_txns,bridge_table,customer_table
-account_id__customer_id__customer_name                                           DIMENSION       JOINED,MULTI_HOP                      account_month_txns,bridge_table,customer_table
-account_id__customer_id__customer_third_hop_id                                   ENTITY          ENTITY,JOINED,MULTI_HOP               account_month_txns,bridge_table,customer_other_data
-account_id__ds__alien_day                                                        TIME_DIMENSION  DERIVED_TIME_GRANULARITY,LOCAL        account_month_txns
-account_id__ds__day                                                              TIME_DIMENSION  LOCAL                                 account_month_txns
-account_id__ds__extract_day                                                      TIME_DIMENSION  DATE_PART,LOCAL                       account_month_txns
-account_id__ds__extract_dow                                                      TIME_DIMENSION  DATE_PART,LOCAL                       account_month_txns
-account_id__ds__extract_doy                                                      TIME_DIMENSION  DATE_PART,LOCAL                       account_month_txns
-account_id__ds__extract_month                                                    TIME_DIMENSION  DATE_PART,LOCAL                       account_month_txns
-account_id__ds__extract_quarter                                                  TIME_DIMENSION  DATE_PART,LOCAL                       account_month_txns
-account_id__ds__extract_year                                                     TIME_DIMENSION  DATE_PART,LOCAL                       account_month_txns
-account_id__ds__month                                                            TIME_DIMENSION  DERIVED_TIME_GRANULARITY,LOCAL        account_month_txns
-account_id__ds__quarter                                                          TIME_DIMENSION  DERIVED_TIME_GRANULARITY,LOCAL        account_month_txns
-account_id__ds__week                                                             TIME_DIMENSION  DERIVED_TIME_GRANULARITY,LOCAL        account_month_txns
-account_id__ds__year                                                             TIME_DIMENSION  DERIVED_TIME_GRANULARITY,LOCAL        account_month_txns
-account_id__extra_dim                                                            DIMENSION       JOINED                                account_month_txns,bridge_table
-account_id__txn_count                            account_id                      METRIC          JOINED,METRIC                         account_month_txns
-metric_time__alien_day                                                           TIME_DIMENSION  DERIVED_TIME_GRANULARITY,METRIC_TIME  account_month_txns
-metric_time__day                                                                 TIME_DIMENSION  METRIC_TIME                           account_month_txns
-metric_time__extract_day                                                         TIME_DIMENSION  DATE_PART,METRIC_TIME                 account_month_txns
-metric_time__extract_dow                                                         TIME_DIMENSION  DATE_PART,METRIC_TIME                 account_month_txns
-metric_time__extract_doy                                                         TIME_DIMENSION  DATE_PART,METRIC_TIME                 account_month_txns
-metric_time__extract_month                                                       TIME_DIMENSION  DATE_PART,METRIC_TIME                 account_month_txns
-metric_time__extract_quarter                                                     TIME_DIMENSION  DATE_PART,METRIC_TIME                 account_month_txns
-metric_time__extract_year                                                        TIME_DIMENSION  DATE_PART,METRIC_TIME                 account_month_txns
-metric_time__month                                                               TIME_DIMENSION  DERIVED_TIME_GRANULARITY,METRIC_TIME  account_month_txns
-metric_time__quarter                                                             TIME_DIMENSION  DERIVED_TIME_GRANULARITY,METRIC_TIME  account_month_txns
-metric_time__week                                                                TIME_DIMENSION  DERIVED_TIME_GRANULARITY,METRIC_TIME  account_month_txns
-metric_time__year                                                                TIME_DIMENSION  DERIVED_TIME_GRANULARITY,METRIC_TIME  account_month_txns
+Dunder Name                                            Metric-Subquery Entity-Links    Type            Properties                                 Derived-From Semantic Models
+-----------------------------------------------------  ------------------------------  --------------  -----------------------------------------  ---------------------------------------------------
+account_id                                                                             ENTITY          ENTITY,LOCAL                               account_month_txns
+account_id__account_month                                                              DIMENSION       LOCAL                                      account_month_txns
+account_id__customer_id                                                                ENTITY          ENTITY,JOINED                              account_month_txns,bridge_table
+account_id__customer_id__acquired_ds__alien_day                                        TIME_DIMENSION  DERIVED_TIME_GRANULARITY,JOINED,MULTI_HOP  account_month_txns,bridge_table,customer_other_data
+account_id__customer_id__acquired_ds__day                                              TIME_DIMENSION  JOINED,MULTI_HOP                           account_month_txns,bridge_table,customer_other_data
+account_id__customer_id__acquired_ds__extract_day                                      TIME_DIMENSION  DATE_PART,JOINED,MULTI_HOP                 account_month_txns,bridge_table,customer_other_data
+account_id__customer_id__acquired_ds__extract_dow                                      TIME_DIMENSION  DATE_PART,JOINED,MULTI_HOP                 account_month_txns,bridge_table,customer_other_data
+account_id__customer_id__acquired_ds__extract_doy                                      TIME_DIMENSION  DATE_PART,JOINED,MULTI_HOP                 account_month_txns,bridge_table,customer_other_data
+account_id__customer_id__acquired_ds__extract_month                                    TIME_DIMENSION  DATE_PART,JOINED,MULTI_HOP                 account_month_txns,bridge_table,customer_other_data
+account_id__customer_id__acquired_ds__extract_quarter                                  TIME_DIMENSION  DATE_PART,JOINED,MULTI_HOP                 account_month_txns,bridge_table,customer_other_data
+account_id__customer_id__acquired_ds__extract_year                                     TIME_DIMENSION  DATE_PART,JOINED,MULTI_HOP                 account_month_txns,bridge_table,customer_other_data
+account_id__customer_id__acquired_ds__month                                            TIME_DIMENSION  DERIVED_TIME_GRANULARITY,JOINED,MULTI_HOP  account_month_txns,bridge_table,customer_other_data
+account_id__customer_id__acquired_ds__quarter                                          TIME_DIMENSION  DERIVED_TIME_GRANULARITY,JOINED,MULTI_HOP  account_month_txns,bridge_table,customer_other_data
+account_id__customer_id__acquired_ds__week                                             TIME_DIMENSION  DERIVED_TIME_GRANULARITY,JOINED,MULTI_HOP  account_month_txns,bridge_table,customer_other_data
+account_id__customer_id__acquired_ds__year                                             TIME_DIMENSION  DERIVED_TIME_GRANULARITY,JOINED,MULTI_HOP  account_month_txns,bridge_table,customer_other_data
+account_id__customer_id__country                                                       DIMENSION       JOINED,MULTI_HOP                           account_month_txns,bridge_table,customer_other_data
+account_id__customer_id__customer_atomic_weight                                        DIMENSION       JOINED,MULTI_HOP                           account_month_txns,bridge_table,customer_table
+account_id__customer_id__customer_name                                                 DIMENSION       JOINED,MULTI_HOP                           account_month_txns,bridge_table,customer_table
+account_id__customer_id__customer_third_hop_id                                         ENTITY          ENTITY,JOINED,MULTI_HOP                    account_month_txns,bridge_table,customer_other_data
+account_id__ds__alien_day                                                              TIME_DIMENSION  DERIVED_TIME_GRANULARITY,LOCAL             account_month_txns
+account_id__ds__day                                                                    TIME_DIMENSION  LOCAL                                      account_month_txns
+account_id__ds__extract_day                                                            TIME_DIMENSION  DATE_PART,LOCAL                            account_month_txns
+account_id__ds__extract_dow                                                            TIME_DIMENSION  DATE_PART,LOCAL                            account_month_txns
+account_id__ds__extract_doy                                                            TIME_DIMENSION  DATE_PART,LOCAL                            account_month_txns
+account_id__ds__extract_month                                                          TIME_DIMENSION  DATE_PART,LOCAL                            account_month_txns
+account_id__ds__extract_quarter                                                        TIME_DIMENSION  DATE_PART,LOCAL                            account_month_txns
+account_id__ds__extract_year                                                           TIME_DIMENSION  DATE_PART,LOCAL                            account_month_txns
+account_id__ds__month                                                                  TIME_DIMENSION  DERIVED_TIME_GRANULARITY,LOCAL             account_month_txns
+account_id__ds__quarter                                                                TIME_DIMENSION  DERIVED_TIME_GRANULARITY,LOCAL             account_month_txns
+account_id__ds__week                                                                   TIME_DIMENSION  DERIVED_TIME_GRANULARITY,LOCAL             account_month_txns
+account_id__ds__year                                                                   TIME_DIMENSION  DERIVED_TIME_GRANULARITY,LOCAL             account_month_txns
+account_id__extra_dim                                                                  DIMENSION       JOINED                                     account_month_txns,bridge_table
+account_id__txn_count                                  account_id                      METRIC          JOINED,METRIC                              account_month_txns
+metric_time__alien_day                                                                 TIME_DIMENSION  DERIVED_TIME_GRANULARITY,METRIC_TIME       account_month_txns
+metric_time__day                                                                       TIME_DIMENSION  METRIC_TIME                                account_month_txns
+metric_time__extract_day                                                               TIME_DIMENSION  DATE_PART,METRIC_TIME                      account_month_txns
+metric_time__extract_dow                                                               TIME_DIMENSION  DATE_PART,METRIC_TIME                      account_month_txns
+metric_time__extract_doy                                                               TIME_DIMENSION  DATE_PART,METRIC_TIME                      account_month_txns
+metric_time__extract_month                                                             TIME_DIMENSION  DATE_PART,METRIC_TIME                      account_month_txns
+metric_time__extract_quarter                                                           TIME_DIMENSION  DATE_PART,METRIC_TIME                      account_month_txns
+metric_time__extract_year                                                              TIME_DIMENSION  DATE_PART,METRIC_TIME                      account_month_txns
+metric_time__month                                                                     TIME_DIMENSION  DERIVED_TIME_GRANULARITY,METRIC_TIME       account_month_txns
+metric_time__quarter                                                                   TIME_DIMENSION  DERIVED_TIME_GRANULARITY,METRIC_TIME       account_month_txns
+metric_time__week                                                                      TIME_DIMENSION  DERIVED_TIME_GRANULARITY,METRIC_TIME       account_month_txns
+metric_time__year                                                                      TIME_DIMENSION  DERIVED_TIME_GRANULARITY,METRIC_TIME       account_month_txns


### PR DESCRIPTION
This PR makes a couple of fixes to the semantic manifests used in test cases.

* In `simple_manifest`, `booking_value` is used as a metric, but it wasn't defined as one.
* There are two semantic manifests `multi_hop_join_manifest` and `partitioned_multi_hop_join_manifest` that are supposed to be the same, except the latter has a partition dimension in the models. It seems they have diverged, so additional elements have been added.