### PR TITLE
Add `dimension_lookup` to `ModelObjectLookup`

### DIFF
--- a/requirements-files/dev-env-requirements.txt
+++ b/requirements-files/dev-env-requirements.txt
@@ -6,6 +6,7 @@ duckdb-engine>=0.13.0, <0.14.0
 # https://github.com/duckdb/duckdb/issues/16617
 # Version 1.4.0 seems to have issues as well, so pinning to <1.4.0 until those are resolved.
 duckdb !=1.2.1, <1.4.0
+graphviz>=0.18.2, <0.21
 tomli >=2.3.0, <3
 varname >=0.15.1, < 1
 # Developer tools
@@ -15,6 +16,7 @@ Pympler >=1.1, <=2.0
 pytest-mock>=3.14.0, <3.15.0
 pytest-xdist>=3.6.0, <3.7.0
 pytest>=8.0.0, < 9.0.0
+tabulate>=0.8.9
 termcolor>=3.0, <4.0
 types-PyYAML
 types-python-dateutil

--- a/requirements-files/requirements.txt
+++ b/requirements-files/requirements.txt
@@ -1,13 +1,9 @@
-click>=8.0, <9.0
 importlib_metadata>=4.0
-Jinja2>=3.1.6, <3.7.0
+Jinja2>=3.1.6, <3.7
 jsonschema>=4.17, <5.0
-graphviz>=0.18.2, <0.21
-PyYAML>=6.0, <7.0.0
-more-itertools>=10.0.0, <11.0.0
+more-itertools>=10.0.0, <11.0
 referencing>=0.28
 pydantic>=1.10.0, <3.0
-python-dateutil>=2.9.0, <2.10.0
+python-dateutil>=2.9.0, <2.10
 rapidfuzz>=3.0, <4.0
-tabulate>=0.8.9
 typing_extensions>=4.4, <5.0


### PR DESCRIPTION
This PR adds the `dimension_lookup` to `ModelObjectLookup` as a small step towards migrating `SemanticModelLookup` to `ModelObjectLookup`. The goal of the migration was to simplify the lookup classes and to move more lookups to the semantic graph for performance reasons.