### PR TITLE
Bump dsi version to allow for 'is_private' on metrics from mantle

### DIFF
--- a/metricflow-semantics/requirements-files/requirements.txt
+++ b/metricflow-semantics/requirements-files/requirements.txt
@@ -1,7 +1,7 @@
 # Always support a range of production DSI versions capped at the next breaking version in metricflow-semantics.
 # This allows us to sync new, non-breaking changes to dbt-core without getting a version mismatch in dbt-mantle,
 # which depends on a specific commit of DSI.
-dbt-semantic-interfaces~=0.9.3.dev1
+dbt-semantic-interfaces~=0.9.3.dev2
 graphviz>=0.18.2, <0.21
 python-dateutil>=2.9.0, <2.10.0
 rapidfuzz>=3.0, <4.0

--- a/requirements-files/requirements.txt
+++ b/requirements-files/requirements.txt
@@ -1,5 +1,5 @@
 Jinja2>=3.1.6, <3.7.0
-dbt-semantic-interfaces==0.9.3.dev1
+dbt-semantic-interfaces==0.9.3.dev2
 more-itertools>=8.10.0, <10.2.0
 pydantic>=1.10.0, <3.0
 tabulate>=0.8.9


### PR DESCRIPTION
We don't want to receive metric fields that our pydantic implementations don't know how to handle, so I'm bumping the version here before it can be bumped in other parts of dbt.

I'll bump MFS after this.