### PR TITLE
Refactor saved query validation in MetricFlowEngine to remove redundant checks.

### DIFF
--- a/.changes/unreleased/Under the Hood-20251017-065715.yaml
+++ b/.changes/unreleased/Under the Hood-20251017-065715.yaml
@@ -3,4 +3,4 @@ body: Refactor saved query validation to eliminate redundant checks in MetricFlo
 time: 2025-10-17T06:57:15.698158+09:00
 custom:
     Author: kiwamizamurai
-    Issue: "1911"
+    Issue: "1912"

--- a/.changes/unreleased/Under the Hood-20251017-065715.yaml
+++ b/.changes/unreleased/Under the Hood-20251017-065715.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Refactor saved query validation to eliminate redundant checks in MetricFlowEngine
+time: 2025-10-17T06:57:15.698158+09:00
+custom:
+    Author: kiwamizamurai
+    Issue: "1911"

--- a/metricflow-semantics/metricflow_semantics/query/query_parser.py
+++ b/metricflow-semantics/metricflow_semantics/query/query_parser.py
@@ -100,11 +100,21 @@ class MetricFlowQueryParser:
         order_by_names: Optional[Sequence[str]] = None,
         order_by_parameters: Optional[Sequence[OrderByQueryParameter]] = None,
         apply_group_by: bool = True,
+        metrics: Optional[Sequence[MetricQueryParameter]] = None,
+        metric_names: Optional[Sequence[str]] = None,
+        group_by: Optional[Sequence[GroupByQueryParameter]] = None,
+        group_by_names: Optional[Sequence[str]] = None,
     ) -> ParseQueryResult:
         """Parse and validate a query using parameters from a pre-defined / saved query.
 
         Additional parameters act in conjunction with the parameters in the saved query.
         """
+        # Validate that metrics and group_by items cannot be specified with saved queries
+        if metrics or metric_names:
+            raise InvalidQueryException("Metrics can't be specified with a saved query.")
+        if group_by or group_by_names:
+            raise InvalidQueryException("Group by items can't be specified with a saved query.")
+
         saved_query = self._get_saved_query(saved_query_parameter)
 
         # Merge interface could streamline this.

--- a/metricflow/engine/metricflow_engine.py
+++ b/metricflow/engine/metricflow_engine.py
@@ -512,10 +512,6 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
             SequentialIdGenerator.reset(MetricFlowEngine._ID_ENUMERATION_START_VALUE_FOR_QUERIES)
 
         if mf_query_request.saved_query_name is not None:
-            if mf_query_request.metrics or mf_query_request.metric_names:
-                raise InvalidQueryException("Metrics can't be specified with a saved query.")
-            if mf_query_request.group_by or mf_query_request.group_by_names:
-                raise InvalidQueryException("Group by items can't be specified with a saved query.")
             query_spec = self._query_parser.parse_and_validate_saved_query(
                 saved_query_parameter=SavedQueryParameter(mf_query_request.saved_query_name),
                 where_filters=(
@@ -532,6 +528,10 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
                 order_by_names=mf_query_request.order_by_names,
                 order_by_parameters=mf_query_request.order_by,
                 apply_group_by=mf_query_request.apply_group_by,
+                metrics=mf_query_request.metrics,
+                metric_names=mf_query_request.metric_names,
+                group_by=mf_query_request.group_by,
+                group_by_names=mf_query_request.group_by_names,
             ).query_spec
         else:
             query_spec = self._query_parser.parse_and_validate_query(


### PR DESCRIPTION
## Summary
- Moves saved query validation from MetricFlowEngine to QueryParser
- Eliminates redundant validation checks in query execution flow
- Improves code organization and maintainability

## Changes
- Added `metrics`, `metric_names`, `group_by`, and `group_by_names` parameters to `parse_and_validate_saved_query`
- Moved validation logic that prevents metrics/group_by with saved queries into the parser
- Removed duplicate validation checks from `MetricFlowEngine._create_execution_plan`
- Passes all parameters through to parser for centralized validation