### PR TITLE
Bug fix: don't error if there are no time dims in manifest

### DIFF
--- a/.changes/unreleased/Fixes-20250916-121517.yaml
+++ b/.changes/unreleased/Fixes-20250916-121517.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Don't error for lack of time dimensions in manfest
+time: 2025-09-16T12:15:17.278238-07:00
+custom:
+  Author: courtneyholcomb
+  Issue: "1848"

--- a/dbt-metricflow/dbt_metricflow/__about__.py
+++ b/dbt-metricflow/dbt_metricflow/__about__.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-__version__ = "0.10.1"
+__version__ = "0.10.2.dev0"

--- a/metricflow-semantics/metricflow_semantics/experimental/dsi/manifest_object_lookup.py
+++ b/metricflow-semantics/metricflow_semantics/experimental/dsi/manifest_object_lookup.py
@@ -4,10 +4,11 @@ import logging
 from collections import defaultdict
 from enum import Enum
 from functools import cached_property
-from typing import Iterable, Mapping, Sequence
+from typing import Iterable, Mapping, Optional, Sequence
 
 from dbt_semantic_interfaces.protocols import Metric, SemanticManifest, SemanticModel
 from dbt_semantic_interfaces.type_enums import TimeGranularity
+from more_itertools import peekable
 from typing_extensions import override
 
 from metricflow_semantics.collection_helpers.mf_type_aliases import AnyLengthTuple, T
@@ -16,7 +17,6 @@ from metricflow_semantics.experimental.dsi.measure_model_object_lookup import Me
 from metricflow_semantics.experimental.dsi.model_object_lookup import (
     ModelObjectLookup,
 )
-from metricflow_semantics.experimental.metricflow_exception import InvalidManifestException
 from metricflow_semantics.experimental.ordered_set import FrozenOrderedSet, MutableOrderedSet, OrderedSet
 from metricflow_semantics.experimental.semantic_graph.model_id import SemanticModelId
 from metricflow_semantics.mf_logging.attribute_pretty_format import AttributeMapping, AttributePrettyFormattable
@@ -123,24 +123,16 @@ class ManifestObjectLookup(AttributePrettyFormattable):
         return mf_first_item(sorted(self._time_spine_sources.keys()))
 
     @cached_property
-    def min_time_grain_used_in_models(self) -> TimeGranularity:
+    def min_time_grain_used_in_models(self) -> Optional[TimeGranularity]:
         """Return the smallest time grain that's used to define a time dimension."""
-        min_time_grain = min(
-            mf_flatten(
-                model_object_lookup.time_dimension_name_to_grain.values()
-                for model_object_lookup in self.model_object_lookups
-            )
+        time_grains = mf_flatten(
+            model_object_lookup.time_dimension_name_to_grain.values()
+            for model_object_lookup in self.model_object_lookups
         )
+        if not peekable(time_grains):
+            return None
 
-        if min_time_grain is None:
-            raise InvalidManifestException(
-                LazyFormat(
-                    "Did not find any time dimensions in the manifest",
-                    min_time_grain=min_time_grain,
-                    semantic_model_count=len(self._semantic_manifest.semantic_models),
-                )
-            )
-        return min_time_grain
+        return min(time_grains)
 
     @cached_property
     def expanded_time_grains(self) -> AnyLengthTuple[ExpandedTimeGranularity]:

--- a/metricflow-semantics/metricflow_semantics/experimental/dsi/manifest_object_lookup.py
+++ b/metricflow-semantics/metricflow_semantics/experimental/dsi/manifest_object_lookup.py
@@ -129,10 +129,13 @@ class ManifestObjectLookup(AttributePrettyFormattable):
             model_object_lookup.time_dimension_name_to_grain.values()
             for model_object_lookup in self.model_object_lookups
         )
-        if not peekable(time_grains):
+        peekable_grains = peekable(time_grains)
+        try:
+            peekable_grains.peek()
+        except StopIteration:
             return None
 
-        return min(time_grains)
+        return min(peekable_grains)
 
     @cached_property
     def expanded_time_grains(self) -> AnyLengthTuple[ExpandedTimeGranularity]:

--- a/metricflow-semantics/metricflow_semantics/experimental/semantic_graph/builder/time_entity_subgraph.py
+++ b/metricflow-semantics/metricflow_semantics/experimental/semantic_graph/builder/time_entity_subgraph.py
@@ -48,12 +48,12 @@ class TimeEntitySubgraphGenerator(SemanticSubgraphGenerator):
 
     @override
     def add_edges_for_manifest(self, edge_list: list[SemanticGraphEdge]) -> None:
+        min_time_grain_in_models = self._manifest_object_lookup.min_time_grain_used_in_models
+        min_time_grains = [self._manifest_object_lookup.min_time_grain_in_time_spine]
+        if min_time_grain_in_models is not None:
+            min_time_grains.append(min_time_grain_in_models)
         self._add_edges_for_time_entity_subgraph(
-            min_time_grain=min(
-                self._manifest_object_lookup.min_time_grain_used_in_models,
-                self._manifest_object_lookup.min_time_grain_in_time_spine,
-                key=lambda time_grain: time_grain.to_int(),
-            ),
+            min_time_grain=min(min_time_grains, key=lambda time_grain: time_grain.to_int()),
             edge_list=edge_list,
         )
 


### PR DESCRIPTION
This was already approved, but I rebased it on top of my stack due to some of the CI version resolutions that were needed to unblock CI. Something weird happened where it automatically merged into the base branch at that point, so I needed to create a new PR for this.
TLDR; this bug fix was already approved but needs re-approval.