### PR TITLE
Cleanup: fix duckdb version + remove accidental commenting

### DIFF
--- a/requirements-files/dev-env-requirements.txt
+++ b/requirements-files/dev-env-requirements.txt
@@ -7,4 +7,5 @@ dbt-core>=1.10.4, <1.11.0
 dbt-duckdb>=1.8.0, <1.9.0
 # Excluding 1.2.1 due to window functions returning incorrect results:
 # https://github.com/duckdb/duckdb/issues/16617
+# Version 1.4.0 seems to have issues as well, so pinning to <1.4.0 until those are resolved.
 duckdb !=1.2.1, <1.4.0

--- a/requirements-files/dev-env-requirements.txt
+++ b/requirements-files/dev-env-requirements.txt
@@ -7,4 +7,4 @@ dbt-core>=1.10.4, <1.11.0
 dbt-duckdb>=1.8.0, <1.9.0
 # Excluding 1.2.1 due to window functions returning incorrect results:
 # https://github.com/duckdb/duckdb/issues/16617
-duckdb !=1.2.1
+duckdb !=1.2.1, <1.4.0

--- a/tests_metricflow/generate_snapshots.py
+++ b/tests_metricflow/generate_snapshots.py
@@ -81,34 +81,34 @@ class MetricFlowTestCredentialSetForAllEngines(FrozenBaseModel):  # noqa: D101
     @property
     def as_configurations(self) -> Sequence[MetricFlowEngineConfiguration]:  # noqa: D102
         return (
-            # MetricFlowEngineConfiguration(
-            #     engine=SqlEngine.DUCKDB,
-            #     credential_set=self.duck_db,
-            # ),
-            # MetricFlowEngineConfiguration(
-            #     engine=SqlEngine.REDSHIFT,
-            #     credential_set=self.redshift,
-            # ),
-            # MetricFlowEngineConfiguration(
-            #     engine=SqlEngine.SNOWFLAKE,
-            #     credential_set=self.snowflake,
-            # ),
-            # MetricFlowEngineConfiguration(
-            #     engine=SqlEngine.BIGQUERY,
-            #     credential_set=self.big_query,
-            # ),
+            MetricFlowEngineConfiguration(
+                engine=SqlEngine.DUCKDB,
+                credential_set=self.duck_db,
+            ),
+            MetricFlowEngineConfiguration(
+                engine=SqlEngine.REDSHIFT,
+                credential_set=self.redshift,
+            ),
+            MetricFlowEngineConfiguration(
+                engine=SqlEngine.SNOWFLAKE,
+                credential_set=self.snowflake,
+            ),
+            MetricFlowEngineConfiguration(
+                engine=SqlEngine.BIGQUERY,
+                credential_set=self.big_query,
+            ),
             MetricFlowEngineConfiguration(
                 engine=SqlEngine.DATABRICKS,
                 credential_set=self.databricks,
             ),
-            # MetricFlowEngineConfiguration(
-            #     engine=SqlEngine.POSTGRES,
-            #     credential_set=self.postgres,
-            # ),
-            # MetricFlowEngineConfiguration(
-            #     engine=SqlEngine.TRINO,
-            #     credential_set=self.trino,
-            # ),
+            MetricFlowEngineConfiguration(
+                engine=SqlEngine.POSTGRES,
+                credential_set=self.postgres,
+            ),
+            MetricFlowEngineConfiguration(
+                engine=SqlEngine.TRINO,
+                credential_set=self.trino,
+            ),
         )
 
 


### PR DESCRIPTION
There appears to be some issues with the latest duckdb version, so pinning to a lower version.
Also removes a some commenting that was accidentally merged in a previous commit.