### PR TITLE
Get MF using the new dsi transformations

### DIFF
--- a/.changes/unreleased/Features-20251002-171248.yaml
+++ b/.changes/unreleased/Features-20251002-171248.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Add new transformations to production from dsi that produce metrics from old-style measures.
+time: 2025-10-02T17:12:48.436607-07:00
+custom:
+    Author: theyostalservice
+    Issue: "387"

--- a/metricflow-semantics/metricflow_semantics/model/dbt_manifest_parser.py
+++ b/metricflow-semantics/metricflow_semantics/model/dbt_manifest_parser.py
@@ -3,8 +3,15 @@ from __future__ import annotations
 from dbt_semantic_interfaces.implementations.semantic_manifest import (
     PydanticSemanticManifest,
 )
+from dbt_semantic_interfaces.transformations.flatten_simple_metrics_with_measure_inputs import (
+    FlattenSimpleMetricsWithMeasureInputsRule,
+)
 from dbt_semantic_interfaces.transformations.names import LowerCaseNamesRule
+from dbt_semantic_interfaces.transformations.proxy_measure import CreateProxyMeasureRule
 from dbt_semantic_interfaces.transformations.pydantic_rule_set import PydanticSemanticManifestTransformRuleSet
+from dbt_semantic_interfaces.transformations.replace_input_measures_with_simple_metrics_transformation import (
+    ReplaceInputMeasuresWithSimpleMetricsTransformationRule,
+)
 from dbt_semantic_interfaces.transformations.semantic_manifest_transformer import (
     PydanticSemanticManifestTransformer,
 )
@@ -27,7 +34,12 @@ def parse_manifest_from_dbt_generated_manifest(manifest_json_string: str) -> Pyd
         (
             *rule_set.legacy_measure_update_rules,
             DedupeMetricInputMeasuresRule(),  # Remove once fix is in core
-            *rule_set.convert_legacy_measures_to_metrics_rules,
+            # These individual rules come from rule_set.convert_legacy_measures_to_metrics_rules, but
+            # dsi requires AddInputMetricMeasuresRule, and metricflow requires that we do NOT run that rule
+            # as it is incompatible with a parser like dbt-core that pre-populates input measures.
+            CreateProxyMeasureRule(),
+            FlattenSimpleMetricsWithMeasureInputsRule(),
+            ReplaceInputMeasuresWithSimpleMetricsTransformationRule(),
             *rule_set.general_metric_update_rules,
         ),
     )

--- a/metricflow-semantics/metricflow_semantics/model/dbt_manifest_parser.py
+++ b/metricflow-semantics/metricflow_semantics/model/dbt_manifest_parser.py
@@ -3,16 +3,8 @@ from __future__ import annotations
 from dbt_semantic_interfaces.implementations.semantic_manifest import (
     PydanticSemanticManifest,
 )
-from dbt_semantic_interfaces.transformations.boolean_measure import (
-    BooleanMeasureAggregationRule,
-)
-from dbt_semantic_interfaces.transformations.convert_count import ConvertCountToSumRule
-from dbt_semantic_interfaces.transformations.convert_median import (
-    ConvertMedianToPercentileRule,
-)
-from dbt_semantic_interfaces.transformations.cumulative_type_params import SetCumulativeTypeParamsRule
 from dbt_semantic_interfaces.transformations.names import LowerCaseNamesRule
-from dbt_semantic_interfaces.transformations.proxy_measure import CreateProxyMeasureRule
+from dbt_semantic_interfaces.transformations.pydantic_rule_set import PydanticSemanticManifestTransformRuleSet
 from dbt_semantic_interfaces.transformations.semantic_manifest_transformer import (
     PydanticSemanticManifestTransformer,
 )
@@ -27,17 +19,16 @@ def parse_manifest_from_dbt_generated_manifest(manifest_json_string: str) -> Pyd
     # this time, which causes failures with input measure resolution.
     # TODO: remove this transform call once the upstream changes are integrated into our dependency tree
     # TODO: align rules between DSI, here, and MFS (if possible!)
+    rule_set = PydanticSemanticManifestTransformRuleSet()
     rules = (
         # Primary
         (LowerCaseNamesRule(),),
-        # Secondary
+        # Secondary - broken out into groups because we run DedupeMetricInputMeasuresRule in the middle.
         (
-            CreateProxyMeasureRule(),
-            BooleanMeasureAggregationRule(),
-            ConvertCountToSumRule(),
-            ConvertMedianToPercentileRule(),
+            *rule_set.legacy_measure_update_rules,
             DedupeMetricInputMeasuresRule(),  # Remove once fix is in core
-            SetCumulativeTypeParamsRule(),
+            *rule_set.convert_legacy_measures_to_metrics_rules,
+            *rule_set.general_metric_update_rules,
         ),
     )
     model = PydanticSemanticManifestTransformer.transform(raw_model, rules)


### PR DESCRIPTION
Depends on #1876 

Upstream PR bumps the dsi version, implicitly updating tests to using the default ruleset from dsi.  We can't do that for production MF rn because MF uses an extra transformation internally, so this PR adds all the newer built in PRs from dsi to metricflow-semantics/metricflow_semantics/model/dbt_manifest_parser.py to be used in real circumstances.

(If time was less limited before coalesce, I'd prefer to move the rule upstream if possible, but I don't want to pick up extra work before code freeze.)

Edit: There's also a rule (AddInputMeasuresToMetrics) that only works in dsi.  It probably merits a refactor/rewrite later to clean up the usage code here, but I'd rather prioritize getting this updated here for now.