### PR TITLE
Clean up group by metric error

### DIFF
--- a/metricflow-semantics/metricflow_semantics/specs/patterns/typed_patterns.py
+++ b/metricflow-semantics/metricflow_semantics/specs/patterns/typed_patterns.py
@@ -13,6 +13,7 @@ from dbt_semantic_interfaces.references import EntityReference
 from dbt_semantic_interfaces.type_enums.date_part import DatePart
 from typing_extensions import override
 
+from metricflow_semantics.errors.error_classes import UnableToSatisfyQueryError
 from metricflow_semantics.model.linkable_element_property import GroupByItemProperty
 from metricflow_semantics.model.semantics.element_filter import GroupByItemSetFilter
 from metricflow_semantics.naming.linkable_spec_name import StructuredLinkableSpecName
@@ -178,10 +179,7 @@ class GroupByMetricPattern(EntityLinkPattern):
         # This looks hacky because the typing for the interface does not match the implementation, but that's temporary!
         # This will get a lot less hacky once we enable multiple entities and dimensions in the group by.
         if len(metric_call_parameter_set.group_by) != 1:
-            raise RuntimeError(
-                "Currently only one group by item is allowed for Metric filters. "
-                "This should have been caught by validations."
-            )
+            raise UnableToSatisfyQueryError("Currently only one group by item is allowed for Metric filters.")
         group_by = metric_call_parameter_set.group_by[0]
         # custom_granularity_names is empty because we are not parsing any dimensions here with grain
         structured_name = StructuredLinkableSpecName.from_name(


### PR DESCRIPTION
Make error string more accurate & raise a user error instead of an internal error. This will categorize it as user error in our logs. Currently seeing it pop up as [internal error.](https://dbtlabsmt.datadoghq.com/logs?query=env%3A%2Aprod%2A%20service%3Ametricflow-server%20%40levelname%3AERROR%20-%40channel%3Addtrace.internal.writer.writer%20-%22Exception%20in%20callback%20functools.partial%22%20-%22Unclosed%20connector%22%20-%22Unclosed%20client%20session%22&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZo2K8DKI1xNVwAAABhBWm8ySzhqM0FBQUVkRnI0ajFHX0RRQWEAAAAkZjE5YTM2MzAtZjQ4Yy00Y2QyLWJmNDgtYzkwODUwZmI0ZWM1AAplHw&fromUser=true&link_source=monitor_notif&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1761844003000&to_ts=1761845803000&live=false)