### PR TITLE
Switch back to using minimum time grain from models

### DIFF
--- a/.changes/unreleased/Under the Hood-20250819-123055.yaml
+++ b/.changes/unreleased/Under the Hood-20250819-123055.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Switch back to using minimum time grain from models
+time: 2025-08-19T12:30:55.758428-07:00
+custom:
+  Author: plypaul
+  Issue: "1822"

--- a/metricflow-semantics/metricflow_semantics/experimental/dsi/manifest_object_lookup.py
+++ b/metricflow-semantics/metricflow_semantics/experimental/dsi/manifest_object_lookup.py
@@ -11,11 +11,12 @@ from dbt_semantic_interfaces.type_enums import TimeGranularity
 from typing_extensions import override
 
 from metricflow_semantics.collection_helpers.mf_type_aliases import AnyLengthTuple, T
-from metricflow_semantics.collection_helpers.syntactic_sugar import mf_first_item
+from metricflow_semantics.collection_helpers.syntactic_sugar import mf_first_item, mf_flatten
 from metricflow_semantics.experimental.dsi.measure_model_object_lookup import MeasureContainingModelObjectLookup
 from metricflow_semantics.experimental.dsi.model_object_lookup import (
     ModelObjectLookup,
 )
+from metricflow_semantics.experimental.metricflow_exception import InvalidManifestException
 from metricflow_semantics.experimental.ordered_set import FrozenOrderedSet, MutableOrderedSet, OrderedSet
 from metricflow_semantics.experimental.semantic_graph.model_id import SemanticModelId
 from metricflow_semantics.mf_logging.attribute_pretty_format import AttributeMapping, AttributePrettyFormattable
@@ -120,6 +121,26 @@ class ManifestObjectLookup(AttributePrettyFormattable):
     def min_time_grain(self) -> TimeGranularity:
         """Return the smallest time grain as configured in the time spine."""
         return mf_first_item(sorted(self._time_spine_sources.keys()))
+
+    @cached_property
+    def min_time_grain_used_in_models(self) -> TimeGranularity:
+        """Return the smallest time grain that's used to define a time dimension."""
+        min_time_grain = min(
+            mf_flatten(
+                model_object_lookup.time_dimension_name_to_grain.values()
+                for model_object_lookup in self.model_object_lookups
+            )
+        )
+
+        if min_time_grain is None:
+            raise InvalidManifestException(
+                LazyFormat(
+                    "Did not find any time dimensions in the manifest",
+                    min_time_grain=min_time_grain,
+                    semantic_model_count=len(self._semantic_manifest.semantic_models),
+                )
+            )
+        return min_time_grain
 
     @cached_property
     def expanded_time_grains(self) -> AnyLengthTuple[ExpandedTimeGranularity]:

--- a/metricflow-semantics/metricflow_semantics/experimental/dsi/manifest_object_lookup.py
+++ b/metricflow-semantics/metricflow_semantics/experimental/dsi/manifest_object_lookup.py
@@ -118,7 +118,7 @@ class ManifestObjectLookup(AttributePrettyFormattable):
         )
 
     @cached_property
-    def min_time_grain(self) -> TimeGranularity:
+    def min_time_grain_in_time_spine(self) -> TimeGranularity:
         """Return the smallest time grain as configured in the time spine."""
         return mf_first_item(sorted(self._time_spine_sources.keys()))
 
@@ -185,7 +185,12 @@ class ManifestObjectLookup(AttributePrettyFormattable):
             **super()._attribute_mapping,
             **{
                 attribute_name: getattr(self, attribute_name)
-                for attribute_name in ("model_object_lookups", "min_time_grain", "expanded_time_grains")
+                for attribute_name in (
+                    "model_object_lookups",
+                    "min_time_grain_in_time_spine",
+                    "min_time_grain_used_in_models",
+                    "expanded_time_grains",
+                )
             },
         )
 

--- a/metricflow-semantics/metricflow_semantics/experimental/semantic_graph/attribute_resolution/sg_linkable_spec_resolver.py
+++ b/metricflow-semantics/metricflow_semantics/experimental/semantic_graph/attribute_resolution/sg_linkable_spec_resolver.py
@@ -142,7 +142,7 @@ class SemanticGraphLinkableSpecResolver(LinkableSpecResolver):
 
         # Since `TimeEntitySubgraphGenerator` could add time grain nodes that are finer than the grain of time spine,
         # filter those out.
-        int_value_of_min_time_spine_grain = self._manifest_object_lookup.min_time_grain.to_int()
+        int_value_of_min_time_spine_grain = self._manifest_object_lookup.min_time_grain_in_time_spine.to_int()
         filtered_items_from_metric_time_trie: list[tuple[IndexedDunderName, DunderNameDescriptor]] = []
 
         for indexed_dunder_name, descriptor in metric_time_trie.name_items():

--- a/metricflow-semantics/metricflow_semantics/experimental/semantic_graph/builder/time_entity_subgraph.py
+++ b/metricflow-semantics/metricflow_semantics/experimental/semantic_graph/builder/time_entity_subgraph.py
@@ -8,7 +8,6 @@ from dbt_semantic_interfaces.type_enums import DatePart, TimeGranularity
 from typing_extensions import override
 
 from metricflow_semantics.collection_helpers.mf_type_aliases import AnyLengthTuple
-from metricflow_semantics.experimental.metricflow_exception import InvalidManifestException
 from metricflow_semantics.experimental.semantic_graph.attribute_resolution.attribute_recipe_step import (
     AttributeRecipeStep,
 )
@@ -27,7 +26,6 @@ from metricflow_semantics.experimental.semantic_graph.nodes.entity_nodes import 
 from metricflow_semantics.experimental.semantic_graph.sg_interfaces import (
     SemanticGraphEdge,
 )
-from metricflow_semantics.mf_logging.lazy_formattable import LazyFormat
 from metricflow_semantics.model.linkable_element_property import LinkableElementProperty
 from metricflow_semantics.time.granularity import ExpandedTimeGranularity
 
@@ -50,21 +48,7 @@ class TimeEntitySubgraphGenerator(SemanticSubgraphGenerator):
 
     @override
     def add_edges_for_manifest(self, edge_list: list[SemanticGraphEdge]) -> None:
-        min_time_grain = self._manifest_object_lookup.min_time_grain
-
-        if min_time_grain is None:
-            raise InvalidManifestException(
-                LazyFormat(
-                    "Did not find any time dimensions in the manifest",
-                    min_time_grain=min_time_grain,
-                    semantic_models=[
-                        model_lookup.semantic_model
-                        for model_lookup in self._manifest_object_lookup.model_object_lookups
-                    ],
-                )
-            )
-
-        self._add_edges_for_time_entity_subgraph(min_time_grain, edge_list)
+        self._add_edges_for_time_entity_subgraph(self._manifest_object_lookup.min_time_grain_used_in_models, edge_list)
 
     def _add_edges_for_time_entity_subgraph(
         self, min_time_grain: TimeGranularity, edge_list: list[SemanticGraphEdge]

--- a/metricflow-semantics/metricflow_semantics/model/semantic_manifest_lookup.py
+++ b/metricflow-semantics/metricflow_semantics/model/semantic_manifest_lookup.py
@@ -61,6 +61,7 @@ class SemanticManifestLookup:
             semantic_graph = graph_builder.build()
 
             linkable_spec_resolver = SemanticGraphLinkableSpecResolver(
+                manifest_object_lookup=manifest_object_lookup,
                 semantic_graph=semantic_graph,
                 path_finder=pathfinder,
             )

--- a/metricflow-semantics/tests_metricflow_semantics/experimental/semantic_graph/sg_fixtures.py
+++ b/metricflow-semantics/tests_metricflow_semantics/experimental/semantic_graph/sg_fixtures.py
@@ -66,6 +66,7 @@ class SemanticGraphTestFixture:
 
     def create_sg_resolver(self) -> SemanticGraphLinkableSpecResolver:  # noqa: D102
         return SemanticGraphLinkableSpecResolver(
+            manifest_object_lookup=self.manifest_object_lookup,
             semantic_graph=self.semantic_graph,
             path_finder=self.pathfinder,
         )

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_manifest_object_lookup.py/ManifestObjectLookup/test_lookup_attributes__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_manifest_object_lookup.py/ManifestObjectLookup/test_lookup_attributes__result.txt
@@ -27,6 +27,7 @@ ManifestObjectLookup(
       ),
     ),
   ),
-  min_time_grain=QUARTER,
+  min_time_grain_in_time_spine=QUARTER,
+  min_time_grain_used_in_models=QUARTER,
   expanded_time_grains=(ExpandedTimeGranularity(name='custom_year', base_granularity=YEAR),),
 )


### PR DESCRIPTION
The semantic graph implementation initially used the minimum grain used in a semantic model as the minimum valid grain (original comment here: https://github.com/dbt-labs/metricflow/blob/4a2edcfbf272f4cc9aef998fd51475b9d8040aad/metricflow-semantics/metricflow_semantics/experimental/semantic_graph/builder/time_entity_subgraph.py#L43), but then later was changed to use the minimum grain of the time spine as it seemed like it was the correct behavior. To aid migration however, this changes the logic back to the initial implementation.