### PR TITLE
Fixes issue where metricflow can't identify profiles.yml in the home directory

### DIFF
--- a/dbt-metricflow/dbt_metricflow/cli/cli_configuration.py
+++ b/dbt-metricflow/dbt_metricflow/cli/cli_configuration.py
@@ -77,7 +77,7 @@ class CLIConfiguration:
         dbt_project_dir_from_env = (
             pathlib.Path(dbt_project_dir_env_var) if dbt_project_dir_env_var is not None else None
         )
-        
+
         dbt_profiles_path = dbt_profiles_path or dbt_profiles_dir_from_env or dbt_profiles_dir_default_path
         dbt_project_path = dbt_project_path or dbt_project_dir_from_env or cwd
         dbt_project_yaml_path = dbt_project_path / "dbt_project.yml"

--- a/tests_metricflow/snapshots/test_isolated_command_runner.py/str/test_home_profiles_dir__result.txt
+++ b/tests_metricflow/snapshots/test_isolated_command_runner.py/str/test_home_profiles_dir__result.txt
@@ -1,0 +1,10 @@
+test_name: test_home_profiles_dir
+test_filename: test_isolated_command_runner.py
+docstring:
+  Tests running an MF CLI command with the profiles file in the home directory.
+expectation_description:
+  A table showing the `transactions` metric.
+---
+  transactions
+--------------
+            50


### PR DESCRIPTION
Since v0.207.3 metricflow is not able to properly locate the profiles.yml file if it's inside the ~/.dbt folder. [issues/1719](https://github.com/dbt-labs/metricflow/issues/1719)
Following the current implementation form [dbt-core](https://github.com/dbt-labs/dbt-core/blob/1bd81f50257a212eb027bc9cef630fb731146d9d/core/dbt/cli/resolvers.py#L14) we can ensure profiles can still be used.