### PR TITLE
Add test for group-by items using the cyclic manifest

### DIFF
--- a/metricflow-semantics/tests_metricflow_semantics/experimental/semantic_graph/resolver/test_other_manifest.py
+++ b/metricflow-semantics/tests_metricflow_semantics/experimental/semantic_graph/resolver/test_other_manifest.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import logging
+
+import pytest
+from _pytest.fixtures import FixtureRequest
+from dbt_semantic_interfaces.protocols import SemanticManifest
+from metricflow_semantics.test_helpers.config_helpers import MetricFlowTestConfiguration
+
+from tests_metricflow_semantics.experimental.semantic_graph.sg_fixtures import SemanticGraphTestFixture
+from tests_metricflow_semantics.experimental.semantic_graph.sg_tester import SemanticGraphTester
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture
+def sg_tester_cyclic_manifest(  # noqa: D103
+    request: FixtureRequest,
+    mf_test_configuration: MetricFlowTestConfiguration,
+    cyclic_join_manifest: SemanticManifest,
+) -> SemanticGraphTester:
+    fixture = SemanticGraphTestFixture(
+        request=request, snapshot_configuration=mf_test_configuration, semantic_manifest=cyclic_join_manifest
+    )
+    return SemanticGraphTester(fixture)
+
+
+def test_measure_with_cyclic_join_path(sg_tester_cyclic_manifest: SemanticGraphTester) -> None:
+    """Check that a cyclic join path doesn't cause infinite loop / recursion."""
+    cases = ("listings",)
+    sg_tester_cyclic_manifest.assert_attribute_set_snapshot_equal_for_a_measure(cases)

--- a/metricflow-semantics/tests_metricflow_semantics/experimental/semantic_graph/resolver/test_sg_resolver_output.py
+++ b/metricflow-semantics/tests_metricflow_semantics/experimental/semantic_graph/resolver/test_sg_resolver_output.py
@@ -31,11 +31,7 @@ def sg_tester(  # noqa: D103
 def test_set_for_measures(sg_tester: SemanticGraphTester) -> None:
     """Check the set for a few measures."""
     cases = ("bookings", "account_balance")
-    description_to_set = {
-        str(measure_name): sg_tester.sg_resolver.get_linkable_element_set_for_measure(MeasureReference(measure_name))
-        for measure_name in cases
-    }
-    sg_tester.assert_attribute_set_snapshot_equal(description_to_set)
+    sg_tester.assert_attribute_set_snapshot_equal_for_a_measure(cases)
 
 
 def test_set_filtering_for_measure(sg_tester: SemanticGraphTester) -> None:

--- a/metricflow-semantics/tests_metricflow_semantics/experimental/semantic_graph/sg_tester.py
+++ b/metricflow-semantics/tests_metricflow_semantics/experimental/semantic_graph/sg_tester.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Mapping
-from typing import Callable, Iterable, Optional
+from typing import Callable, Iterable, Optional, Sequence
 
-from dbt_semantic_interfaces.references import MetricReference
+from dbt_semantic_interfaces.references import MeasureReference, MetricReference
 from metricflow_semantics.experimental.dataclass_helpers import fast_frozen_dataclass
 from metricflow_semantics.experimental.semantic_graph.attribute_resolution.recipe_writer_path import (
     RecipeWriterPathfinder,
@@ -68,6 +68,18 @@ class SemanticGraphTester:
         comparison_helper.add_left_rows(left_rows)
         comparison_helper.add_right_rows(right_rows)
         comparison_helper.assert_tables_equal(log_result_table)
+
+    def assert_attribute_set_snapshot_equal_for_a_measure(  # noqa: D102
+        self,
+        measure_names: Sequence[str],
+        expectation_description: Optional[str] = None,
+    ) -> None:
+        sg_resolver = self.sg_resolver
+        description_to_set = {
+            str(measure_name): sg_resolver.get_linkable_element_set_for_measure(MeasureReference(measure_name))
+            for measure_name in measure_names
+        }
+        self.assert_attribute_set_snapshot_equal(description_to_set, expectation_description)
 
     def assert_attribute_set_snapshot_equal(  # noqa: D102
         self,

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_other_manifest.py/str/test_measure_with_cyclic_join_path__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_other_manifest.py/str/test_measure_with_cyclic_join_path__result.txt
@@ -1,0 +1,54 @@
+test_name: test_measure_with_cyclic_join_path
+test_filename: test_other_manifest.py
+docstring:
+  Check that a cyclic join path doesn't cause infinite loop / recursion.
+---
+listings:
+  ┌──────────────────────────────────────┬────────────────────────────────┬──────────────────┬────────────────────────────────────────┬──────────────────────────────────────────┐
+  │ Dunder Name                          │ Metric-Subquery Entity-Links   │ Type             │ Properties                             │ Derived-From Semantic Models             │
+  ├──────────────────────────────────────┼────────────────────────────────┼──────────────────┼────────────────────────────────────────┼──────────────────────────────────────────┤
+  │ cyclic_entity                        │                                │ ENTITY           │ ENTITY,LOCAL                           │ listings_latest                          │
+  │ cyclic_entity__capacity_latest       │                                │ DIMENSION        │ JOINED                                 │ listings_latest,listings_latest_cyclic   │
+  │ cyclic_entity__country_latest        │                                │ DIMENSION        │ LOCAL                                  │ listings_latest                          │
+  │ cyclic_entity__ds__alien_day         │                                │ TIME_DIMENSION   │ DERIVED_TIME_GRANULARITY,LOCAL         │ listings_latest                          │
+  │ cyclic_entity__ds__day               │                                │ TIME_DIMENSION   │ LOCAL                                  │ listings_latest                          │
+  │ cyclic_entity__ds__extract_day       │                                │ TIME_DIMENSION   │ DATE_PART,LOCAL                        │ listings_latest                          │
+  │ cyclic_entity__ds__extract_dow       │                                │ TIME_DIMENSION   │ DATE_PART,LOCAL                        │ listings_latest                          │
+  │ cyclic_entity__ds__extract_doy       │                                │ TIME_DIMENSION   │ DATE_PART,LOCAL                        │ listings_latest                          │
+  │ cyclic_entity__ds__extract_month     │                                │ TIME_DIMENSION   │ DATE_PART,LOCAL                        │ listings_latest                          │
+  │ cyclic_entity__ds__extract_quarter   │                                │ TIME_DIMENSION   │ DATE_PART,LOCAL                        │ listings_latest                          │
+  │ cyclic_entity__ds__extract_year      │                                │ TIME_DIMENSION   │ DATE_PART,LOCAL                        │ listings_latest                          │
+  │ cyclic_entity__ds__month             │                                │ TIME_DIMENSION   │ DERIVED_TIME_GRANULARITY,LOCAL         │ listings_latest                          │
+  │ cyclic_entity__ds__quarter           │                                │ TIME_DIMENSION   │ DERIVED_TIME_GRANULARITY,LOCAL         │ listings_latest                          │
+  │ cyclic_entity__ds__week              │                                │ TIME_DIMENSION   │ DERIVED_TIME_GRANULARITY,LOCAL         │ listings_latest                          │
+  │ cyclic_entity__ds__year              │                                │ TIME_DIMENSION   │ DERIVED_TIME_GRANULARITY,LOCAL         │ listings_latest                          │
+  │ cyclic_entity__listings              │ cyclic_entity                  │ METRIC           │ JOINED,METRIC                          │ listings_latest                          │
+  │ listing                              │                                │ ENTITY           │ ENTITY,LOCAL                           │ listings_latest                          │
+  │ listing__capacity_latest             │                                │ DIMENSION        │ JOINED                                 │ listings_latest,listings_latest_cyclic   │
+  │ listing__country_latest              │                                │ DIMENSION        │ LOCAL                                  │ listings_latest                          │
+  │ listing__ds__alien_day               │                                │ TIME_DIMENSION   │ DERIVED_TIME_GRANULARITY,LOCAL         │ listings_latest                          │
+  │ listing__ds__day                     │                                │ TIME_DIMENSION   │ LOCAL                                  │ listings_latest                          │
+  │ listing__ds__extract_day             │                                │ TIME_DIMENSION   │ DATE_PART,LOCAL                        │ listings_latest                          │
+  │ listing__ds__extract_dow             │                                │ TIME_DIMENSION   │ DATE_PART,LOCAL                        │ listings_latest                          │
+  │ listing__ds__extract_doy             │                                │ TIME_DIMENSION   │ DATE_PART,LOCAL                        │ listings_latest                          │
+  │ listing__ds__extract_month           │                                │ TIME_DIMENSION   │ DATE_PART,LOCAL                        │ listings_latest                          │
+  │ listing__ds__extract_quarter         │                                │ TIME_DIMENSION   │ DATE_PART,LOCAL                        │ listings_latest                          │
+  │ listing__ds__extract_year            │                                │ TIME_DIMENSION   │ DATE_PART,LOCAL                        │ listings_latest                          │
+  │ listing__ds__month                   │                                │ TIME_DIMENSION   │ DERIVED_TIME_GRANULARITY,LOCAL         │ listings_latest                          │
+  │ listing__ds__quarter                 │                                │ TIME_DIMENSION   │ DERIVED_TIME_GRANULARITY,LOCAL         │ listings_latest                          │
+  │ listing__ds__week                    │                                │ TIME_DIMENSION   │ DERIVED_TIME_GRANULARITY,LOCAL         │ listings_latest                          │
+  │ listing__ds__year                    │                                │ TIME_DIMENSION   │ DERIVED_TIME_GRANULARITY,LOCAL         │ listings_latest                          │
+  │ listing__listings                    │ listing                        │ METRIC           │ JOINED,METRIC                          │ listings_latest                          │
+  │ metric_time__alien_day               │                                │ TIME_DIMENSION   │ DERIVED_TIME_GRANULARITY,METRIC_TIME   │ listings_latest                          │
+  │ metric_time__day                     │                                │ TIME_DIMENSION   │ METRIC_TIME                            │ listings_latest                          │
+  │ metric_time__extract_day             │                                │ TIME_DIMENSION   │ DATE_PART,METRIC_TIME                  │ listings_latest                          │
+  │ metric_time__extract_dow             │                                │ TIME_DIMENSION   │ DATE_PART,METRIC_TIME                  │ listings_latest                          │
+  │ metric_time__extract_doy             │                                │ TIME_DIMENSION   │ DATE_PART,METRIC_TIME                  │ listings_latest                          │
+  │ metric_time__extract_month           │                                │ TIME_DIMENSION   │ DATE_PART,METRIC_TIME                  │ listings_latest                          │
+  │ metric_time__extract_quarter         │                                │ TIME_DIMENSION   │ DATE_PART,METRIC_TIME                  │ listings_latest                          │
+  │ metric_time__extract_year            │                                │ TIME_DIMENSION   │ DATE_PART,METRIC_TIME                  │ listings_latest                          │
+  │ metric_time__month                   │                                │ TIME_DIMENSION   │ DERIVED_TIME_GRANULARITY,METRIC_TIME   │ listings_latest                          │
+  │ metric_time__quarter                 │                                │ TIME_DIMENSION   │ DERIVED_TIME_GRANULARITY,METRIC_TIME   │ listings_latest                          │
+  │ metric_time__week                    │                                │ TIME_DIMENSION   │ DERIVED_TIME_GRANULARITY,METRIC_TIME   │ listings_latest                          │
+  │ metric_time__year                    │                                │ TIME_DIMENSION   │ DERIVED_TIME_GRANULARITY,METRIC_TIME   │ listings_latest                          │
+  └──────────────────────────────────────┴────────────────────────────────┴──────────────────┴────────────────────────────────────────┴──────────────────────────────────────────┘


### PR DESCRIPTION
This PR adds a test for group-by items using the cyclic manifest to verify that join cycles do not cause an infinite loop.