### PR TITLE
Add a test case for time-offset metric with non-queried item in the filter

### DIFF
--- a/.changes/unreleased/Under the Hood-20260404-074842.yaml
+++ b/.changes/unreleased/Under the Hood-20260404-074842.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Add a test case for time-offset metric with non-queried item in the filter
+time: 2026-04-04T07:48:42.469268-07:00
+custom:
+  Author: plypaul
+  Issue: "2009"

--- a/scripts/generate_snapshots.py
+++ b/scripts/generate_snapshots.py
@@ -51,7 +51,7 @@ logger = logging.getLogger(__name__)
 
 
 MF_TEST_DIRECTORY = "tests_metricflow"
-MF_SEMANTICS_TEST_DIRECTORY = "metricflow-semantics/tests_metricflow_semantics"
+MF_SEMANTICS_TEST_DIRECTORY = "tests_metricflow_semantics"
 
 # Tests that generate SQL engine snapshots have this `pytest` marker set.
 SQL_ENGINE_SNAPSHOT_MARKER_NAME = "sql_engine_snapshot"

--- a/tests_metricflow/integration/test_cases/itest_metrics.yaml
+++ b/tests_metricflow/integration/test_cases/itest_metrics.yaml
@@ -1624,7 +1624,7 @@ integration_test:
   model: SIMPLE_MODEL
   metrics: ["bookings_offset_twice"]
   group_by_objs: [{ "name": "metric_time", "grain": "day" }]
-  where_filter: "{{ render_time_constraint('metric_time__day', '2020-01-08', '2020-01-09') }}"
+  where_filter: "{{ render_time_constraint(render_time_dimension_template('metric_time'), '2020-01-08', '2020-01-09') }}"
   check_query: |
     SELECT
       subq_9.ds AS metric_time__day

--- a/tests_metricflow/metric_evaluation/me_test_helpers.py
+++ b/tests_metricflow/metric_evaluation/me_test_helpers.py
@@ -153,6 +153,20 @@ METRIC_EVALUATION_TEST_CASES = (
             where_constraints=["{{ TimeDimension('metric_time', 'day') }} = '2020-01-01' "],
         ),
     ),
+    MetricEvaluationTestCase(
+        case_id_suffix="time_nested_offset_metric_with_non_queried_element_in_filter",
+        description="Query for a nested time offset metric with a `metric_time` filter",
+        request=MetricFlowQueryRequest.create(
+            request_id=_get_next_request_id(),
+            metric_names=["bookings_offset_twice"],
+            group_by_names=["metric_time"],
+            where_constraints=["{{ Entity('listing') }} = '1'"],
+        ),
+        expectation_description=mf_wrap(
+            "The query for `bookings` should contain the filter and only have `metric_time` in the group-by items."
+            " The current snapshot does not reflect the correct result."
+        ),
+    ),
 )
 
 

--- a/tests_metricflow/query_rendering/test_offset_metrics_with_filters.py
+++ b/tests_metricflow/query_rendering/test_offset_metrics_with_filters.py
@@ -190,3 +190,37 @@ def test_offset_metric_with_string_filter(  # noqa: D103
             "branch. However, the appropriate behavior may be to not push at all."
         ),
     )
+
+
+@pytest.mark.duckdb_only
+@pytest.mark.sql_engine_snapshot
+def test_nested_offset_metric_with_non_queried_element_in_filter(  # noqa: D103
+    request: FixtureRequest,
+    mf_test_configuration: MetricFlowTestConfiguration,
+    query_parser: MetricFlowQueryParser,
+    dataflow_plan_builder: DataflowPlanBuilder,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
+    sql_client: SqlClient,
+    create_source_tables: bool,
+) -> None:
+    """Tests that a non-queried filter element does not remain in the aggregation grain."""
+    query_spec = query_parser.parse_and_validate_query(
+        metric_names=("bookings_offset_twice",),
+        group_by_names=(METRIC_TIME_ELEMENT_NAME,),
+        where_constraint_strs=["{{ Entity('listing') }} = '1'"],
+    ).query_spec
+
+    render_and_check(
+        request=request,
+        mf_test_configuration=mf_test_configuration,
+        dataflow_to_sql_converter=dataflow_to_sql_converter,
+        sql_client=sql_client,
+        dataflow_plan_builder=dataflow_plan_builder,
+        query_spec=query_spec,
+        expectation_description=(
+            "The non-queried listing filter should be available for filtering the "
+            "nested offset metric, but it should not remain part of the aggregation "
+            "grain after filtering. The current snapshot does not reflect the "
+            "correct result."
+        ),
+    )

--- a/tests_metricflow/snapshots/test_dfs_planner.py/str/test_cases_with_dfs_planner__08__time_nested_offset_metric_with_non_queried_element_in_filter__result.txt
+++ b/tests_metricflow/snapshots/test_dfs_planner.py/str/test_cases_with_dfs_planner__08__time_nested_offset_metric_with_non_queried_element_in_filter__result.txt
@@ -1,0 +1,174 @@
+test_name: test_cases_with_dfs_planner[08__time_nested_offset_metric_with_non_queried_element_in_filter]
+test_filename: test_dfs_planner.py
+docstring:
+  Test enumerated cases using the `DepthFirstSearchMetricEvaluationPlanner`.
+expectation_description:
+  The query for `bookings` should contain the filter and only have `metric_time`
+  in the group-by items. The current snapshot does not reflect the correct result.
+---
+Query for a nested time offset metric with a `metric_time` filter
+
+  Metric Names: ['bookings_offset_twice']
+  Group-By Names: ['metric_time']
+  Metric Evaluation Overview:
+    ┌───────┬───────────┬───────────────────────┬───────────────────────┬───────────────────────┬──────────────────┐
+    │ id    │ src_ids   │ computed_outputs      │ passthrough_outputs   │ source_metrics        │ semantic_model   │
+    ├───────┼───────────┼───────────────────────┼───────────────────────┼───────────────────────┼──────────────────┤
+    │ smp_0 │           │ bookings              │                       │                       │ bookings_source  │
+    ├───────┼───────────┼───────────────────────┼───────────────────────┼───────────────────────┼──────────────────┤
+    │ drv_0 │ smp_0     │ bookings_offset_once  │                       │ bookings              │                  │
+    ├───────┼───────────┼───────────────────────┼───────────────────────┼───────────────────────┼──────────────────┤
+    │ drv_1 │ drv_0     │ bookings_offset_twice │                       │ bookings_offset_once  │                  │
+    ├───────┼───────────┼───────────────────────┼───────────────────────┼───────────────────────┼──────────────────┤
+    │ tpl_0 │ drv_1     │                       │ bookings_offset_twice │ bookings_offset_twice │                  │
+    └───────┴───────────┴───────────────────────┴───────────────────────┴───────────────────────┴──────────────────┘
+  Metric Query Output:
+    ┌───────┬─────────────────────────────────────────────────────────┬────────────────────────────────────────────────────────┐
+    │ id    │ output_specs                                            │ output_properties                                      │
+    ├───────┼─────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────┤
+    │ smp_0 │ MetricSpec(                                             │ MetricQueryPropertySet(                                │
+    │       │   element_name='bookings',                              │   group_by_item_specs=['metric_time__day', 'listing'], │
+    │       │   offset_window=TimeWindow(count=5, granularity='day'), │ )                                                      │
+    │       │ )                                                       │                                                        │
+    ├───────┼─────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────┤
+    │ drv_0 │ MetricSpec(                                             │ MetricQueryPropertySet(                                │
+    │       │   element_name='bookings_offset_once',                  │   group_by_item_specs=['metric_time__day'],            │
+    │       │   where_filter_specs=(                                  │   pushdown_enabled_types={                             │
+    │       │     WhereFilterSpec(                                    │     TIME_RANGE_CONSTRAINT,                             │
+    │       │       where_sql="listing = '1'",                        │     CATEGORICAL_DIMENSION,                             │
+    │       │       bind_parameters=SqlBindParameterSet(),            │   },                                                   │
+    │       │       element_set=GroupByItemSet(                       │ )                                                      │
+    │       │         annotated_specs=(                               │                                                        │
+    │       │           AnnotatedSpec(                                │                                                        │
+    │       │             element_type=ENTITY,                        │                                                        │
+    │       │             element_name='listing',                     │                                                        │
+    │       │             element_properties=(                        │                                                        │
+    │       │               ENTITY,                                   │                                                        │
+    │       │               LOCAL,                                    │                                                        │
+    │       │             ),                                          │                                                        │
+    │       │             origin_semantic_model_names=(               │                                                        │
+    │       │               'bookings_source',                        │                                                        │
+    │       │             ),                                          │                                                        │
+    │       │             derived_from_semantic_model_names=(         │                                                        │
+    │       │               'bookings_source',                        │                                                        │
+    │       │             ),                                          │                                                        │
+    │       │           ),                                            │                                                        │
+    │       │         ),                                              │                                                        │
+    │       │       ),                                                │                                                        │
+    │       │     ),                                                  │                                                        │
+    │       │   ),                                                    │                                                        │
+    │       │   offset_window=TimeWindow(count=2, granularity='day'), │                                                        │
+    │       │ )                                                       │                                                        │
+    ├───────┼─────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────┤
+    │ drv_1 │ MetricSpec(                                             │ MetricQueryPropertySet(                                │
+    │       │   element_name='bookings_offset_twice',                 │   group_by_item_specs=['metric_time__day'],            │
+    │       │   where_filter_specs=(                                  │   pushdown_enabled_types={                             │
+    │       │     WhereFilterSpec(                                    │     TIME_RANGE_CONSTRAINT,                             │
+    │       │       where_sql="listing = '1'",                        │     CATEGORICAL_DIMENSION,                             │
+    │       │       bind_parameters=SqlBindParameterSet(),            │   },                                                   │
+    │       │       element_set=GroupByItemSet(                       │ )                                                      │
+    │       │         annotated_specs=(                               │                                                        │
+    │       │           AnnotatedSpec(                                │                                                        │
+    │       │             element_type=ENTITY,                        │                                                        │
+    │       │             element_name='listing',                     │                                                        │
+    │       │             element_properties=(                        │                                                        │
+    │       │               ENTITY,                                   │                                                        │
+    │       │               LOCAL,                                    │                                                        │
+    │       │             ),                                          │                                                        │
+    │       │             origin_semantic_model_names=(               │                                                        │
+    │       │               'bookings_source',                        │                                                        │
+    │       │             ),                                          │                                                        │
+    │       │             derived_from_semantic_model_names=(         │                                                        │
+    │       │               'bookings_source',                        │                                                        │
+    │       │             ),                                          │                                                        │
+    │       │           ),                                            │                                                        │
+    │       │         ),                                              │                                                        │
+    │       │       ),                                                │                                                        │
+    │       │     ),                                                  │                                                        │
+    │       │   ),                                                    │                                                        │
+    │       │ )                                                       │                                                        │
+    ├───────┼─────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────┤
+    │ tpl_0 │ MetricSpec(                                             │ MetricQueryPropertySet(                                │
+    │       │   element_name='bookings_offset_twice',                 │   group_by_item_specs=['metric_time__day'],            │
+    │       │   where_filter_specs=(                                  │   pushdown_enabled_types={                             │
+    │       │     WhereFilterSpec(                                    │     TIME_RANGE_CONSTRAINT,                             │
+    │       │       where_sql="listing = '1'",                        │     CATEGORICAL_DIMENSION,                             │
+    │       │       bind_parameters=SqlBindParameterSet(),            │   },                                                   │
+    │       │       element_set=GroupByItemSet(                       │ )                                                      │
+    │       │         annotated_specs=(                               │                                                        │
+    │       │           AnnotatedSpec(                                │                                                        │
+    │       │             element_type=ENTITY,                        │                                                        │
+    │       │             element_name='listing',                     │                                                        │
+    │       │             element_properties=(                        │                                                        │
+    │       │               ENTITY,                                   │                                                        │
+    │       │               LOCAL,                                    │                                                        │
+    │       │             ),                                          │                                                        │
+    │       │             origin_semantic_model_names=(               │                                                        │
+    │       │               'bookings_source',                        │                                                        │
+    │       │             ),                                          │                                                        │
+    │       │             derived_from_semantic_model_names=(         │                                                        │
+    │       │               'bookings_source',                        │                                                        │
+    │       │             ),                                          │                                                        │
+    │       │           ),                                            │                                                        │
+    │       │         ),                                              │                                                        │
+    │       │       ),                                                │                                                        │
+    │       │     ),                                                  │                                                        │
+    │       │   ),                                                    │                                                        │
+    │       │ )                                                       │                                                        │
+    └───────┴─────────────────────────────────────────────────────────┴────────────────────────────────────────────────────────┘
+  SQL:
+    WITH rss_28018_cte AS (
+      SELECT
+        ds AS ds__day
+      FROM ***************************.mf_time_spine time_spine_src_28006
+    )
+
+    SELECT
+      metric_time__day AS metric_time__day
+      , 2 * bookings_offset_once AS bookings_offset_twice
+    FROM (
+      SELECT
+        metric_time__day
+        , bookings_offset_once
+      FROM (
+        SELECT
+          rss_28018_cte.ds__day AS metric_time__day
+          , subq_11.listing AS listing
+          , subq_11.bookings_offset_once AS bookings_offset_once
+        FROM rss_28018_cte
+        INNER JOIN (
+          SELECT
+            metric_time__day
+            , listing
+            , 2 * bookings AS bookings_offset_once
+          FROM (
+            SELECT
+              rss_28018_cte.ds__day AS metric_time__day
+              , subq_4.listing AS listing
+              , subq_4.__bookings AS bookings
+            FROM rss_28018_cte
+            INNER JOIN (
+              SELECT
+                metric_time__day
+                , listing
+                , SUM(__bookings) AS __bookings
+              FROM (
+                SELECT
+                  DATE_TRUNC('day', ds) AS metric_time__day
+                  , listing_id AS listing
+                  , 1 AS __bookings
+                FROM ***************************.fct_bookings bookings_source_src_28000
+              ) subq_3
+              GROUP BY
+                metric_time__day
+                , listing
+            ) subq_4
+            ON
+              rss_28018_cte.ds__day - INTERVAL 5 day = subq_4.metric_time__day
+          ) subq_10
+        ) subq_11
+        ON
+          rss_28018_cte.ds__day - INTERVAL 2 day = subq_11.metric_time__day
+      ) subq_16
+      WHERE listing = '1'
+    ) subq_18

--- a/tests_metricflow/snapshots/test_offset_metrics_with_filters.py/SqlPlan/DuckDB/test_nested_offset_metric_with_non_queried_element_in_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_offset_metrics_with_filters.py/SqlPlan/DuckDB/test_nested_offset_metric_with_non_queried_element_in_filter__plan0.sql
@@ -1,0 +1,389 @@
+test_name: test_nested_offset_metric_with_non_queried_element_in_filter
+test_filename: test_offset_metrics_with_filters.py
+docstring:
+  Tests that a non-queried filter element does not remain in the aggregation grain.
+sql_engine: DuckDB
+expectation_description:
+  The non-queried listing filter should be available for filtering the nested
+  offset metric, but it should not remain part of the aggregation grain after
+  filtering. The current snapshot does not reflect the correct result.
+---
+-- Write to DataTable
+SELECT
+  subq_19.metric_time__day
+  , subq_19.bookings_offset_twice
+FROM (
+  -- Compute Metrics via Expressions
+  SELECT
+    subq_18.metric_time__day
+    , 2 * bookings_offset_once AS bookings_offset_twice
+  FROM (
+    -- Select: ['metric_time__day', 'bookings_offset_once']
+    SELECT
+      subq_17.metric_time__day
+      , subq_17.bookings_offset_once
+    FROM (
+      -- Constrain Output with WHERE
+      SELECT
+        subq_16.metric_time__day
+        , subq_16.listing
+        , subq_16.bookings_offset_once
+      FROM (
+        -- Join to Time Spine Dataset
+        SELECT
+          subq_15.metric_time__day AS metric_time__day
+          , subq_11.listing AS listing
+          , subq_11.bookings_offset_once AS bookings_offset_once
+        FROM (
+          -- Select: ['metric_time__day']
+          SELECT
+            subq_14.metric_time__day
+          FROM (
+            -- Select: ['metric_time__day']
+            SELECT
+              subq_13.metric_time__day
+            FROM (
+              -- Change Column Aliases
+              SELECT
+                subq_12.ds__day AS metric_time__day
+                , subq_12.ds__week
+                , subq_12.ds__month
+                , subq_12.ds__quarter
+                , subq_12.ds__year
+                , subq_12.ds__extract_year
+                , subq_12.ds__extract_quarter
+                , subq_12.ds__extract_month
+                , subq_12.ds__extract_day
+                , subq_12.ds__extract_dow
+                , subq_12.ds__extract_doy
+                , subq_12.ds__alien_day
+              FROM (
+                -- Read From Time Spine 'mf_time_spine'
+                SELECT
+                  time_spine_src_28006.ds AS ds__day
+                  , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week
+                  , DATE_TRUNC('month', time_spine_src_28006.ds) AS ds__month
+                  , DATE_TRUNC('quarter', time_spine_src_28006.ds) AS ds__quarter
+                  , DATE_TRUNC('year', time_spine_src_28006.ds) AS ds__year
+                  , EXTRACT(year FROM time_spine_src_28006.ds) AS ds__extract_year
+                  , EXTRACT(quarter FROM time_spine_src_28006.ds) AS ds__extract_quarter
+                  , EXTRACT(month FROM time_spine_src_28006.ds) AS ds__extract_month
+                  , EXTRACT(day FROM time_spine_src_28006.ds) AS ds__extract_day
+                  , EXTRACT(isodow FROM time_spine_src_28006.ds) AS ds__extract_dow
+                  , EXTRACT(doy FROM time_spine_src_28006.ds) AS ds__extract_doy
+                  , time_spine_src_28006.alien_day AS ds__alien_day
+                FROM ***************************.mf_time_spine time_spine_src_28006
+              ) subq_12
+            ) subq_13
+          ) subq_14
+        ) subq_15
+        INNER JOIN (
+          -- Compute Metrics via Expressions
+          SELECT
+            subq_10.metric_time__day
+            , subq_10.listing
+            , 2 * bookings AS bookings_offset_once
+          FROM (
+            -- Compute Metrics via Expressions
+            SELECT
+              subq_9.metric_time__day
+              , subq_9.listing
+              , subq_9.__bookings AS bookings
+            FROM (
+              -- Join to Time Spine Dataset
+              SELECT
+                subq_8.metric_time__day AS metric_time__day
+                , subq_4.listing AS listing
+                , subq_4.__bookings AS __bookings
+              FROM (
+                -- Select: ['metric_time__day']
+                SELECT
+                  subq_7.metric_time__day
+                FROM (
+                  -- Select: ['metric_time__day']
+                  SELECT
+                    subq_6.metric_time__day
+                  FROM (
+                    -- Change Column Aliases
+                    SELECT
+                      subq_5.ds__day AS metric_time__day
+                      , subq_5.ds__week
+                      , subq_5.ds__month
+                      , subq_5.ds__quarter
+                      , subq_5.ds__year
+                      , subq_5.ds__extract_year
+                      , subq_5.ds__extract_quarter
+                      , subq_5.ds__extract_month
+                      , subq_5.ds__extract_day
+                      , subq_5.ds__extract_dow
+                      , subq_5.ds__extract_doy
+                      , subq_5.ds__alien_day
+                    FROM (
+                      -- Read From Time Spine 'mf_time_spine'
+                      SELECT
+                        time_spine_src_28006.ds AS ds__day
+                        , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week
+                        , DATE_TRUNC('month', time_spine_src_28006.ds) AS ds__month
+                        , DATE_TRUNC('quarter', time_spine_src_28006.ds) AS ds__quarter
+                        , DATE_TRUNC('year', time_spine_src_28006.ds) AS ds__year
+                        , EXTRACT(year FROM time_spine_src_28006.ds) AS ds__extract_year
+                        , EXTRACT(quarter FROM time_spine_src_28006.ds) AS ds__extract_quarter
+                        , EXTRACT(month FROM time_spine_src_28006.ds) AS ds__extract_month
+                        , EXTRACT(day FROM time_spine_src_28006.ds) AS ds__extract_day
+                        , EXTRACT(isodow FROM time_spine_src_28006.ds) AS ds__extract_dow
+                        , EXTRACT(doy FROM time_spine_src_28006.ds) AS ds__extract_doy
+                        , time_spine_src_28006.alien_day AS ds__alien_day
+                      FROM ***************************.mf_time_spine time_spine_src_28006
+                    ) subq_5
+                  ) subq_6
+                ) subq_7
+              ) subq_8
+              INNER JOIN (
+                -- Aggregate Inputs for Simple Metrics
+                SELECT
+                  subq_3.metric_time__day
+                  , subq_3.listing
+                  , SUM(subq_3.__bookings) AS __bookings
+                FROM (
+                  -- Select: ['__bookings', 'metric_time__day', 'listing']
+                  SELECT
+                    subq_2.metric_time__day
+                    , subq_2.listing
+                    , subq_2.__bookings
+                  FROM (
+                    -- Select: ['__bookings', 'metric_time__day', 'listing']
+                    SELECT
+                      subq_1.metric_time__day
+                      , subq_1.listing
+                      , subq_1.__bookings
+                    FROM (
+                      -- Metric Time Dimension 'ds'
+                      SELECT
+                        subq_0.ds__day
+                        , subq_0.ds__week
+                        , subq_0.ds__month
+                        , subq_0.ds__quarter
+                        , subq_0.ds__year
+                        , subq_0.ds__extract_year
+                        , subq_0.ds__extract_quarter
+                        , subq_0.ds__extract_month
+                        , subq_0.ds__extract_day
+                        , subq_0.ds__extract_dow
+                        , subq_0.ds__extract_doy
+                        , subq_0.ds_partitioned__day
+                        , subq_0.ds_partitioned__week
+                        , subq_0.ds_partitioned__month
+                        , subq_0.ds_partitioned__quarter
+                        , subq_0.ds_partitioned__year
+                        , subq_0.ds_partitioned__extract_year
+                        , subq_0.ds_partitioned__extract_quarter
+                        , subq_0.ds_partitioned__extract_month
+                        , subq_0.ds_partitioned__extract_day
+                        , subq_0.ds_partitioned__extract_dow
+                        , subq_0.ds_partitioned__extract_doy
+                        , subq_0.paid_at__day
+                        , subq_0.paid_at__week
+                        , subq_0.paid_at__month
+                        , subq_0.paid_at__quarter
+                        , subq_0.paid_at__year
+                        , subq_0.paid_at__extract_year
+                        , subq_0.paid_at__extract_quarter
+                        , subq_0.paid_at__extract_month
+                        , subq_0.paid_at__extract_day
+                        , subq_0.paid_at__extract_dow
+                        , subq_0.paid_at__extract_doy
+                        , subq_0.booking__ds__day
+                        , subq_0.booking__ds__week
+                        , subq_0.booking__ds__month
+                        , subq_0.booking__ds__quarter
+                        , subq_0.booking__ds__year
+                        , subq_0.booking__ds__extract_year
+                        , subq_0.booking__ds__extract_quarter
+                        , subq_0.booking__ds__extract_month
+                        , subq_0.booking__ds__extract_day
+                        , subq_0.booking__ds__extract_dow
+                        , subq_0.booking__ds__extract_doy
+                        , subq_0.booking__ds_partitioned__day
+                        , subq_0.booking__ds_partitioned__week
+                        , subq_0.booking__ds_partitioned__month
+                        , subq_0.booking__ds_partitioned__quarter
+                        , subq_0.booking__ds_partitioned__year
+                        , subq_0.booking__ds_partitioned__extract_year
+                        , subq_0.booking__ds_partitioned__extract_quarter
+                        , subq_0.booking__ds_partitioned__extract_month
+                        , subq_0.booking__ds_partitioned__extract_day
+                        , subq_0.booking__ds_partitioned__extract_dow
+                        , subq_0.booking__ds_partitioned__extract_doy
+                        , subq_0.booking__paid_at__day
+                        , subq_0.booking__paid_at__week
+                        , subq_0.booking__paid_at__month
+                        , subq_0.booking__paid_at__quarter
+                        , subq_0.booking__paid_at__year
+                        , subq_0.booking__paid_at__extract_year
+                        , subq_0.booking__paid_at__extract_quarter
+                        , subq_0.booking__paid_at__extract_month
+                        , subq_0.booking__paid_at__extract_day
+                        , subq_0.booking__paid_at__extract_dow
+                        , subq_0.booking__paid_at__extract_doy
+                        , subq_0.ds__day AS metric_time__day
+                        , subq_0.ds__week AS metric_time__week
+                        , subq_0.ds__month AS metric_time__month
+                        , subq_0.ds__quarter AS metric_time__quarter
+                        , subq_0.ds__year AS metric_time__year
+                        , subq_0.ds__extract_year AS metric_time__extract_year
+                        , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                        , subq_0.ds__extract_month AS metric_time__extract_month
+                        , subq_0.ds__extract_day AS metric_time__extract_day
+                        , subq_0.ds__extract_dow AS metric_time__extract_dow
+                        , subq_0.ds__extract_doy AS metric_time__extract_doy
+                        , subq_0.listing
+                        , subq_0.guest
+                        , subq_0.host
+                        , subq_0.booking__listing
+                        , subq_0.booking__guest
+                        , subq_0.booking__host
+                        , subq_0.is_instant
+                        , subq_0.booking__is_instant
+                        , subq_0.__bookings
+                        , subq_0.__average_booking_value
+                        , subq_0.__instant_bookings
+                        , subq_0.__booking_value
+                        , subq_0.__max_booking_value
+                        , subq_0.__min_booking_value
+                        , subq_0.__instant_booking_value
+                        , subq_0.__average_instant_booking_value
+                        , subq_0.__booking_value_for_non_null_listing_id
+                        , subq_0.__bookers
+                        , subq_0.__referred_bookings
+                        , subq_0.__median_booking_value
+                        , subq_0.__booking_value_p99
+                        , subq_0.__discrete_booking_value_p99
+                        , subq_0.__approximate_continuous_booking_value_p99
+                        , subq_0.__approximate_discrete_booking_value_p99
+                        , subq_0.__bookings_join_to_time_spine
+                        , subq_0.__bookings_fill_nulls_with_0_without_time_spine
+                        , subq_0.__bookings_fill_nulls_with_0
+                        , subq_0.__instant_bookings_with_measure_filter
+                        , subq_0.__bookings_join_to_time_spine_with_tiered_filters
+                        , subq_0.__bookers_fill_nulls_with_0_join_to_timespine
+                      FROM (
+                        -- Read Elements From Semantic Model 'bookings_source'
+                        SELECT
+                          1 AS __bookings
+                          , bookings_source_src_28000.booking_value AS __average_booking_value
+                          , CASE WHEN is_instant THEN 1 ELSE 0 END AS __instant_bookings
+                          , bookings_source_src_28000.booking_value AS __booking_value
+                          , bookings_source_src_28000.booking_value AS __max_booking_value
+                          , bookings_source_src_28000.booking_value AS __min_booking_value
+                          , bookings_source_src_28000.booking_value AS __instant_booking_value
+                          , bookings_source_src_28000.booking_value AS __average_instant_booking_value
+                          , bookings_source_src_28000.booking_value AS __booking_value_for_non_null_listing_id
+                          , bookings_source_src_28000.guest_id AS __bookers
+                          , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS __referred_bookings
+                          , bookings_source_src_28000.booking_value AS __median_booking_value
+                          , bookings_source_src_28000.booking_value AS __booking_value_p99
+                          , bookings_source_src_28000.booking_value AS __discrete_booking_value_p99
+                          , bookings_source_src_28000.booking_value AS __approximate_continuous_booking_value_p99
+                          , bookings_source_src_28000.booking_value AS __approximate_discrete_booking_value_p99
+                          , 1 AS __bookings_join_to_time_spine
+                          , 1 AS __bookings_fill_nulls_with_0_without_time_spine
+                          , 1 AS __bookings_fill_nulls_with_0
+                          , 1 AS __instant_bookings_with_measure_filter
+                          , 1 AS __bookings_join_to_time_spine_with_tiered_filters
+                          , bookings_source_src_28000.guest_id AS __bookers_fill_nulls_with_0_join_to_timespine
+                          , bookings_source_src_28000.booking_value AS __booking_payments
+                          , bookings_source_src_28000.is_instant
+                          , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                          , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                          , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                          , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                          , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                          , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                          , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                          , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                          , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                          , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                          , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                          , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                          , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                          , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                          , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                          , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                          , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                          , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                          , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                          , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                          , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                          , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                          , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                          , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                          , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                          , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                          , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                          , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                          , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                          , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                          , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                          , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                          , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                          , bookings_source_src_28000.is_instant AS booking__is_instant
+                          , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                          , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                          , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                          , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                          , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                          , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                          , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                          , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                          , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                          , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                          , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                          , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                          , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                          , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                          , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                          , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                          , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                          , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                          , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                          , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                          , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                          , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                          , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                          , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                          , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                          , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                          , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                          , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                          , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                          , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                          , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                          , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                          , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                          , bookings_source_src_28000.listing_id AS listing
+                          , bookings_source_src_28000.guest_id AS guest
+                          , bookings_source_src_28000.host_id AS host
+                          , bookings_source_src_28000.listing_id AS booking__listing
+                          , bookings_source_src_28000.guest_id AS booking__guest
+                          , bookings_source_src_28000.host_id AS booking__host
+                        FROM ***************************.fct_bookings bookings_source_src_28000
+                      ) subq_0
+                    ) subq_1
+                  ) subq_2
+                ) subq_3
+                GROUP BY
+                  subq_3.metric_time__day
+                  , subq_3.listing
+              ) subq_4
+              ON
+                subq_8.metric_time__day - INTERVAL 5 day = subq_4.metric_time__day
+            ) subq_9
+          ) subq_10
+        ) subq_11
+        ON
+          subq_15.metric_time__day - INTERVAL 2 day = subq_11.metric_time__day
+      ) subq_16
+      WHERE listing = '1'
+    ) subq_17
+  ) subq_18
+) subq_19

--- a/tests_metricflow/snapshots/test_offset_metrics_with_filters.py/SqlPlan/DuckDB/test_nested_offset_metric_with_non_queried_element_in_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_offset_metrics_with_filters.py/SqlPlan/DuckDB/test_nested_offset_metric_with_non_queried_element_in_filter__plan0_optimized.sql
@@ -1,0 +1,79 @@
+test_name: test_nested_offset_metric_with_non_queried_element_in_filter
+test_filename: test_offset_metrics_with_filters.py
+docstring:
+  Tests that a non-queried filter element does not remain in the aggregation grain.
+sql_engine: DuckDB
+expectation_description:
+  The non-queried listing filter should be available for filtering the nested
+  offset metric, but it should not remain part of the aggregation grain after
+  filtering. The current snapshot does not reflect the correct result.
+---
+-- Compute Metrics via Expressions
+-- Write to DataTable
+WITH rss_28018_cte AS (
+  -- Read From Time Spine 'mf_time_spine'
+  SELECT
+    ds AS ds__day
+  FROM ***************************.mf_time_spine time_spine_src_28006
+)
+
+SELECT
+  metric_time__day AS metric_time__day
+  , 2 * bookings_offset_once AS bookings_offset_twice
+FROM (
+  -- Constrain Output with WHERE
+  -- Select: ['metric_time__day', 'bookings_offset_once']
+  SELECT
+    metric_time__day
+    , bookings_offset_once
+  FROM (
+    -- Join to Time Spine Dataset
+    SELECT
+      rss_28018_cte.ds__day AS metric_time__day
+      , subq_31.listing AS listing
+      , subq_31.bookings_offset_once AS bookings_offset_once
+    FROM rss_28018_cte
+    INNER JOIN (
+      -- Compute Metrics via Expressions
+      SELECT
+        metric_time__day
+        , listing
+        , 2 * bookings AS bookings_offset_once
+      FROM (
+        -- Join to Time Spine Dataset
+        -- Compute Metrics via Expressions
+        SELECT
+          rss_28018_cte.ds__day AS metric_time__day
+          , subq_24.listing AS listing
+          , subq_24.__bookings AS bookings
+        FROM rss_28018_cte
+        INNER JOIN (
+          -- Aggregate Inputs for Simple Metrics
+          SELECT
+            metric_time__day
+            , listing
+            , SUM(__bookings) AS __bookings
+          FROM (
+            -- Read Elements From Semantic Model 'bookings_source'
+            -- Metric Time Dimension 'ds'
+            -- Select: ['__bookings', 'metric_time__day', 'listing']
+            -- Select: ['__bookings', 'metric_time__day', 'listing']
+            SELECT
+              DATE_TRUNC('day', ds) AS metric_time__day
+              , listing_id AS listing
+              , 1 AS __bookings
+            FROM ***************************.fct_bookings bookings_source_src_28000
+          ) subq_23
+          GROUP BY
+            metric_time__day
+            , listing
+        ) subq_24
+        ON
+          rss_28018_cte.ds__day - INTERVAL 5 day = subq_24.metric_time__day
+      ) subq_30
+    ) subq_31
+    ON
+      rss_28018_cte.ds__day - INTERVAL 2 day = subq_31.metric_time__day
+  ) subq_36
+  WHERE listing = '1'
+) subq_38

--- a/tests_metricflow/snapshots/test_passthrough_planner.py/str/test_cases_with_passthrough_planner__08__time_nested_offset_metric_with_non_queried_element_in_filter__result.txt
+++ b/tests_metricflow/snapshots/test_passthrough_planner.py/str/test_cases_with_passthrough_planner__08__time_nested_offset_metric_with_non_queried_element_in_filter__result.txt
@@ -1,0 +1,174 @@
+test_name: test_cases_with_passthrough_planner[08__time_nested_offset_metric_with_non_queried_element_in_filter]
+test_filename: test_passthrough_planner.py
+docstring:
+  Test enumerated cases using the `PassThroughMetricEvaluationPlanner`.
+expectation_description:
+  The query for `bookings` should contain the filter and only have `metric_time`
+  in the group-by items. The current snapshot does not reflect the correct result.
+---
+Query for a nested time offset metric with a `metric_time` filter
+
+  Metric Names: ['bookings_offset_twice']
+  Group-By Names: ['metric_time']
+  Metric Evaluation Overview:
+    ┌───────┬───────────┬───────────────────────┬───────────────────────┬───────────────────────┬──────────────────┐
+    │ id    │ src_ids   │ computed_outputs      │ passthrough_outputs   │ source_metrics        │ semantic_model   │
+    ├───────┼───────────┼───────────────────────┼───────────────────────┼───────────────────────┼──────────────────┤
+    │ smp_0 │           │ bookings              │                       │                       │ bookings_source  │
+    ├───────┼───────────┼───────────────────────┼───────────────────────┼───────────────────────┼──────────────────┤
+    │ drv_0 │ smp_0     │ bookings_offset_once  │                       │ bookings              │                  │
+    ├───────┼───────────┼───────────────────────┼───────────────────────┼───────────────────────┼──────────────────┤
+    │ drv_1 │ drv_0     │ bookings_offset_twice │                       │ bookings_offset_once  │                  │
+    ├───────┼───────────┼───────────────────────┼───────────────────────┼───────────────────────┼──────────────────┤
+    │ tpl_0 │ drv_1     │                       │ bookings_offset_twice │ bookings_offset_twice │                  │
+    └───────┴───────────┴───────────────────────┴───────────────────────┴───────────────────────┴──────────────────┘
+  Metric Query Output:
+    ┌───────┬─────────────────────────────────────────────────────────┬────────────────────────────────────────────────────────┐
+    │ id    │ output_specs                                            │ output_properties                                      │
+    ├───────┼─────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────┤
+    │ smp_0 │ MetricSpec(                                             │ MetricQueryPropertySet(                                │
+    │       │   element_name='bookings',                              │   group_by_item_specs=['metric_time__day', 'listing'], │
+    │       │   offset_window=TimeWindow(count=5, granularity='day'), │ )                                                      │
+    │       │ )                                                       │                                                        │
+    ├───────┼─────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────┤
+    │ drv_0 │ MetricSpec(                                             │ MetricQueryPropertySet(                                │
+    │       │   element_name='bookings_offset_once',                  │   group_by_item_specs=['metric_time__day'],            │
+    │       │   where_filter_specs=(                                  │   pushdown_enabled_types={                             │
+    │       │     WhereFilterSpec(                                    │     TIME_RANGE_CONSTRAINT,                             │
+    │       │       where_sql="listing = '1'",                        │     CATEGORICAL_DIMENSION,                             │
+    │       │       bind_parameters=SqlBindParameterSet(),            │   },                                                   │
+    │       │       element_set=GroupByItemSet(                       │ )                                                      │
+    │       │         annotated_specs=(                               │                                                        │
+    │       │           AnnotatedSpec(                                │                                                        │
+    │       │             element_type=ENTITY,                        │                                                        │
+    │       │             element_name='listing',                     │                                                        │
+    │       │             element_properties=(                        │                                                        │
+    │       │               ENTITY,                                   │                                                        │
+    │       │               LOCAL,                                    │                                                        │
+    │       │             ),                                          │                                                        │
+    │       │             origin_semantic_model_names=(               │                                                        │
+    │       │               'bookings_source',                        │                                                        │
+    │       │             ),                                          │                                                        │
+    │       │             derived_from_semantic_model_names=(         │                                                        │
+    │       │               'bookings_source',                        │                                                        │
+    │       │             ),                                          │                                                        │
+    │       │           ),                                            │                                                        │
+    │       │         ),                                              │                                                        │
+    │       │       ),                                                │                                                        │
+    │       │     ),                                                  │                                                        │
+    │       │   ),                                                    │                                                        │
+    │       │   offset_window=TimeWindow(count=2, granularity='day'), │                                                        │
+    │       │ )                                                       │                                                        │
+    ├───────┼─────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────┤
+    │ drv_1 │ MetricSpec(                                             │ MetricQueryPropertySet(                                │
+    │       │   element_name='bookings_offset_twice',                 │   group_by_item_specs=['metric_time__day'],            │
+    │       │   where_filter_specs=(                                  │   pushdown_enabled_types={                             │
+    │       │     WhereFilterSpec(                                    │     TIME_RANGE_CONSTRAINT,                             │
+    │       │       where_sql="listing = '1'",                        │     CATEGORICAL_DIMENSION,                             │
+    │       │       bind_parameters=SqlBindParameterSet(),            │   },                                                   │
+    │       │       element_set=GroupByItemSet(                       │ )                                                      │
+    │       │         annotated_specs=(                               │                                                        │
+    │       │           AnnotatedSpec(                                │                                                        │
+    │       │             element_type=ENTITY,                        │                                                        │
+    │       │             element_name='listing',                     │                                                        │
+    │       │             element_properties=(                        │                                                        │
+    │       │               ENTITY,                                   │                                                        │
+    │       │               LOCAL,                                    │                                                        │
+    │       │             ),                                          │                                                        │
+    │       │             origin_semantic_model_names=(               │                                                        │
+    │       │               'bookings_source',                        │                                                        │
+    │       │             ),                                          │                                                        │
+    │       │             derived_from_semantic_model_names=(         │                                                        │
+    │       │               'bookings_source',                        │                                                        │
+    │       │             ),                                          │                                                        │
+    │       │           ),                                            │                                                        │
+    │       │         ),                                              │                                                        │
+    │       │       ),                                                │                                                        │
+    │       │     ),                                                  │                                                        │
+    │       │   ),                                                    │                                                        │
+    │       │ )                                                       │                                                        │
+    ├───────┼─────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────┤
+    │ tpl_0 │ MetricSpec(                                             │ MetricQueryPropertySet(                                │
+    │       │   element_name='bookings_offset_twice',                 │   group_by_item_specs=['metric_time__day'],            │
+    │       │   where_filter_specs=(                                  │   pushdown_enabled_types={                             │
+    │       │     WhereFilterSpec(                                    │     TIME_RANGE_CONSTRAINT,                             │
+    │       │       where_sql="listing = '1'",                        │     CATEGORICAL_DIMENSION,                             │
+    │       │       bind_parameters=SqlBindParameterSet(),            │   },                                                   │
+    │       │       element_set=GroupByItemSet(                       │ )                                                      │
+    │       │         annotated_specs=(                               │                                                        │
+    │       │           AnnotatedSpec(                                │                                                        │
+    │       │             element_type=ENTITY,                        │                                                        │
+    │       │             element_name='listing',                     │                                                        │
+    │       │             element_properties=(                        │                                                        │
+    │       │               ENTITY,                                   │                                                        │
+    │       │               LOCAL,                                    │                                                        │
+    │       │             ),                                          │                                                        │
+    │       │             origin_semantic_model_names=(               │                                                        │
+    │       │               'bookings_source',                        │                                                        │
+    │       │             ),                                          │                                                        │
+    │       │             derived_from_semantic_model_names=(         │                                                        │
+    │       │               'bookings_source',                        │                                                        │
+    │       │             ),                                          │                                                        │
+    │       │           ),                                            │                                                        │
+    │       │         ),                                              │                                                        │
+    │       │       ),                                                │                                                        │
+    │       │     ),                                                  │                                                        │
+    │       │   ),                                                    │                                                        │
+    │       │ )                                                       │                                                        │
+    └───────┴─────────────────────────────────────────────────────────┴────────────────────────────────────────────────────────┘
+  SQL:
+    WITH rss_28018_cte AS (
+      SELECT
+        ds AS ds__day
+      FROM ***************************.mf_time_spine time_spine_src_28006
+    )
+
+    SELECT
+      metric_time__day AS metric_time__day
+      , 2 * bookings_offset_once AS bookings_offset_twice
+    FROM (
+      SELECT
+        metric_time__day
+        , bookings_offset_once
+      FROM (
+        SELECT
+          rss_28018_cte.ds__day AS metric_time__day
+          , subq_11.listing AS listing
+          , subq_11.bookings_offset_once AS bookings_offset_once
+        FROM rss_28018_cte
+        INNER JOIN (
+          SELECT
+            metric_time__day
+            , listing
+            , 2 * bookings AS bookings_offset_once
+          FROM (
+            SELECT
+              rss_28018_cte.ds__day AS metric_time__day
+              , subq_4.listing AS listing
+              , subq_4.__bookings AS bookings
+            FROM rss_28018_cte
+            INNER JOIN (
+              SELECT
+                metric_time__day
+                , listing
+                , SUM(__bookings) AS __bookings
+              FROM (
+                SELECT
+                  DATE_TRUNC('day', ds) AS metric_time__day
+                  , listing_id AS listing
+                  , 1 AS __bookings
+                FROM ***************************.fct_bookings bookings_source_src_28000
+              ) subq_3
+              GROUP BY
+                metric_time__day
+                , listing
+            ) subq_4
+            ON
+              rss_28018_cte.ds__day - INTERVAL 5 day = subq_4.metric_time__day
+          ) subq_10
+        ) subq_11
+        ON
+          rss_28018_cte.ds__day - INTERVAL 2 day = subq_11.metric_time__day
+      ) subq_16
+      WHERE listing = '1'
+    ) subq_18


### PR DESCRIPTION
This PR adds a test case that demonstrates a bug when a nested time-offset metric is queried with a non-queried item in the filter. The filter should be placed before the aggregation, and the aggregation should not include the non-queried item.