### PR TITLE
Fix check for aggregation time dimensions in filters

### DIFF
--- a/.changes/unreleased/Fixes-20260404-074931.yaml
+++ b/.changes/unreleased/Fixes-20260404-074931.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix check for aggregation time dimensions in filters
+time: 2026-04-04T07:49:31.096475-07:00
+custom:
+  Author: plypaul
+  Issue: "2012"

--- a/metricflow/dataflow/builder/dataflow_plan_builder.py
+++ b/metricflow/dataflow/builder/dataflow_plan_builder.py
@@ -1619,7 +1619,9 @@ class DataflowPlanBuilder:
 
         for filter_spec in metric_where_filter_specs:
             included_agg_time_specs = agg_time_dimension_specs_for_metric.intersection(filter_spec.linkable_specs)
-            if len(included_agg_time_specs) == len(filter_spec.linkable_specs):
+            # The filter might contain no linkable specs, and we only want cases where it has only aggregation time
+            # dimension specs.
+            if filter_spec.linkable_specs and len(included_agg_time_specs) == len(filter_spec.linkable_specs):
                 agg_time_only_filters.append(filter_spec)
 
         # Filters that include group-by-items that are not aggregation time dimensions for the metric.
@@ -1628,7 +1630,7 @@ class DataflowPlanBuilder:
         non_agg_time_only_filters: List[WhereFilterSpec] = []
         for filter_spec in after_aggregation_where_filter_specs:
             included_agg_time_specs = agg_time_dimension_specs_for_metric.intersection(filter_spec.linkable_specs)
-            if len(included_agg_time_specs) == len(filter_spec.linkable_specs):
+            if filter_spec.linkable_specs and len(included_agg_time_specs) == len(filter_spec.linkable_specs):
                 agg_time_only_filters.append(filter_spec)
             else:
                 non_agg_time_only_filters.append(filter_spec)
@@ -1659,7 +1661,7 @@ class DataflowPlanBuilder:
         queried_non_agg_time_filter_specs = [
             filter_spec
             for filter_spec in non_agg_time_only_filters
-            if set(filter_spec.linkable_specs).issubset(set(queried_linkable_specs))
+            if filter_spec.linkable_specs and set(filter_spec.linkable_specs).issubset(set(queried_linkable_specs))
         ]
         if len(queried_non_agg_time_filter_specs) > 0:
             output_node = WhereFilterNode.create(

--- a/metricflow/dataflow/builder/dataflow_plan_builder.py
+++ b/metricflow/dataflow/builder/dataflow_plan_builder.py
@@ -1661,7 +1661,7 @@ class DataflowPlanBuilder:
         queried_non_agg_time_filter_specs = [
             filter_spec
             for filter_spec in non_agg_time_only_filters
-            if filter_spec.linkable_specs and set(filter_spec.linkable_specs).issubset(set(queried_linkable_specs))
+            if set(filter_spec.linkable_specs).issubset(set(queried_linkable_specs))
         ]
         if len(queried_non_agg_time_filter_specs) > 0:
             output_node = WhereFilterNode.create(

--- a/tests_metricflow/snapshots/test_offset_metrics_with_filters.py/SqlPlan/DuckDB/test_offset_metric_with_string_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_offset_metrics_with_filters.py/SqlPlan/DuckDB/test_offset_metric_with_string_filter__plan0.sql
@@ -23,16 +23,17 @@ FROM (
       subq_11.metric_time__day
       , subq_11.__bookings AS bookings
     FROM (
-      -- Join to Time Spine Dataset
+      -- Constrain Output with WHERE
       SELECT
-        subq_10.metric_time__day AS metric_time__day
-        , subq_5.__bookings AS __bookings
+        subq_10.bookings AS __bookings
+        , subq_10.metric_time__day
       FROM (
-        -- Select: ['metric_time__day']
+        -- Join to Time Spine Dataset
         SELECT
-          subq_9.metric_time__day
+          subq_9.metric_time__day AS metric_time__day
+          , subq_5.__bookings AS bookings
         FROM (
-          -- Constrain Output with WHERE
+          -- Select: ['metric_time__day']
           SELECT
             subq_8.metric_time__day
           FROM (
@@ -73,251 +74,251 @@ FROM (
               ) subq_6
             ) subq_7
           ) subq_8
-          WHERE TRUE
         ) subq_9
-      ) subq_10
-      INNER JOIN (
-        -- Aggregate Inputs for Simple Metrics
-        SELECT
-          subq_4.metric_time__day
-          , SUM(subq_4.__bookings) AS __bookings
-        FROM (
-          -- Select: ['__bookings', 'metric_time__day']
+        INNER JOIN (
+          -- Aggregate Inputs for Simple Metrics
           SELECT
-            subq_3.metric_time__day
-            , subq_3.__bookings
+            subq_4.metric_time__day
+            , SUM(subq_4.__bookings) AS __bookings
           FROM (
-            -- Constrain Output with WHERE
+            -- Select: ['__bookings', 'metric_time__day']
             SELECT
-              subq_2.bookings AS __bookings
-              , subq_2.metric_time__day
+              subq_3.metric_time__day
+              , subq_3.__bookings
             FROM (
-              -- Select: ['__bookings', 'metric_time__day']
+              -- Constrain Output with WHERE
               SELECT
-                subq_1.metric_time__day
-                , subq_1.__bookings AS bookings
+                subq_2.bookings AS __bookings
+                , subq_2.metric_time__day
               FROM (
-                -- Metric Time Dimension 'ds'
+                -- Select: ['__bookings', 'metric_time__day']
                 SELECT
-                  subq_0.ds__day
-                  , subq_0.ds__week
-                  , subq_0.ds__month
-                  , subq_0.ds__quarter
-                  , subq_0.ds__year
-                  , subq_0.ds__extract_year
-                  , subq_0.ds__extract_quarter
-                  , subq_0.ds__extract_month
-                  , subq_0.ds__extract_day
-                  , subq_0.ds__extract_dow
-                  , subq_0.ds__extract_doy
-                  , subq_0.ds_partitioned__day
-                  , subq_0.ds_partitioned__week
-                  , subq_0.ds_partitioned__month
-                  , subq_0.ds_partitioned__quarter
-                  , subq_0.ds_partitioned__year
-                  , subq_0.ds_partitioned__extract_year
-                  , subq_0.ds_partitioned__extract_quarter
-                  , subq_0.ds_partitioned__extract_month
-                  , subq_0.ds_partitioned__extract_day
-                  , subq_0.ds_partitioned__extract_dow
-                  , subq_0.ds_partitioned__extract_doy
-                  , subq_0.paid_at__day
-                  , subq_0.paid_at__week
-                  , subq_0.paid_at__month
-                  , subq_0.paid_at__quarter
-                  , subq_0.paid_at__year
-                  , subq_0.paid_at__extract_year
-                  , subq_0.paid_at__extract_quarter
-                  , subq_0.paid_at__extract_month
-                  , subq_0.paid_at__extract_day
-                  , subq_0.paid_at__extract_dow
-                  , subq_0.paid_at__extract_doy
-                  , subq_0.booking__ds__day
-                  , subq_0.booking__ds__week
-                  , subq_0.booking__ds__month
-                  , subq_0.booking__ds__quarter
-                  , subq_0.booking__ds__year
-                  , subq_0.booking__ds__extract_year
-                  , subq_0.booking__ds__extract_quarter
-                  , subq_0.booking__ds__extract_month
-                  , subq_0.booking__ds__extract_day
-                  , subq_0.booking__ds__extract_dow
-                  , subq_0.booking__ds__extract_doy
-                  , subq_0.booking__ds_partitioned__day
-                  , subq_0.booking__ds_partitioned__week
-                  , subq_0.booking__ds_partitioned__month
-                  , subq_0.booking__ds_partitioned__quarter
-                  , subq_0.booking__ds_partitioned__year
-                  , subq_0.booking__ds_partitioned__extract_year
-                  , subq_0.booking__ds_partitioned__extract_quarter
-                  , subq_0.booking__ds_partitioned__extract_month
-                  , subq_0.booking__ds_partitioned__extract_day
-                  , subq_0.booking__ds_partitioned__extract_dow
-                  , subq_0.booking__ds_partitioned__extract_doy
-                  , subq_0.booking__paid_at__day
-                  , subq_0.booking__paid_at__week
-                  , subq_0.booking__paid_at__month
-                  , subq_0.booking__paid_at__quarter
-                  , subq_0.booking__paid_at__year
-                  , subq_0.booking__paid_at__extract_year
-                  , subq_0.booking__paid_at__extract_quarter
-                  , subq_0.booking__paid_at__extract_month
-                  , subq_0.booking__paid_at__extract_day
-                  , subq_0.booking__paid_at__extract_dow
-                  , subq_0.booking__paid_at__extract_doy
-                  , subq_0.ds__day AS metric_time__day
-                  , subq_0.ds__week AS metric_time__week
-                  , subq_0.ds__month AS metric_time__month
-                  , subq_0.ds__quarter AS metric_time__quarter
-                  , subq_0.ds__year AS metric_time__year
-                  , subq_0.ds__extract_year AS metric_time__extract_year
-                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_0.ds__extract_month AS metric_time__extract_month
-                  , subq_0.ds__extract_day AS metric_time__extract_day
-                  , subq_0.ds__extract_dow AS metric_time__extract_dow
-                  , subq_0.ds__extract_doy AS metric_time__extract_doy
-                  , subq_0.listing
-                  , subq_0.guest
-                  , subq_0.host
-                  , subq_0.booking__listing
-                  , subq_0.booking__guest
-                  , subq_0.booking__host
-                  , subq_0.is_instant
-                  , subq_0.booking__is_instant
-                  , subq_0.__bookings
-                  , subq_0.__average_booking_value
-                  , subq_0.__instant_bookings
-                  , subq_0.__booking_value
-                  , subq_0.__max_booking_value
-                  , subq_0.__min_booking_value
-                  , subq_0.__instant_booking_value
-                  , subq_0.__average_instant_booking_value
-                  , subq_0.__booking_value_for_non_null_listing_id
-                  , subq_0.__bookers
-                  , subq_0.__referred_bookings
-                  , subq_0.__median_booking_value
-                  , subq_0.__booking_value_p99
-                  , subq_0.__discrete_booking_value_p99
-                  , subq_0.__approximate_continuous_booking_value_p99
-                  , subq_0.__approximate_discrete_booking_value_p99
-                  , subq_0.__bookings_join_to_time_spine
-                  , subq_0.__bookings_fill_nulls_with_0_without_time_spine
-                  , subq_0.__bookings_fill_nulls_with_0
-                  , subq_0.__instant_bookings_with_measure_filter
-                  , subq_0.__bookings_join_to_time_spine_with_tiered_filters
-                  , subq_0.__bookers_fill_nulls_with_0_join_to_timespine
+                  subq_1.metric_time__day
+                  , subq_1.__bookings AS bookings
                 FROM (
-                  -- Read Elements From Semantic Model 'bookings_source'
+                  -- Metric Time Dimension 'ds'
                   SELECT
-                    1 AS __bookings
-                    , bookings_source_src_28000.booking_value AS __average_booking_value
-                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS __instant_bookings
-                    , bookings_source_src_28000.booking_value AS __booking_value
-                    , bookings_source_src_28000.booking_value AS __max_booking_value
-                    , bookings_source_src_28000.booking_value AS __min_booking_value
-                    , bookings_source_src_28000.booking_value AS __instant_booking_value
-                    , bookings_source_src_28000.booking_value AS __average_instant_booking_value
-                    , bookings_source_src_28000.booking_value AS __booking_value_for_non_null_listing_id
-                    , bookings_source_src_28000.guest_id AS __bookers
-                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS __referred_bookings
-                    , bookings_source_src_28000.booking_value AS __median_booking_value
-                    , bookings_source_src_28000.booking_value AS __booking_value_p99
-                    , bookings_source_src_28000.booking_value AS __discrete_booking_value_p99
-                    , bookings_source_src_28000.booking_value AS __approximate_continuous_booking_value_p99
-                    , bookings_source_src_28000.booking_value AS __approximate_discrete_booking_value_p99
-                    , 1 AS __bookings_join_to_time_spine
-                    , 1 AS __bookings_fill_nulls_with_0_without_time_spine
-                    , 1 AS __bookings_fill_nulls_with_0
-                    , 1 AS __instant_bookings_with_measure_filter
-                    , 1 AS __bookings_join_to_time_spine_with_tiered_filters
-                    , bookings_source_src_28000.guest_id AS __bookers_fill_nulls_with_0_join_to_timespine
-                    , bookings_source_src_28000.booking_value AS __booking_payments
-                    , bookings_source_src_28000.is_instant
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                    , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                    , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                    , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                    , bookings_source_src_28000.is_instant AS booking__is_instant
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                    , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                    , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                    , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                    , bookings_source_src_28000.listing_id AS listing
-                    , bookings_source_src_28000.guest_id AS guest
-                    , bookings_source_src_28000.host_id AS host
-                    , bookings_source_src_28000.listing_id AS booking__listing
-                    , bookings_source_src_28000.guest_id AS booking__guest
-                    , bookings_source_src_28000.host_id AS booking__host
-                  FROM ***************************.fct_bookings bookings_source_src_28000
-                ) subq_0
-              ) subq_1
-            ) subq_2
-            WHERE TRUE
-          ) subq_3
-        ) subq_4
-        GROUP BY
-          subq_4.metric_time__day
-      ) subq_5
-      ON
-        subq_10.metric_time__day - INTERVAL 5 day = subq_5.metric_time__day
+                    subq_0.ds__day
+                    , subq_0.ds__week
+                    , subq_0.ds__month
+                    , subq_0.ds__quarter
+                    , subq_0.ds__year
+                    , subq_0.ds__extract_year
+                    , subq_0.ds__extract_quarter
+                    , subq_0.ds__extract_month
+                    , subq_0.ds__extract_day
+                    , subq_0.ds__extract_dow
+                    , subq_0.ds__extract_doy
+                    , subq_0.ds_partitioned__day
+                    , subq_0.ds_partitioned__week
+                    , subq_0.ds_partitioned__month
+                    , subq_0.ds_partitioned__quarter
+                    , subq_0.ds_partitioned__year
+                    , subq_0.ds_partitioned__extract_year
+                    , subq_0.ds_partitioned__extract_quarter
+                    , subq_0.ds_partitioned__extract_month
+                    , subq_0.ds_partitioned__extract_day
+                    , subq_0.ds_partitioned__extract_dow
+                    , subq_0.ds_partitioned__extract_doy
+                    , subq_0.paid_at__day
+                    , subq_0.paid_at__week
+                    , subq_0.paid_at__month
+                    , subq_0.paid_at__quarter
+                    , subq_0.paid_at__year
+                    , subq_0.paid_at__extract_year
+                    , subq_0.paid_at__extract_quarter
+                    , subq_0.paid_at__extract_month
+                    , subq_0.paid_at__extract_day
+                    , subq_0.paid_at__extract_dow
+                    , subq_0.paid_at__extract_doy
+                    , subq_0.booking__ds__day
+                    , subq_0.booking__ds__week
+                    , subq_0.booking__ds__month
+                    , subq_0.booking__ds__quarter
+                    , subq_0.booking__ds__year
+                    , subq_0.booking__ds__extract_year
+                    , subq_0.booking__ds__extract_quarter
+                    , subq_0.booking__ds__extract_month
+                    , subq_0.booking__ds__extract_day
+                    , subq_0.booking__ds__extract_dow
+                    , subq_0.booking__ds__extract_doy
+                    , subq_0.booking__ds_partitioned__day
+                    , subq_0.booking__ds_partitioned__week
+                    , subq_0.booking__ds_partitioned__month
+                    , subq_0.booking__ds_partitioned__quarter
+                    , subq_0.booking__ds_partitioned__year
+                    , subq_0.booking__ds_partitioned__extract_year
+                    , subq_0.booking__ds_partitioned__extract_quarter
+                    , subq_0.booking__ds_partitioned__extract_month
+                    , subq_0.booking__ds_partitioned__extract_day
+                    , subq_0.booking__ds_partitioned__extract_dow
+                    , subq_0.booking__ds_partitioned__extract_doy
+                    , subq_0.booking__paid_at__day
+                    , subq_0.booking__paid_at__week
+                    , subq_0.booking__paid_at__month
+                    , subq_0.booking__paid_at__quarter
+                    , subq_0.booking__paid_at__year
+                    , subq_0.booking__paid_at__extract_year
+                    , subq_0.booking__paid_at__extract_quarter
+                    , subq_0.booking__paid_at__extract_month
+                    , subq_0.booking__paid_at__extract_day
+                    , subq_0.booking__paid_at__extract_dow
+                    , subq_0.booking__paid_at__extract_doy
+                    , subq_0.ds__day AS metric_time__day
+                    , subq_0.ds__week AS metric_time__week
+                    , subq_0.ds__month AS metric_time__month
+                    , subq_0.ds__quarter AS metric_time__quarter
+                    , subq_0.ds__year AS metric_time__year
+                    , subq_0.ds__extract_year AS metric_time__extract_year
+                    , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                    , subq_0.ds__extract_month AS metric_time__extract_month
+                    , subq_0.ds__extract_day AS metric_time__extract_day
+                    , subq_0.ds__extract_dow AS metric_time__extract_dow
+                    , subq_0.ds__extract_doy AS metric_time__extract_doy
+                    , subq_0.listing
+                    , subq_0.guest
+                    , subq_0.host
+                    , subq_0.booking__listing
+                    , subq_0.booking__guest
+                    , subq_0.booking__host
+                    , subq_0.is_instant
+                    , subq_0.booking__is_instant
+                    , subq_0.__bookings
+                    , subq_0.__average_booking_value
+                    , subq_0.__instant_bookings
+                    , subq_0.__booking_value
+                    , subq_0.__max_booking_value
+                    , subq_0.__min_booking_value
+                    , subq_0.__instant_booking_value
+                    , subq_0.__average_instant_booking_value
+                    , subq_0.__booking_value_for_non_null_listing_id
+                    , subq_0.__bookers
+                    , subq_0.__referred_bookings
+                    , subq_0.__median_booking_value
+                    , subq_0.__booking_value_p99
+                    , subq_0.__discrete_booking_value_p99
+                    , subq_0.__approximate_continuous_booking_value_p99
+                    , subq_0.__approximate_discrete_booking_value_p99
+                    , subq_0.__bookings_join_to_time_spine
+                    , subq_0.__bookings_fill_nulls_with_0_without_time_spine
+                    , subq_0.__bookings_fill_nulls_with_0
+                    , subq_0.__instant_bookings_with_measure_filter
+                    , subq_0.__bookings_join_to_time_spine_with_tiered_filters
+                    , subq_0.__bookers_fill_nulls_with_0_join_to_timespine
+                  FROM (
+                    -- Read Elements From Semantic Model 'bookings_source'
+                    SELECT
+                      1 AS __bookings
+                      , bookings_source_src_28000.booking_value AS __average_booking_value
+                      , CASE WHEN is_instant THEN 1 ELSE 0 END AS __instant_bookings
+                      , bookings_source_src_28000.booking_value AS __booking_value
+                      , bookings_source_src_28000.booking_value AS __max_booking_value
+                      , bookings_source_src_28000.booking_value AS __min_booking_value
+                      , bookings_source_src_28000.booking_value AS __instant_booking_value
+                      , bookings_source_src_28000.booking_value AS __average_instant_booking_value
+                      , bookings_source_src_28000.booking_value AS __booking_value_for_non_null_listing_id
+                      , bookings_source_src_28000.guest_id AS __bookers
+                      , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS __referred_bookings
+                      , bookings_source_src_28000.booking_value AS __median_booking_value
+                      , bookings_source_src_28000.booking_value AS __booking_value_p99
+                      , bookings_source_src_28000.booking_value AS __discrete_booking_value_p99
+                      , bookings_source_src_28000.booking_value AS __approximate_continuous_booking_value_p99
+                      , bookings_source_src_28000.booking_value AS __approximate_discrete_booking_value_p99
+                      , 1 AS __bookings_join_to_time_spine
+                      , 1 AS __bookings_fill_nulls_with_0_without_time_spine
+                      , 1 AS __bookings_fill_nulls_with_0
+                      , 1 AS __instant_bookings_with_measure_filter
+                      , 1 AS __bookings_join_to_time_spine_with_tiered_filters
+                      , bookings_source_src_28000.guest_id AS __bookers_fill_nulls_with_0_join_to_timespine
+                      , bookings_source_src_28000.booking_value AS __booking_payments
+                      , bookings_source_src_28000.is_instant
+                      , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                      , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                      , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                      , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                      , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                      , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                      , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                      , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                      , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                      , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                      , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                      , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                      , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                      , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                      , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                      , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                      , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                      , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                      , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                      , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                      , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                      , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                      , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                      , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                      , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                      , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                      , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                      , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                      , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                      , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                      , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                      , bookings_source_src_28000.is_instant AS booking__is_instant
+                      , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                      , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                      , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                      , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                      , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                      , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                      , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                      , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                      , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                      , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                      , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                      , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                      , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                      , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                      , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                      , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                      , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                      , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                      , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                      , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                      , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                      , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                      , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                      , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                      , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                      , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                      , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                      , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                      , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                      , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                      , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                      , bookings_source_src_28000.listing_id AS listing
+                      , bookings_source_src_28000.guest_id AS guest
+                      , bookings_source_src_28000.host_id AS host
+                      , bookings_source_src_28000.listing_id AS booking__listing
+                      , bookings_source_src_28000.guest_id AS booking__guest
+                      , bookings_source_src_28000.host_id AS booking__host
+                    FROM ***************************.fct_bookings bookings_source_src_28000
+                  ) subq_0
+                ) subq_1
+              ) subq_2
+              WHERE TRUE
+            ) subq_3
+          ) subq_4
+          GROUP BY
+            subq_4.metric_time__day
+        ) subq_5
+        ON
+          subq_9.metric_time__day - INTERVAL 5 day = subq_5.metric_time__day
+      ) subq_10
+      WHERE TRUE
     ) subq_11
   ) subq_12
 ) subq_13

--- a/tests_metricflow/snapshots/test_offset_metrics_with_filters.py/SqlPlan/DuckDB/test_offset_metric_with_string_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_offset_metrics_with_filters.py/SqlPlan/DuckDB/test_offset_metric_with_string_filter__plan0_optimized.sql
@@ -14,46 +14,39 @@ SELECT
   metric_time__day
   , 2 * bookings AS bookings_offset_once
 FROM (
-  -- Join to Time Spine Dataset
+  -- Constrain Output with WHERE
   -- Compute Metrics via Expressions
   SELECT
-    subq_24.metric_time__day AS metric_time__day
-    , subq_19.__bookings AS bookings
+    metric_time__day
+    , bookings
   FROM (
-    -- Constrain Output with WHERE
-    -- Select: ['metric_time__day']
+    -- Join to Time Spine Dataset
     SELECT
-      metric_time__day
-    FROM (
-      -- Read From Time Spine 'mf_time_spine'
-      -- Change Column Aliases
-      -- Select: ['metric_time__day']
-      SELECT
-        ds AS metric_time__day
-      FROM ***************************.mf_time_spine time_spine_src_28006
-    ) subq_22
-    WHERE TRUE
-  ) subq_24
-  INNER JOIN (
-    -- Constrain Output with WHERE
-    -- Select: ['__bookings', 'metric_time__day']
-    -- Aggregate Inputs for Simple Metrics
-    SELECT
-      metric_time__day
-      , SUM(bookings) AS __bookings
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
+      time_spine_src_28006.ds AS metric_time__day
+      , subq_19.__bookings AS bookings
+    FROM ***************************.mf_time_spine time_spine_src_28006
+    INNER JOIN (
+      -- Constrain Output with WHERE
       -- Select: ['__bookings', 'metric_time__day']
+      -- Aggregate Inputs for Simple Metrics
       SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_16
-    WHERE TRUE
-    GROUP BY
-      metric_time__day
-  ) subq_19
-  ON
-    subq_24.metric_time__day - INTERVAL 5 day = subq_19.metric_time__day
+        metric_time__day
+        , SUM(bookings) AS __bookings
+      FROM (
+        -- Read Elements From Semantic Model 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        -- Select: ['__bookings', 'metric_time__day']
+        SELECT
+          DATE_TRUNC('day', ds) AS metric_time__day
+          , 1 AS bookings
+        FROM ***************************.fct_bookings bookings_source_src_28000
+      ) subq_16
+      WHERE TRUE
+      GROUP BY
+        metric_time__day
+    ) subq_19
+    ON
+      time_spine_src_28006.ds - INTERVAL 5 day = subq_19.metric_time__day
+  ) subq_24
+  WHERE TRUE
 ) subq_26


### PR DESCRIPTION
This PR fixes one of the bugs that is causing incorrect filter placement. The check to see if the filter is only on aggregation time dimensions

```
if len(included_agg_time_specs) == len(filter_spec.linkable_specs):
```

has an edge case when both are empty.
