### PR TITLE
Add changelog for ambiguous-join-path detection fix 

### DIFF
--- a/.changes/unreleased/Fixes-20250909-140537.yaml
+++ b/.changes/unreleased/Fixes-20250909-140537.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix ambiguous-join-path detection for `UNIQUE` entities
+time: 2025-09-09T14:05:37.368996-07:00
+custom:
+  Author: plypaul
+  Issue: "1835"


### PR DESCRIPTION
This fix was included with , but not mentioned in the changelog. When detecting ambiguous join paths, a semantic model with a `UNIQUE` entity should be considered as a candidate model for joining on that entity. Previously, it was not, and the generated query could produce inconsistent results. The fix detects the ambiguous path in such queries and raises an error.