### PR TITLE
chore: update dependency `more-itertools`

### DIFF
--- a/requirements-files/requirements.txt
+++ b/requirements-files/requirements.txt
@@ -1,7 +1,7 @@
 Jinja2>=3.1.6, <3.7.0
 # bumping to 0.9.3 will cause test failures, so pinning to dev2 until fixed
 dbt-semantic-interfaces==0.9.3.dev4
-more-itertools>=8.10.0, <10.2.0
+more-itertools>=8.10.0, <10.8.0
 pydantic>=1.10.0, <3.0
 tabulate>=0.8.9
 typing_extensions>=4.4, <5.0


### PR DESCRIPTION
This package currently conflicts with new versions of `more-itertools`, so we should widen the supported version range.

