### PR TITLE
Pin to a non-dev version of DSI for release

### DIFF
--- a/.changes/unreleased/Fixes-20250918-070122.yaml
+++ b/.changes/unreleased/Fixes-20250918-070122.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Pin to the latest non-dev release of dbt-semantic-interfaces.
+time: 2025-09-18T07:01:22.294658-07:00
+custom:
+  Author: courtneyholcomb
+  Issue: "1854"

--- a/.github/actions/setup-python-env/action.yaml
+++ b/.github/actions/setup-python-env/action.yaml
@@ -67,7 +67,10 @@ runs:
 
   - name: Install Hatch
     shell: bash
-    run: pip3 install hatch
+    # Pin click to avoid bug in 8.3.0 - can remove when a fix is released
+    run: |
+      pip3 install "click<8.3.0"
+      pip3 install hatch
 
   # Running any command will install the dependencies for the project. Add this step so that the `hatch` environment is
   # cached.

--- a/metricflow-semantics/requirements-files/requirements.txt
+++ b/metricflow-semantics/requirements-files/requirements.txt
@@ -1,7 +1,7 @@
 # Always support a range of production DSI versions capped at the next breaking version in metricflow-semantics.
 # This allows us to sync new, non-breaking changes to dbt-core without getting a version mismatch in dbt-mantle,
 # which depends on a specific commit of DSI.
-dbt-semantic-interfaces~=0.9.3.dev1
+dbt-semantic-interfaces~=0.9.0
 graphviz>=0.18.2, <0.21
 python-dateutil>=2.9.0, <2.10.0
 rapidfuzz>=3.0, <4.0

--- a/requirements-files/requirements.txt
+++ b/requirements-files/requirements.txt
@@ -1,5 +1,5 @@
 Jinja2>=3.1.6, <3.7.0
-dbt-semantic-interfaces==0.9.3.dev1
+dbt-semantic-interfaces==0.9.0
 more-itertools>=8.10.0, <10.2.0
 pydantic>=1.10.0, <3.0
 tabulate>=0.8.9


### PR DESCRIPTION
DSI was pinned to a dev version in the last release, which is a problem for some users who use python package managers that ignore dev versions. This pins it to the prior valid version so we can cut a new release pointing to that.

Also pins click due to a bad release that went out today and caused issues building hatch with python 3.12.