### PR TITLE
Bump to new DSI dev version (again)

### DIFF
--- a/metricflow-semantics/requirements-files/requirements.txt
+++ b/metricflow-semantics/requirements-files/requirements.txt
@@ -1,7 +1,7 @@
 # Always support a range of production DSI versions capped at the next breaking version in metricflow-semantics.
 # This allows us to sync new, non-breaking changes to dbt-core without getting a version mismatch in dbt-mantle,
 # which depends on a specific commit of DSI.
-dbt-semantic-interfaces~=0.9.0
+dbt-semantic-interfaces~=0.9.3.dev1
 graphviz>=0.18.2, <0.21
 python-dateutil>=2.9.0, <2.10.0
 rapidfuzz>=3.0, <4.0

--- a/requirements-files/requirements.txt
+++ b/requirements-files/requirements.txt
@@ -1,5 +1,5 @@
 Jinja2>=3.1.6, <3.7.0
-dbt-semantic-interfaces==0.9.0
+dbt-semantic-interfaces==0.9.3.dev1
 more-itertools>=8.10.0, <10.2.0
 pydantic>=1.10.0, <3.0
 tabulate>=0.8.9


### PR DESCRIPTION
We previously upgraded to this version of DSI, then reverted back to a non-dev version for release. Now that the release is finished, we should again use the newer version of DSI. This is needed before releasing a new version of MF to the server. This is because mantle might be producing manifests with the new fields included in the new DSI version, and MFS needs to ensure it can consume those fields.