### PR TITLE
Revert "Bump dsi version to 0.9.1"

### DIFF
--- a/metricflow-semantics/metricflow_semantics/experimental/semantic_graph/builder/metric_subgraph.py
+++ b/metricflow-semantics/metricflow_semantics/experimental/semantic_graph/builder/metric_subgraph.py
@@ -142,9 +142,6 @@ class MetricSubgraphGenerator(SemanticSubgraphGenerator):
             # resolving the associated group-by items.
             conversion_type_params = base_metric.type_params.conversion_type_params
             if conversion_type_params is not None:
-                assert (
-                    conversion_type_params.conversion_measure is not None
-                ), "A conversion metric must have a conversion measure."
                 conversion_measure_name = conversion_type_params.conversion_measure.name
                 measure_name_to_labels_for_metric_to_measure_edge[
                     conversion_measure_name

--- a/metricflow-semantics/metricflow_semantics/model/semantics/linkable_spec_index_builder.py
+++ b/metricflow-semantics/metricflow_semantics/model/semantics/linkable_spec_index_builder.py
@@ -115,9 +115,6 @@ class LinkableSpecIndexBuilder:
                     assert (
                         conversion_type_params
                     ), "A conversion metric should have type_params.conversion_type_params defined."
-                    assert (
-                        conversion_type_params.base_measure is not None
-                    ), "A conversion metric must have a base measure."
                     if measure == conversion_type_params.base_measure.measure_reference:
                         # Only can query against the base measure's linkable elements
                         # as it joins everything back to the base measure data set so

--- a/metricflow-semantics/metricflow_semantics/query/group_by_item/resolution_dag/dag_builder.py
+++ b/metricflow-semantics/metricflow_semantics/query/group_by_item/resolution_dag/dag_builder.py
@@ -49,7 +49,6 @@ class GroupByItemResolutionDagBuilder:
                 assert (
                     conversion_type_params
                 ), "A conversion metric should have type_params.conversion_type_params defined."
-                assert conversion_type_params.base_measure is not None, "A conversion metric must have a base measure."
                 measure_references_for_metric = (conversion_type_params.base_measure.measure_reference,)
             else:
                 measure_references_for_metric = tuple(

--- a/metricflow-semantics/metricflow_semantics/query/query_resolver.py
+++ b/metricflow-semantics/metricflow_semantics/query/query_resolver.py
@@ -709,10 +709,6 @@ class MetricFlowQueryResolver:
                 continue
 
             # The base measure should be in a DAG, but just in case.
-            assert conversion_type_params.base_measure is not None, "A conversion metric must have a base measure."
-            assert (
-                conversion_type_params.conversion_measure is not None
-            ), "A conversion metric must have a conversion measure."
             measure_references.add(conversion_type_params.base_measure.measure_reference)
             measure_references.add(conversion_type_params.conversion_measure.measure_reference)
 

--- a/metricflow-semantics/requirements-files/requirements.txt
+++ b/metricflow-semantics/requirements-files/requirements.txt
@@ -1,7 +1,7 @@
 # Always support a range of production DSI versions capped at the next breaking version in metricflow-semantics.
 # This allows us to sync new, non-breaking changes to dbt-core without getting a version mismatch in dbt-mantle,
 # which depends on a specific commit of DSI.
-dbt-semantic-interfaces>=0.9.1, <0.10.0
+dbt-semantic-interfaces>=0.9.0, <0.10.0
 graphviz>=0.18.2, <0.21
 python-dateutil>=2.9.0, <2.10.0
 rapidfuzz>=3.0, <4.0

--- a/metricflow/dataflow/builder/dataflow_plan_builder.py
+++ b/metricflow/dataflow/builder/dataflow_plan_builder.py
@@ -1309,11 +1309,6 @@ class DataflowPlanBuilder:
         if metric.type is not MetricType.CONVERSION:
             raise ValueError("This should only be called for conversion metrics.")
 
-        assert conversion_type_params.base_measure is not None, "A conversion metric must have a base measure."
-        assert (
-            conversion_type_params.conversion_measure is not None
-        ), "A conversion metric must have a conversion measure."
-
         base_input_measure, conversion_input_measure = [
             self._build_input_measure_spec(
                 filter_spec_factory=filter_spec_factory,

--- a/metricflow/plan_conversion/to_sql_plan/dataflow_to_subquery.py
+++ b/metricflow/plan_conversion/to_sql_plan/dataflow_to_subquery.py
@@ -665,9 +665,7 @@ class DataflowNodeToSqlSubqueryVisitor(DataflowPlanNodeVisitor[SqlDataSet]):
                     conversion_type_params
                 ), "A conversion metric should have type_params.conversion_type_params defined."
                 base_measure = conversion_type_params.base_measure
-                assert base_measure is not None, "A conversion metric must have a base measure."
                 conversion_measure = conversion_type_params.conversion_measure
-                assert conversion_measure is not None, "A conversion metric must have a conversion measure."
                 base_measure_column = self._column_association_resolver.resolve_spec(
                     MeasureSpec(element_name=base_measure.post_aggregation_measure_reference.element_name)
                 ).column_name

--- a/requirements-files/requirements.txt
+++ b/requirements-files/requirements.txt
@@ -1,5 +1,5 @@
 Jinja2>=3.1.6, <3.7.0
-dbt-semantic-interfaces==0.9.1
+dbt-semantic-interfaces==0.9.0
 more-itertools>=8.10.0, <10.2.0
 pydantic>=1.10.0, <3.0
 tabulate>=0.8.9


### PR DESCRIPTION
Reverts dbt-labs/metricflow#1829

There is a validation in this DSI version that might be a breaking change for some users. Removing this dependency so we can yank the version from PyPI.