### PR TITLE
Return empty set when no metrics are passed to`get_linkable_elements_for_metrics`

### DIFF
--- a/metricflow-semantics/metricflow_semantics/experimental/semantic_graph/attribute_resolution/sg_linkable_spec_resolver.py
+++ b/metricflow-semantics/metricflow_semantics/experimental/semantic_graph/attribute_resolution/sg_linkable_spec_resolver.py
@@ -145,6 +145,9 @@ class SemanticGraphLinkableSpecResolver(LinkableSpecResolver):
         metric_references: Sequence[MetricReference],
         element_filter: Optional[LinkableElementFilter] = None,
     ) -> BaseLinkableElementSet:
+        if len(metric_references) == 0:
+            return AnnotatedSpecLinkableElementSet()
+
         cache_key = (FrozenOrderedSet(sorted(metric_references)), element_filter)
         cache_result = self._result_cache_for_metrics.get(cache_key)
         if cache_result:

--- a/metricflow-semantics/tests_metricflow_semantics/experimental/semantic_graph/resolver/test_sg_lsr_output.py
+++ b/metricflow-semantics/tests_metricflow_semantics/experimental/semantic_graph/resolver/test_sg_lsr_output.py
@@ -60,6 +60,10 @@ def test_metric_correctness(sg_tester: SemanticGraphTester) -> None:  # noqa: D1
     )
 
 
+def test_metric_correctness_for_empty_set(sg_tester: SemanticGraphTester) -> None:  # noqa: D103
+    sg_tester.compare_resolver_outputs_for_metrics((), element_filter=LinkableElementFilter())
+
+
 def test_multi_metric_correctness(sg_tester: SemanticGraphTester) -> None:  # noqa: D103
     sg_tester.compare_resolver_outputs_for_metrics(
         (MetricReference("bookings"), MetricReference("listings")),


### PR DESCRIPTION
This PR updates the behavior of `get_linkable_elements_for_metrics` when using the semantic graph to return an empty set when no metrics are passed in.