### PR TITLE
Bug fix: don't error if there are no time dims in manifest

### DIFF
--- a/.changes/unreleased/Fixes-20250916-121517.yaml
+++ b/.changes/unreleased/Fixes-20250916-121517.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Don't error for lack of time dimensions in manfest
+time: 2025-09-16T12:15:17.278238-07:00
+custom:
+  Author: courtneyholcomb
+  Issue: "1848"

--- a/metricflow-semantics/metricflow_semantics/experimental/dsi/manifest_object_lookup.py
+++ b/metricflow-semantics/metricflow_semantics/experimental/dsi/manifest_object_lookup.py
@@ -4,10 +4,11 @@ import logging
 from collections import defaultdict
 from enum import Enum
 from functools import cached_property
-from typing import Iterable, Mapping, Sequence
+from typing import Iterable, Mapping, Optional, Sequence
 
 from dbt_semantic_interfaces.protocols import Metric, SemanticManifest, SemanticModel
 from dbt_semantic_interfaces.type_enums import TimeGranularity
+from more_itertools import peekable
 from typing_extensions import override
 
 from metricflow_semantics.collection_helpers.mf_type_aliases import AnyLengthTuple, T
@@ -16,7 +17,6 @@ from metricflow_semantics.experimental.dsi.measure_model_object_lookup import Me
 from metricflow_semantics.experimental.dsi.model_object_lookup import (
     ModelObjectLookup,
 )
-from metricflow_semantics.experimental.metricflow_exception import InvalidManifestException
 from metricflow_semantics.experimental.ordered_set import FrozenOrderedSet, MutableOrderedSet, OrderedSet
 from metricflow_semantics.experimental.semantic_graph.model_id import SemanticModelId
 from metricflow_semantics.mf_logging.attribute_pretty_format import AttributeMapping, AttributePrettyFormattable
@@ -123,24 +123,16 @@ class ManifestObjectLookup(AttributePrettyFormattable):
         return mf_first_item(sorted(self._time_spine_sources.keys()))
 
     @cached_property
-    def min_time_grain_used_in_models(self) -> TimeGranularity:
+    def min_time_grain_used_in_models(self) -> Optional[TimeGranularity]:
         """Return the smallest time grain that's used to define a time dimension."""
-        min_time_grain = min(
-            mf_flatten(
-                model_object_lookup.time_dimension_name_to_grain.values()
-                for model_object_lookup in self.model_object_lookups
-            )
+        time_grains = mf_flatten(
+            model_object_lookup.time_dimension_name_to_grain.values()
+            for model_object_lookup in self.model_object_lookups
         )
+        if not peekable(time_grains):
+            return None
 
-        if min_time_grain is None:
-            raise InvalidManifestException(
-                LazyFormat(
-                    "Did not find any time dimensions in the manifest",
-                    min_time_grain=min_time_grain,
-                    semantic_model_count=len(self._semantic_manifest.semantic_models),
-                )
-            )
-        return min_time_grain
+        return min(time_grains)
 
     @cached_property
     def expanded_time_grains(self) -> AnyLengthTuple[ExpandedTimeGranularity]:

--- a/metricflow-semantics/metricflow_semantics/experimental/dsi/manifest_object_lookup.py
+++ b/metricflow-semantics/metricflow_semantics/experimental/dsi/manifest_object_lookup.py
@@ -129,10 +129,13 @@ class ManifestObjectLookup(AttributePrettyFormattable):
             model_object_lookup.time_dimension_name_to_grain.values()
             for model_object_lookup in self.model_object_lookups
         )
-        if not peekable(time_grains):
+        peekable_grains = peekable(time_grains)
+        try:
+            peekable_grains.peek()
+        except StopIteration:
             return None
 
-        return min(time_grains)
+        return min(peekable_grains)
 
     @cached_property
     def expanded_time_grains(self) -> AnyLengthTuple[ExpandedTimeGranularity]:

--- a/metricflow-semantics/metricflow_semantics/experimental/semantic_graph/builder/time_entity_subgraph.py
+++ b/metricflow-semantics/metricflow_semantics/experimental/semantic_graph/builder/time_entity_subgraph.py
@@ -48,12 +48,12 @@ class TimeEntitySubgraphGenerator(SemanticSubgraphGenerator):
 
     @override
     def add_edges_for_manifest(self, edge_list: list[SemanticGraphEdge]) -> None:
+        min_time_grain_in_models = self._manifest_object_lookup.min_time_grain_used_in_models
+        min_time_grains = [self._manifest_object_lookup.min_time_grain_in_time_spine]
+        if min_time_grain_in_models is not None:
+            min_time_grains.append(min_time_grain_in_models)
         self._add_edges_for_time_entity_subgraph(
-            min_time_grain=min(
-                self._manifest_object_lookup.min_time_grain_used_in_models,
-                self._manifest_object_lookup.min_time_grain_in_time_spine,
-                key=lambda time_grain: time_grain.to_int(),
-            ),
+            min_time_grain=min(min_time_grains, key=lambda time_grain: time_grain.to_int()),
             edge_list=edge_list,
         )
 


### PR DESCRIPTION
Seeing some [error logs](https://dbtlabsmt.datadoghq.com/logs?query=trace_id%3A68c91dce0000000098a793d8afe08253&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&event=AwAAAZlRnG__fSBcoAAAABhBWmxSbklLT0FBQUsweGo5Z1Y1dVJRQXIAAAAkZjE5OTUxYTAtMzU5OC00M2Q0LWJmZmQtMDQxNzNkNjAzODczAAE5ww&fromUser=true&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=desc&viz=stream&from_ts=1758009830199&to_ts=1758011830854&live=false) where this min() is called on an empty list. This removes the error.

A manifest without any time dimensions isn't likely very useful (probably in a partially complete state - measures require time dimensions so there can't be any metrics in this case), but this is not where it should error. Instead there are just no metrics to query.