### PR TITLE
Assorted fixes for `GroupByItemSetFilter`

### DIFF
--- a/.changes/unreleased/Under the Hood-20251002-131616.yaml
+++ b/.changes/unreleased/Under the Hood-20251002-131616.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Assorted fixes for `GroupByItemSetFilter`
+time: 2025-10-02T13:16:16.00412-07:00
+custom:
+  Author: plypaul
+  Issue: "1873"

--- a/metricflow-semantics/metricflow_semantics/experimental/semantic_graph/attribute_resolution/annotated_spec_linkable_element_set.py
+++ b/metricflow-semantics/metricflow_semantics/experimental/semantic_graph/attribute_resolution/annotated_spec_linkable_element_set.py
@@ -104,8 +104,8 @@ class GroupByItemSet(BaseGroupByItemSet, SerializableDataclass):
 
     @override
     def filter(self, element_filter: GroupByItemSetFilter) -> GroupByItemSet:
-        allow_element_name_set = element_filter.element_names
-        deny_property_set = element_filter.without_any_of
+        allow_element_name_set = element_filter.element_name_allowlist
+        deny_property_set = element_filter.any_properties_denylist
 
         new_specs: list[AnnotatedSpec] = []
         for annotated_spec in self.annotated_specs:
@@ -114,7 +114,7 @@ class GroupByItemSet(BaseGroupByItemSet, SerializableDataclass):
 
             property_set = annotated_spec.property_set
 
-            if not element_filter.with_any_of.intersection(annotated_spec.property_set):
+            if not element_filter.any_properties_allowlist.intersection(annotated_spec.property_set):
                 continue
 
             if deny_property_set and len(deny_property_set.intersection(property_set)) > 0:

--- a/metricflow-semantics/metricflow_semantics/experimental/semantic_graph/attribute_resolution/annotated_spec_linkable_element_set.py
+++ b/metricflow-semantics/metricflow_semantics/experimental/semantic_graph/attribute_resolution/annotated_spec_linkable_element_set.py
@@ -104,12 +104,12 @@ class GroupByItemSet(BaseGroupByItemSet, SerializableDataclass):
 
     @override
     def filter(self, element_filter: GroupByItemSetFilter) -> GroupByItemSet:
-        allow_element_name_set = element_filter.element_name_allowlist
-        deny_property_set = element_filter.any_properties_denylist
+        element_name_allowlist = element_filter.element_name_allowlist
+        any_properties_denylist = element_filter.any_properties_denylist
 
         new_specs: list[AnnotatedSpec] = []
         for annotated_spec in self.annotated_specs:
-            if allow_element_name_set is not None and annotated_spec.element_name not in allow_element_name_set:
+            if element_name_allowlist is not None and annotated_spec.element_name not in element_name_allowlist:
                 continue
 
             property_set = annotated_spec.property_set
@@ -117,7 +117,7 @@ class GroupByItemSet(BaseGroupByItemSet, SerializableDataclass):
             if not element_filter.any_properties_allowlist.intersection(annotated_spec.property_set):
                 continue
 
-            if deny_property_set and len(deny_property_set.intersection(property_set)) > 0:
+            if any_properties_denylist and len(any_properties_denylist.intersection(property_set)) > 0:
                 continue
 
             new_specs.append(annotated_spec)

--- a/metricflow-semantics/metricflow_semantics/experimental/semantic_graph/attribute_resolution/annotated_spec_linkable_element_set.py
+++ b/metricflow-semantics/metricflow_semantics/experimental/semantic_graph/attribute_resolution/annotated_spec_linkable_element_set.py
@@ -106,7 +106,6 @@ class GroupByItemSet(BaseGroupByItemSet, SerializableDataclass):
     def filter(self, element_filter: GroupByItemSetFilter) -> GroupByItemSet:
         allow_element_name_set = element_filter.element_names
         deny_property_set = element_filter.without_any_of
-        deny_match_all_property_set = element_filter.without_all_of
 
         new_specs: list[AnnotatedSpec] = []
         for annotated_spec in self.annotated_specs:
@@ -121,11 +120,6 @@ class GroupByItemSet(BaseGroupByItemSet, SerializableDataclass):
             if deny_property_set and len(deny_property_set.intersection(property_set)) > 0:
                 continue
 
-            if (
-                len(deny_match_all_property_set) > 0
-                and deny_match_all_property_set.intersection(property_set) == deny_match_all_property_set
-            ):
-                continue
             new_specs.append(annotated_spec)
 
         return GroupByItemSet(annotated_specs=tuple(new_specs))

--- a/metricflow-semantics/metricflow_semantics/experimental/semantic_graph/attribute_resolution/recipe_writer_weight.py
+++ b/metricflow-semantics/metricflow_semantics/experimental/semantic_graph/attribute_resolution/recipe_writer_weight.py
@@ -202,7 +202,7 @@ class AttributeRecipeWriterWeightFunction(
         next_node: SemanticGraphNode,
         steps: AnyLengthTuple[AttributeRecipeStep],
     ) -> bool:
-        property_deny_set = element_filter.without_any_of
+        property_deny_set = element_filter.any_properties_denylist
         if property_deny_set and any(
             element_property in property_deny_set
             for element_property in itertools.chain.from_iterable(
@@ -211,7 +211,7 @@ class AttributeRecipeWriterWeightFunction(
         ):
             return True
 
-        name_element_allow_set = element_filter.element_names
+        name_element_allow_set = element_filter.element_name_allowlist
         # Generally, element name should be checked at the attribute node, but it can be done at time dimension nodes
         # as they are an entity node that adds an element name. This can speed up traversal by pruning edges.
         if (

--- a/metricflow-semantics/metricflow_semantics/experimental/semantic_graph/attribute_resolution/recipe_writer_weight.py
+++ b/metricflow-semantics/metricflow_semantics/experimental/semantic_graph/attribute_resolution/recipe_writer_weight.py
@@ -202,9 +202,9 @@ class AttributeRecipeWriterWeightFunction(
         next_node: SemanticGraphNode,
         steps: AnyLengthTuple[AttributeRecipeStep],
     ) -> bool:
-        property_deny_set = element_filter.any_properties_denylist
-        if property_deny_set and any(
-            element_property in property_deny_set
+        any_properties_denylist = element_filter.any_properties_denylist
+        if any_properties_denylist and any(
+            element_property in any_properties_denylist
             for element_property in itertools.chain.from_iterable(
                 step.add_properties for step in steps if step.add_properties
             )

--- a/metricflow-semantics/metricflow_semantics/experimental/semantic_graph/attribute_resolution/sg_linkable_spec_resolver.py
+++ b/metricflow-semantics/metricflow_semantics/experimental/semantic_graph/attribute_resolution/sg_linkable_spec_resolver.py
@@ -79,8 +79,10 @@ class SemanticGraphGroupByItemSetResolver(GroupByItemSetResolver):
         self._result_cache_for_common_set: ResultCache[_CommonSetCacheKey, BaseGroupByItemSet] = ResultCache()
 
     @override
-    def get_set_for_distinct_values_query(self, element_filter: GroupByItemSetFilter) -> BaseGroupByItemSet:
-        cache_key = (element_filter,)
+    def get_set_for_distinct_values_query(
+        self, set_filter: Optional[GroupByItemSetFilter] = None
+    ) -> BaseGroupByItemSet:
+        cache_key = (set_filter,)
         cache_result = self._result_cache_for_distinct_values.get(cache_key)
         if cache_result:
             return cache_result.value
@@ -88,17 +90,15 @@ class SemanticGraphGroupByItemSetResolver(GroupByItemSetResolver):
         for local_model_node in self._local_model_nodes:
             source_nodes = FrozenOrderedSet((local_model_node,))
             local_model_trie = self._simple_resolver_limit_one_model.resolve_trie(
-                source_nodes, element_filter
+                source_nodes, set_filter
             ).dunder_name_trie
             group_by_metric_trie = self._group_by_metric_resolver.resolve_trie(
-                source_nodes, element_filter
+                source_nodes, set_filter
             ).dunder_name_trie
             tries_to_union.append(local_model_trie)
             tries_to_union.append(group_by_metric_trie)
 
-        metric_time_trie = self._simple_resolver.resolve_trie(
-            self._metric_time_node_set, element_filter
-        ).dunder_name_trie
+        metric_time_trie = self._simple_resolver.resolve_trie(self._metric_time_node_set, set_filter).dunder_name_trie
 
         # Since `TimeEntitySubgraphGenerator` could add time grain nodes that are finer than the grain of time spine,
         # filter those out.

--- a/metricflow-semantics/metricflow_semantics/experimental/semantic_graph/trie_resolver/group_by_metric_resolver.py
+++ b/metricflow-semantics/metricflow_semantics/experimental/semantic_graph/trie_resolver/group_by_metric_resolver.py
@@ -131,7 +131,7 @@ class GroupByMetricTrieResolver(DunderNameTrieResolver):
         metric_names_allow_set: Optional[Set[str]] = None
 
         if element_filter is not None:
-            metric_names_allow_set = element_filter.element_names
+            metric_names_allow_set = element_filter.element_name_allowlist
             # Group-by metrics always have these properties, so return an empty set if the filter doesn't allow them.
             if not element_filter.allow(
                 element_name=None, element_properties=(GroupByItemProperty.METRIC, GroupByItemProperty.JOINED)

--- a/metricflow-semantics/metricflow_semantics/experimental/semantic_graph/trie_resolver/simple_resolver.py
+++ b/metricflow-semantics/metricflow_semantics/experimental/semantic_graph/trie_resolver/simple_resolver.py
@@ -121,7 +121,7 @@ class SimpleTrieResolver(DunderNameTrieResolver):
             if element_filter is None:
                 element_filter = GroupByItemSetFilter()
             element_filter = element_filter.copy(
-                without_any_of=element_filter.without_any_of.union((GroupByItemProperty.DATE_PART,))
+                any_properties_denylist=element_filter.any_properties_denylist.union((GroupByItemProperty.DATE_PART,))
             )
 
         result_intersection_source_nodes = tuple(find_descendants_result.reachable_target_nodes)

--- a/metricflow-semantics/metricflow_semantics/experimental/semantic_graph/trie_resolver/simple_resolver.py
+++ b/metricflow-semantics/metricflow_semantics/experimental/semantic_graph/trie_resolver/simple_resolver.py
@@ -119,7 +119,7 @@ class SimpleTrieResolver(DunderNameTrieResolver):
             source_nodes=source_nodes, collected_labels=find_descendants_result.labels_collected_during_traversal
         ):
             if element_filter is None:
-                element_filter = GroupByItemSetFilter()
+                element_filter = GroupByItemSetFilter.create()
             element_filter = element_filter.copy(
                 any_properties_denylist=element_filter.any_properties_denylist.union((GroupByItemProperty.DATE_PART,))
             )

--- a/metricflow-semantics/metricflow_semantics/model/semantics/element_filter.py
+++ b/metricflow-semantics/metricflow_semantics/model/semantics/element_filter.py
@@ -17,21 +17,18 @@ class GroupByItemSetFilter(Mergeable):
     element_names: Optional[FrozenSet[str]] = None
     with_any_of: FrozenSet[GroupByItemProperty] = GroupByItemProperty.all_properties()
     without_any_of: FrozenSet[GroupByItemProperty] = frozenset()
-    without_all_of: FrozenSet[GroupByItemProperty] = frozenset()
 
     def copy(
         self,
         element_names: Optional[FrozenSet[str]] = None,
         with_any_of: Optional[FrozenSet[GroupByItemProperty]] = None,
         without_any_of: Optional[FrozenSet[GroupByItemProperty]] = None,
-        without_all_of: Optional[FrozenSet[GroupByItemProperty]] = None,
     ) -> GroupByItemSetFilter:
         """Create a copy of this with the given non-None fields replaced."""
         return GroupByItemSetFilter(
             element_names=element_names if element_names is not None else self.element_names,
             with_any_of=with_any_of if with_any_of is not None else self.with_any_of,
             without_any_of=without_any_of if without_any_of is not None else self.without_any_of,
-            without_all_of=without_all_of if without_all_of is not None else self.without_all_of,
         )
 
     @override
@@ -44,7 +41,6 @@ class GroupByItemSetFilter(Mergeable):
             element_names=element_names,
             with_any_of=self.with_any_of.union(other.with_any_of),
             without_any_of=self.without_any_of.union(other.without_any_of),
-            without_all_of=self.without_all_of.union(other.without_all_of),
         )
 
     @classmethod
@@ -57,7 +53,6 @@ class GroupByItemSetFilter(Mergeable):
         return GroupByItemSetFilter(
             with_any_of=self.with_any_of,
             without_any_of=self.without_any_of,
-            without_all_of=self.without_all_of,
         )
 
     def allow(self, element_name: Optional[str], element_properties: Optional[Iterable[GroupByItemProperty]]) -> bool:
@@ -76,12 +71,5 @@ class GroupByItemSetFilter(Mergeable):
             denied_property_set = self.without_any_of
             if denied_property_set and len(denied_property_set.intersection(element_properties)) > 0:
                 return False
-            denied_full_match_property_set = self.without_all_of
-            if denied_full_match_property_set:
-                denied_full_match_property_set_length = len(denied_full_match_property_set)
-                if denied_full_match_property_set_length > 0 and denied_full_match_property_set_length == len(
-                    denied_full_match_property_set.intersection(element_properties)
-                ):
-                    return False
 
         return True

--- a/metricflow-semantics/metricflow_semantics/model/semantics/element_filter.py
+++ b/metricflow-semantics/metricflow_semantics/model/semantics/element_filter.py
@@ -70,10 +70,10 @@ class GroupByItemSetFilter(Mergeable):
 
     def without_element_name_allowlist(self) -> GroupByItemSetFilter:
         """Return this filter without the `element_name_allowlist` filter set."""
-        return GroupByItemSetFilter(
+        return GroupByItemSetFilter.create(
             element_name_allowlist=None,
             any_properties_denylist=self.any_properties_denylist,
-            any_properties_allowlist=self.any_properties_denylist,
+            any_properties_allowlist=self.any_properties_allowlist,
         )
 
     def allow(self, element_name: Optional[str], element_properties: Optional[Iterable[GroupByItemProperty]]) -> bool:

--- a/metricflow-semantics/metricflow_semantics/model/semantics/element_filter.py
+++ b/metricflow-semantics/metricflow_semantics/model/semantics/element_filter.py
@@ -14,45 +14,66 @@ class GroupByItemSetFilter(Mergeable):
     """Describes a way to filter the items in a `BaseGroupByItemSet`."""
 
     # A `None` value for element names means no filtering on element names.
-    element_names: Optional[FrozenSet[str]] = None
-    with_any_of: FrozenSet[GroupByItemProperty] = GroupByItemProperty.all_properties()
-    without_any_of: FrozenSet[GroupByItemProperty] = frozenset()
+    element_name_allowlist: Optional[FrozenSet[str]] = None
+    any_properties_allowlist: FrozenSet[GroupByItemProperty] = GroupByItemProperty.all_properties()
+    any_properties_denylist: FrozenSet[GroupByItemProperty] = frozenset()
+
+    @staticmethod
+    def create(  # noqa: D102
+        element_name_allowlist: Optional[Iterable[str]] = None,
+        any_properties_allowlist: Iterable[GroupByItemProperty] = GroupByItemProperty.all_properties(),
+        any_properties_denylist: Iterable[GroupByItemProperty] = frozenset(),
+    ) -> GroupByItemSetFilter:
+        return GroupByItemSetFilter(
+            element_name_allowlist=frozenset(element_name_allowlist) if element_name_allowlist is not None else None,
+            any_properties_allowlist=frozenset(any_properties_allowlist),
+            any_properties_denylist=frozenset(any_properties_denylist),
+        )
 
     def copy(
         self,
-        element_names: Optional[FrozenSet[str]] = None,
-        with_any_of: Optional[FrozenSet[GroupByItemProperty]] = None,
-        without_any_of: Optional[FrozenSet[GroupByItemProperty]] = None,
+        element_name_allowlist: Optional[FrozenSet[str]] = None,
+        any_properties_allowlist: Optional[FrozenSet[GroupByItemProperty]] = None,
+        any_properties_denylist: Optional[FrozenSet[GroupByItemProperty]] = None,
     ) -> GroupByItemSetFilter:
         """Create a copy of this with the given non-None fields replaced."""
         return GroupByItemSetFilter(
-            element_names=element_names if element_names is not None else self.element_names,
-            with_any_of=with_any_of if with_any_of is not None else self.with_any_of,
-            without_any_of=without_any_of if without_any_of is not None else self.without_any_of,
+            element_name_allowlist=element_name_allowlist
+            if element_name_allowlist is not None
+            else self.element_name_allowlist,
+            any_properties_allowlist=any_properties_allowlist
+            if any_properties_allowlist is not None
+            else self.any_properties_allowlist,
+            any_properties_denylist=any_properties_denylist
+            if any_properties_denylist is not None
+            else self.any_properties_denylist,
         )
 
     @override
     def merge(self: Self, other: GroupByItemSetFilter) -> GroupByItemSetFilter:
-        if self.element_names is None and other.element_names is None:
+        if self.element_name_allowlist is None and other.element_name_allowlist is None:
             element_names = None
         else:
-            element_names = (self.element_names or frozenset()).union(other.element_names or frozenset())
+            element_names = (self.element_name_allowlist or frozenset()).union(
+                other.element_name_allowlist or frozenset()
+            )
         return GroupByItemSetFilter(
-            element_names=element_names,
-            with_any_of=self.with_any_of.union(other.with_any_of),
-            without_any_of=self.without_any_of.union(other.without_any_of),
+            element_name_allowlist=element_names,
+            any_properties_allowlist=self.any_properties_allowlist.union(other.any_properties_allowlist),
+            any_properties_denylist=self.any_properties_denylist.union(other.any_properties_denylist),
         )
 
     @classmethod
     @override
     def empty_instance(cls) -> GroupByItemSetFilter:
-        return GroupByItemSetFilter()
+        return GroupByItemSetFilter.create()
 
-    def without_element_names(self) -> GroupByItemSetFilter:
-        """Return this filter without the `element_names` filter set."""
+    def without_element_name_allowlist(self) -> GroupByItemSetFilter:
+        """Return this filter without the `element_name_allowlist` filter set."""
         return GroupByItemSetFilter(
-            with_any_of=self.with_any_of,
-            without_any_of=self.without_any_of,
+            element_name_allowlist=None,
+            any_properties_denylist=self.any_properties_denylist,
+            any_properties_allowlist=self.any_properties_denylist,
         )
 
     def allow(self, element_name: Optional[str], element_properties: Optional[Iterable[GroupByItemProperty]]) -> bool:
@@ -61,14 +82,14 @@ class GroupByItemSetFilter(Mergeable):
         `None` can be specified in cases of incomplete context.
         """
         if element_name is not None:
-            allowed_element_name_set = self.element_names
+            allowed_element_name_set = self.element_name_allowlist
             if allowed_element_name_set is not None and element_name not in allowed_element_name_set:
                 return False
 
         if element_properties is not None:
-            if len(self.with_any_of.intersection(element_properties)) == 0:
+            if len(self.any_properties_allowlist.intersection(element_properties)) == 0:
                 return False
-            denied_property_set = self.without_any_of
+            denied_property_set = self.any_properties_denylist
             if denied_property_set and len(denied_property_set.intersection(element_properties)) > 0:
                 return False
 

--- a/metricflow-semantics/metricflow_semantics/model/semantics/linkable_element_set_base.py
+++ b/metricflow-semantics/metricflow_semantics/model/semantics/linkable_element_set_base.py
@@ -50,8 +50,7 @@ class BaseGroupByItemSet(SemanticModelDerivation, ABC):
         """Filter elements in the set.
 
         First, only elements with at least one property in the "with_any_of" set are retained. Then, any elements with
-        a property in "without_any_of" set are removed. Lastly, any elements with all properties in without_all_of
-        are removed.
+        a property in "without_any_of" set are removed.
         """
         raise NotImplementedError()
 

--- a/metricflow-semantics/metricflow_semantics/model/semantics/linkable_element_set_base.py
+++ b/metricflow-semantics/metricflow_semantics/model/semantics/linkable_element_set_base.py
@@ -49,8 +49,8 @@ class BaseGroupByItemSet(SemanticModelDerivation, ABC):
     ) -> Self:
         """Filter elements in the set.
 
-        First, only elements with at least one property in the "with_any_of" set are retained. Then, any elements with
-        a property in "without_any_of" set are removed.
+        First, only elements with at least one property in the "any_properties_allowlist" set are retained. Then, any elements with
+        a property in "any_properties_denylist" set are removed.
         """
         raise NotImplementedError()
 

--- a/metricflow-semantics/metricflow_semantics/model/semantics/linkable_spec_resolver.py
+++ b/metricflow-semantics/metricflow_semantics/model/semantics/linkable_spec_resolver.py
@@ -21,7 +21,7 @@ class GroupByItemSetResolver(ABC):
     @abstractmethod
     def get_set_for_distinct_values_query(
         self,
-        element_filter: GroupByItemSetFilter,
+        set_filter: Optional[GroupByItemSetFilter] = None,
     ) -> BaseGroupByItemSet:
         """Returns queryable items for a distinct group-by-item values query.
 

--- a/metricflow-semantics/metricflow_semantics/model/semantics/metric_lookup.py
+++ b/metricflow-semantics/metricflow_semantics/model/semantics/metric_lookup.py
@@ -27,8 +27,8 @@ from metricflow_semantics.time.granularity import ExpandedTimeGranularity
 logger = logging.getLogger(__name__)
 
 
-DEFAULT_COMMON_SET_FILTER: Final[GroupByItemSetFilter] = GroupByItemSetFilter(
-    any_properties_denylist=frozenset((GroupByItemProperty.METRIC,))
+DEFAULT_COMMON_SET_FILTER: Final[GroupByItemSetFilter] = GroupByItemSetFilter.create(
+    any_properties_denylist=(GroupByItemProperty.METRIC,)
 )
 
 
@@ -66,7 +66,7 @@ class MetricLookup:
         ] = {}
 
     def get_group_by_items_for_distinct_values_query(
-        self, set_filter: GroupByItemSetFilter = GroupByItemSetFilter()
+        self, set_filter: GroupByItemSetFilter = GroupByItemSetFilter.create()
     ) -> BaseGroupByItemSet:
         """Return the reachable linkable elements for a dimension values query with no metrics."""
         return self._group_by_item_set_resolver.get_set_for_distinct_values_query(set_filter)

--- a/metricflow-semantics/metricflow_semantics/model/semantics/metric_lookup.py
+++ b/metricflow-semantics/metricflow_semantics/model/semantics/metric_lookup.py
@@ -28,7 +28,7 @@ logger = logging.getLogger(__name__)
 
 
 DEFAULT_COMMON_SET_FILTER: Final[GroupByItemSetFilter] = GroupByItemSetFilter(
-    without_any_of=frozenset((GroupByItemProperty.METRIC,))
+    any_properties_denylist=frozenset((GroupByItemProperty.METRIC,))
 )
 
 
@@ -78,7 +78,7 @@ class MetricLookup:
         set_filter: GroupByItemSetFilter = DEFAULT_COMMON_SET_FILTER,
     ) -> BaseGroupByItemSet:
         """Gets the set of the valid group-by items common to all inputs."""
-        if set_filter.element_names is None:
+        if set_filter.element_name_allowlist is None:
             return self._group_by_item_set_resolver.get_common_set(
                 measure_references=measure_references,
                 metric_references=metric_references,
@@ -87,7 +87,7 @@ class MetricLookup:
 
         # If the filter specifies element names, make the call to the resolver without element names to get better
         # cache hit rates.
-        filter_without_element_name_condition = set_filter.without_element_names()
+        filter_without_element_name_condition = set_filter.without_element_name_allowlist()
 
         result_superset = self._group_by_item_set_resolver.get_common_set(
             measure_references=measure_references,
@@ -99,7 +99,7 @@ class MetricLookup:
             annotated_specs=tuple(
                 annotated_spec
                 for annotated_spec in result_superset.annotated_specs
-                if annotated_spec.element_name in set_filter.element_names
+                if annotated_spec.element_name in set_filter.element_name_allowlist
             )
         )
 

--- a/metricflow-semantics/metricflow_semantics/model/semantics/metric_lookup.py
+++ b/metricflow-semantics/metricflow_semantics/model/semantics/metric_lookup.py
@@ -66,10 +66,10 @@ class MetricLookup:
         ] = {}
 
     def get_group_by_items_for_distinct_values_query(
-        self, element_set_filter: GroupByItemSetFilter = GroupByItemSetFilter()
+        self, set_filter: GroupByItemSetFilter = GroupByItemSetFilter()
     ) -> BaseGroupByItemSet:
         """Return the reachable linkable elements for a dimension values query with no metrics."""
-        return self._group_by_item_set_resolver.get_set_for_distinct_values_query(element_set_filter)
+        return self._group_by_item_set_resolver.get_set_for_distinct_values_query(set_filter)
 
     def get_common_group_by_items(
         self,

--- a/metricflow-semantics/metricflow_semantics/query/group_by_item/candidate_push_down/push_down_visitor.py
+++ b/metricflow-semantics/metricflow_semantics/query/group_by_item/candidate_push_down/push_down_visitor.py
@@ -177,7 +177,7 @@ class _PushDownGroupByItemCandidatesVisitor(GroupByItemResolutionNodeVisitor[Pus
             group_by_items_for_measure = self._semantic_manifest_lookup.metric_lookup.get_common_group_by_items(
                 measure_references=(node.measure_reference,),
                 # The filter should allow everything, except for the ones blocked by the spec patterns.
-                set_filter=GroupByItemSetFilter().merge(
+                set_filter=GroupByItemSetFilter.create().merge(
                     GroupByItemSetFilter.merge_iterable(
                         spec_pattern.element_pre_filter for spec_pattern in self._source_spec_patterns
                     ),

--- a/metricflow-semantics/metricflow_semantics/query/validation_rules/metric_time_requirements.py
+++ b/metricflow-semantics/metricflow_semantics/query/validation_rules/metric_time_requirements.py
@@ -57,7 +57,7 @@ class MetricTimeQueryValidationRule(PostResolutionQueryValidationRule):
         )
 
         self._query_includes_metric_time = not self._resolve_group_by_item_result.linkable_element_set.filter(
-            GroupByItemSetFilter(any_properties_allowlist=frozenset({GroupByItemProperty.METRIC_TIME}))
+            GroupByItemSetFilter.create(any_properties_allowlist=(GroupByItemProperty.METRIC_TIME,))
         ).is_empty
 
     def _query_includes_agg_time_dimension_of_metric(self, metric_reference: MetricReference) -> bool:

--- a/metricflow-semantics/metricflow_semantics/query/validation_rules/metric_time_requirements.py
+++ b/metricflow-semantics/metricflow_semantics/query/validation_rules/metric_time_requirements.py
@@ -57,7 +57,7 @@ class MetricTimeQueryValidationRule(PostResolutionQueryValidationRule):
         )
 
         self._query_includes_metric_time = not self._resolve_group_by_item_result.linkable_element_set.filter(
-            GroupByItemSetFilter(with_any_of=frozenset({GroupByItemProperty.METRIC_TIME}))
+            GroupByItemSetFilter(any_properties_allowlist=frozenset({GroupByItemProperty.METRIC_TIME}))
         ).is_empty
 
     def _query_includes_agg_time_dimension_of_metric(self, metric_reference: MetricReference) -> bool:

--- a/metricflow-semantics/metricflow_semantics/specs/patterns/entity_link_pattern.py
+++ b/metricflow-semantics/metricflow_semantics/specs/patterns/entity_link_pattern.py
@@ -165,9 +165,9 @@ class EntityLinkPattern(SpecPattern):
             or len(self.parameter_set.metric_subquery_entity_links) == 0
         ):
             return GroupByItemSetFilter(
-                element_names=element_names, without_any_of=frozenset({GroupByItemProperty.METRIC})
+                element_name_allowlist=element_names, any_properties_denylist=frozenset({GroupByItemProperty.METRIC})
             )
 
         return GroupByItemSetFilter(
-            element_names=element_names,
+            element_name_allowlist=element_names,
         )

--- a/metricflow-semantics/metricflow_semantics/specs/patterns/entity_link_pattern.py
+++ b/metricflow-semantics/metricflow_semantics/specs/patterns/entity_link_pattern.py
@@ -164,10 +164,10 @@ class EntityLinkPattern(SpecPattern):
             self.parameter_set.metric_subquery_entity_links is None
             or len(self.parameter_set.metric_subquery_entity_links) == 0
         ):
-            return GroupByItemSetFilter(
-                element_name_allowlist=element_names, any_properties_denylist=frozenset({GroupByItemProperty.METRIC})
+            return GroupByItemSetFilter.create(
+                element_name_allowlist=element_names, any_properties_denylist=(GroupByItemProperty.METRIC,)
             )
 
-        return GroupByItemSetFilter(
+        return GroupByItemSetFilter.create(
             element_name_allowlist=element_names,
         )

--- a/metricflow-semantics/metricflow_semantics/specs/patterns/no_group_by_metric.py
+++ b/metricflow-semantics/metricflow_semantics/specs/patterns/no_group_by_metric.py
@@ -32,4 +32,4 @@ class NoGroupByMetricPattern(SpecPattern):
     @property
     @override
     def element_pre_filter(self) -> GroupByItemSetFilter:
-        return GroupByItemSetFilter(without_any_of=frozenset({GroupByItemProperty.METRIC}))
+        return GroupByItemSetFilter(any_properties_denylist=frozenset({GroupByItemProperty.METRIC}))

--- a/metricflow-semantics/metricflow_semantics/specs/patterns/no_group_by_metric.py
+++ b/metricflow-semantics/metricflow_semantics/specs/patterns/no_group_by_metric.py
@@ -32,4 +32,4 @@ class NoGroupByMetricPattern(SpecPattern):
     @property
     @override
     def element_pre_filter(self) -> GroupByItemSetFilter:
-        return GroupByItemSetFilter(any_properties_denylist=frozenset({GroupByItemProperty.METRIC}))
+        return GroupByItemSetFilter.create(any_properties_denylist=(GroupByItemProperty.METRIC,))

--- a/metricflow-semantics/metricflow_semantics/specs/patterns/spec_pattern.py
+++ b/metricflow-semantics/metricflow_semantics/specs/patterns/spec_pattern.py
@@ -30,4 +30,4 @@ class SpecPattern(ABC):
 
         i.e. the filter can produce a superset of the elements that will match.
         """
-        return GroupByItemSetFilter()
+        return GroupByItemSetFilter.create()

--- a/metricflow-semantics/metricflow_semantics/specs/patterns/typed_patterns.py
+++ b/metricflow-semantics/metricflow_semantics/specs/patterns/typed_patterns.py
@@ -59,7 +59,7 @@ class DimensionPattern(EntityLinkPattern):
     @override
     def element_pre_filter(self) -> GroupByItemSetFilter:
         return super().element_pre_filter.merge(
-            GroupByItemSetFilter(any_properties_denylist=frozenset({GroupByItemProperty.METRIC}))
+            GroupByItemSetFilter.create(any_properties_denylist=(GroupByItemProperty.METRIC,))
         )
 
 
@@ -120,7 +120,7 @@ class TimeDimensionPattern(EntityLinkPattern):
     @override
     def element_pre_filter(self) -> GroupByItemSetFilter:
         return super().element_pre_filter.merge(
-            GroupByItemSetFilter(any_properties_denylist=frozenset({GroupByItemProperty.METRIC}))
+            GroupByItemSetFilter.create(any_properties_denylist=(GroupByItemProperty.METRIC,))
         )
 
 
@@ -153,7 +153,7 @@ class EntityPattern(EntityLinkPattern):
     @property
     @override
     def element_pre_filter(self) -> GroupByItemSetFilter:
-        return GroupByItemSetFilter(any_properties_denylist=frozenset({GroupByItemProperty.METRIC}))
+        return GroupByItemSetFilter.create(any_properties_denylist=(GroupByItemProperty.METRIC,))
 
 
 @dataclass(frozen=True)

--- a/metricflow-semantics/metricflow_semantics/specs/patterns/typed_patterns.py
+++ b/metricflow-semantics/metricflow_semantics/specs/patterns/typed_patterns.py
@@ -59,7 +59,7 @@ class DimensionPattern(EntityLinkPattern):
     @override
     def element_pre_filter(self) -> GroupByItemSetFilter:
         return super().element_pre_filter.merge(
-            GroupByItemSetFilter(without_any_of=frozenset({GroupByItemProperty.METRIC}))
+            GroupByItemSetFilter(any_properties_denylist=frozenset({GroupByItemProperty.METRIC}))
         )
 
 
@@ -120,7 +120,7 @@ class TimeDimensionPattern(EntityLinkPattern):
     @override
     def element_pre_filter(self) -> GroupByItemSetFilter:
         return super().element_pre_filter.merge(
-            GroupByItemSetFilter(without_any_of=frozenset({GroupByItemProperty.METRIC}))
+            GroupByItemSetFilter(any_properties_denylist=frozenset({GroupByItemProperty.METRIC}))
         )
 
 
@@ -153,7 +153,7 @@ class EntityPattern(EntityLinkPattern):
     @property
     @override
     def element_pre_filter(self) -> GroupByItemSetFilter:
-        return GroupByItemSetFilter(without_any_of=frozenset({GroupByItemProperty.METRIC}))
+        return GroupByItemSetFilter(any_properties_denylist=frozenset({GroupByItemProperty.METRIC}))
 
 
 @dataclass(frozen=True)

--- a/metricflow-semantics/tests_metricflow_semantics/experimental/semantic_graph/resolver/test_sg_resolver_output.py
+++ b/metricflow-semantics/tests_metricflow_semantics/experimental/semantic_graph/resolver/test_sg_resolver_output.py
@@ -63,7 +63,7 @@ def test_set_for_metrics(sg_tester: SemanticGraphTester) -> None:
     ):
         # Group-by metrics should not be called for metrics, so skip them for smaller snapshots.
         metric_references = tuple(MetricReference(metric_name) for metric_name in metric_names)
-        set_filter = GroupByItemSetFilter(any_properties_denylist=frozenset((GroupByItemProperty.METRIC,)))
+        set_filter = GroupByItemSetFilter.create(any_properties_denylist=(GroupByItemProperty.METRIC,))
         complete_set = sg_resolver.get_common_set(metric_references=metric_references, set_filter=set_filter)
         description_to_set[str(metric_names)] = complete_set
         sg_tester.check_set_filtering(
@@ -82,13 +82,17 @@ def test_set_for_metrics(sg_tester: SemanticGraphTester) -> None:
 def test_set_for_distinct_values_query(sg_tester: SemanticGraphTester) -> None:
     """Check the attribute set for a distinct-values query / no-metric query."""
     sg_tester.assert_attribute_set_snapshot_equal(
-        {"Distinct-Values Query": sg_tester.sg_resolver.get_set_for_distinct_values_query(GroupByItemSetFilter())}
+        {
+            "Distinct-Values Query": sg_tester.sg_resolver.get_set_for_distinct_values_query(
+                GroupByItemSetFilter.create()
+            )
+        }
     )
 
 
 def test_set_filtering_for_distinct_values_query(sg_tester: SemanticGraphTester) -> None:
     """Check filtering of the set for a distinct values query."""
-    complete_set = sg_tester.sg_resolver.get_set_for_distinct_values_query(GroupByItemSetFilter())
+    complete_set = sg_tester.sg_resolver.get_set_for_distinct_values_query(GroupByItemSetFilter.create())
     sg_tester.check_set_filtering(
         complete_set=complete_set,
         filtered_set_callable=lambda set_filter: sg_tester.sg_resolver.get_set_for_distinct_values_query(set_filter),

--- a/metricflow-semantics/tests_metricflow_semantics/experimental/semantic_graph/resolver/test_sg_resolver_output.py
+++ b/metricflow-semantics/tests_metricflow_semantics/experimental/semantic_graph/resolver/test_sg_resolver_output.py
@@ -63,14 +63,16 @@ def test_set_for_metrics(sg_tester: SemanticGraphTester) -> None:
     ):
         # Group-by metrics should not be called for metrics, so skip them for smaller snapshots.
         metric_references = tuple(MetricReference(metric_name) for metric_name in metric_names)
-        set_filter = GroupByItemSetFilter(without_any_of=frozenset((GroupByItemProperty.METRIC,)))
+        set_filter = GroupByItemSetFilter(any_properties_denylist=frozenset((GroupByItemProperty.METRIC,)))
         complete_set = sg_resolver.get_common_set(metric_references=metric_references, set_filter=set_filter)
         description_to_set[str(metric_names)] = complete_set
         sg_tester.check_set_filtering(
             complete_set=complete_set,
             filtered_set_callable=lambda _filter: sg_resolver.get_common_set(
                 metric_references=metric_references,
-                set_filter=_filter.copy(without_any_of=_filter.without_any_of.union((GroupByItemProperty.METRIC,))),
+                set_filter=_filter.copy(
+                    any_properties_denylist=_filter.any_properties_denylist.union((GroupByItemProperty.METRIC,))
+                ),
             ),
         )
 

--- a/metricflow-semantics/tests_metricflow_semantics/experimental/semantic_graph/resolver/test_sg_resolver_performance.py
+++ b/metricflow-semantics/tests_metricflow_semantics/experimental/semantic_graph/resolver/test_sg_resolver_performance.py
@@ -60,7 +60,7 @@ def test_resolver_query_time(high_complexity_manifest_sg_fixture: SemanticGraphT
         @override
         def run(self) -> None:
             # Replicate the behavior of get_linkable_elements_for_metrics which filters out METRIC properties
-            base_filter = GroupByItemSetFilter(without_any_of=frozenset((GroupByItemProperty.METRIC,)))
+            base_filter = GroupByItemSetFilter(any_properties_denylist=frozenset((GroupByItemProperty.METRIC,)))
             self._resolver.get_common_set(metric_references=metric_references, set_filter=base_filter)
 
     PerformanceBenchmark.assert_function_performance(

--- a/metricflow-semantics/tests_metricflow_semantics/experimental/semantic_graph/resolver/test_sg_resolver_performance.py
+++ b/metricflow-semantics/tests_metricflow_semantics/experimental/semantic_graph/resolver/test_sg_resolver_performance.py
@@ -60,7 +60,7 @@ def test_resolver_query_time(high_complexity_manifest_sg_fixture: SemanticGraphT
         @override
         def run(self) -> None:
             # Replicate the behavior of get_linkable_elements_for_metrics which filters out METRIC properties
-            base_filter = GroupByItemSetFilter(any_properties_denylist=frozenset((GroupByItemProperty.METRIC,)))
+            base_filter = GroupByItemSetFilter.create(any_properties_denylist=(GroupByItemProperty.METRIC,))
             self._resolver.get_common_set(metric_references=metric_references, set_filter=base_filter)
 
     PerformanceBenchmark.assert_function_performance(

--- a/metricflow-semantics/tests_metricflow_semantics/experimental/semantic_graph/sg_tester.py
+++ b/metricflow-semantics/tests_metricflow_semantics/experimental/semantic_graph/sg_tester.py
@@ -115,17 +115,17 @@ class SemanticGraphTester:
         set generation.
         """
         for element_property in GroupByItemProperty:
-            with_any_of_filter = GroupByItemSetFilter(with_any_of=frozenset((element_property,)))
-            filtered_set = filtered_set_callable(with_any_of_filter)
+            allow_if_any_property_filter = GroupByItemSetFilter(any_properties_allowlist=frozenset((element_property,)))
+            filtered_set = filtered_set_callable(allow_if_any_property_filter)
             # The resolver uses the filter to limit graph traversal, so this is not the same logic.
-            expected_items = set(complete_set.filter(with_any_of_filter).annotated_specs)
+            expected_items = set(complete_set.filter(allow_if_any_property_filter).annotated_specs)
             actual_items = set(filtered_set.annotated_specs)
 
             assert expected_items == actual_items
 
-            without_any_of_filter = GroupByItemSetFilter(without_any_of=frozenset((element_property,)))
-            filtered_set = filtered_set_callable(without_any_of_filter)
-            expected_items = set(complete_set.filter(without_any_of_filter).annotated_specs)
+            deny_if_any_property_filter = GroupByItemSetFilter(any_properties_denylist=frozenset((element_property,)))
+            filtered_set = filtered_set_callable(deny_if_any_property_filter)
+            expected_items = set(complete_set.filter(deny_if_any_property_filter).annotated_specs)
             actual_items = set(filtered_set.annotated_specs)
 
             assert expected_items == actual_items

--- a/metricflow-semantics/tests_metricflow_semantics/experimental/semantic_graph/sg_tester.py
+++ b/metricflow-semantics/tests_metricflow_semantics/experimental/semantic_graph/sg_tester.py
@@ -115,17 +115,17 @@ class SemanticGraphTester:
         set generation.
         """
         for element_property in GroupByItemProperty:
-            allow_if_any_property_filter = GroupByItemSetFilter(any_properties_allowlist=frozenset((element_property,)))
-            filtered_set = filtered_set_callable(allow_if_any_property_filter)
+            any_properties_allowlist_filter = GroupByItemSetFilter.create(any_properties_allowlist=(element_property,))
+            filtered_set = filtered_set_callable(any_properties_allowlist_filter)
             # The resolver uses the filter to limit graph traversal, so this is not the same logic.
-            expected_items = set(complete_set.filter(allow_if_any_property_filter).annotated_specs)
+            expected_items = set(complete_set.filter(any_properties_allowlist_filter).annotated_specs)
             actual_items = set(filtered_set.annotated_specs)
 
             assert expected_items == actual_items
 
-            deny_if_any_property_filter = GroupByItemSetFilter(any_properties_denylist=frozenset((element_property,)))
-            filtered_set = filtered_set_callable(deny_if_any_property_filter)
-            expected_items = set(complete_set.filter(deny_if_any_property_filter).annotated_specs)
+            any_properties_denylist_filter = GroupByItemSetFilter.create(any_properties_denylist=(element_property,))
+            filtered_set = filtered_set_callable(any_properties_denylist_filter)
+            expected_items = set(complete_set.filter(any_properties_denylist_filter).annotated_specs)
             actual_items = set(filtered_set.annotated_specs)
 
             assert expected_items == actual_items

--- a/metricflow/engine/metricflow_engine.py
+++ b/metricflow/engine/metricflow_engine.py
@@ -689,8 +689,8 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
 
         group_by_item_set = self._semantic_manifest_lookup.metric_lookup.get_common_group_by_items(
             metric_references=tuple(MetricReference(element_name=mname) for mname in metric_names),
-            set_filter=GroupByItemSetFilter(
-                any_properties_denylist=frozenset(without_any_property),
+            set_filter=GroupByItemSetFilter.create(
+                any_properties_denylist=without_any_property,
             ),
         )
         return self._filter_simple_linkable_dimensions(group_by_item_set=group_by_item_set)
@@ -791,8 +791,8 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
     def entities_for_metrics(self, metric_names: List[str]) -> List[Entity]:  # noqa: D102
         group_by_item_set = self._semantic_manifest_lookup.metric_lookup.get_common_group_by_items(
             metric_references=tuple(MetricReference(element_name=mname) for mname in metric_names),
-            set_filter=GroupByItemSetFilter(
-                any_properties_allowlist=frozenset(ENTITY_WITH_ANY_PROPERTIES),
+            set_filter=GroupByItemSetFilter.create(
+                any_properties_allowlist=ENTITY_WITH_ANY_PROPERTIES,
             ),
         )
 
@@ -932,8 +932,8 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
                 without_any_of = without_any_of - {GroupByItemProperty.DERIVED_TIME_GRANULARITY}
             group_by_item_set = self._semantic_manifest_lookup.metric_lookup.get_common_group_by_items(
                 metric_references=tuple(MetricReference(element_name=mname) for mname in metric_names),
-                set_filter=GroupByItemSetFilter(
-                    any_properties_denylist=frozenset(without_any_of),
+                set_filter=GroupByItemSetFilter.create(
+                    any_properties_denylist=without_any_of,
                 ),
             )
             group_bys: Sequence = self._filter_linkable_entities(

--- a/metricflow/engine/metricflow_engine.py
+++ b/metricflow/engine/metricflow_engine.py
@@ -690,7 +690,7 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
         group_by_item_set = self._semantic_manifest_lookup.metric_lookup.get_common_group_by_items(
             metric_references=tuple(MetricReference(element_name=mname) for mname in metric_names),
             set_filter=GroupByItemSetFilter(
-                without_any_of=frozenset(without_any_property),
+                any_properties_denylist=frozenset(without_any_property),
             ),
         )
         return self._filter_simple_linkable_dimensions(group_by_item_set=group_by_item_set)
@@ -792,7 +792,7 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
         group_by_item_set = self._semantic_manifest_lookup.metric_lookup.get_common_group_by_items(
             metric_references=tuple(MetricReference(element_name=mname) for mname in metric_names),
             set_filter=GroupByItemSetFilter(
-                with_any_of=frozenset(ENTITY_WITH_ANY_PROPERTIES),
+                any_properties_allowlist=frozenset(ENTITY_WITH_ANY_PROPERTIES),
             ),
         )
 
@@ -933,7 +933,7 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
             group_by_item_set = self._semantic_manifest_lookup.metric_lookup.get_common_group_by_items(
                 metric_references=tuple(MetricReference(element_name=mname) for mname in metric_names),
                 set_filter=GroupByItemSetFilter(
-                    without_any_of=frozenset(without_any_of),
+                    any_properties_denylist=frozenset(without_any_of),
                 ),
             )
             group_bys: Sequence = self._filter_linkable_entities(

--- a/tests_metricflow/dataflow/builder/test_dataflow_plan_builder.py
+++ b/tests_metricflow/dataflow/builder/test_dataflow_plan_builder.py
@@ -1348,7 +1348,7 @@ def test_all_available_metric_filters(
     metric_lookup = mf_engine_test_fixture.semantic_manifest_lookup.metric_lookup
     bookings_group_by_item_set = metric_lookup.get_common_group_by_items(
         measure_references=(MeasureReference("bookings"),),
-        set_filter=GroupByItemSetFilter(with_any_of=frozenset((GroupByItemProperty.METRIC,))),
+        set_filter=GroupByItemSetFilter(any_properties_allowlist=frozenset((GroupByItemProperty.METRIC,))),
     )
     for group_by_metric_spec in group_specs_by_type(bookings_group_by_item_set.specs).group_by_metric_specs:
         entity_spec = group_by_metric_spec.metric_subquery_entity_spec

--- a/tests_metricflow/dataflow/builder/test_dataflow_plan_builder.py
+++ b/tests_metricflow/dataflow/builder/test_dataflow_plan_builder.py
@@ -1348,7 +1348,7 @@ def test_all_available_metric_filters(
     metric_lookup = mf_engine_test_fixture.semantic_manifest_lookup.metric_lookup
     bookings_group_by_item_set = metric_lookup.get_common_group_by_items(
         measure_references=(MeasureReference("bookings"),),
-        set_filter=GroupByItemSetFilter(any_properties_allowlist=frozenset((GroupByItemProperty.METRIC,))),
+        set_filter=GroupByItemSetFilter.create(any_properties_allowlist=(GroupByItemProperty.METRIC,)),
     )
     for group_by_metric_spec in group_specs_by_type(bookings_group_by_item_set.specs).group_by_metric_specs:
         entity_spec = group_by_metric_spec.metric_subquery_entity_spec


### PR DESCRIPTION
This PR changes the names of the fields in `GroupByItemSetFilter` to be more noun-like and adds `.create()` to make it easier to instantiate.