### PR TITLE
fix: correct typos 'seperate' and 'occured'

### DIFF
--- a/metricflow-semantic-interfaces/metricflow_semantic_interfaces/parsing/dir_to_model.py
+++ b/metricflow-semantic-interfaces/metricflow_semantic_interfaces/parsing/dir_to_model.py
@@ -392,7 +392,7 @@ def parse_config_yaml(
                         extra_detail="".join(traceback.format_tb(e.__traceback__)),
                     )
                 )
-    # If a runtime error occured, we still want this to break things
+    # If a runtime error occurred, we still want this to break things
     except RuntimeError:
         raise
     # Any other error should be handled as an issue  # type: ignore[misc]

--- a/metricflow-semantics/metricflow_semantics/semantic_graph/nodes/entity_nodes.py
+++ b/metricflow-semantics/metricflow_semantics/semantic_graph/nodes/entity_nodes.py
@@ -105,7 +105,7 @@ class JoinedModelNode(SemanticGraphNode, Singleton):
     can be queried with the associated primary entity name as the entity link even when the query does not require
     joining semantic models.
 
-    To capture this behavior, semantic models are represented with 2 seperate nodes.
+    To capture this behavior, semantic models are represented with 2 separate nodes.
     """
 
     model_id: SemanticModelId


### PR DESCRIPTION
Fixes two minor typos:
- 'seperate' → 'separate' in entity_nodes.py
- 'occured' → 'occurred' in dir_to_model.py