### PR TITLE
Simplify `metricflow` dependencies

### DIFF
--- a/.changes/unreleased/Under the Hood-20260404-074544.yaml
+++ b/.changes/unreleased/Under the Hood-20260404-074544.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Simplify `metricflow` dependencies
+time: 2026-04-04T07:45:44.583884-07:00
+custom:
+  Author: plypaul
+  Issue: "2015"

--- a/dbt-metricflow/dbt_metricflow/cli/main.py
+++ b/dbt-metricflow/dbt_metricflow/cli/main.py
@@ -32,13 +32,16 @@ from dbt_metricflow.cli.utils import (
     query_options,
     start_end_time_options,
 )
+from dbt_metricflow.cli.validation_result_formatter import ValidationResultFormatter
 from metricflow.engine.metricflow_engine import MetricFlowExplainResult, MetricFlowQueryRequest, MetricFlowQueryResult
 from metricflow.telemetry.models import TelemetryLevel
 from metricflow.telemetry.reporter import TelemetryReporter, log_call
 from metricflow.validation.data_warehouse_model_validator import DataWarehouseModelValidator
 from metricflow_semantic_interfaces.protocols.semantic_manifest import SemanticManifest
 from metricflow_semantic_interfaces.validations.semantic_manifest_validator import SemanticManifestValidator
-from metricflow_semantic_interfaces.validations.validator_helpers import SemanticManifestValidationResults
+from metricflow_semantic_interfaces.validations.validator_helpers import (
+    SemanticManifestValidationResults,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -478,15 +481,15 @@ def dimension_values(
 
 
 def _print_issues(
-    issues: SemanticManifestValidationResults, show_non_blocking: bool = False, verbose: bool = False
+    result: SemanticManifestValidationResults, show_non_blocking: bool = False, verbose: bool = False
 ) -> None:
-    for issue in issues.errors:
-        print(f"• {issue.as_cli_formatted_str(verbose=verbose)}")
+    for issue in result.errors:
+        print(f"• {ValidationResultFormatter.format_validation_issue(issue, verbose=verbose)}")
     if show_non_blocking:
-        for issue in issues.future_errors:
-            print(f"• {issue.as_cli_formatted_str(verbose=verbose)}")
-        for issue in issues.warnings:
-            print(f"• {issue.as_cli_formatted_str(verbose=verbose)}")
+        for issue in result.future_errors:
+            print(f"• {ValidationResultFormatter.format_validation_issue(issue, verbose=verbose)}")
+        for issue in result.warnings:
+            print(f"• {ValidationResultFormatter.format_validation_issue(issue, verbose=verbose)}")
 
 
 def _run_dw_validations(
@@ -501,10 +504,12 @@ def _run_dw_validations(
 
     results = validation_func(manifest, timeout)
     if not results.has_blocking_issues:
-        spinner.succeed(f"🎉 Successfully validated {validation_type} against data warehouse ({results.summary()})")
+        spinner.succeed(
+            f"🎉 Successfully validated {validation_type} against data warehouse ({ValidationResultFormatter.format_summary(results)})"
+        )
     else:
         spinner.fail(
-            f"Breaking issues found when validating {validation_type} against data warehouse ({results.summary()})"
+            f"Breaking issues found when validating {validation_type} against data warehouse ({ValidationResultFormatter.format_summary(results)})"
         )
     return results
 
@@ -591,17 +596,19 @@ def validate_configs(
     # Semantic validation
     semantic_spinner = Halo(text="Validating semantics of built manifest", spinner="dots")
     semantic_spinner.start()
-    model_issues = SemanticManifestValidator[SemanticManifest](
+    validation_result = SemanticManifestValidator[SemanticManifest](
         max_workers=semantic_validation_workers
     ).validate_semantic_manifest(semantic_manifest)
 
-    if not model_issues.has_blocking_issues:
-        semantic_spinner.succeed(f"🎉 Successfully validated the semantics of built manifest ({model_issues.summary()})")
+    if not validation_result.has_blocking_issues:
+        semantic_spinner.succeed(
+            f"🎉 Successfully validated the semantics of built manifest ({ValidationResultFormatter.format_summary(validation_result)})"
+        )
     else:
         semantic_spinner.fail(
-            f"Breaking issues found when checking semantics of built manifest ({model_issues.summary()})"
+            f"Breaking issues found when checking semantics of built manifest ({ValidationResultFormatter.format_summary(validation_result)})"
         )
-        _print_issues(model_issues, show_non_blocking=show_all, verbose=verbose_issues)
+        _print_issues(validation_result, show_non_blocking=show_all, verbose=verbose_issues)
         exit(1)
 
     dw_results = SemanticManifestValidationResults()
@@ -612,7 +619,7 @@ def validate_configs(
             dw_validator=dw_validator, manifest=semantic_manifest, timeout=dw_timeout
         )
 
-    merged_results = SemanticManifestValidationResults.merge([model_issues, dw_results])
+    merged_results = SemanticManifestValidationResults.merge([validation_result, dw_results])
     _print_issues(merged_results, show_non_blocking=show_all, verbose=verbose_issues)
     if merged_results.has_blocking_issues:
         exit(1)

--- a/dbt-metricflow/dbt_metricflow/cli/validation_result_formatter.py
+++ b/dbt-metricflow/dbt_metricflow/cli/validation_result_formatter.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import logging
+
+import click
+
+from metricflow_semantic_interfaces.validations.validator_helpers import (
+    SemanticManifestValidationResults,
+    ValidationIssue,
+    ValidationIssueLevel,
+)
+
+logger = logging.getLogger(__name__)
+
+
+ISSUE_COLOR_MAP = {
+    ValidationIssueLevel.WARNING: "cyan",
+    ValidationIssueLevel.ERROR: "bright_red",
+    ValidationIssueLevel.FUTURE_ERROR: "bright_yellow",
+}
+
+
+class ValidationResultFormatter:
+    """Helps format the results of validating a semantic manifest."""
+
+    @staticmethod
+    def format_validation_issue(issue: ValidationIssue, verbose: bool = False) -> str:
+        """Returns a color-coded readable string for rendering issues in the CLI."""
+        return issue.as_readable_str(
+            verbose=verbose, prefix=click.style(issue.level.name, bold=True, fg=ISSUE_COLOR_MAP[issue.level])
+        )
+
+    @staticmethod
+    def format_summary(result: SemanticManifestValidationResults) -> str:
+        """Returns a stylized summary string for issues."""
+        errors = click.style(
+            text=f"{ValidationIssueLevel.ERROR.name_plural}: {len(result.errors)}",
+            fg=ISSUE_COLOR_MAP[ValidationIssueLevel.ERROR],
+        )
+        future_errors = click.style(
+            text=f"{ValidationIssueLevel.FUTURE_ERROR.name_plural}: {len(result.future_errors)}",
+            fg=ISSUE_COLOR_MAP[ValidationIssueLevel.FUTURE_ERROR],
+        )
+        warnings = click.style(
+            text=f"{ValidationIssueLevel.WARNING.name_plural}: {len(result.warnings)}",
+            fg=ISSUE_COLOR_MAP[ValidationIssueLevel.WARNING],
+        )
+        return f"{errors}, {future_errors}, {warnings}"

--- a/metricflow_semantic_interfaces/validations/validator_helpers.py
+++ b/metricflow_semantic_interfaces/validations/validator_helpers.py
@@ -18,7 +18,6 @@ from typing import (
     Union,
 )
 
-import click
 from typing_extensions import ParamSpec
 
 from metricflow_semantic_interfaces.implementations.base import FrozenBaseModel
@@ -212,12 +211,6 @@ class ValidationIssue(ABC, BaseModel):
 
         return issue_str
 
-    def as_cli_formatted_str(self, verbose: bool = False) -> str:
-        """Returns a color-coded readable string for rendering issues in the CLI."""
-        return self.as_readable_str(
-            verbose=verbose, prefix=click.style(self.level.name, bold=True, fg=ISSUE_COLOR_MAP[self.level])
-        )
-
     @property
     @abstractmethod
     def as_issue_set(self) -> ValidationIssueSet:  # noqa: D102
@@ -347,22 +340,6 @@ class SemanticManifestValidationResults(FrozenBaseModel):
     def all_issues(self) -> Tuple[ValidationIssue, ...]:
         """For when a singular list of issues is needed."""
         return self.errors + self.future_errors + self.warnings
-
-    def summary(self) -> str:
-        """Returns a stylized summary string for issues."""
-        errors = click.style(
-            text=f"{ValidationIssueLevel.ERROR.name_plural}: {len(self.errors)}",
-            fg=ISSUE_COLOR_MAP[ValidationIssueLevel.ERROR],
-        )
-        future_errors = click.style(
-            text=f"{ValidationIssueLevel.FUTURE_ERROR.name_plural}: {len(self.future_errors)}",
-            fg=ISSUE_COLOR_MAP[ValidationIssueLevel.FUTURE_ERROR],
-        )
-        warnings = click.style(
-            text=f"{ValidationIssueLevel.WARNING.name_plural}: {len(self.warnings)}",
-            fg=ISSUE_COLOR_MAP[ValidationIssueLevel.WARNING],
-        )
-        return f"{errors}, {future_errors}, {warnings}"
 
 
 def generate_exception_issue(

--- a/requirements-files/dev-env-requirements.txt
+++ b/requirements-files/dev-env-requirements.txt
@@ -6,6 +6,7 @@ duckdb-engine>=0.13.0, <0.14.0
 # https://github.com/duckdb/duckdb/issues/16617
 # Version 1.4.0 seems to have issues as well, so pinning to <1.4.0 until those are resolved.
 duckdb !=1.2.1, <1.4.0
+graphviz>=0.18.2, <0.21
 tomli >=2.3.0, <3
 varname >=0.15.1, < 1
 # Developer tools

--- a/requirements-files/requirements.txt
+++ b/requirements-files/requirements.txt
@@ -1,13 +1,11 @@
-click>=8.0, <9.0
 importlib_metadata>=4.0
-Jinja2>=3.1.6, <3.7.0
+Jinja2>=3.1.6, <3.7
 jsonschema>=4.17, <5.0
-graphviz>=0.18.2, <0.21
-PyYAML>=6.0, <7.0.0
-more-itertools>=10.0.0, <11.0.0
+more-itertools>=10.0.0, <11.0
 referencing>=0.28
 pydantic>=1.10.0, <3.0
-python-dateutil>=2.9.0, <2.10.0
+python-dateutil>=2.9.0, <2.10
+PyYAML>=6.0, <7.0
 rapidfuzz>=3.0, <4.0
 tabulate>=0.8.9
 typing_extensions>=4.4, <5.0


### PR DESCRIPTION
This PR removes a few unused dependencies from `metricflow` and also shifts some test-related dpendencies. 