### PR TITLE
Enable `DimensionPattern` without time dimensions

### DIFF
--- a/metricflow-semantics/metricflow_semantics/specs/patterns/typed_patterns.py
+++ b/metricflow-semantics/metricflow_semantics/specs/patterns/typed_patterns.py
@@ -32,15 +32,20 @@ class DimensionPattern(EntityLinkPattern):
     Analogous pattern for Dimension() in the object builder naming scheme.
     """
 
+    include_time_dimensions: bool = True
+
     @override
     def match(self, candidate_specs: Sequence[InstanceSpec]) -> Sequence[LinkableInstanceSpec]:
         spec_set = group_specs_by_type(candidate_specs)
-        filtered_specs: Sequence[LinkableInstanceSpec] = spec_set.dimension_specs + spec_set.time_dimension_specs
+        filtered_specs: Tuple[LinkableInstanceSpec, ...] = spec_set.dimension_specs
+        if self.include_time_dimensions:
+            filtered_specs += spec_set.time_dimension_specs
         return super().match(filtered_specs)
 
     @staticmethod
     def from_call_parameter_set(  # noqa: D102
         dimension_call_parameter_set: DimensionCallParameterSet,
+        include_time_dimensions: bool = True,
     ) -> DimensionPattern:
         return DimensionPattern(
             parameter_set=SpecPatternParameterSet.from_parameters(
@@ -52,7 +57,8 @@ class DimensionPattern(EntityLinkPattern):
                 element_name=dimension_call_parameter_set.dimension_reference.element_name,
                 entity_links=dimension_call_parameter_set.entity_path,
                 descending=dimension_call_parameter_set.descending,
-            )
+            ),
+            include_time_dimensions=include_time_dimensions,
         )
 
     @property

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_parse_and_validate_where_constraint_dims__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_parse_and_validate_where_constraint_dims__result.txt
@@ -91,6 +91,7 @@ ParseQueryResult(
                 ),
               ),
             ),
+            include_time_dimensions=True,
           ),
           filter_location_path=MetricFlowQueryResolutionPath(
             resolution_path_nodes=(


### PR DESCRIPTION
There's a bug in MFS due to the `LooseTimeDimensionParameter` workaround. This workaround was intended to allow you to pass a grain on a categorical dimension without error in order to avoid breaking some integrations. However, it also has the unintended consequence of not raising an error if the grain you requested is not supported for the selected time dimension. Adding this parameter will enable fixing this issue in MFS. Draft PR [here](https://github.com/dbt-labs/metricflow-server/pull/1618) to see how this will be used.