### PR TITLE
Consolidate measure / metric methods of `GroupByItemSetResolver`

### DIFF
--- a/.changes/unreleased/Under the Hood-20251002-122925.yaml
+++ b/.changes/unreleased/Under the Hood-20251002-122925.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Consolidate measure / metric methods of `GroupByItemSetResolver`
+time: 2025-10-02T12:29:25.789492-07:00
+custom:
+  Author: plypaul
+  Issue: "1871"

--- a/.changes/unreleased/Under the Hood-20251002-123044.yaml
+++ b/.changes/unreleased/Under the Hood-20251002-123044.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Add test for group-by items using the cyclic manifest
+time: 2025-10-02T12:30:44.181205-07:00
+custom:
+  Author: plypaul
+  Issue: "1869"

--- a/.changes/unreleased/Under the Hood-20251002-123232.yaml
+++ b/.changes/unreleased/Under the Hood-20251002-123232.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Add workflow to check changelog files
+time: 2025-10-02T12:32:32.797437-07:00
+custom:
+  Author: plypaul
+  Issue: "1847"

--- a/.changes/unreleased/Under the Hood-20251002-123407.yaml
+++ b/.changes/unreleased/Under the Hood-20251002-123407.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Remove `LinkableElementSet`
+time: 2025-10-02T12:34:07.522688-07:00
+custom:
+  Author: plypaul
+  Issue: "1866"

--- a/.changes/unreleased/Under the Hood-20251002-123447.yaml
+++ b/.changes/unreleased/Under the Hood-20251002-123447.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Rename classes for group-by items
+time: 2025-10-02T12:34:47.609972-07:00
+custom:
+  Author: plypaul
+  Issue: "1870"

--- a/.changes/unreleased/Under the Hood-20251002-123542.yaml
+++ b/.changes/unreleased/Under the Hood-20251002-123542.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Consolidate measure-related operations into `MeasureLookup`
+time: 2025-10-02T12:35:42.003889-07:00
+custom:
+  Author: plypaul
+  Issue: "1868"

--- a/metricflow-semantics/metricflow_semantics/experimental/semantic_graph/attribute_resolution/sg_linkable_spec_resolver.py
+++ b/metricflow-semantics/metricflow_semantics/experimental/semantic_graph/attribute_resolution/sg_linkable_spec_resolver.py
@@ -124,9 +124,7 @@ class SemanticGraphGroupByItemSetResolver(GroupByItemSetResolver):
         )
 
     @override
-    def get_linkable_elements_for_distinct_values_query(
-        self, element_filter: GroupByItemSetFilter
-    ) -> BaseGroupByItemSet:
+    def get_set_for_distinct_values_query(self, element_filter: GroupByItemSetFilter) -> BaseGroupByItemSet:
         cache_key = (element_filter,)
         cache_result = self._result_cache_for_distinct_values.get(cache_key)
         if cache_result:

--- a/metricflow-semantics/metricflow_semantics/experimental/semantic_graph/trie_resolver/group_by_metric_resolver.py
+++ b/metricflow-semantics/metricflow_semantics/experimental/semantic_graph/trie_resolver/group_by_metric_resolver.py
@@ -24,8 +24,6 @@ from metricflow_semantics.experimental.semantic_graph.model_id import SemanticMo
 from metricflow_semantics.experimental.semantic_graph.nodes.entity_nodes import MetricTimeNode
 from metricflow_semantics.experimental.semantic_graph.nodes.node_labels import (
     BaseMetricLabel,
-    ConfiguredEntityLabel,
-    JoinedModelLabel,
     LocalModelLabel,
     MeasureLabel,
     MetricLabel,
@@ -73,17 +71,8 @@ class GroupByMetricTrieResolver(DunderNameTrieResolver):
     ) -> None:
         super().__init__(semantic_graph=semantic_graph, path_finder=path_finder)
         self._local_model_nodes = semantic_graph.nodes_with_labels(self._local_model_label)
-        self._key_attribute_nodes = semantic_graph.nodes_with_labels(self._entity_key_attribute_label)
-        self._node_allow_set = self._local_model_nodes.union(
-            self._key_attribute_nodes,
-            self._semantic_graph.nodes_with_labels(
-                JoinedModelLabel.get_instance(),
-                ConfiguredEntityLabel.get_instance(),
-            ),
-        )
         self._metric_nodes = semantic_graph.nodes_with_labels(MetricLabel.get_instance())
-        self._measure_nodes = semantic_graph.nodes_with_labels(MeasureLabel.get_instance())
-        self._base_metric_nodes = semantic_graph.nodes_with_labels(BaseMetricLabel.get_instance())
+
         self._nodes_in_path_from_metric_nodes_to_local_model_nodes = semantic_graph.nodes_with_labels(
             MetricLabel.get_instance(),
             MeasureLabel.get_instance(),
@@ -160,7 +149,7 @@ class GroupByMetricTrieResolver(DunderNameTrieResolver):
             graph=self._semantic_graph,
             source_nodes=source_nodes,
             target_nodes=self._local_model_nodes,
-            node_allow_set=self._node_allow_set,
+            node_allow_set=self._nodes_in_path_from_metric_nodes_to_local_model_nodes,
             deny_labels={self._deny_visible_attributes_label},
         )
         reachable_local_model_nodes = tuple(find_descendants_result.reachable_target_nodes)

--- a/metricflow-semantics/metricflow_semantics/model/semantics/linkable_spec_resolver.py
+++ b/metricflow-semantics/metricflow_semantics/model/semantics/linkable_spec_resolver.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from abc import ABC, abstractmethod
-from typing import Sequence
+from typing import Iterable, Optional, Sequence
 
 from dbt_semantic_interfaces.references import (
     MeasureReference,
@@ -50,4 +50,14 @@ class GroupByItemSetResolver(ABC):
         through a separate and more comprehensive resolution process (`GroupByItemResolver`).
         # TODO: Consolidate resolution processes.
         """
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_common_set(
+        self,
+        measure_references: Iterable[MeasureReference] = (),
+        metric_references: Iterable[MetricReference] = (),
+        set_filter: Optional[GroupByItemSetFilter] = None,
+    ) -> BaseGroupByItemSet:
+        """Gets the set of the valid group-by items common to all inputs."""
         raise NotImplementedError

--- a/metricflow-semantics/metricflow_semantics/model/semantics/linkable_spec_resolver.py
+++ b/metricflow-semantics/metricflow_semantics/model/semantics/linkable_spec_resolver.py
@@ -28,7 +28,7 @@ class GroupByItemSetResolver(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def get_linkable_elements_for_distinct_values_query(
+    def get_set_for_distinct_values_query(
         self,
         element_filter: GroupByItemSetFilter,
     ) -> BaseGroupByItemSet:

--- a/metricflow-semantics/metricflow_semantics/model/semantics/linkable_spec_resolver.py
+++ b/metricflow-semantics/metricflow_semantics/model/semantics/linkable_spec_resolver.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from abc import ABC, abstractmethod
-from typing import Iterable, Optional, Sequence
+from typing import Iterable, Optional
 
 from dbt_semantic_interfaces.references import (
     MeasureReference,
@@ -19,15 +19,6 @@ class GroupByItemSetResolver(ABC):
     """Resolves available group-by items for measures and metrics."""
 
     @abstractmethod
-    def get_linkable_element_set_for_measure(
-        self,
-        measure_reference: MeasureReference,
-        element_filter: GroupByItemSetFilter,
-    ) -> BaseGroupByItemSet:
-        """Get the valid linkable elements for the given measure."""
-        raise NotImplementedError
-
-    @abstractmethod
     def get_set_for_distinct_values_query(
         self,
         element_filter: GroupByItemSetFilter,
@@ -35,20 +26,6 @@ class GroupByItemSetResolver(ABC):
         """Returns queryable items for a distinct group-by-item values query.
 
         A distinct group-by-item values query does not include any metrics.
-        """
-        raise NotImplementedError
-
-    @abstractmethod
-    def get_linkable_elements_for_metrics(
-        self,
-        metric_references: Sequence[MetricReference],
-        element_filter: GroupByItemSetFilter = GroupByItemSetFilter(),
-    ) -> BaseGroupByItemSet:
-        """Gets the valid linkable elements that are common to all requested metrics.
-
-        The results of this method don't actually match what will be allowed for the metric because resolution goes
-        through a separate and more comprehensive resolution process (`GroupByItemResolver`).
-        # TODO: Consolidate resolution processes.
         """
         raise NotImplementedError
 

--- a/metricflow-semantics/metricflow_semantics/model/semantics/metric_lookup.py
+++ b/metricflow-semantics/metricflow_semantics/model/semantics/metric_lookup.py
@@ -130,7 +130,7 @@ class MetricLookup:
         if result is not None:
             return result
 
-        result = self._group_by_item_set_resolver.get_linkable_elements_for_distinct_values_query(element_set_filter)
+        result = self._group_by_item_set_resolver.get_set_for_distinct_values_query(element_set_filter)
         self._group_by_items_for_no_metrics_query_cache.set(cache_key, result)
         return result
 

--- a/metricflow-semantics/metricflow_semantics/model/semantics/metric_lookup.py
+++ b/metricflow-semantics/metricflow_semantics/model/semantics/metric_lookup.py
@@ -61,15 +61,15 @@ class MetricLookup:
         ] = {}
 
         # Cache for `linkable_elements_for_measure()`.
-        self._linkable_element_set_for_measure_cache: Dict[
+        self._group_by_item_set_for_measure_cache: Dict[
             Tuple[MeasureReference, GroupByItemSetFilter], BaseGroupByItemSet
         ] = {}
 
-        self._linkable_elements_including_group_by_metrics_cache = LruCache[
+        self._group_by_items_including_metrics_cache = LruCache[
             Tuple[MeasureReference, GroupByItemSetFilter], BaseGroupByItemSet
         ](128)
-        self._linkable_elements_for_no_metrics_query_cache = LruCache[GroupByItemSetFilter, BaseGroupByItemSet](128)
-        self._linkable_elements_for_metrics_cache = LruCache[
+        self._group_by_items_for_no_metrics_query_cache = LruCache[GroupByItemSetFilter, BaseGroupByItemSet](128)
+        self._group_by_items_for_metrics_cache = LruCache[
             Tuple[Sequence[MetricReference], GroupByItemSetFilter], BaseGroupByItemSet
         ](128)
 
@@ -88,34 +88,34 @@ class MetricLookup:
             and GroupByItemProperty.METRIC not in element_filter.without_any_of
         ):
             cache_key = (measure_reference, element_filter)
-            result = self._linkable_elements_including_group_by_metrics_cache.get(cache_key)
+            result = self._group_by_items_including_metrics_cache.get(cache_key)
             if result is not None:
                 return result
 
-            result = self._group_by_item_set_resolver.get_linkable_element_set_for_measure(
-                measure_reference, element_filter
+            result = self._group_by_item_set_resolver.get_common_set(
+                measure_references=[measure_reference], metric_references=[], set_filter=element_filter
             )
-            self._linkable_elements_including_group_by_metrics_cache.set(cache_key, result)
+            self._group_by_items_including_metrics_cache.set(cache_key, result)
             return result
 
         # Cache the result without element names in the filter for better hit rates.
-        element_filter_without_element_names = element_filter.without_element_names()
-        cache_key = (measure_reference, element_filter_without_element_names)
+        set_filter_without_element_names = element_filter.without_element_names()
+        cache_key = (measure_reference, set_filter_without_element_names)
 
-        result = self._linkable_element_set_for_measure_cache.get(cache_key)
+        result = self._group_by_item_set_for_measure_cache.get(cache_key)
         if result is not None:
             return result.filter(element_filter)
 
-        result = self._group_by_item_set_resolver.get_linkable_element_set_for_measure(
-            measure_reference, element_filter_without_element_names
+        result = self._group_by_item_set_resolver.get_common_set(
+            measure_references=[measure_reference], metric_references=[], set_filter=set_filter_without_element_names
         )
-        self._linkable_element_set_for_measure_cache[cache_key] = result
+        self._group_by_item_set_for_measure_cache[cache_key] = result
 
         logger.debug(
             LazyFormat(
                 "Finished getting linkable elements",
                 measure_reference=measure_reference,
-                element_filter=element_filter,
+                set_filter=element_filter,
                 runtime=time.perf_counter() - start_time,
             )
         )
@@ -126,12 +126,12 @@ class MetricLookup:
     ) -> BaseGroupByItemSet:
         """Return the reachable linkable elements for a dimension values query with no metrics."""
         cache_key = element_set_filter
-        result = self._linkable_elements_for_no_metrics_query_cache.get(cache_key)
+        result = self._group_by_items_for_no_metrics_query_cache.get(cache_key)
         if result is not None:
             return result
 
         result = self._group_by_item_set_resolver.get_linkable_elements_for_distinct_values_query(element_set_filter)
-        self._linkable_elements_for_no_metrics_query_cache.set(cache_key, result)
+        self._group_by_items_for_no_metrics_query_cache.set(cache_key, result)
         return result
 
     def linkable_elements_for_metrics(
@@ -139,14 +139,14 @@ class MetricLookup:
     ) -> BaseGroupByItemSet:
         """Retrieve the matching set of linkable elements common to all metrics requested (intersection)."""
         cache_key = (metric_references, element_set_filter)
-        result = self._linkable_elements_for_metrics_cache.get(cache_key)
+        result = self._group_by_items_for_metrics_cache.get(cache_key)
         if result is not None:
             return result
 
         result = self._group_by_item_set_resolver.get_linkable_elements_for_metrics(
             metric_references=metric_references, element_filter=element_set_filter
         )
-        self._linkable_elements_for_metrics_cache.set(cache_key, result)
+        self._group_by_items_for_metrics_cache.set(cache_key, result)
         return result
 
     def get_metrics(self, metric_references: Iterable[MetricReference]) -> Sequence[Metric]:  # noqa: D102

--- a/metricflow-semantics/metricflow_semantics/query/group_by_item/candidate_push_down/push_down_visitor.py
+++ b/metricflow-semantics/metricflow_semantics/query/group_by_item/candidate_push_down/push_down_visitor.py
@@ -460,10 +460,11 @@ class _PushDownGroupByItemCandidatesVisitor(GroupByItemResolutionNodeVisitor[Pus
         with self._path_from_start_node_tracker.track_node_visit(node) as current_traversal_path:
             logger.debug(LazyFormat(lambda: f"Handling {node.ui_description}"))
             # This is a case for distinct dimension values from semantic models.
-            candidate_elements = self._semantic_manifest_lookup.metric_lookup.linkable_elements_for_no_metrics_query()
-            if logger.isEnabledFor(logging.DEBUG):
-                logger.debug(LazyFormat(lambda: f"Candidate elements are:\n{mf_pformat(candidate_elements)}"))
-            candidates_after_filtering = candidate_elements.filter_by_spec_patterns(self._source_spec_patterns)
+            candidate_group_by_items = (
+                self._semantic_manifest_lookup.metric_lookup.linkable_elements_for_no_metrics_query()
+            )
+            logger.debug(LazyFormat("Retrieved candidates", candidate_group_by_items=candidate_group_by_items))
+            candidates_after_filtering = candidate_group_by_items.filter_by_spec_patterns(self._source_spec_patterns)
 
             if candidates_after_filtering.is_empty:
                 return PushDownResult(

--- a/metricflow-semantics/tests_metricflow_semantics/experimental/semantic_graph/resolver/test_sg_resolver_output.py
+++ b/metricflow-semantics/tests_metricflow_semantics/experimental/semantic_graph/resolver/test_sg_resolver_output.py
@@ -80,20 +80,14 @@ def test_set_for_metrics(sg_tester: SemanticGraphTester) -> None:
 def test_set_for_distinct_values_query(sg_tester: SemanticGraphTester) -> None:
     """Check the attribute set for a distinct-values query / no-metric query."""
     sg_tester.assert_attribute_set_snapshot_equal(
-        {
-            "Distinct-Values Query": sg_tester.sg_resolver.get_linkable_elements_for_distinct_values_query(
-                GroupByItemSetFilter()
-            )
-        }
+        {"Distinct-Values Query": sg_tester.sg_resolver.get_set_for_distinct_values_query(GroupByItemSetFilter())}
     )
 
 
 def test_set_filtering_for_distinct_values_query(sg_tester: SemanticGraphTester) -> None:
     """Check filtering of the set for a distinct values query."""
-    complete_set = sg_tester.sg_resolver.get_linkable_elements_for_distinct_values_query(GroupByItemSetFilter())
+    complete_set = sg_tester.sg_resolver.get_set_for_distinct_values_query(GroupByItemSetFilter())
     sg_tester.check_set_filtering(
         complete_set=complete_set,
-        filtered_set_callable=lambda set_filter: sg_tester.sg_resolver.get_linkable_elements_for_distinct_values_query(
-            set_filter
-        ),
+        filtered_set_callable=lambda set_filter: sg_tester.sg_resolver.get_set_for_distinct_values_query(set_filter),
     )

--- a/metricflow-semantics/tests_metricflow_semantics/experimental/semantic_graph/resolver/test_sg_resolver_output.py
+++ b/metricflow-semantics/tests_metricflow_semantics/experimental/semantic_graph/resolver/test_sg_resolver_output.py
@@ -38,11 +38,11 @@ def test_set_filtering_for_measure(sg_tester: SemanticGraphTester) -> None:
     """Check filtering of the set for a measure."""
     measure_reference = MeasureReference("bookings")
     sg_resolver = sg_tester.sg_resolver
-    complete_set = sg_resolver.get_linkable_element_set_for_measure(measure_reference)
+    complete_set = sg_resolver.get_common_set(measure_references=(measure_reference,))
     sg_tester.check_set_filtering(
         complete_set=complete_set,
-        filtered_set_callable=lambda set_filter: sg_resolver.get_linkable_element_set_for_measure(
-            measure_reference, set_filter
+        filtered_set_callable=lambda set_filter: sg_resolver.get_common_set(
+            measure_references=(measure_reference,), set_filter=set_filter
         ),
     )
 

--- a/metricflow-semantics/tests_metricflow_semantics/experimental/semantic_graph/resolver/test_sg_resolver_performance.py
+++ b/metricflow-semantics/tests_metricflow_semantics/experimental/semantic_graph/resolver/test_sg_resolver_performance.py
@@ -11,6 +11,8 @@ from metricflow_semantics.experimental.test_helpers.benchmark_helpers import (
     OneSecondFunction,
     PerformanceBenchmark,
 )
+from metricflow_semantics.model.linkable_element_property import GroupByItemProperty
+from metricflow_semantics.model.semantics.element_filter import GroupByItemSetFilter
 from metricflow_semantics.test_helpers.config_helpers import MetricFlowTestConfiguration
 from typing_extensions import override
 
@@ -57,7 +59,9 @@ def test_resolver_query_time(high_complexity_manifest_sg_fixture: SemanticGraphT
 
         @override
         def run(self) -> None:
-            self._resolver.get_linkable_elements_for_metrics(metric_references)
+            # Replicate the behavior of get_linkable_elements_for_metrics which filters out METRIC properties
+            base_filter = GroupByItemSetFilter(without_any_of=frozenset((GroupByItemProperty.METRIC,)))
+            self._resolver.get_common_set(metric_references=metric_references, set_filter=base_filter)
 
     PerformanceBenchmark.assert_function_performance(
         left_function_class=OneSecondFunction,

--- a/metricflow-semantics/tests_metricflow_semantics/experimental/semantic_graph/sg_tester.py
+++ b/metricflow-semantics/tests_metricflow_semantics/experimental/semantic_graph/sg_tester.py
@@ -76,7 +76,10 @@ class SemanticGraphTester:
     ) -> None:
         sg_resolver = self.sg_resolver
         description_to_set = {
-            str(measure_name): sg_resolver.get_linkable_element_set_for_measure(MeasureReference(measure_name))
+            str(measure_name): sg_resolver.get_common_set(
+                measure_references=(MeasureReference(measure_name),),
+                set_filter=None,
+            )
             for measure_name in measure_names
         }
         self.assert_attribute_set_snapshot_equal(description_to_set, expectation_description)

--- a/metricflow/engine/metricflow_engine.py
+++ b/metricflow/engine/metricflow_engine.py
@@ -687,18 +687,18 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
     ) -> List[Dimension]:
         self._check_metric_names(metric_names)
 
-        linkable_element_set = self._semantic_manifest_lookup.metric_lookup.linkable_elements_for_metrics(
+        group_by_item_set = self._semantic_manifest_lookup.metric_lookup.linkable_elements_for_metrics(
             metric_references=tuple(MetricReference(element_name=mname) for mname in metric_names),
-            element_set_filter=GroupByItemSetFilter(
+            set_filter=GroupByItemSetFilter(
                 without_any_of=frozenset(without_any_property),
             ),
         )
-        return self._filter_simple_linkable_dimensions(linkable_element_set=linkable_element_set)
+        return self._filter_simple_linkable_dimensions(group_by_item_set=group_by_item_set)
 
-    def _filter_simple_linkable_dimensions(self, linkable_element_set: BaseGroupByItemSet) -> List[Dimension]:
+    def _filter_simple_linkable_dimensions(self, group_by_item_set: BaseGroupByItemSet) -> List[Dimension]:
         dimensions: List[Dimension] = []
 
-        for annotated_spec in linkable_element_set.annotated_specs:
+        for annotated_spec in group_by_item_set.annotated_specs:
             properties = annotated_spec.property_set
             element_type = annotated_spec.element_type
             if element_type is LinkableElementType.TIME_DIMENSION:
@@ -789,20 +789,20 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
         return sorted(set(dimensions), key=sort_dimensions)
 
     def entities_for_metrics(self, metric_names: List[str]) -> List[Entity]:  # noqa: D102
-        linkable_element_set = self._semantic_manifest_lookup.metric_lookup.linkable_elements_for_metrics(
+        group_by_item_set = self._semantic_manifest_lookup.metric_lookup.linkable_elements_for_metrics(
             metric_references=tuple(MetricReference(element_name=mname) for mname in metric_names),
-            element_set_filter=GroupByItemSetFilter(
+            set_filter=GroupByItemSetFilter(
                 with_any_of=frozenset(ENTITY_WITH_ANY_PROPERTIES),
             ),
         )
 
-        entities = self._filter_linkable_entities(linkable_element_set=linkable_element_set)
+        entities = self._filter_linkable_entities(group_by_item_set=group_by_item_set)
         return sorted(set(entities), key=lambda x: x.default_search_and_sort_attribute)
 
-    def _filter_linkable_entities(self, linkable_element_set: BaseGroupByItemSet) -> List[Entity]:
+    def _filter_linkable_entities(self, group_by_item_set: BaseGroupByItemSet) -> List[Entity]:
         entities: List[Entity] = []
 
-        for annotated_spec in linkable_element_set.annotated_specs:
+        for annotated_spec in group_by_item_set.annotated_specs:
             element_type = annotated_spec.element_type
             if element_type is LinkableElementType.ENTITY:
                 semantic_model = self._semantic_manifest_lookup.semantic_model_lookup.get_by_reference(
@@ -928,15 +928,15 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
             without_any_of = SIMPLE_DIMENSIONS_WITHOUT_ANY_PROPERTIES - ENTITY_WITH_ANY_PROPERTIES
             if include_derived_time_granularities:
                 without_any_of = without_any_of - {GroupByItemProperty.DERIVED_TIME_GRANULARITY}
-            linkable_element_set = self._semantic_manifest_lookup.metric_lookup.linkable_elements_for_metrics(
+            group_by_item_set = self._semantic_manifest_lookup.metric_lookup.linkable_elements_for_metrics(
                 metric_references=tuple(MetricReference(element_name=mname) for mname in metric_names),
-                element_set_filter=GroupByItemSetFilter(
+                set_filter=GroupByItemSetFilter(
                     without_any_of=frozenset(without_any_of),
                 ),
             )
             group_bys: Sequence = self._filter_linkable_entities(
-                linkable_element_set=linkable_element_set
-            ) + self._filter_simple_linkable_dimensions(linkable_element_set=linkable_element_set)
+                group_by_item_set=group_by_item_set
+            ) + self._filter_simple_linkable_dimensions(group_by_item_set=group_by_item_set)
         else:
             # TODO: better support for querying entities without metrics; include entities here at that time
             group_bys = self.list_dimensions()


### PR DESCRIPTION
This PR consolidates methods that handle measures and metrics separately in `GroupByItemSetResolver` to aid the `measure -> simple metric` migration.