### PR TITLE
Fix bug with filters applied before aggregation in time-offset metrics

### DIFF
--- a/.changes/unreleased/Fixes-20260404-094212.yaml
+++ b/.changes/unreleased/Fixes-20260404-094212.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix bug with filters applied before aggregation in time-offset metrics
+time: 2026-04-04T09:42:12.113467-07:00
+custom:
+  Author: plypaul
+  Issue: "2016"

--- a/metricflow/dataflow/builder/dataflow_plan_builder.py
+++ b/metricflow/dataflow/builder/dataflow_plan_builder.py
@@ -1415,6 +1415,20 @@ class DataflowPlanBuilder:
         if child_metric_offset_window is not None or child_metric_offset_to_grain is not None:
             time_spine_filters = tuple(filters_with_only_agg_time_dimension_references)
 
+            # Since filters referencing only aggregation time dimensions are applied to the time spine,
+            # those don't need to be added pre-aggregation since the filtered time-spine + inner join
+            # effectively applies the filters.
+            pre_aggregation_filter_specs = tuple(
+                itertools.chain(
+                    metric_filter_split.filters_without_agg_time_dimension_references,
+                    additional_filter_split.filters_without_agg_time_dimension_references,
+                    # It is incorrect to apply filters referencing both aggregation time dimensions and non-aggregation
+                    # time dimensions. However, this reproduces existing behavior until a fix can be made.
+                    metric_filter_split.filters_with_mixed_references,
+                    additional_filter_split.filters_with_mixed_references,
+                )
+            )
+
             if child_metric_offset_window is not None:
                 offset_grain_name = child_metric_offset_window.granularity
                 if ExpandedTimeGranularity.is_standard_granularity_name(offset_grain_name):
@@ -1796,6 +1810,7 @@ class DataflowPlanBuilder:
         time_spine_node = self._build_time_spine_node(
             queried_time_spine_specs=required_time_spine_specs,
             custom_offset_window=join_description.custom_offset_window,
+            where_filter_specs=join_description.time_spine_filter_specs,
             join_on_time_dimension_spec=join_on_time_dimension_spec,
             use_offset_custom_granularity_node=use_offset_custom_granularity_node,
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,10 +99,6 @@ run = "run-coverage --no-cov"
 features = ["dev-env-requirements"]
 
 
-[tool.hatch.envs.dev-env.env-vars]
-MF_SQL_ENGINE_URL="duckdb://"
-
-
 [tool.hatch.envs.postgres-env.env-vars]
 MF_SQL_ENGINE_URL="postgresql://metricflow@localhost:5432/metricflow"
 MF_SQL_ENGINE_PASSWORD="metricflowing"

--- a/tests_metricflow/fixtures/setup_fixtures.py
+++ b/tests_metricflow/fixtures/setup_fixtures.py
@@ -26,8 +26,22 @@ from tests_metricflow_semantics.fixtures.setup_fixtures import mf_add_slow_marke
 logger = logging.getLogger(__name__)
 
 
+# `pytest` CLI options
 DISPLAY_GRAPHS_CLI_FLAG = "--display-graphs"
 USE_PERSISTENT_SOURCE_SCHEMA_CLI_FLAG = "--use-persistent-source-schema"
+
+# Name of the pytest marker for tests that generate SQL-engine specific snapshots.
+SQL_ENGINE_SNAPSHOT_MARKER_NAME = "sql_engine_snapshot"
+# Name of the pytest marker to indicate that the test should only be run when the test session is configured to use
+# DuckDB as the SQL engine.
+DUCKDB_ONLY_MARKER_NAME = "duckdb_only"
+
+# Environment variables to configure the SQL engine used for tests.
+SQL_ENGINE_URL_ENVIRONMENT_VARIABLE_NAME = "MF_SQL_ENGINE_URL"
+SQL_ENGINE_PASSWORD_ENVIRONMENT_VARIABLE_NAME = "MF_SQL_ENGINE_PASSWORD"
+
+# Default URL to use DuckDB.
+SQL_ENGINE_DEFAULT_URL = "duckdb://"
 
 
 def add_display_graphs_cli_flag(parser: _pytest.config.argparsing.Parser) -> None:  # noqa: D103
@@ -53,13 +67,6 @@ def pytest_addoption(parser: _pytest.config.argparsing.Parser) -> None:
     add_display_snapshots_cli_flag(parser)
     add_display_graphs_cli_flag(parser)
     add_use_persistent_source_schema_cli_flag(parser)
-
-
-# Name of the pytest marker for tests that generate SQL-engine specific snapshots.
-SQL_ENGINE_SNAPSHOT_MARKER_NAME = "sql_engine_snapshot"
-# Name of the pytest marker to indicate that the test should only be run when the test session is configured to use
-# DuckDB as the SQL engine.
-DUCKDB_ONLY_MARKER_NAME = "duckdb_only"
 
 
 def pytest_configure(config: _pytest.config.Config) -> None:
@@ -101,11 +108,18 @@ def mf_test_configuration(  # noqa: D103
     request: FixtureRequest,
     source_table_snapshot_repository: SqlTableSnapshotRepository,
 ) -> MetricFlowTestConfiguration:
-    engine_url = os.environ.get("MF_SQL_ENGINE_URL")
-    assert engine_url is not None, (
-        "MF_SQL_ENGINE_URL environment variable has not been set! Are you running in a properly configured "
-        "environment? Check out our CONTRIBUTING.md for pointers to our environment configurations."
-    )
+    engine_url = os.environ.get(SQL_ENGINE_URL_ENVIRONMENT_VARIABLE_NAME)
+
+    if engine_url is None:
+        logger.info(
+            LazyFormat(
+                "The SQL engine URL environment variable is not set, so using the default.",
+                SQL_ENGINE_URL_ENVIRONMENT_VARIABLE_NAME=SQL_ENGINE_URL_ENVIRONMENT_VARIABLE_NAME,
+                SQL_ENGINE_DEFAULT_URL=SQL_ENGINE_DEFAULT_URL,
+            )
+        )
+        engine_url = SQL_ENGINE_DEFAULT_URL
+
     engine_password = os.environ.get("MF_SQL_ENGINE_PASSWORD", "")
 
     current_time = datetime.datetime.now().strftime("%Y_%m_%d")

--- a/tests_metricflow/query_rendering/test_offset_metrics_with_filters.py
+++ b/tests_metricflow/query_rendering/test_offset_metrics_with_filters.py
@@ -128,6 +128,43 @@ def test_offset_metric_with_metric_time_and_dimension_filter(  # noqa: D103
 
 @pytest.mark.sql_engine_snapshot
 @pytest.mark.duckdb_only
+def test_offset_metric_with_separate_metric_time_and_dimension_filters(  # noqa: D103
+    request: FixtureRequest,
+    mf_test_configuration: MetricFlowTestConfiguration,
+    query_parser: MetricFlowQueryParser,
+    dataflow_plan_builder: DataflowPlanBuilder,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
+    sql_client: SqlClient,
+    create_source_tables: bool,
+) -> None:
+    """Test querying a time-offset metric with separate filters that allow for different filter placement."""
+    query_spec = query_parser.parse_and_validate_query(
+        metric_names=("bookings_offset_once",),
+        group_by_names=(METRIC_TIME_ELEMENT_NAME,),
+        where_constraint_strs=[
+            "{{ TimeDimension('metric_time', 'day') }} = '2020-01-01'",
+            "{{ Dimension('listing__country_latest') }} == 'us'",
+        ],
+    ).query_spec
+
+    render_and_check(
+        request=request,
+        mf_test_configuration=mf_test_configuration,
+        dataflow_to_sql_converter=dataflow_to_sql_converter,
+        sql_client=sql_client,
+        dataflow_plan_builder=dataflow_plan_builder,
+        query_spec=query_spec,
+        expectation_description=(
+            "The metric_time portion of the filter (`{{ TimeDimension('metric_time', 'day') }} = '2020-01-01'`) "
+            "should be applied on the time spine / output side of the offset join, ideally by pushing it to the "
+            "time spine before the join, while the dimension portion "
+            "(`{{ Dimension('listing__country_latest') }} == 'us'`) should stay on the pre-offset metric input."
+        ),
+    )
+
+
+@pytest.mark.sql_engine_snapshot
+@pytest.mark.duckdb_only
 def test_offset_cumulative_metric_with_metric_time_filter(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/BigQuery/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/BigQuery/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
@@ -4,52 +4,52 @@ sql_engine: BigQuery
 ---
 -- Write to DataTable
 SELECT
-  subq_14.metric_time__day
-  , subq_14.bookings_5_day_lag
+  subq_13.metric_time__day
+  , subq_13.bookings_5_day_lag
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_13.metric_time__day
+    subq_12.metric_time__day
     , bookings_5_days_ago AS bookings_5_day_lag
   FROM (
     -- Compute Metrics via Expressions
     SELECT
-      subq_12.metric_time__day
-      , subq_12.__bookings AS bookings_5_days_ago
+      subq_11.metric_time__day
+      , subq_11.__bookings AS bookings_5_days_ago
     FROM (
       -- Join to Time Spine Dataset
       SELECT
-        subq_11.metric_time__day AS metric_time__day
-        , subq_6.__bookings AS __bookings
+        subq_10.metric_time__day AS metric_time__day
+        , subq_5.__bookings AS __bookings
       FROM (
         -- Select: ['metric_time__day']
         SELECT
-          subq_10.metric_time__day
+          subq_9.metric_time__day
         FROM (
           -- Constrain Output with WHERE
           SELECT
-            subq_9.metric_time__day
-            , subq_9.metric_time__alien_day
+            subq_8.metric_time__day
+            , subq_8.metric_time__alien_day
           FROM (
             -- Select: ['metric_time__day', 'metric_time__alien_day']
             SELECT
-              subq_8.metric_time__day
-              , subq_8.metric_time__alien_day
+              subq_7.metric_time__day
+              , subq_7.metric_time__alien_day
             FROM (
               -- Change Column Aliases
               SELECT
-                subq_7.ds__day AS metric_time__day
-                , subq_7.ds__week
-                , subq_7.ds__month
-                , subq_7.ds__quarter
-                , subq_7.ds__year
-                , subq_7.ds__extract_year
-                , subq_7.ds__extract_quarter
-                , subq_7.ds__extract_month
-                , subq_7.ds__extract_day
-                , subq_7.ds__extract_dow
-                , subq_7.ds__extract_doy
-                , subq_7.ds__alien_day AS metric_time__alien_day
+                subq_6.ds__day AS metric_time__day
+                , subq_6.ds__week
+                , subq_6.ds__month
+                , subq_6.ds__quarter
+                , subq_6.ds__year
+                , subq_6.ds__extract_year
+                , subq_6.ds__extract_quarter
+                , subq_6.ds__extract_month
+                , subq_6.ds__extract_day
+                , subq_6.ds__extract_dow
+                , subq_6.ds__extract_doy
+                , subq_6.ds__alien_day AS metric_time__alien_day
               FROM (
                 -- Read From Time Spine 'mf_time_spine'
                 SELECT
@@ -66,262 +66,253 @@ FROM (
                   , EXTRACT(dayofyear FROM time_spine_src_28006.ds) AS ds__extract_doy
                   , time_spine_src_28006.alien_day AS ds__alien_day
                 FROM ***************************.mf_time_spine time_spine_src_28006
-              ) subq_7
-            ) subq_8
-          ) subq_9
+              ) subq_6
+            ) subq_7
+          ) subq_8
           WHERE metric_time__alien_day = '2020-01-01'
-        ) subq_10
-      ) subq_11
+        ) subq_9
+      ) subq_10
       INNER JOIN (
         -- Aggregate Inputs for Simple Metrics
         SELECT
-          subq_5.metric_time__day
-          , SUM(subq_5.__bookings) AS __bookings
+          subq_4.metric_time__day
+          , SUM(subq_4.__bookings) AS __bookings
         FROM (
           -- Select: ['__bookings', 'metric_time__day']
           SELECT
-            subq_4.metric_time__day
-            , subq_4.__bookings
+            subq_3.metric_time__day
+            , subq_3.__bookings
           FROM (
-            -- Constrain Output with WHERE
+            -- Select: ['__bookings', 'metric_time__day']
             SELECT
-              subq_3.bookings AS __bookings
-              , subq_3.metric_time__alien_day
-              , subq_3.metric_time__day
+              subq_2.metric_time__day
+              , subq_2.__bookings
             FROM (
-              -- Select: ['__bookings', 'metric_time__day', 'metric_time__alien_day']
+              -- Metric Time Dimension 'ds'
+              -- Join to Custom Granularity Dataset
               SELECT
-                subq_2.metric_time__alien_day
-                , subq_2.metric_time__day
-                , subq_2.__bookings AS bookings
+                subq_0.ds__day AS ds__day
+                , subq_0.ds__week AS ds__week
+                , subq_0.ds__month AS ds__month
+                , subq_0.ds__quarter AS ds__quarter
+                , subq_0.ds__year AS ds__year
+                , subq_0.ds__extract_year AS ds__extract_year
+                , subq_0.ds__extract_quarter AS ds__extract_quarter
+                , subq_0.ds__extract_month AS ds__extract_month
+                , subq_0.ds__extract_day AS ds__extract_day
+                , subq_0.ds__extract_dow AS ds__extract_dow
+                , subq_0.ds__extract_doy AS ds__extract_doy
+                , subq_0.ds_partitioned__day AS ds_partitioned__day
+                , subq_0.ds_partitioned__week AS ds_partitioned__week
+                , subq_0.ds_partitioned__month AS ds_partitioned__month
+                , subq_0.ds_partitioned__quarter AS ds_partitioned__quarter
+                , subq_0.ds_partitioned__year AS ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year AS ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month AS ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day AS ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+                , subq_0.paid_at__day AS paid_at__day
+                , subq_0.paid_at__week AS paid_at__week
+                , subq_0.paid_at__month AS paid_at__month
+                , subq_0.paid_at__quarter AS paid_at__quarter
+                , subq_0.paid_at__year AS paid_at__year
+                , subq_0.paid_at__extract_year AS paid_at__extract_year
+                , subq_0.paid_at__extract_quarter AS paid_at__extract_quarter
+                , subq_0.paid_at__extract_month AS paid_at__extract_month
+                , subq_0.paid_at__extract_day AS paid_at__extract_day
+                , subq_0.paid_at__extract_dow AS paid_at__extract_dow
+                , subq_0.paid_at__extract_doy AS paid_at__extract_doy
+                , subq_0.booking__ds__day AS booking__ds__day
+                , subq_0.booking__ds__week AS booking__ds__week
+                , subq_0.booking__ds__month AS booking__ds__month
+                , subq_0.booking__ds__quarter AS booking__ds__quarter
+                , subq_0.booking__ds__year AS booking__ds__year
+                , subq_0.booking__ds__extract_year AS booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter AS booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month AS booking__ds__extract_month
+                , subq_0.booking__ds__extract_day AS booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow AS booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy AS booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day AS booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week AS booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month AS booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year AS booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day AS booking__paid_at__day
+                , subq_0.booking__paid_at__week AS booking__paid_at__week
+                , subq_0.booking__paid_at__month AS booking__paid_at__month
+                , subq_0.booking__paid_at__quarter AS booking__paid_at__quarter
+                , subq_0.booking__paid_at__year AS booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year AS booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month AS booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day AS booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing AS listing
+                , subq_0.guest AS guest
+                , subq_0.host AS host
+                , subq_0.booking__listing AS booking__listing
+                , subq_0.booking__guest AS booking__guest
+                , subq_0.booking__host AS booking__host
+                , subq_0.is_instant AS is_instant
+                , subq_0.booking__is_instant AS booking__is_instant
+                , subq_0.__bookings AS __bookings
+                , subq_0.__average_booking_value AS __average_booking_value
+                , subq_0.__instant_bookings AS __instant_bookings
+                , subq_0.__booking_value AS __booking_value
+                , subq_0.__max_booking_value AS __max_booking_value
+                , subq_0.__min_booking_value AS __min_booking_value
+                , subq_0.__instant_booking_value AS __instant_booking_value
+                , subq_0.__average_instant_booking_value AS __average_instant_booking_value
+                , subq_0.__booking_value_for_non_null_listing_id AS __booking_value_for_non_null_listing_id
+                , subq_0.__bookers AS __bookers
+                , subq_0.__referred_bookings AS __referred_bookings
+                , subq_0.__median_booking_value AS __median_booking_value
+                , subq_0.__booking_value_p99 AS __booking_value_p99
+                , subq_0.__discrete_booking_value_p99 AS __discrete_booking_value_p99
+                , subq_0.__approximate_continuous_booking_value_p99 AS __approximate_continuous_booking_value_p99
+                , subq_0.__approximate_discrete_booking_value_p99 AS __approximate_discrete_booking_value_p99
+                , subq_0.__bookings_join_to_time_spine AS __bookings_join_to_time_spine
+                , subq_0.__bookings_fill_nulls_with_0_without_time_spine AS __bookings_fill_nulls_with_0_without_time_spine
+                , subq_0.__bookings_fill_nulls_with_0 AS __bookings_fill_nulls_with_0
+                , subq_0.__instant_bookings_with_measure_filter AS __instant_bookings_with_measure_filter
+                , subq_0.__bookings_join_to_time_spine_with_tiered_filters AS __bookings_join_to_time_spine_with_tiered_filters
+                , subq_0.__bookers_fill_nulls_with_0_join_to_timespine AS __bookers_fill_nulls_with_0_join_to_timespine
+                , subq_1.alien_day AS metric_time__alien_day
               FROM (
-                -- Metric Time Dimension 'ds'
-                -- Join to Custom Granularity Dataset
+                -- Read Elements From Semantic Model 'bookings_source'
                 SELECT
-                  subq_0.ds__day AS ds__day
-                  , subq_0.ds__week AS ds__week
-                  , subq_0.ds__month AS ds__month
-                  , subq_0.ds__quarter AS ds__quarter
-                  , subq_0.ds__year AS ds__year
-                  , subq_0.ds__extract_year AS ds__extract_year
-                  , subq_0.ds__extract_quarter AS ds__extract_quarter
-                  , subq_0.ds__extract_month AS ds__extract_month
-                  , subq_0.ds__extract_day AS ds__extract_day
-                  , subq_0.ds__extract_dow AS ds__extract_dow
-                  , subq_0.ds__extract_doy AS ds__extract_doy
-                  , subq_0.ds_partitioned__day AS ds_partitioned__day
-                  , subq_0.ds_partitioned__week AS ds_partitioned__week
-                  , subq_0.ds_partitioned__month AS ds_partitioned__month
-                  , subq_0.ds_partitioned__quarter AS ds_partitioned__quarter
-                  , subq_0.ds_partitioned__year AS ds_partitioned__year
-                  , subq_0.ds_partitioned__extract_year AS ds_partitioned__extract_year
-                  , subq_0.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
-                  , subq_0.ds_partitioned__extract_month AS ds_partitioned__extract_month
-                  , subq_0.ds_partitioned__extract_day AS ds_partitioned__extract_day
-                  , subq_0.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
-                  , subq_0.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
-                  , subq_0.paid_at__day AS paid_at__day
-                  , subq_0.paid_at__week AS paid_at__week
-                  , subq_0.paid_at__month AS paid_at__month
-                  , subq_0.paid_at__quarter AS paid_at__quarter
-                  , subq_0.paid_at__year AS paid_at__year
-                  , subq_0.paid_at__extract_year AS paid_at__extract_year
-                  , subq_0.paid_at__extract_quarter AS paid_at__extract_quarter
-                  , subq_0.paid_at__extract_month AS paid_at__extract_month
-                  , subq_0.paid_at__extract_day AS paid_at__extract_day
-                  , subq_0.paid_at__extract_dow AS paid_at__extract_dow
-                  , subq_0.paid_at__extract_doy AS paid_at__extract_doy
-                  , subq_0.booking__ds__day AS booking__ds__day
-                  , subq_0.booking__ds__week AS booking__ds__week
-                  , subq_0.booking__ds__month AS booking__ds__month
-                  , subq_0.booking__ds__quarter AS booking__ds__quarter
-                  , subq_0.booking__ds__year AS booking__ds__year
-                  , subq_0.booking__ds__extract_year AS booking__ds__extract_year
-                  , subq_0.booking__ds__extract_quarter AS booking__ds__extract_quarter
-                  , subq_0.booking__ds__extract_month AS booking__ds__extract_month
-                  , subq_0.booking__ds__extract_day AS booking__ds__extract_day
-                  , subq_0.booking__ds__extract_dow AS booking__ds__extract_dow
-                  , subq_0.booking__ds__extract_doy AS booking__ds__extract_doy
-                  , subq_0.booking__ds_partitioned__day AS booking__ds_partitioned__day
-                  , subq_0.booking__ds_partitioned__week AS booking__ds_partitioned__week
-                  , subq_0.booking__ds_partitioned__month AS booking__ds_partitioned__month
-                  , subq_0.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
-                  , subq_0.booking__ds_partitioned__year AS booking__ds_partitioned__year
-                  , subq_0.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
-                  , subq_0.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
-                  , subq_0.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
-                  , subq_0.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
-                  , subq_0.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
-                  , subq_0.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
-                  , subq_0.booking__paid_at__day AS booking__paid_at__day
-                  , subq_0.booking__paid_at__week AS booking__paid_at__week
-                  , subq_0.booking__paid_at__month AS booking__paid_at__month
-                  , subq_0.booking__paid_at__quarter AS booking__paid_at__quarter
-                  , subq_0.booking__paid_at__year AS booking__paid_at__year
-                  , subq_0.booking__paid_at__extract_year AS booking__paid_at__extract_year
-                  , subq_0.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
-                  , subq_0.booking__paid_at__extract_month AS booking__paid_at__extract_month
-                  , subq_0.booking__paid_at__extract_day AS booking__paid_at__extract_day
-                  , subq_0.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
-                  , subq_0.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
-                  , subq_0.ds__day AS metric_time__day
-                  , subq_0.ds__week AS metric_time__week
-                  , subq_0.ds__month AS metric_time__month
-                  , subq_0.ds__quarter AS metric_time__quarter
-                  , subq_0.ds__year AS metric_time__year
-                  , subq_0.ds__extract_year AS metric_time__extract_year
-                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_0.ds__extract_month AS metric_time__extract_month
-                  , subq_0.ds__extract_day AS metric_time__extract_day
-                  , subq_0.ds__extract_dow AS metric_time__extract_dow
-                  , subq_0.ds__extract_doy AS metric_time__extract_doy
-                  , subq_0.listing AS listing
-                  , subq_0.guest AS guest
-                  , subq_0.host AS host
-                  , subq_0.booking__listing AS booking__listing
-                  , subq_0.booking__guest AS booking__guest
-                  , subq_0.booking__host AS booking__host
-                  , subq_0.is_instant AS is_instant
-                  , subq_0.booking__is_instant AS booking__is_instant
-                  , subq_0.__bookings AS __bookings
-                  , subq_0.__average_booking_value AS __average_booking_value
-                  , subq_0.__instant_bookings AS __instant_bookings
-                  , subq_0.__booking_value AS __booking_value
-                  , subq_0.__max_booking_value AS __max_booking_value
-                  , subq_0.__min_booking_value AS __min_booking_value
-                  , subq_0.__instant_booking_value AS __instant_booking_value
-                  , subq_0.__average_instant_booking_value AS __average_instant_booking_value
-                  , subq_0.__booking_value_for_non_null_listing_id AS __booking_value_for_non_null_listing_id
-                  , subq_0.__bookers AS __bookers
-                  , subq_0.__referred_bookings AS __referred_bookings
-                  , subq_0.__median_booking_value AS __median_booking_value
-                  , subq_0.__booking_value_p99 AS __booking_value_p99
-                  , subq_0.__discrete_booking_value_p99 AS __discrete_booking_value_p99
-                  , subq_0.__approximate_continuous_booking_value_p99 AS __approximate_continuous_booking_value_p99
-                  , subq_0.__approximate_discrete_booking_value_p99 AS __approximate_discrete_booking_value_p99
-                  , subq_0.__bookings_join_to_time_spine AS __bookings_join_to_time_spine
-                  , subq_0.__bookings_fill_nulls_with_0_without_time_spine AS __bookings_fill_nulls_with_0_without_time_spine
-                  , subq_0.__bookings_fill_nulls_with_0 AS __bookings_fill_nulls_with_0
-                  , subq_0.__instant_bookings_with_measure_filter AS __instant_bookings_with_measure_filter
-                  , subq_0.__bookings_join_to_time_spine_with_tiered_filters AS __bookings_join_to_time_spine_with_tiered_filters
-                  , subq_0.__bookers_fill_nulls_with_0_join_to_timespine AS __bookers_fill_nulls_with_0_join_to_timespine
-                  , subq_1.alien_day AS metric_time__alien_day
-                FROM (
-                  -- Read Elements From Semantic Model 'bookings_source'
-                  SELECT
-                    1 AS __bookings
-                    , bookings_source_src_28000.booking_value AS __average_booking_value
-                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS __instant_bookings
-                    , bookings_source_src_28000.booking_value AS __booking_value
-                    , bookings_source_src_28000.booking_value AS __max_booking_value
-                    , bookings_source_src_28000.booking_value AS __min_booking_value
-                    , bookings_source_src_28000.booking_value AS __instant_booking_value
-                    , bookings_source_src_28000.booking_value AS __average_instant_booking_value
-                    , bookings_source_src_28000.booking_value AS __booking_value_for_non_null_listing_id
-                    , bookings_source_src_28000.guest_id AS __bookers
-                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS __referred_bookings
-                    , bookings_source_src_28000.booking_value AS __median_booking_value
-                    , bookings_source_src_28000.booking_value AS __booking_value_p99
-                    , bookings_source_src_28000.booking_value AS __discrete_booking_value_p99
-                    , bookings_source_src_28000.booking_value AS __approximate_continuous_booking_value_p99
-                    , bookings_source_src_28000.booking_value AS __approximate_discrete_booking_value_p99
-                    , 1 AS __bookings_join_to_time_spine
-                    , 1 AS __bookings_fill_nulls_with_0_without_time_spine
-                    , 1 AS __bookings_fill_nulls_with_0
-                    , 1 AS __instant_bookings_with_measure_filter
-                    , 1 AS __bookings_join_to_time_spine_with_tiered_filters
-                    , bookings_source_src_28000.guest_id AS __bookers_fill_nulls_with_0_join_to_timespine
-                    , bookings_source_src_28000.booking_value AS __booking_payments
-                    , bookings_source_src_28000.is_instant
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds, day) AS ds__day
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds, isoweek) AS ds__week
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds, month) AS ds__month
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds, quarter) AS ds__quarter
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds, year) AS ds__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                    , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS ds__extract_dow
-                    , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS ds_partitioned__day
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS ds_partitioned__week
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS ds_partitioned__month
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS ds_partitioned__quarter
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS ds_partitioned__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                    , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS ds_partitioned__extract_dow
-                    , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, day) AS paid_at__day
-                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS paid_at__week
-                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, month) AS paid_at__month
-                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, quarter) AS paid_at__quarter
-                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, year) AS paid_at__year
-                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                    , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS paid_at__extract_dow
-                    , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                    , bookings_source_src_28000.is_instant AS booking__is_instant
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds, day) AS booking__ds__day
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds, isoweek) AS booking__ds__week
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds, month) AS booking__ds__month
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds, quarter) AS booking__ds__quarter
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds, year) AS booking__ds__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                    , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS booking__ds__extract_dow
-                    , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS booking__ds_partitioned__day
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS booking__ds_partitioned__week
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS booking__ds_partitioned__month
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS booking__ds_partitioned__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                    , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS booking__ds_partitioned__extract_dow
-                    , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, day) AS booking__paid_at__day
-                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS booking__paid_at__week
-                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, month) AS booking__paid_at__month
-                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, quarter) AS booking__paid_at__quarter
-                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, year) AS booking__paid_at__year
-                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                    , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS booking__paid_at__extract_dow
-                    , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                    , bookings_source_src_28000.listing_id AS listing
-                    , bookings_source_src_28000.guest_id AS guest
-                    , bookings_source_src_28000.host_id AS host
-                    , bookings_source_src_28000.listing_id AS booking__listing
-                    , bookings_source_src_28000.guest_id AS booking__guest
-                    , bookings_source_src_28000.host_id AS booking__host
-                  FROM ***************************.fct_bookings bookings_source_src_28000
-                ) subq_0
-                LEFT OUTER JOIN
-                  ***************************.mf_time_spine subq_1
-                ON
-                  subq_0.ds__day = subq_1.ds
-              ) subq_2
-            ) subq_3
-            WHERE metric_time__alien_day = '2020-01-01'
-          ) subq_4
-        ) subq_5
+                  1 AS __bookings
+                  , bookings_source_src_28000.booking_value AS __average_booking_value
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS __instant_bookings
+                  , bookings_source_src_28000.booking_value AS __booking_value
+                  , bookings_source_src_28000.booking_value AS __max_booking_value
+                  , bookings_source_src_28000.booking_value AS __min_booking_value
+                  , bookings_source_src_28000.booking_value AS __instant_booking_value
+                  , bookings_source_src_28000.booking_value AS __average_instant_booking_value
+                  , bookings_source_src_28000.booking_value AS __booking_value_for_non_null_listing_id
+                  , bookings_source_src_28000.guest_id AS __bookers
+                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS __referred_bookings
+                  , bookings_source_src_28000.booking_value AS __median_booking_value
+                  , bookings_source_src_28000.booking_value AS __booking_value_p99
+                  , bookings_source_src_28000.booking_value AS __discrete_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS __approximate_continuous_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS __approximate_discrete_booking_value_p99
+                  , 1 AS __bookings_join_to_time_spine
+                  , 1 AS __bookings_fill_nulls_with_0_without_time_spine
+                  , 1 AS __bookings_fill_nulls_with_0
+                  , 1 AS __instant_bookings_with_measure_filter
+                  , 1 AS __bookings_join_to_time_spine_with_tiered_filters
+                  , bookings_source_src_28000.guest_id AS __bookers_fill_nulls_with_0_join_to_timespine
+                  , bookings_source_src_28000.booking_value AS __booking_payments
+                  , bookings_source_src_28000.is_instant
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds, day) AS ds__day
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds, isoweek) AS ds__week
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds, month) AS ds__month
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds, quarter) AS ds__quarter
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds, year) AS ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                  , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS ds__extract_dow
+                  , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS ds_partitioned__day
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS ds_partitioned__week
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS ds_partitioned__month
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS ds_partitioned__quarter
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                  , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS ds_partitioned__extract_dow
+                  , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, day) AS paid_at__day
+                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS paid_at__week
+                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, month) AS paid_at__month
+                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, quarter) AS paid_at__quarter
+                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, year) AS paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                  , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS paid_at__extract_dow
+                  , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                  , bookings_source_src_28000.is_instant AS booking__is_instant
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds, day) AS booking__ds__day
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds, isoweek) AS booking__ds__week
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds, month) AS booking__ds__month
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds, quarter) AS booking__ds__quarter
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds, year) AS booking__ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                  , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS booking__ds__extract_dow
+                  , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS booking__ds_partitioned__day
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS booking__ds_partitioned__week
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS booking__ds_partitioned__month
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS booking__ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                  , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS booking__ds_partitioned__extract_dow
+                  , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, day) AS booking__paid_at__day
+                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS booking__paid_at__week
+                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, month) AS booking__paid_at__month
+                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, quarter) AS booking__paid_at__quarter
+                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, year) AS booking__paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                  , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS booking__paid_at__extract_dow
+                  , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                  , bookings_source_src_28000.listing_id AS listing
+                  , bookings_source_src_28000.guest_id AS guest
+                  , bookings_source_src_28000.host_id AS host
+                  , bookings_source_src_28000.listing_id AS booking__listing
+                  , bookings_source_src_28000.guest_id AS booking__guest
+                  , bookings_source_src_28000.host_id AS booking__host
+                FROM ***************************.fct_bookings bookings_source_src_28000
+              ) subq_0
+              LEFT OUTER JOIN
+                ***************************.mf_time_spine subq_1
+              ON
+                subq_0.ds__day = subq_1.ds
+            ) subq_2
+          ) subq_3
+        ) subq_4
         GROUP BY
           metric_time__day
-      ) subq_6
+      ) subq_5
       ON
-        DATE_SUB(CAST(subq_11.metric_time__day AS DATETIME), INTERVAL 5 day) = subq_6.metric_time__day
-    ) subq_12
-  ) subq_13
-) subq_14
+        DATE_SUB(CAST(subq_10.metric_time__day AS DATETIME), INTERVAL 5 day) = subq_5.metric_time__day
+    ) subq_11
+  ) subq_12
+) subq_13

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/BigQuery/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/BigQuery/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0_optimized.sql
@@ -11,8 +11,8 @@ FROM (
   -- Join to Time Spine Dataset
   -- Compute Metrics via Expressions
   SELECT
-    subq_26.metric_time__day AS metric_time__day
-    , subq_21.__bookings AS bookings_5_days_ago
+    subq_24.metric_time__day AS metric_time__day
+    , subq_19.__bookings AS bookings_5_days_ago
   FROM (
     -- Constrain Output with WHERE
     -- Select: ['metric_time__day']
@@ -26,40 +26,32 @@ FROM (
         ds AS metric_time__day
         , alien_day AS metric_time__alien_day
       FROM ***************************.mf_time_spine time_spine_src_28006
-    ) subq_24
+    ) subq_22
     WHERE metric_time__alien_day = '2020-01-01'
-  ) subq_26
+  ) subq_24
   INNER JOIN (
-    -- Constrain Output with WHERE
+    -- Metric Time Dimension 'ds'
+    -- Join to Custom Granularity Dataset
+    -- Select: ['__bookings', 'metric_time__day']
     -- Select: ['__bookings', 'metric_time__day']
     -- Aggregate Inputs for Simple Metrics
     SELECT
-      metric_time__day
-      , SUM(bookings) AS __bookings
+      subq_14.ds__day AS metric_time__day
+      , SUM(subq_14.__bookings) AS __bookings
     FROM (
-      -- Metric Time Dimension 'ds'
-      -- Join to Custom Granularity Dataset
-      -- Select: ['__bookings', 'metric_time__day', 'metric_time__alien_day']
+      -- Read Elements From Semantic Model 'bookings_source'
       SELECT
-        subq_16.alien_day AS metric_time__alien_day
-        , subq_15.ds__day AS metric_time__day
-        , subq_15.__bookings AS bookings
-      FROM (
-        -- Read Elements From Semantic Model 'bookings_source'
-        SELECT
-          1 AS __bookings
-          , DATETIME_TRUNC(ds, day) AS ds__day
-        FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_15
-      LEFT OUTER JOIN
-        ***************************.mf_time_spine subq_16
-      ON
-        subq_15.ds__day = subq_16.ds
-    ) subq_18
-    WHERE metric_time__alien_day = '2020-01-01'
+        1 AS __bookings
+        , DATETIME_TRUNC(ds, day) AS ds__day
+      FROM ***************************.fct_bookings bookings_source_src_28000
+    ) subq_14
+    LEFT OUTER JOIN
+      ***************************.mf_time_spine subq_15
+    ON
+      subq_14.ds__day = subq_15.ds
     GROUP BY
       metric_time__day
-  ) subq_21
+  ) subq_19
   ON
-    DATE_SUB(CAST(subq_26.metric_time__day AS DATETIME), INTERVAL 5 day) = subq_21.metric_time__day
-) subq_28
+    DATE_SUB(CAST(subq_24.metric_time__day AS DATETIME), INTERVAL 5 day) = subq_19.metric_time__day
+) subq_26

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Databricks/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Databricks/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
@@ -4,52 +4,52 @@ sql_engine: Databricks
 ---
 -- Write to DataTable
 SELECT
-  subq_14.metric_time__day
-  , subq_14.bookings_5_day_lag
+  subq_13.metric_time__day
+  , subq_13.bookings_5_day_lag
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_13.metric_time__day
+    subq_12.metric_time__day
     , bookings_5_days_ago AS bookings_5_day_lag
   FROM (
     -- Compute Metrics via Expressions
     SELECT
-      subq_12.metric_time__day
-      , subq_12.__bookings AS bookings_5_days_ago
+      subq_11.metric_time__day
+      , subq_11.__bookings AS bookings_5_days_ago
     FROM (
       -- Join to Time Spine Dataset
       SELECT
-        subq_11.metric_time__day AS metric_time__day
-        , subq_6.__bookings AS __bookings
+        subq_10.metric_time__day AS metric_time__day
+        , subq_5.__bookings AS __bookings
       FROM (
         -- Select: ['metric_time__day']
         SELECT
-          subq_10.metric_time__day
+          subq_9.metric_time__day
         FROM (
           -- Constrain Output with WHERE
           SELECT
-            subq_9.metric_time__day
-            , subq_9.metric_time__alien_day
+            subq_8.metric_time__day
+            , subq_8.metric_time__alien_day
           FROM (
             -- Select: ['metric_time__day', 'metric_time__alien_day']
             SELECT
-              subq_8.metric_time__day
-              , subq_8.metric_time__alien_day
+              subq_7.metric_time__day
+              , subq_7.metric_time__alien_day
             FROM (
               -- Change Column Aliases
               SELECT
-                subq_7.ds__day AS metric_time__day
-                , subq_7.ds__week
-                , subq_7.ds__month
-                , subq_7.ds__quarter
-                , subq_7.ds__year
-                , subq_7.ds__extract_year
-                , subq_7.ds__extract_quarter
-                , subq_7.ds__extract_month
-                , subq_7.ds__extract_day
-                , subq_7.ds__extract_dow
-                , subq_7.ds__extract_doy
-                , subq_7.ds__alien_day AS metric_time__alien_day
+                subq_6.ds__day AS metric_time__day
+                , subq_6.ds__week
+                , subq_6.ds__month
+                , subq_6.ds__quarter
+                , subq_6.ds__year
+                , subq_6.ds__extract_year
+                , subq_6.ds__extract_quarter
+                , subq_6.ds__extract_month
+                , subq_6.ds__extract_day
+                , subq_6.ds__extract_dow
+                , subq_6.ds__extract_doy
+                , subq_6.ds__alien_day AS metric_time__alien_day
               FROM (
                 -- Read From Time Spine 'mf_time_spine'
                 SELECT
@@ -66,262 +66,253 @@ FROM (
                   , EXTRACT(doy FROM time_spine_src_28006.ds) AS ds__extract_doy
                   , time_spine_src_28006.alien_day AS ds__alien_day
                 FROM ***************************.mf_time_spine time_spine_src_28006
-              ) subq_7
-            ) subq_8
-          ) subq_9
+              ) subq_6
+            ) subq_7
+          ) subq_8
           WHERE metric_time__alien_day = '2020-01-01'
-        ) subq_10
-      ) subq_11
+        ) subq_9
+      ) subq_10
       INNER JOIN (
         -- Aggregate Inputs for Simple Metrics
         SELECT
-          subq_5.metric_time__day
-          , SUM(subq_5.__bookings) AS __bookings
+          subq_4.metric_time__day
+          , SUM(subq_4.__bookings) AS __bookings
         FROM (
           -- Select: ['__bookings', 'metric_time__day']
           SELECT
-            subq_4.metric_time__day
-            , subq_4.__bookings
+            subq_3.metric_time__day
+            , subq_3.__bookings
           FROM (
-            -- Constrain Output with WHERE
+            -- Select: ['__bookings', 'metric_time__day']
             SELECT
-              subq_3.bookings AS __bookings
-              , subq_3.metric_time__alien_day
-              , subq_3.metric_time__day
+              subq_2.metric_time__day
+              , subq_2.__bookings
             FROM (
-              -- Select: ['__bookings', 'metric_time__day', 'metric_time__alien_day']
+              -- Metric Time Dimension 'ds'
+              -- Join to Custom Granularity Dataset
               SELECT
-                subq_2.metric_time__alien_day
-                , subq_2.metric_time__day
-                , subq_2.__bookings AS bookings
+                subq_0.ds__day AS ds__day
+                , subq_0.ds__week AS ds__week
+                , subq_0.ds__month AS ds__month
+                , subq_0.ds__quarter AS ds__quarter
+                , subq_0.ds__year AS ds__year
+                , subq_0.ds__extract_year AS ds__extract_year
+                , subq_0.ds__extract_quarter AS ds__extract_quarter
+                , subq_0.ds__extract_month AS ds__extract_month
+                , subq_0.ds__extract_day AS ds__extract_day
+                , subq_0.ds__extract_dow AS ds__extract_dow
+                , subq_0.ds__extract_doy AS ds__extract_doy
+                , subq_0.ds_partitioned__day AS ds_partitioned__day
+                , subq_0.ds_partitioned__week AS ds_partitioned__week
+                , subq_0.ds_partitioned__month AS ds_partitioned__month
+                , subq_0.ds_partitioned__quarter AS ds_partitioned__quarter
+                , subq_0.ds_partitioned__year AS ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year AS ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month AS ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day AS ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+                , subq_0.paid_at__day AS paid_at__day
+                , subq_0.paid_at__week AS paid_at__week
+                , subq_0.paid_at__month AS paid_at__month
+                , subq_0.paid_at__quarter AS paid_at__quarter
+                , subq_0.paid_at__year AS paid_at__year
+                , subq_0.paid_at__extract_year AS paid_at__extract_year
+                , subq_0.paid_at__extract_quarter AS paid_at__extract_quarter
+                , subq_0.paid_at__extract_month AS paid_at__extract_month
+                , subq_0.paid_at__extract_day AS paid_at__extract_day
+                , subq_0.paid_at__extract_dow AS paid_at__extract_dow
+                , subq_0.paid_at__extract_doy AS paid_at__extract_doy
+                , subq_0.booking__ds__day AS booking__ds__day
+                , subq_0.booking__ds__week AS booking__ds__week
+                , subq_0.booking__ds__month AS booking__ds__month
+                , subq_0.booking__ds__quarter AS booking__ds__quarter
+                , subq_0.booking__ds__year AS booking__ds__year
+                , subq_0.booking__ds__extract_year AS booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter AS booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month AS booking__ds__extract_month
+                , subq_0.booking__ds__extract_day AS booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow AS booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy AS booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day AS booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week AS booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month AS booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year AS booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day AS booking__paid_at__day
+                , subq_0.booking__paid_at__week AS booking__paid_at__week
+                , subq_0.booking__paid_at__month AS booking__paid_at__month
+                , subq_0.booking__paid_at__quarter AS booking__paid_at__quarter
+                , subq_0.booking__paid_at__year AS booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year AS booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month AS booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day AS booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing AS listing
+                , subq_0.guest AS guest
+                , subq_0.host AS host
+                , subq_0.booking__listing AS booking__listing
+                , subq_0.booking__guest AS booking__guest
+                , subq_0.booking__host AS booking__host
+                , subq_0.is_instant AS is_instant
+                , subq_0.booking__is_instant AS booking__is_instant
+                , subq_0.__bookings AS __bookings
+                , subq_0.__average_booking_value AS __average_booking_value
+                , subq_0.__instant_bookings AS __instant_bookings
+                , subq_0.__booking_value AS __booking_value
+                , subq_0.__max_booking_value AS __max_booking_value
+                , subq_0.__min_booking_value AS __min_booking_value
+                , subq_0.__instant_booking_value AS __instant_booking_value
+                , subq_0.__average_instant_booking_value AS __average_instant_booking_value
+                , subq_0.__booking_value_for_non_null_listing_id AS __booking_value_for_non_null_listing_id
+                , subq_0.__bookers AS __bookers
+                , subq_0.__referred_bookings AS __referred_bookings
+                , subq_0.__median_booking_value AS __median_booking_value
+                , subq_0.__booking_value_p99 AS __booking_value_p99
+                , subq_0.__discrete_booking_value_p99 AS __discrete_booking_value_p99
+                , subq_0.__approximate_continuous_booking_value_p99 AS __approximate_continuous_booking_value_p99
+                , subq_0.__approximate_discrete_booking_value_p99 AS __approximate_discrete_booking_value_p99
+                , subq_0.__bookings_join_to_time_spine AS __bookings_join_to_time_spine
+                , subq_0.__bookings_fill_nulls_with_0_without_time_spine AS __bookings_fill_nulls_with_0_without_time_spine
+                , subq_0.__bookings_fill_nulls_with_0 AS __bookings_fill_nulls_with_0
+                , subq_0.__instant_bookings_with_measure_filter AS __instant_bookings_with_measure_filter
+                , subq_0.__bookings_join_to_time_spine_with_tiered_filters AS __bookings_join_to_time_spine_with_tiered_filters
+                , subq_0.__bookers_fill_nulls_with_0_join_to_timespine AS __bookers_fill_nulls_with_0_join_to_timespine
+                , subq_1.alien_day AS metric_time__alien_day
               FROM (
-                -- Metric Time Dimension 'ds'
-                -- Join to Custom Granularity Dataset
+                -- Read Elements From Semantic Model 'bookings_source'
                 SELECT
-                  subq_0.ds__day AS ds__day
-                  , subq_0.ds__week AS ds__week
-                  , subq_0.ds__month AS ds__month
-                  , subq_0.ds__quarter AS ds__quarter
-                  , subq_0.ds__year AS ds__year
-                  , subq_0.ds__extract_year AS ds__extract_year
-                  , subq_0.ds__extract_quarter AS ds__extract_quarter
-                  , subq_0.ds__extract_month AS ds__extract_month
-                  , subq_0.ds__extract_day AS ds__extract_day
-                  , subq_0.ds__extract_dow AS ds__extract_dow
-                  , subq_0.ds__extract_doy AS ds__extract_doy
-                  , subq_0.ds_partitioned__day AS ds_partitioned__day
-                  , subq_0.ds_partitioned__week AS ds_partitioned__week
-                  , subq_0.ds_partitioned__month AS ds_partitioned__month
-                  , subq_0.ds_partitioned__quarter AS ds_partitioned__quarter
-                  , subq_0.ds_partitioned__year AS ds_partitioned__year
-                  , subq_0.ds_partitioned__extract_year AS ds_partitioned__extract_year
-                  , subq_0.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
-                  , subq_0.ds_partitioned__extract_month AS ds_partitioned__extract_month
-                  , subq_0.ds_partitioned__extract_day AS ds_partitioned__extract_day
-                  , subq_0.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
-                  , subq_0.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
-                  , subq_0.paid_at__day AS paid_at__day
-                  , subq_0.paid_at__week AS paid_at__week
-                  , subq_0.paid_at__month AS paid_at__month
-                  , subq_0.paid_at__quarter AS paid_at__quarter
-                  , subq_0.paid_at__year AS paid_at__year
-                  , subq_0.paid_at__extract_year AS paid_at__extract_year
-                  , subq_0.paid_at__extract_quarter AS paid_at__extract_quarter
-                  , subq_0.paid_at__extract_month AS paid_at__extract_month
-                  , subq_0.paid_at__extract_day AS paid_at__extract_day
-                  , subq_0.paid_at__extract_dow AS paid_at__extract_dow
-                  , subq_0.paid_at__extract_doy AS paid_at__extract_doy
-                  , subq_0.booking__ds__day AS booking__ds__day
-                  , subq_0.booking__ds__week AS booking__ds__week
-                  , subq_0.booking__ds__month AS booking__ds__month
-                  , subq_0.booking__ds__quarter AS booking__ds__quarter
-                  , subq_0.booking__ds__year AS booking__ds__year
-                  , subq_0.booking__ds__extract_year AS booking__ds__extract_year
-                  , subq_0.booking__ds__extract_quarter AS booking__ds__extract_quarter
-                  , subq_0.booking__ds__extract_month AS booking__ds__extract_month
-                  , subq_0.booking__ds__extract_day AS booking__ds__extract_day
-                  , subq_0.booking__ds__extract_dow AS booking__ds__extract_dow
-                  , subq_0.booking__ds__extract_doy AS booking__ds__extract_doy
-                  , subq_0.booking__ds_partitioned__day AS booking__ds_partitioned__day
-                  , subq_0.booking__ds_partitioned__week AS booking__ds_partitioned__week
-                  , subq_0.booking__ds_partitioned__month AS booking__ds_partitioned__month
-                  , subq_0.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
-                  , subq_0.booking__ds_partitioned__year AS booking__ds_partitioned__year
-                  , subq_0.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
-                  , subq_0.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
-                  , subq_0.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
-                  , subq_0.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
-                  , subq_0.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
-                  , subq_0.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
-                  , subq_0.booking__paid_at__day AS booking__paid_at__day
-                  , subq_0.booking__paid_at__week AS booking__paid_at__week
-                  , subq_0.booking__paid_at__month AS booking__paid_at__month
-                  , subq_0.booking__paid_at__quarter AS booking__paid_at__quarter
-                  , subq_0.booking__paid_at__year AS booking__paid_at__year
-                  , subq_0.booking__paid_at__extract_year AS booking__paid_at__extract_year
-                  , subq_0.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
-                  , subq_0.booking__paid_at__extract_month AS booking__paid_at__extract_month
-                  , subq_0.booking__paid_at__extract_day AS booking__paid_at__extract_day
-                  , subq_0.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
-                  , subq_0.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
-                  , subq_0.ds__day AS metric_time__day
-                  , subq_0.ds__week AS metric_time__week
-                  , subq_0.ds__month AS metric_time__month
-                  , subq_0.ds__quarter AS metric_time__quarter
-                  , subq_0.ds__year AS metric_time__year
-                  , subq_0.ds__extract_year AS metric_time__extract_year
-                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_0.ds__extract_month AS metric_time__extract_month
-                  , subq_0.ds__extract_day AS metric_time__extract_day
-                  , subq_0.ds__extract_dow AS metric_time__extract_dow
-                  , subq_0.ds__extract_doy AS metric_time__extract_doy
-                  , subq_0.listing AS listing
-                  , subq_0.guest AS guest
-                  , subq_0.host AS host
-                  , subq_0.booking__listing AS booking__listing
-                  , subq_0.booking__guest AS booking__guest
-                  , subq_0.booking__host AS booking__host
-                  , subq_0.is_instant AS is_instant
-                  , subq_0.booking__is_instant AS booking__is_instant
-                  , subq_0.__bookings AS __bookings
-                  , subq_0.__average_booking_value AS __average_booking_value
-                  , subq_0.__instant_bookings AS __instant_bookings
-                  , subq_0.__booking_value AS __booking_value
-                  , subq_0.__max_booking_value AS __max_booking_value
-                  , subq_0.__min_booking_value AS __min_booking_value
-                  , subq_0.__instant_booking_value AS __instant_booking_value
-                  , subq_0.__average_instant_booking_value AS __average_instant_booking_value
-                  , subq_0.__booking_value_for_non_null_listing_id AS __booking_value_for_non_null_listing_id
-                  , subq_0.__bookers AS __bookers
-                  , subq_0.__referred_bookings AS __referred_bookings
-                  , subq_0.__median_booking_value AS __median_booking_value
-                  , subq_0.__booking_value_p99 AS __booking_value_p99
-                  , subq_0.__discrete_booking_value_p99 AS __discrete_booking_value_p99
-                  , subq_0.__approximate_continuous_booking_value_p99 AS __approximate_continuous_booking_value_p99
-                  , subq_0.__approximate_discrete_booking_value_p99 AS __approximate_discrete_booking_value_p99
-                  , subq_0.__bookings_join_to_time_spine AS __bookings_join_to_time_spine
-                  , subq_0.__bookings_fill_nulls_with_0_without_time_spine AS __bookings_fill_nulls_with_0_without_time_spine
-                  , subq_0.__bookings_fill_nulls_with_0 AS __bookings_fill_nulls_with_0
-                  , subq_0.__instant_bookings_with_measure_filter AS __instant_bookings_with_measure_filter
-                  , subq_0.__bookings_join_to_time_spine_with_tiered_filters AS __bookings_join_to_time_spine_with_tiered_filters
-                  , subq_0.__bookers_fill_nulls_with_0_join_to_timespine AS __bookers_fill_nulls_with_0_join_to_timespine
-                  , subq_1.alien_day AS metric_time__alien_day
-                FROM (
-                  -- Read Elements From Semantic Model 'bookings_source'
-                  SELECT
-                    1 AS __bookings
-                    , bookings_source_src_28000.booking_value AS __average_booking_value
-                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS __instant_bookings
-                    , bookings_source_src_28000.booking_value AS __booking_value
-                    , bookings_source_src_28000.booking_value AS __max_booking_value
-                    , bookings_source_src_28000.booking_value AS __min_booking_value
-                    , bookings_source_src_28000.booking_value AS __instant_booking_value
-                    , bookings_source_src_28000.booking_value AS __average_instant_booking_value
-                    , bookings_source_src_28000.booking_value AS __booking_value_for_non_null_listing_id
-                    , bookings_source_src_28000.guest_id AS __bookers
-                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS __referred_bookings
-                    , bookings_source_src_28000.booking_value AS __median_booking_value
-                    , bookings_source_src_28000.booking_value AS __booking_value_p99
-                    , bookings_source_src_28000.booking_value AS __discrete_booking_value_p99
-                    , bookings_source_src_28000.booking_value AS __approximate_continuous_booking_value_p99
-                    , bookings_source_src_28000.booking_value AS __approximate_discrete_booking_value_p99
-                    , 1 AS __bookings_join_to_time_spine
-                    , 1 AS __bookings_fill_nulls_with_0_without_time_spine
-                    , 1 AS __bookings_fill_nulls_with_0
-                    , 1 AS __instant_bookings_with_measure_filter
-                    , 1 AS __bookings_join_to_time_spine_with_tiered_filters
-                    , bookings_source_src_28000.guest_id AS __bookers_fill_nulls_with_0_join_to_timespine
-                    , bookings_source_src_28000.booking_value AS __booking_payments
-                    , bookings_source_src_28000.is_instant
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                    , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS ds__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                    , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                    , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                    , bookings_source_src_28000.is_instant AS booking__is_instant
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                    , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                    , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                    , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                    , bookings_source_src_28000.listing_id AS listing
-                    , bookings_source_src_28000.guest_id AS guest
-                    , bookings_source_src_28000.host_id AS host
-                    , bookings_source_src_28000.listing_id AS booking__listing
-                    , bookings_source_src_28000.guest_id AS booking__guest
-                    , bookings_source_src_28000.host_id AS booking__host
-                  FROM ***************************.fct_bookings bookings_source_src_28000
-                ) subq_0
-                LEFT OUTER JOIN
-                  ***************************.mf_time_spine subq_1
-                ON
-                  subq_0.ds__day = subq_1.ds
-              ) subq_2
-            ) subq_3
-            WHERE metric_time__alien_day = '2020-01-01'
-          ) subq_4
-        ) subq_5
+                  1 AS __bookings
+                  , bookings_source_src_28000.booking_value AS __average_booking_value
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS __instant_bookings
+                  , bookings_source_src_28000.booking_value AS __booking_value
+                  , bookings_source_src_28000.booking_value AS __max_booking_value
+                  , bookings_source_src_28000.booking_value AS __min_booking_value
+                  , bookings_source_src_28000.booking_value AS __instant_booking_value
+                  , bookings_source_src_28000.booking_value AS __average_instant_booking_value
+                  , bookings_source_src_28000.booking_value AS __booking_value_for_non_null_listing_id
+                  , bookings_source_src_28000.guest_id AS __bookers
+                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS __referred_bookings
+                  , bookings_source_src_28000.booking_value AS __median_booking_value
+                  , bookings_source_src_28000.booking_value AS __booking_value_p99
+                  , bookings_source_src_28000.booking_value AS __discrete_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS __approximate_continuous_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS __approximate_discrete_booking_value_p99
+                  , 1 AS __bookings_join_to_time_spine
+                  , 1 AS __bookings_fill_nulls_with_0_without_time_spine
+                  , 1 AS __bookings_fill_nulls_with_0
+                  , 1 AS __instant_bookings_with_measure_filter
+                  , 1 AS __bookings_join_to_time_spine_with_tiered_filters
+                  , bookings_source_src_28000.guest_id AS __bookers_fill_nulls_with_0_join_to_timespine
+                  , bookings_source_src_28000.booking_value AS __booking_payments
+                  , bookings_source_src_28000.is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                  , bookings_source_src_28000.is_instant AS booking__is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                  , bookings_source_src_28000.listing_id AS listing
+                  , bookings_source_src_28000.guest_id AS guest
+                  , bookings_source_src_28000.host_id AS host
+                  , bookings_source_src_28000.listing_id AS booking__listing
+                  , bookings_source_src_28000.guest_id AS booking__guest
+                  , bookings_source_src_28000.host_id AS booking__host
+                FROM ***************************.fct_bookings bookings_source_src_28000
+              ) subq_0
+              LEFT OUTER JOIN
+                ***************************.mf_time_spine subq_1
+              ON
+                subq_0.ds__day = subq_1.ds
+            ) subq_2
+          ) subq_3
+        ) subq_4
         GROUP BY
-          subq_5.metric_time__day
-      ) subq_6
+          subq_4.metric_time__day
+      ) subq_5
       ON
-        DATEADD(day, -5, subq_11.metric_time__day) = subq_6.metric_time__day
-    ) subq_12
-  ) subq_13
-) subq_14
+        DATEADD(day, -5, subq_10.metric_time__day) = subq_5.metric_time__day
+    ) subq_11
+  ) subq_12
+) subq_13

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Databricks/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Databricks/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0_optimized.sql
@@ -11,8 +11,8 @@ FROM (
   -- Join to Time Spine Dataset
   -- Compute Metrics via Expressions
   SELECT
-    subq_26.metric_time__day AS metric_time__day
-    , subq_21.__bookings AS bookings_5_days_ago
+    subq_24.metric_time__day AS metric_time__day
+    , subq_19.__bookings AS bookings_5_days_ago
   FROM (
     -- Constrain Output with WHERE
     -- Select: ['metric_time__day']
@@ -26,40 +26,32 @@ FROM (
         ds AS metric_time__day
         , alien_day AS metric_time__alien_day
       FROM ***************************.mf_time_spine time_spine_src_28006
-    ) subq_24
+    ) subq_22
     WHERE metric_time__alien_day = '2020-01-01'
-  ) subq_26
+  ) subq_24
   INNER JOIN (
-    -- Constrain Output with WHERE
+    -- Metric Time Dimension 'ds'
+    -- Join to Custom Granularity Dataset
+    -- Select: ['__bookings', 'metric_time__day']
     -- Select: ['__bookings', 'metric_time__day']
     -- Aggregate Inputs for Simple Metrics
     SELECT
-      metric_time__day
-      , SUM(bookings) AS __bookings
+      subq_14.ds__day AS metric_time__day
+      , SUM(subq_14.__bookings) AS __bookings
     FROM (
-      -- Metric Time Dimension 'ds'
-      -- Join to Custom Granularity Dataset
-      -- Select: ['__bookings', 'metric_time__day', 'metric_time__alien_day']
+      -- Read Elements From Semantic Model 'bookings_source'
       SELECT
-        subq_16.alien_day AS metric_time__alien_day
-        , subq_15.ds__day AS metric_time__day
-        , subq_15.__bookings AS bookings
-      FROM (
-        -- Read Elements From Semantic Model 'bookings_source'
-        SELECT
-          1 AS __bookings
-          , DATE_TRUNC('day', ds) AS ds__day
-        FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_15
-      LEFT OUTER JOIN
-        ***************************.mf_time_spine subq_16
-      ON
-        subq_15.ds__day = subq_16.ds
-    ) subq_18
-    WHERE metric_time__alien_day = '2020-01-01'
+        1 AS __bookings
+        , DATE_TRUNC('day', ds) AS ds__day
+      FROM ***************************.fct_bookings bookings_source_src_28000
+    ) subq_14
+    LEFT OUTER JOIN
+      ***************************.mf_time_spine subq_15
+    ON
+      subq_14.ds__day = subq_15.ds
     GROUP BY
-      metric_time__day
-  ) subq_21
+      subq_14.ds__day
+  ) subq_19
   ON
-    DATEADD(day, -5, subq_26.metric_time__day) = subq_21.metric_time__day
-) subq_28
+    DATEADD(day, -5, subq_24.metric_time__day) = subq_19.metric_time__day
+) subq_26

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/DuckDB/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/DuckDB/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
@@ -4,52 +4,52 @@ sql_engine: DuckDB
 ---
 -- Write to DataTable
 SELECT
-  subq_14.metric_time__day
-  , subq_14.bookings_5_day_lag
+  subq_13.metric_time__day
+  , subq_13.bookings_5_day_lag
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_13.metric_time__day
+    subq_12.metric_time__day
     , bookings_5_days_ago AS bookings_5_day_lag
   FROM (
     -- Compute Metrics via Expressions
     SELECT
-      subq_12.metric_time__day
-      , subq_12.__bookings AS bookings_5_days_ago
+      subq_11.metric_time__day
+      , subq_11.__bookings AS bookings_5_days_ago
     FROM (
       -- Join to Time Spine Dataset
       SELECT
-        subq_11.metric_time__day AS metric_time__day
-        , subq_6.__bookings AS __bookings
+        subq_10.metric_time__day AS metric_time__day
+        , subq_5.__bookings AS __bookings
       FROM (
         -- Select: ['metric_time__day']
         SELECT
-          subq_10.metric_time__day
+          subq_9.metric_time__day
         FROM (
           -- Constrain Output with WHERE
           SELECT
-            subq_9.metric_time__day
-            , subq_9.metric_time__alien_day
+            subq_8.metric_time__day
+            , subq_8.metric_time__alien_day
           FROM (
             -- Select: ['metric_time__day', 'metric_time__alien_day']
             SELECT
-              subq_8.metric_time__day
-              , subq_8.metric_time__alien_day
+              subq_7.metric_time__day
+              , subq_7.metric_time__alien_day
             FROM (
               -- Change Column Aliases
               SELECT
-                subq_7.ds__day AS metric_time__day
-                , subq_7.ds__week
-                , subq_7.ds__month
-                , subq_7.ds__quarter
-                , subq_7.ds__year
-                , subq_7.ds__extract_year
-                , subq_7.ds__extract_quarter
-                , subq_7.ds__extract_month
-                , subq_7.ds__extract_day
-                , subq_7.ds__extract_dow
-                , subq_7.ds__extract_doy
-                , subq_7.ds__alien_day AS metric_time__alien_day
+                subq_6.ds__day AS metric_time__day
+                , subq_6.ds__week
+                , subq_6.ds__month
+                , subq_6.ds__quarter
+                , subq_6.ds__year
+                , subq_6.ds__extract_year
+                , subq_6.ds__extract_quarter
+                , subq_6.ds__extract_month
+                , subq_6.ds__extract_day
+                , subq_6.ds__extract_dow
+                , subq_6.ds__extract_doy
+                , subq_6.ds__alien_day AS metric_time__alien_day
               FROM (
                 -- Read From Time Spine 'mf_time_spine'
                 SELECT
@@ -66,262 +66,253 @@ FROM (
                   , EXTRACT(doy FROM time_spine_src_28006.ds) AS ds__extract_doy
                   , time_spine_src_28006.alien_day AS ds__alien_day
                 FROM ***************************.mf_time_spine time_spine_src_28006
-              ) subq_7
-            ) subq_8
-          ) subq_9
+              ) subq_6
+            ) subq_7
+          ) subq_8
           WHERE metric_time__alien_day = '2020-01-01'
-        ) subq_10
-      ) subq_11
+        ) subq_9
+      ) subq_10
       INNER JOIN (
         -- Aggregate Inputs for Simple Metrics
         SELECT
-          subq_5.metric_time__day
-          , SUM(subq_5.__bookings) AS __bookings
+          subq_4.metric_time__day
+          , SUM(subq_4.__bookings) AS __bookings
         FROM (
           -- Select: ['__bookings', 'metric_time__day']
           SELECT
-            subq_4.metric_time__day
-            , subq_4.__bookings
+            subq_3.metric_time__day
+            , subq_3.__bookings
           FROM (
-            -- Constrain Output with WHERE
+            -- Select: ['__bookings', 'metric_time__day']
             SELECT
-              subq_3.bookings AS __bookings
-              , subq_3.metric_time__alien_day
-              , subq_3.metric_time__day
+              subq_2.metric_time__day
+              , subq_2.__bookings
             FROM (
-              -- Select: ['__bookings', 'metric_time__day', 'metric_time__alien_day']
+              -- Metric Time Dimension 'ds'
+              -- Join to Custom Granularity Dataset
               SELECT
-                subq_2.metric_time__alien_day
-                , subq_2.metric_time__day
-                , subq_2.__bookings AS bookings
+                subq_0.ds__day AS ds__day
+                , subq_0.ds__week AS ds__week
+                , subq_0.ds__month AS ds__month
+                , subq_0.ds__quarter AS ds__quarter
+                , subq_0.ds__year AS ds__year
+                , subq_0.ds__extract_year AS ds__extract_year
+                , subq_0.ds__extract_quarter AS ds__extract_quarter
+                , subq_0.ds__extract_month AS ds__extract_month
+                , subq_0.ds__extract_day AS ds__extract_day
+                , subq_0.ds__extract_dow AS ds__extract_dow
+                , subq_0.ds__extract_doy AS ds__extract_doy
+                , subq_0.ds_partitioned__day AS ds_partitioned__day
+                , subq_0.ds_partitioned__week AS ds_partitioned__week
+                , subq_0.ds_partitioned__month AS ds_partitioned__month
+                , subq_0.ds_partitioned__quarter AS ds_partitioned__quarter
+                , subq_0.ds_partitioned__year AS ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year AS ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month AS ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day AS ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+                , subq_0.paid_at__day AS paid_at__day
+                , subq_0.paid_at__week AS paid_at__week
+                , subq_0.paid_at__month AS paid_at__month
+                , subq_0.paid_at__quarter AS paid_at__quarter
+                , subq_0.paid_at__year AS paid_at__year
+                , subq_0.paid_at__extract_year AS paid_at__extract_year
+                , subq_0.paid_at__extract_quarter AS paid_at__extract_quarter
+                , subq_0.paid_at__extract_month AS paid_at__extract_month
+                , subq_0.paid_at__extract_day AS paid_at__extract_day
+                , subq_0.paid_at__extract_dow AS paid_at__extract_dow
+                , subq_0.paid_at__extract_doy AS paid_at__extract_doy
+                , subq_0.booking__ds__day AS booking__ds__day
+                , subq_0.booking__ds__week AS booking__ds__week
+                , subq_0.booking__ds__month AS booking__ds__month
+                , subq_0.booking__ds__quarter AS booking__ds__quarter
+                , subq_0.booking__ds__year AS booking__ds__year
+                , subq_0.booking__ds__extract_year AS booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter AS booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month AS booking__ds__extract_month
+                , subq_0.booking__ds__extract_day AS booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow AS booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy AS booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day AS booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week AS booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month AS booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year AS booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day AS booking__paid_at__day
+                , subq_0.booking__paid_at__week AS booking__paid_at__week
+                , subq_0.booking__paid_at__month AS booking__paid_at__month
+                , subq_0.booking__paid_at__quarter AS booking__paid_at__quarter
+                , subq_0.booking__paid_at__year AS booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year AS booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month AS booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day AS booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing AS listing
+                , subq_0.guest AS guest
+                , subq_0.host AS host
+                , subq_0.booking__listing AS booking__listing
+                , subq_0.booking__guest AS booking__guest
+                , subq_0.booking__host AS booking__host
+                , subq_0.is_instant AS is_instant
+                , subq_0.booking__is_instant AS booking__is_instant
+                , subq_0.__bookings AS __bookings
+                , subq_0.__average_booking_value AS __average_booking_value
+                , subq_0.__instant_bookings AS __instant_bookings
+                , subq_0.__booking_value AS __booking_value
+                , subq_0.__max_booking_value AS __max_booking_value
+                , subq_0.__min_booking_value AS __min_booking_value
+                , subq_0.__instant_booking_value AS __instant_booking_value
+                , subq_0.__average_instant_booking_value AS __average_instant_booking_value
+                , subq_0.__booking_value_for_non_null_listing_id AS __booking_value_for_non_null_listing_id
+                , subq_0.__bookers AS __bookers
+                , subq_0.__referred_bookings AS __referred_bookings
+                , subq_0.__median_booking_value AS __median_booking_value
+                , subq_0.__booking_value_p99 AS __booking_value_p99
+                , subq_0.__discrete_booking_value_p99 AS __discrete_booking_value_p99
+                , subq_0.__approximate_continuous_booking_value_p99 AS __approximate_continuous_booking_value_p99
+                , subq_0.__approximate_discrete_booking_value_p99 AS __approximate_discrete_booking_value_p99
+                , subq_0.__bookings_join_to_time_spine AS __bookings_join_to_time_spine
+                , subq_0.__bookings_fill_nulls_with_0_without_time_spine AS __bookings_fill_nulls_with_0_without_time_spine
+                , subq_0.__bookings_fill_nulls_with_0 AS __bookings_fill_nulls_with_0
+                , subq_0.__instant_bookings_with_measure_filter AS __instant_bookings_with_measure_filter
+                , subq_0.__bookings_join_to_time_spine_with_tiered_filters AS __bookings_join_to_time_spine_with_tiered_filters
+                , subq_0.__bookers_fill_nulls_with_0_join_to_timespine AS __bookers_fill_nulls_with_0_join_to_timespine
+                , subq_1.alien_day AS metric_time__alien_day
               FROM (
-                -- Metric Time Dimension 'ds'
-                -- Join to Custom Granularity Dataset
+                -- Read Elements From Semantic Model 'bookings_source'
                 SELECT
-                  subq_0.ds__day AS ds__day
-                  , subq_0.ds__week AS ds__week
-                  , subq_0.ds__month AS ds__month
-                  , subq_0.ds__quarter AS ds__quarter
-                  , subq_0.ds__year AS ds__year
-                  , subq_0.ds__extract_year AS ds__extract_year
-                  , subq_0.ds__extract_quarter AS ds__extract_quarter
-                  , subq_0.ds__extract_month AS ds__extract_month
-                  , subq_0.ds__extract_day AS ds__extract_day
-                  , subq_0.ds__extract_dow AS ds__extract_dow
-                  , subq_0.ds__extract_doy AS ds__extract_doy
-                  , subq_0.ds_partitioned__day AS ds_partitioned__day
-                  , subq_0.ds_partitioned__week AS ds_partitioned__week
-                  , subq_0.ds_partitioned__month AS ds_partitioned__month
-                  , subq_0.ds_partitioned__quarter AS ds_partitioned__quarter
-                  , subq_0.ds_partitioned__year AS ds_partitioned__year
-                  , subq_0.ds_partitioned__extract_year AS ds_partitioned__extract_year
-                  , subq_0.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
-                  , subq_0.ds_partitioned__extract_month AS ds_partitioned__extract_month
-                  , subq_0.ds_partitioned__extract_day AS ds_partitioned__extract_day
-                  , subq_0.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
-                  , subq_0.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
-                  , subq_0.paid_at__day AS paid_at__day
-                  , subq_0.paid_at__week AS paid_at__week
-                  , subq_0.paid_at__month AS paid_at__month
-                  , subq_0.paid_at__quarter AS paid_at__quarter
-                  , subq_0.paid_at__year AS paid_at__year
-                  , subq_0.paid_at__extract_year AS paid_at__extract_year
-                  , subq_0.paid_at__extract_quarter AS paid_at__extract_quarter
-                  , subq_0.paid_at__extract_month AS paid_at__extract_month
-                  , subq_0.paid_at__extract_day AS paid_at__extract_day
-                  , subq_0.paid_at__extract_dow AS paid_at__extract_dow
-                  , subq_0.paid_at__extract_doy AS paid_at__extract_doy
-                  , subq_0.booking__ds__day AS booking__ds__day
-                  , subq_0.booking__ds__week AS booking__ds__week
-                  , subq_0.booking__ds__month AS booking__ds__month
-                  , subq_0.booking__ds__quarter AS booking__ds__quarter
-                  , subq_0.booking__ds__year AS booking__ds__year
-                  , subq_0.booking__ds__extract_year AS booking__ds__extract_year
-                  , subq_0.booking__ds__extract_quarter AS booking__ds__extract_quarter
-                  , subq_0.booking__ds__extract_month AS booking__ds__extract_month
-                  , subq_0.booking__ds__extract_day AS booking__ds__extract_day
-                  , subq_0.booking__ds__extract_dow AS booking__ds__extract_dow
-                  , subq_0.booking__ds__extract_doy AS booking__ds__extract_doy
-                  , subq_0.booking__ds_partitioned__day AS booking__ds_partitioned__day
-                  , subq_0.booking__ds_partitioned__week AS booking__ds_partitioned__week
-                  , subq_0.booking__ds_partitioned__month AS booking__ds_partitioned__month
-                  , subq_0.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
-                  , subq_0.booking__ds_partitioned__year AS booking__ds_partitioned__year
-                  , subq_0.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
-                  , subq_0.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
-                  , subq_0.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
-                  , subq_0.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
-                  , subq_0.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
-                  , subq_0.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
-                  , subq_0.booking__paid_at__day AS booking__paid_at__day
-                  , subq_0.booking__paid_at__week AS booking__paid_at__week
-                  , subq_0.booking__paid_at__month AS booking__paid_at__month
-                  , subq_0.booking__paid_at__quarter AS booking__paid_at__quarter
-                  , subq_0.booking__paid_at__year AS booking__paid_at__year
-                  , subq_0.booking__paid_at__extract_year AS booking__paid_at__extract_year
-                  , subq_0.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
-                  , subq_0.booking__paid_at__extract_month AS booking__paid_at__extract_month
-                  , subq_0.booking__paid_at__extract_day AS booking__paid_at__extract_day
-                  , subq_0.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
-                  , subq_0.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
-                  , subq_0.ds__day AS metric_time__day
-                  , subq_0.ds__week AS metric_time__week
-                  , subq_0.ds__month AS metric_time__month
-                  , subq_0.ds__quarter AS metric_time__quarter
-                  , subq_0.ds__year AS metric_time__year
-                  , subq_0.ds__extract_year AS metric_time__extract_year
-                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_0.ds__extract_month AS metric_time__extract_month
-                  , subq_0.ds__extract_day AS metric_time__extract_day
-                  , subq_0.ds__extract_dow AS metric_time__extract_dow
-                  , subq_0.ds__extract_doy AS metric_time__extract_doy
-                  , subq_0.listing AS listing
-                  , subq_0.guest AS guest
-                  , subq_0.host AS host
-                  , subq_0.booking__listing AS booking__listing
-                  , subq_0.booking__guest AS booking__guest
-                  , subq_0.booking__host AS booking__host
-                  , subq_0.is_instant AS is_instant
-                  , subq_0.booking__is_instant AS booking__is_instant
-                  , subq_0.__bookings AS __bookings
-                  , subq_0.__average_booking_value AS __average_booking_value
-                  , subq_0.__instant_bookings AS __instant_bookings
-                  , subq_0.__booking_value AS __booking_value
-                  , subq_0.__max_booking_value AS __max_booking_value
-                  , subq_0.__min_booking_value AS __min_booking_value
-                  , subq_0.__instant_booking_value AS __instant_booking_value
-                  , subq_0.__average_instant_booking_value AS __average_instant_booking_value
-                  , subq_0.__booking_value_for_non_null_listing_id AS __booking_value_for_non_null_listing_id
-                  , subq_0.__bookers AS __bookers
-                  , subq_0.__referred_bookings AS __referred_bookings
-                  , subq_0.__median_booking_value AS __median_booking_value
-                  , subq_0.__booking_value_p99 AS __booking_value_p99
-                  , subq_0.__discrete_booking_value_p99 AS __discrete_booking_value_p99
-                  , subq_0.__approximate_continuous_booking_value_p99 AS __approximate_continuous_booking_value_p99
-                  , subq_0.__approximate_discrete_booking_value_p99 AS __approximate_discrete_booking_value_p99
-                  , subq_0.__bookings_join_to_time_spine AS __bookings_join_to_time_spine
-                  , subq_0.__bookings_fill_nulls_with_0_without_time_spine AS __bookings_fill_nulls_with_0_without_time_spine
-                  , subq_0.__bookings_fill_nulls_with_0 AS __bookings_fill_nulls_with_0
-                  , subq_0.__instant_bookings_with_measure_filter AS __instant_bookings_with_measure_filter
-                  , subq_0.__bookings_join_to_time_spine_with_tiered_filters AS __bookings_join_to_time_spine_with_tiered_filters
-                  , subq_0.__bookers_fill_nulls_with_0_join_to_timespine AS __bookers_fill_nulls_with_0_join_to_timespine
-                  , subq_1.alien_day AS metric_time__alien_day
-                FROM (
-                  -- Read Elements From Semantic Model 'bookings_source'
-                  SELECT
-                    1 AS __bookings
-                    , bookings_source_src_28000.booking_value AS __average_booking_value
-                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS __instant_bookings
-                    , bookings_source_src_28000.booking_value AS __booking_value
-                    , bookings_source_src_28000.booking_value AS __max_booking_value
-                    , bookings_source_src_28000.booking_value AS __min_booking_value
-                    , bookings_source_src_28000.booking_value AS __instant_booking_value
-                    , bookings_source_src_28000.booking_value AS __average_instant_booking_value
-                    , bookings_source_src_28000.booking_value AS __booking_value_for_non_null_listing_id
-                    , bookings_source_src_28000.guest_id AS __bookers
-                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS __referred_bookings
-                    , bookings_source_src_28000.booking_value AS __median_booking_value
-                    , bookings_source_src_28000.booking_value AS __booking_value_p99
-                    , bookings_source_src_28000.booking_value AS __discrete_booking_value_p99
-                    , bookings_source_src_28000.booking_value AS __approximate_continuous_booking_value_p99
-                    , bookings_source_src_28000.booking_value AS __approximate_discrete_booking_value_p99
-                    , 1 AS __bookings_join_to_time_spine
-                    , 1 AS __bookings_fill_nulls_with_0_without_time_spine
-                    , 1 AS __bookings_fill_nulls_with_0
-                    , 1 AS __instant_bookings_with_measure_filter
-                    , 1 AS __bookings_join_to_time_spine_with_tiered_filters
-                    , bookings_source_src_28000.guest_id AS __bookers_fill_nulls_with_0_join_to_timespine
-                    , bookings_source_src_28000.booking_value AS __booking_payments
-                    , bookings_source_src_28000.is_instant
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                    , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                    , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                    , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                    , bookings_source_src_28000.is_instant AS booking__is_instant
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                    , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                    , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                    , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                    , bookings_source_src_28000.listing_id AS listing
-                    , bookings_source_src_28000.guest_id AS guest
-                    , bookings_source_src_28000.host_id AS host
-                    , bookings_source_src_28000.listing_id AS booking__listing
-                    , bookings_source_src_28000.guest_id AS booking__guest
-                    , bookings_source_src_28000.host_id AS booking__host
-                  FROM ***************************.fct_bookings bookings_source_src_28000
-                ) subq_0
-                LEFT OUTER JOIN
-                  ***************************.mf_time_spine subq_1
-                ON
-                  subq_0.ds__day = subq_1.ds
-              ) subq_2
-            ) subq_3
-            WHERE metric_time__alien_day = '2020-01-01'
-          ) subq_4
-        ) subq_5
+                  1 AS __bookings
+                  , bookings_source_src_28000.booking_value AS __average_booking_value
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS __instant_bookings
+                  , bookings_source_src_28000.booking_value AS __booking_value
+                  , bookings_source_src_28000.booking_value AS __max_booking_value
+                  , bookings_source_src_28000.booking_value AS __min_booking_value
+                  , bookings_source_src_28000.booking_value AS __instant_booking_value
+                  , bookings_source_src_28000.booking_value AS __average_instant_booking_value
+                  , bookings_source_src_28000.booking_value AS __booking_value_for_non_null_listing_id
+                  , bookings_source_src_28000.guest_id AS __bookers
+                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS __referred_bookings
+                  , bookings_source_src_28000.booking_value AS __median_booking_value
+                  , bookings_source_src_28000.booking_value AS __booking_value_p99
+                  , bookings_source_src_28000.booking_value AS __discrete_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS __approximate_continuous_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS __approximate_discrete_booking_value_p99
+                  , 1 AS __bookings_join_to_time_spine
+                  , 1 AS __bookings_fill_nulls_with_0_without_time_spine
+                  , 1 AS __bookings_fill_nulls_with_0
+                  , 1 AS __instant_bookings_with_measure_filter
+                  , 1 AS __bookings_join_to_time_spine_with_tiered_filters
+                  , bookings_source_src_28000.guest_id AS __bookers_fill_nulls_with_0_join_to_timespine
+                  , bookings_source_src_28000.booking_value AS __booking_payments
+                  , bookings_source_src_28000.is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                  , bookings_source_src_28000.is_instant AS booking__is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                  , bookings_source_src_28000.listing_id AS listing
+                  , bookings_source_src_28000.guest_id AS guest
+                  , bookings_source_src_28000.host_id AS host
+                  , bookings_source_src_28000.listing_id AS booking__listing
+                  , bookings_source_src_28000.guest_id AS booking__guest
+                  , bookings_source_src_28000.host_id AS booking__host
+                FROM ***************************.fct_bookings bookings_source_src_28000
+              ) subq_0
+              LEFT OUTER JOIN
+                ***************************.mf_time_spine subq_1
+              ON
+                subq_0.ds__day = subq_1.ds
+            ) subq_2
+          ) subq_3
+        ) subq_4
         GROUP BY
-          subq_5.metric_time__day
-      ) subq_6
+          subq_4.metric_time__day
+      ) subq_5
       ON
-        subq_11.metric_time__day - INTERVAL 5 day = subq_6.metric_time__day
-    ) subq_12
-  ) subq_13
-) subq_14
+        subq_10.metric_time__day - INTERVAL 5 day = subq_5.metric_time__day
+    ) subq_11
+  ) subq_12
+) subq_13

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/DuckDB/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/DuckDB/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0_optimized.sql
@@ -11,8 +11,8 @@ FROM (
   -- Join to Time Spine Dataset
   -- Compute Metrics via Expressions
   SELECT
-    subq_26.metric_time__day AS metric_time__day
-    , subq_21.__bookings AS bookings_5_days_ago
+    subq_24.metric_time__day AS metric_time__day
+    , subq_19.__bookings AS bookings_5_days_ago
   FROM (
     -- Constrain Output with WHERE
     -- Select: ['metric_time__day']
@@ -26,40 +26,32 @@ FROM (
         ds AS metric_time__day
         , alien_day AS metric_time__alien_day
       FROM ***************************.mf_time_spine time_spine_src_28006
-    ) subq_24
+    ) subq_22
     WHERE metric_time__alien_day = '2020-01-01'
-  ) subq_26
+  ) subq_24
   INNER JOIN (
-    -- Constrain Output with WHERE
+    -- Metric Time Dimension 'ds'
+    -- Join to Custom Granularity Dataset
+    -- Select: ['__bookings', 'metric_time__day']
     -- Select: ['__bookings', 'metric_time__day']
     -- Aggregate Inputs for Simple Metrics
     SELECT
-      metric_time__day
-      , SUM(bookings) AS __bookings
+      subq_14.ds__day AS metric_time__day
+      , SUM(subq_14.__bookings) AS __bookings
     FROM (
-      -- Metric Time Dimension 'ds'
-      -- Join to Custom Granularity Dataset
-      -- Select: ['__bookings', 'metric_time__day', 'metric_time__alien_day']
+      -- Read Elements From Semantic Model 'bookings_source'
       SELECT
-        subq_16.alien_day AS metric_time__alien_day
-        , subq_15.ds__day AS metric_time__day
-        , subq_15.__bookings AS bookings
-      FROM (
-        -- Read Elements From Semantic Model 'bookings_source'
-        SELECT
-          1 AS __bookings
-          , DATE_TRUNC('day', ds) AS ds__day
-        FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_15
-      LEFT OUTER JOIN
-        ***************************.mf_time_spine subq_16
-      ON
-        subq_15.ds__day = subq_16.ds
-    ) subq_18
-    WHERE metric_time__alien_day = '2020-01-01'
+        1 AS __bookings
+        , DATE_TRUNC('day', ds) AS ds__day
+      FROM ***************************.fct_bookings bookings_source_src_28000
+    ) subq_14
+    LEFT OUTER JOIN
+      ***************************.mf_time_spine subq_15
+    ON
+      subq_14.ds__day = subq_15.ds
     GROUP BY
-      metric_time__day
-  ) subq_21
+      subq_14.ds__day
+  ) subq_19
   ON
-    subq_26.metric_time__day - INTERVAL 5 day = subq_21.metric_time__day
-) subq_28
+    subq_24.metric_time__day - INTERVAL 5 day = subq_19.metric_time__day
+) subq_26

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Postgres/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Postgres/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
@@ -4,52 +4,52 @@ sql_engine: Postgres
 ---
 -- Write to DataTable
 SELECT
-  subq_14.metric_time__day
-  , subq_14.bookings_5_day_lag
+  subq_13.metric_time__day
+  , subq_13.bookings_5_day_lag
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_13.metric_time__day
+    subq_12.metric_time__day
     , bookings_5_days_ago AS bookings_5_day_lag
   FROM (
     -- Compute Metrics via Expressions
     SELECT
-      subq_12.metric_time__day
-      , subq_12.__bookings AS bookings_5_days_ago
+      subq_11.metric_time__day
+      , subq_11.__bookings AS bookings_5_days_ago
     FROM (
       -- Join to Time Spine Dataset
       SELECT
-        subq_11.metric_time__day AS metric_time__day
-        , subq_6.__bookings AS __bookings
+        subq_10.metric_time__day AS metric_time__day
+        , subq_5.__bookings AS __bookings
       FROM (
         -- Select: ['metric_time__day']
         SELECT
-          subq_10.metric_time__day
+          subq_9.metric_time__day
         FROM (
           -- Constrain Output with WHERE
           SELECT
-            subq_9.metric_time__day
-            , subq_9.metric_time__alien_day
+            subq_8.metric_time__day
+            , subq_8.metric_time__alien_day
           FROM (
             -- Select: ['metric_time__day', 'metric_time__alien_day']
             SELECT
-              subq_8.metric_time__day
-              , subq_8.metric_time__alien_day
+              subq_7.metric_time__day
+              , subq_7.metric_time__alien_day
             FROM (
               -- Change Column Aliases
               SELECT
-                subq_7.ds__day AS metric_time__day
-                , subq_7.ds__week
-                , subq_7.ds__month
-                , subq_7.ds__quarter
-                , subq_7.ds__year
-                , subq_7.ds__extract_year
-                , subq_7.ds__extract_quarter
-                , subq_7.ds__extract_month
-                , subq_7.ds__extract_day
-                , subq_7.ds__extract_dow
-                , subq_7.ds__extract_doy
-                , subq_7.ds__alien_day AS metric_time__alien_day
+                subq_6.ds__day AS metric_time__day
+                , subq_6.ds__week
+                , subq_6.ds__month
+                , subq_6.ds__quarter
+                , subq_6.ds__year
+                , subq_6.ds__extract_year
+                , subq_6.ds__extract_quarter
+                , subq_6.ds__extract_month
+                , subq_6.ds__extract_day
+                , subq_6.ds__extract_dow
+                , subq_6.ds__extract_doy
+                , subq_6.ds__alien_day AS metric_time__alien_day
               FROM (
                 -- Read From Time Spine 'mf_time_spine'
                 SELECT
@@ -66,262 +66,253 @@ FROM (
                   , EXTRACT(doy FROM time_spine_src_28006.ds) AS ds__extract_doy
                   , time_spine_src_28006.alien_day AS ds__alien_day
                 FROM ***************************.mf_time_spine time_spine_src_28006
-              ) subq_7
-            ) subq_8
-          ) subq_9
+              ) subq_6
+            ) subq_7
+          ) subq_8
           WHERE metric_time__alien_day = '2020-01-01'
-        ) subq_10
-      ) subq_11
+        ) subq_9
+      ) subq_10
       INNER JOIN (
         -- Aggregate Inputs for Simple Metrics
         SELECT
-          subq_5.metric_time__day
-          , SUM(subq_5.__bookings) AS __bookings
+          subq_4.metric_time__day
+          , SUM(subq_4.__bookings) AS __bookings
         FROM (
           -- Select: ['__bookings', 'metric_time__day']
           SELECT
-            subq_4.metric_time__day
-            , subq_4.__bookings
+            subq_3.metric_time__day
+            , subq_3.__bookings
           FROM (
-            -- Constrain Output with WHERE
+            -- Select: ['__bookings', 'metric_time__day']
             SELECT
-              subq_3.bookings AS __bookings
-              , subq_3.metric_time__alien_day
-              , subq_3.metric_time__day
+              subq_2.metric_time__day
+              , subq_2.__bookings
             FROM (
-              -- Select: ['__bookings', 'metric_time__day', 'metric_time__alien_day']
+              -- Metric Time Dimension 'ds'
+              -- Join to Custom Granularity Dataset
               SELECT
-                subq_2.metric_time__alien_day
-                , subq_2.metric_time__day
-                , subq_2.__bookings AS bookings
+                subq_0.ds__day AS ds__day
+                , subq_0.ds__week AS ds__week
+                , subq_0.ds__month AS ds__month
+                , subq_0.ds__quarter AS ds__quarter
+                , subq_0.ds__year AS ds__year
+                , subq_0.ds__extract_year AS ds__extract_year
+                , subq_0.ds__extract_quarter AS ds__extract_quarter
+                , subq_0.ds__extract_month AS ds__extract_month
+                , subq_0.ds__extract_day AS ds__extract_day
+                , subq_0.ds__extract_dow AS ds__extract_dow
+                , subq_0.ds__extract_doy AS ds__extract_doy
+                , subq_0.ds_partitioned__day AS ds_partitioned__day
+                , subq_0.ds_partitioned__week AS ds_partitioned__week
+                , subq_0.ds_partitioned__month AS ds_partitioned__month
+                , subq_0.ds_partitioned__quarter AS ds_partitioned__quarter
+                , subq_0.ds_partitioned__year AS ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year AS ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month AS ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day AS ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+                , subq_0.paid_at__day AS paid_at__day
+                , subq_0.paid_at__week AS paid_at__week
+                , subq_0.paid_at__month AS paid_at__month
+                , subq_0.paid_at__quarter AS paid_at__quarter
+                , subq_0.paid_at__year AS paid_at__year
+                , subq_0.paid_at__extract_year AS paid_at__extract_year
+                , subq_0.paid_at__extract_quarter AS paid_at__extract_quarter
+                , subq_0.paid_at__extract_month AS paid_at__extract_month
+                , subq_0.paid_at__extract_day AS paid_at__extract_day
+                , subq_0.paid_at__extract_dow AS paid_at__extract_dow
+                , subq_0.paid_at__extract_doy AS paid_at__extract_doy
+                , subq_0.booking__ds__day AS booking__ds__day
+                , subq_0.booking__ds__week AS booking__ds__week
+                , subq_0.booking__ds__month AS booking__ds__month
+                , subq_0.booking__ds__quarter AS booking__ds__quarter
+                , subq_0.booking__ds__year AS booking__ds__year
+                , subq_0.booking__ds__extract_year AS booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter AS booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month AS booking__ds__extract_month
+                , subq_0.booking__ds__extract_day AS booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow AS booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy AS booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day AS booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week AS booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month AS booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year AS booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day AS booking__paid_at__day
+                , subq_0.booking__paid_at__week AS booking__paid_at__week
+                , subq_0.booking__paid_at__month AS booking__paid_at__month
+                , subq_0.booking__paid_at__quarter AS booking__paid_at__quarter
+                , subq_0.booking__paid_at__year AS booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year AS booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month AS booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day AS booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing AS listing
+                , subq_0.guest AS guest
+                , subq_0.host AS host
+                , subq_0.booking__listing AS booking__listing
+                , subq_0.booking__guest AS booking__guest
+                , subq_0.booking__host AS booking__host
+                , subq_0.is_instant AS is_instant
+                , subq_0.booking__is_instant AS booking__is_instant
+                , subq_0.__bookings AS __bookings
+                , subq_0.__average_booking_value AS __average_booking_value
+                , subq_0.__instant_bookings AS __instant_bookings
+                , subq_0.__booking_value AS __booking_value
+                , subq_0.__max_booking_value AS __max_booking_value
+                , subq_0.__min_booking_value AS __min_booking_value
+                , subq_0.__instant_booking_value AS __instant_booking_value
+                , subq_0.__average_instant_booking_value AS __average_instant_booking_value
+                , subq_0.__booking_value_for_non_null_listing_id AS __booking_value_for_non_null_listing_id
+                , subq_0.__bookers AS __bookers
+                , subq_0.__referred_bookings AS __referred_bookings
+                , subq_0.__median_booking_value AS __median_booking_value
+                , subq_0.__booking_value_p99 AS __booking_value_p99
+                , subq_0.__discrete_booking_value_p99 AS __discrete_booking_value_p99
+                , subq_0.__approximate_continuous_booking_value_p99 AS __approximate_continuous_booking_value_p99
+                , subq_0.__approximate_discrete_booking_value_p99 AS __approximate_discrete_booking_value_p99
+                , subq_0.__bookings_join_to_time_spine AS __bookings_join_to_time_spine
+                , subq_0.__bookings_fill_nulls_with_0_without_time_spine AS __bookings_fill_nulls_with_0_without_time_spine
+                , subq_0.__bookings_fill_nulls_with_0 AS __bookings_fill_nulls_with_0
+                , subq_0.__instant_bookings_with_measure_filter AS __instant_bookings_with_measure_filter
+                , subq_0.__bookings_join_to_time_spine_with_tiered_filters AS __bookings_join_to_time_spine_with_tiered_filters
+                , subq_0.__bookers_fill_nulls_with_0_join_to_timespine AS __bookers_fill_nulls_with_0_join_to_timespine
+                , subq_1.alien_day AS metric_time__alien_day
               FROM (
-                -- Metric Time Dimension 'ds'
-                -- Join to Custom Granularity Dataset
+                -- Read Elements From Semantic Model 'bookings_source'
                 SELECT
-                  subq_0.ds__day AS ds__day
-                  , subq_0.ds__week AS ds__week
-                  , subq_0.ds__month AS ds__month
-                  , subq_0.ds__quarter AS ds__quarter
-                  , subq_0.ds__year AS ds__year
-                  , subq_0.ds__extract_year AS ds__extract_year
-                  , subq_0.ds__extract_quarter AS ds__extract_quarter
-                  , subq_0.ds__extract_month AS ds__extract_month
-                  , subq_0.ds__extract_day AS ds__extract_day
-                  , subq_0.ds__extract_dow AS ds__extract_dow
-                  , subq_0.ds__extract_doy AS ds__extract_doy
-                  , subq_0.ds_partitioned__day AS ds_partitioned__day
-                  , subq_0.ds_partitioned__week AS ds_partitioned__week
-                  , subq_0.ds_partitioned__month AS ds_partitioned__month
-                  , subq_0.ds_partitioned__quarter AS ds_partitioned__quarter
-                  , subq_0.ds_partitioned__year AS ds_partitioned__year
-                  , subq_0.ds_partitioned__extract_year AS ds_partitioned__extract_year
-                  , subq_0.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
-                  , subq_0.ds_partitioned__extract_month AS ds_partitioned__extract_month
-                  , subq_0.ds_partitioned__extract_day AS ds_partitioned__extract_day
-                  , subq_0.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
-                  , subq_0.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
-                  , subq_0.paid_at__day AS paid_at__day
-                  , subq_0.paid_at__week AS paid_at__week
-                  , subq_0.paid_at__month AS paid_at__month
-                  , subq_0.paid_at__quarter AS paid_at__quarter
-                  , subq_0.paid_at__year AS paid_at__year
-                  , subq_0.paid_at__extract_year AS paid_at__extract_year
-                  , subq_0.paid_at__extract_quarter AS paid_at__extract_quarter
-                  , subq_0.paid_at__extract_month AS paid_at__extract_month
-                  , subq_0.paid_at__extract_day AS paid_at__extract_day
-                  , subq_0.paid_at__extract_dow AS paid_at__extract_dow
-                  , subq_0.paid_at__extract_doy AS paid_at__extract_doy
-                  , subq_0.booking__ds__day AS booking__ds__day
-                  , subq_0.booking__ds__week AS booking__ds__week
-                  , subq_0.booking__ds__month AS booking__ds__month
-                  , subq_0.booking__ds__quarter AS booking__ds__quarter
-                  , subq_0.booking__ds__year AS booking__ds__year
-                  , subq_0.booking__ds__extract_year AS booking__ds__extract_year
-                  , subq_0.booking__ds__extract_quarter AS booking__ds__extract_quarter
-                  , subq_0.booking__ds__extract_month AS booking__ds__extract_month
-                  , subq_0.booking__ds__extract_day AS booking__ds__extract_day
-                  , subq_0.booking__ds__extract_dow AS booking__ds__extract_dow
-                  , subq_0.booking__ds__extract_doy AS booking__ds__extract_doy
-                  , subq_0.booking__ds_partitioned__day AS booking__ds_partitioned__day
-                  , subq_0.booking__ds_partitioned__week AS booking__ds_partitioned__week
-                  , subq_0.booking__ds_partitioned__month AS booking__ds_partitioned__month
-                  , subq_0.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
-                  , subq_0.booking__ds_partitioned__year AS booking__ds_partitioned__year
-                  , subq_0.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
-                  , subq_0.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
-                  , subq_0.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
-                  , subq_0.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
-                  , subq_0.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
-                  , subq_0.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
-                  , subq_0.booking__paid_at__day AS booking__paid_at__day
-                  , subq_0.booking__paid_at__week AS booking__paid_at__week
-                  , subq_0.booking__paid_at__month AS booking__paid_at__month
-                  , subq_0.booking__paid_at__quarter AS booking__paid_at__quarter
-                  , subq_0.booking__paid_at__year AS booking__paid_at__year
-                  , subq_0.booking__paid_at__extract_year AS booking__paid_at__extract_year
-                  , subq_0.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
-                  , subq_0.booking__paid_at__extract_month AS booking__paid_at__extract_month
-                  , subq_0.booking__paid_at__extract_day AS booking__paid_at__extract_day
-                  , subq_0.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
-                  , subq_0.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
-                  , subq_0.ds__day AS metric_time__day
-                  , subq_0.ds__week AS metric_time__week
-                  , subq_0.ds__month AS metric_time__month
-                  , subq_0.ds__quarter AS metric_time__quarter
-                  , subq_0.ds__year AS metric_time__year
-                  , subq_0.ds__extract_year AS metric_time__extract_year
-                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_0.ds__extract_month AS metric_time__extract_month
-                  , subq_0.ds__extract_day AS metric_time__extract_day
-                  , subq_0.ds__extract_dow AS metric_time__extract_dow
-                  , subq_0.ds__extract_doy AS metric_time__extract_doy
-                  , subq_0.listing AS listing
-                  , subq_0.guest AS guest
-                  , subq_0.host AS host
-                  , subq_0.booking__listing AS booking__listing
-                  , subq_0.booking__guest AS booking__guest
-                  , subq_0.booking__host AS booking__host
-                  , subq_0.is_instant AS is_instant
-                  , subq_0.booking__is_instant AS booking__is_instant
-                  , subq_0.__bookings AS __bookings
-                  , subq_0.__average_booking_value AS __average_booking_value
-                  , subq_0.__instant_bookings AS __instant_bookings
-                  , subq_0.__booking_value AS __booking_value
-                  , subq_0.__max_booking_value AS __max_booking_value
-                  , subq_0.__min_booking_value AS __min_booking_value
-                  , subq_0.__instant_booking_value AS __instant_booking_value
-                  , subq_0.__average_instant_booking_value AS __average_instant_booking_value
-                  , subq_0.__booking_value_for_non_null_listing_id AS __booking_value_for_non_null_listing_id
-                  , subq_0.__bookers AS __bookers
-                  , subq_0.__referred_bookings AS __referred_bookings
-                  , subq_0.__median_booking_value AS __median_booking_value
-                  , subq_0.__booking_value_p99 AS __booking_value_p99
-                  , subq_0.__discrete_booking_value_p99 AS __discrete_booking_value_p99
-                  , subq_0.__approximate_continuous_booking_value_p99 AS __approximate_continuous_booking_value_p99
-                  , subq_0.__approximate_discrete_booking_value_p99 AS __approximate_discrete_booking_value_p99
-                  , subq_0.__bookings_join_to_time_spine AS __bookings_join_to_time_spine
-                  , subq_0.__bookings_fill_nulls_with_0_without_time_spine AS __bookings_fill_nulls_with_0_without_time_spine
-                  , subq_0.__bookings_fill_nulls_with_0 AS __bookings_fill_nulls_with_0
-                  , subq_0.__instant_bookings_with_measure_filter AS __instant_bookings_with_measure_filter
-                  , subq_0.__bookings_join_to_time_spine_with_tiered_filters AS __bookings_join_to_time_spine_with_tiered_filters
-                  , subq_0.__bookers_fill_nulls_with_0_join_to_timespine AS __bookers_fill_nulls_with_0_join_to_timespine
-                  , subq_1.alien_day AS metric_time__alien_day
-                FROM (
-                  -- Read Elements From Semantic Model 'bookings_source'
-                  SELECT
-                    1 AS __bookings
-                    , bookings_source_src_28000.booking_value AS __average_booking_value
-                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS __instant_bookings
-                    , bookings_source_src_28000.booking_value AS __booking_value
-                    , bookings_source_src_28000.booking_value AS __max_booking_value
-                    , bookings_source_src_28000.booking_value AS __min_booking_value
-                    , bookings_source_src_28000.booking_value AS __instant_booking_value
-                    , bookings_source_src_28000.booking_value AS __average_instant_booking_value
-                    , bookings_source_src_28000.booking_value AS __booking_value_for_non_null_listing_id
-                    , bookings_source_src_28000.guest_id AS __bookers
-                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS __referred_bookings
-                    , bookings_source_src_28000.booking_value AS __median_booking_value
-                    , bookings_source_src_28000.booking_value AS __booking_value_p99
-                    , bookings_source_src_28000.booking_value AS __discrete_booking_value_p99
-                    , bookings_source_src_28000.booking_value AS __approximate_continuous_booking_value_p99
-                    , bookings_source_src_28000.booking_value AS __approximate_discrete_booking_value_p99
-                    , 1 AS __bookings_join_to_time_spine
-                    , 1 AS __bookings_fill_nulls_with_0_without_time_spine
-                    , 1 AS __bookings_fill_nulls_with_0
-                    , 1 AS __instant_bookings_with_measure_filter
-                    , 1 AS __bookings_join_to_time_spine_with_tiered_filters
-                    , bookings_source_src_28000.guest_id AS __bookers_fill_nulls_with_0_join_to_timespine
-                    , bookings_source_src_28000.booking_value AS __booking_payments
-                    , bookings_source_src_28000.is_instant
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                    , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                    , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                    , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                    , bookings_source_src_28000.is_instant AS booking__is_instant
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                    , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                    , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                    , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                    , bookings_source_src_28000.listing_id AS listing
-                    , bookings_source_src_28000.guest_id AS guest
-                    , bookings_source_src_28000.host_id AS host
-                    , bookings_source_src_28000.listing_id AS booking__listing
-                    , bookings_source_src_28000.guest_id AS booking__guest
-                    , bookings_source_src_28000.host_id AS booking__host
-                  FROM ***************************.fct_bookings bookings_source_src_28000
-                ) subq_0
-                LEFT OUTER JOIN
-                  ***************************.mf_time_spine subq_1
-                ON
-                  subq_0.ds__day = subq_1.ds
-              ) subq_2
-            ) subq_3
-            WHERE metric_time__alien_day = '2020-01-01'
-          ) subq_4
-        ) subq_5
+                  1 AS __bookings
+                  , bookings_source_src_28000.booking_value AS __average_booking_value
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS __instant_bookings
+                  , bookings_source_src_28000.booking_value AS __booking_value
+                  , bookings_source_src_28000.booking_value AS __max_booking_value
+                  , bookings_source_src_28000.booking_value AS __min_booking_value
+                  , bookings_source_src_28000.booking_value AS __instant_booking_value
+                  , bookings_source_src_28000.booking_value AS __average_instant_booking_value
+                  , bookings_source_src_28000.booking_value AS __booking_value_for_non_null_listing_id
+                  , bookings_source_src_28000.guest_id AS __bookers
+                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS __referred_bookings
+                  , bookings_source_src_28000.booking_value AS __median_booking_value
+                  , bookings_source_src_28000.booking_value AS __booking_value_p99
+                  , bookings_source_src_28000.booking_value AS __discrete_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS __approximate_continuous_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS __approximate_discrete_booking_value_p99
+                  , 1 AS __bookings_join_to_time_spine
+                  , 1 AS __bookings_fill_nulls_with_0_without_time_spine
+                  , 1 AS __bookings_fill_nulls_with_0
+                  , 1 AS __instant_bookings_with_measure_filter
+                  , 1 AS __bookings_join_to_time_spine_with_tiered_filters
+                  , bookings_source_src_28000.guest_id AS __bookers_fill_nulls_with_0_join_to_timespine
+                  , bookings_source_src_28000.booking_value AS __booking_payments
+                  , bookings_source_src_28000.is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                  , bookings_source_src_28000.is_instant AS booking__is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                  , bookings_source_src_28000.listing_id AS listing
+                  , bookings_source_src_28000.guest_id AS guest
+                  , bookings_source_src_28000.host_id AS host
+                  , bookings_source_src_28000.listing_id AS booking__listing
+                  , bookings_source_src_28000.guest_id AS booking__guest
+                  , bookings_source_src_28000.host_id AS booking__host
+                FROM ***************************.fct_bookings bookings_source_src_28000
+              ) subq_0
+              LEFT OUTER JOIN
+                ***************************.mf_time_spine subq_1
+              ON
+                subq_0.ds__day = subq_1.ds
+            ) subq_2
+          ) subq_3
+        ) subq_4
         GROUP BY
-          subq_5.metric_time__day
-      ) subq_6
+          subq_4.metric_time__day
+      ) subq_5
       ON
-        subq_11.metric_time__day - MAKE_INTERVAL(days => 5) = subq_6.metric_time__day
-    ) subq_12
-  ) subq_13
-) subq_14
+        subq_10.metric_time__day - MAKE_INTERVAL(days => 5) = subq_5.metric_time__day
+    ) subq_11
+  ) subq_12
+) subq_13

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Postgres/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Postgres/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0_optimized.sql
@@ -11,8 +11,8 @@ FROM (
   -- Join to Time Spine Dataset
   -- Compute Metrics via Expressions
   SELECT
-    subq_26.metric_time__day AS metric_time__day
-    , subq_21.__bookings AS bookings_5_days_ago
+    subq_24.metric_time__day AS metric_time__day
+    , subq_19.__bookings AS bookings_5_days_ago
   FROM (
     -- Constrain Output with WHERE
     -- Select: ['metric_time__day']
@@ -26,40 +26,32 @@ FROM (
         ds AS metric_time__day
         , alien_day AS metric_time__alien_day
       FROM ***************************.mf_time_spine time_spine_src_28006
-    ) subq_24
+    ) subq_22
     WHERE metric_time__alien_day = '2020-01-01'
-  ) subq_26
+  ) subq_24
   INNER JOIN (
-    -- Constrain Output with WHERE
+    -- Metric Time Dimension 'ds'
+    -- Join to Custom Granularity Dataset
+    -- Select: ['__bookings', 'metric_time__day']
     -- Select: ['__bookings', 'metric_time__day']
     -- Aggregate Inputs for Simple Metrics
     SELECT
-      metric_time__day
-      , SUM(bookings) AS __bookings
+      subq_14.ds__day AS metric_time__day
+      , SUM(subq_14.__bookings) AS __bookings
     FROM (
-      -- Metric Time Dimension 'ds'
-      -- Join to Custom Granularity Dataset
-      -- Select: ['__bookings', 'metric_time__day', 'metric_time__alien_day']
+      -- Read Elements From Semantic Model 'bookings_source'
       SELECT
-        subq_16.alien_day AS metric_time__alien_day
-        , subq_15.ds__day AS metric_time__day
-        , subq_15.__bookings AS bookings
-      FROM (
-        -- Read Elements From Semantic Model 'bookings_source'
-        SELECT
-          1 AS __bookings
-          , DATE_TRUNC('day', ds) AS ds__day
-        FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_15
-      LEFT OUTER JOIN
-        ***************************.mf_time_spine subq_16
-      ON
-        subq_15.ds__day = subq_16.ds
-    ) subq_18
-    WHERE metric_time__alien_day = '2020-01-01'
+        1 AS __bookings
+        , DATE_TRUNC('day', ds) AS ds__day
+      FROM ***************************.fct_bookings bookings_source_src_28000
+    ) subq_14
+    LEFT OUTER JOIN
+      ***************************.mf_time_spine subq_15
+    ON
+      subq_14.ds__day = subq_15.ds
     GROUP BY
-      metric_time__day
-  ) subq_21
+      subq_14.ds__day
+  ) subq_19
   ON
-    subq_26.metric_time__day - MAKE_INTERVAL(days => 5) = subq_21.metric_time__day
-) subq_28
+    subq_24.metric_time__day - MAKE_INTERVAL(days => 5) = subq_19.metric_time__day
+) subq_26

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Redshift/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Redshift/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
@@ -4,52 +4,52 @@ sql_engine: Redshift
 ---
 -- Write to DataTable
 SELECT
-  subq_14.metric_time__day
-  , subq_14.bookings_5_day_lag
+  subq_13.metric_time__day
+  , subq_13.bookings_5_day_lag
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_13.metric_time__day
+    subq_12.metric_time__day
     , bookings_5_days_ago AS bookings_5_day_lag
   FROM (
     -- Compute Metrics via Expressions
     SELECT
-      subq_12.metric_time__day
-      , subq_12.__bookings AS bookings_5_days_ago
+      subq_11.metric_time__day
+      , subq_11.__bookings AS bookings_5_days_ago
     FROM (
       -- Join to Time Spine Dataset
       SELECT
-        subq_11.metric_time__day AS metric_time__day
-        , subq_6.__bookings AS __bookings
+        subq_10.metric_time__day AS metric_time__day
+        , subq_5.__bookings AS __bookings
       FROM (
         -- Select: ['metric_time__day']
         SELECT
-          subq_10.metric_time__day
+          subq_9.metric_time__day
         FROM (
           -- Constrain Output with WHERE
           SELECT
-            subq_9.metric_time__day
-            , subq_9.metric_time__alien_day
+            subq_8.metric_time__day
+            , subq_8.metric_time__alien_day
           FROM (
             -- Select: ['metric_time__day', 'metric_time__alien_day']
             SELECT
-              subq_8.metric_time__day
-              , subq_8.metric_time__alien_day
+              subq_7.metric_time__day
+              , subq_7.metric_time__alien_day
             FROM (
               -- Change Column Aliases
               SELECT
-                subq_7.ds__day AS metric_time__day
-                , subq_7.ds__week
-                , subq_7.ds__month
-                , subq_7.ds__quarter
-                , subq_7.ds__year
-                , subq_7.ds__extract_year
-                , subq_7.ds__extract_quarter
-                , subq_7.ds__extract_month
-                , subq_7.ds__extract_day
-                , subq_7.ds__extract_dow
-                , subq_7.ds__extract_doy
-                , subq_7.ds__alien_day AS metric_time__alien_day
+                subq_6.ds__day AS metric_time__day
+                , subq_6.ds__week
+                , subq_6.ds__month
+                , subq_6.ds__quarter
+                , subq_6.ds__year
+                , subq_6.ds__extract_year
+                , subq_6.ds__extract_quarter
+                , subq_6.ds__extract_month
+                , subq_6.ds__extract_day
+                , subq_6.ds__extract_dow
+                , subq_6.ds__extract_doy
+                , subq_6.ds__alien_day AS metric_time__alien_day
               FROM (
                 -- Read From Time Spine 'mf_time_spine'
                 SELECT
@@ -66,262 +66,253 @@ FROM (
                   , EXTRACT(doy FROM time_spine_src_28006.ds) AS ds__extract_doy
                   , time_spine_src_28006.alien_day AS ds__alien_day
                 FROM ***************************.mf_time_spine time_spine_src_28006
-              ) subq_7
-            ) subq_8
-          ) subq_9
+              ) subq_6
+            ) subq_7
+          ) subq_8
           WHERE metric_time__alien_day = '2020-01-01'
-        ) subq_10
-      ) subq_11
+        ) subq_9
+      ) subq_10
       INNER JOIN (
         -- Aggregate Inputs for Simple Metrics
         SELECT
-          subq_5.metric_time__day
-          , SUM(subq_5.__bookings) AS __bookings
+          subq_4.metric_time__day
+          , SUM(subq_4.__bookings) AS __bookings
         FROM (
           -- Select: ['__bookings', 'metric_time__day']
           SELECT
-            subq_4.metric_time__day
-            , subq_4.__bookings
+            subq_3.metric_time__day
+            , subq_3.__bookings
           FROM (
-            -- Constrain Output with WHERE
+            -- Select: ['__bookings', 'metric_time__day']
             SELECT
-              subq_3.bookings AS __bookings
-              , subq_3.metric_time__alien_day
-              , subq_3.metric_time__day
+              subq_2.metric_time__day
+              , subq_2.__bookings
             FROM (
-              -- Select: ['__bookings', 'metric_time__day', 'metric_time__alien_day']
+              -- Metric Time Dimension 'ds'
+              -- Join to Custom Granularity Dataset
               SELECT
-                subq_2.metric_time__alien_day
-                , subq_2.metric_time__day
-                , subq_2.__bookings AS bookings
+                subq_0.ds__day AS ds__day
+                , subq_0.ds__week AS ds__week
+                , subq_0.ds__month AS ds__month
+                , subq_0.ds__quarter AS ds__quarter
+                , subq_0.ds__year AS ds__year
+                , subq_0.ds__extract_year AS ds__extract_year
+                , subq_0.ds__extract_quarter AS ds__extract_quarter
+                , subq_0.ds__extract_month AS ds__extract_month
+                , subq_0.ds__extract_day AS ds__extract_day
+                , subq_0.ds__extract_dow AS ds__extract_dow
+                , subq_0.ds__extract_doy AS ds__extract_doy
+                , subq_0.ds_partitioned__day AS ds_partitioned__day
+                , subq_0.ds_partitioned__week AS ds_partitioned__week
+                , subq_0.ds_partitioned__month AS ds_partitioned__month
+                , subq_0.ds_partitioned__quarter AS ds_partitioned__quarter
+                , subq_0.ds_partitioned__year AS ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year AS ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month AS ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day AS ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+                , subq_0.paid_at__day AS paid_at__day
+                , subq_0.paid_at__week AS paid_at__week
+                , subq_0.paid_at__month AS paid_at__month
+                , subq_0.paid_at__quarter AS paid_at__quarter
+                , subq_0.paid_at__year AS paid_at__year
+                , subq_0.paid_at__extract_year AS paid_at__extract_year
+                , subq_0.paid_at__extract_quarter AS paid_at__extract_quarter
+                , subq_0.paid_at__extract_month AS paid_at__extract_month
+                , subq_0.paid_at__extract_day AS paid_at__extract_day
+                , subq_0.paid_at__extract_dow AS paid_at__extract_dow
+                , subq_0.paid_at__extract_doy AS paid_at__extract_doy
+                , subq_0.booking__ds__day AS booking__ds__day
+                , subq_0.booking__ds__week AS booking__ds__week
+                , subq_0.booking__ds__month AS booking__ds__month
+                , subq_0.booking__ds__quarter AS booking__ds__quarter
+                , subq_0.booking__ds__year AS booking__ds__year
+                , subq_0.booking__ds__extract_year AS booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter AS booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month AS booking__ds__extract_month
+                , subq_0.booking__ds__extract_day AS booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow AS booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy AS booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day AS booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week AS booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month AS booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year AS booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day AS booking__paid_at__day
+                , subq_0.booking__paid_at__week AS booking__paid_at__week
+                , subq_0.booking__paid_at__month AS booking__paid_at__month
+                , subq_0.booking__paid_at__quarter AS booking__paid_at__quarter
+                , subq_0.booking__paid_at__year AS booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year AS booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month AS booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day AS booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing AS listing
+                , subq_0.guest AS guest
+                , subq_0.host AS host
+                , subq_0.booking__listing AS booking__listing
+                , subq_0.booking__guest AS booking__guest
+                , subq_0.booking__host AS booking__host
+                , subq_0.is_instant AS is_instant
+                , subq_0.booking__is_instant AS booking__is_instant
+                , subq_0.__bookings AS __bookings
+                , subq_0.__average_booking_value AS __average_booking_value
+                , subq_0.__instant_bookings AS __instant_bookings
+                , subq_0.__booking_value AS __booking_value
+                , subq_0.__max_booking_value AS __max_booking_value
+                , subq_0.__min_booking_value AS __min_booking_value
+                , subq_0.__instant_booking_value AS __instant_booking_value
+                , subq_0.__average_instant_booking_value AS __average_instant_booking_value
+                , subq_0.__booking_value_for_non_null_listing_id AS __booking_value_for_non_null_listing_id
+                , subq_0.__bookers AS __bookers
+                , subq_0.__referred_bookings AS __referred_bookings
+                , subq_0.__median_booking_value AS __median_booking_value
+                , subq_0.__booking_value_p99 AS __booking_value_p99
+                , subq_0.__discrete_booking_value_p99 AS __discrete_booking_value_p99
+                , subq_0.__approximate_continuous_booking_value_p99 AS __approximate_continuous_booking_value_p99
+                , subq_0.__approximate_discrete_booking_value_p99 AS __approximate_discrete_booking_value_p99
+                , subq_0.__bookings_join_to_time_spine AS __bookings_join_to_time_spine
+                , subq_0.__bookings_fill_nulls_with_0_without_time_spine AS __bookings_fill_nulls_with_0_without_time_spine
+                , subq_0.__bookings_fill_nulls_with_0 AS __bookings_fill_nulls_with_0
+                , subq_0.__instant_bookings_with_measure_filter AS __instant_bookings_with_measure_filter
+                , subq_0.__bookings_join_to_time_spine_with_tiered_filters AS __bookings_join_to_time_spine_with_tiered_filters
+                , subq_0.__bookers_fill_nulls_with_0_join_to_timespine AS __bookers_fill_nulls_with_0_join_to_timespine
+                , subq_1.alien_day AS metric_time__alien_day
               FROM (
-                -- Metric Time Dimension 'ds'
-                -- Join to Custom Granularity Dataset
+                -- Read Elements From Semantic Model 'bookings_source'
                 SELECT
-                  subq_0.ds__day AS ds__day
-                  , subq_0.ds__week AS ds__week
-                  , subq_0.ds__month AS ds__month
-                  , subq_0.ds__quarter AS ds__quarter
-                  , subq_0.ds__year AS ds__year
-                  , subq_0.ds__extract_year AS ds__extract_year
-                  , subq_0.ds__extract_quarter AS ds__extract_quarter
-                  , subq_0.ds__extract_month AS ds__extract_month
-                  , subq_0.ds__extract_day AS ds__extract_day
-                  , subq_0.ds__extract_dow AS ds__extract_dow
-                  , subq_0.ds__extract_doy AS ds__extract_doy
-                  , subq_0.ds_partitioned__day AS ds_partitioned__day
-                  , subq_0.ds_partitioned__week AS ds_partitioned__week
-                  , subq_0.ds_partitioned__month AS ds_partitioned__month
-                  , subq_0.ds_partitioned__quarter AS ds_partitioned__quarter
-                  , subq_0.ds_partitioned__year AS ds_partitioned__year
-                  , subq_0.ds_partitioned__extract_year AS ds_partitioned__extract_year
-                  , subq_0.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
-                  , subq_0.ds_partitioned__extract_month AS ds_partitioned__extract_month
-                  , subq_0.ds_partitioned__extract_day AS ds_partitioned__extract_day
-                  , subq_0.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
-                  , subq_0.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
-                  , subq_0.paid_at__day AS paid_at__day
-                  , subq_0.paid_at__week AS paid_at__week
-                  , subq_0.paid_at__month AS paid_at__month
-                  , subq_0.paid_at__quarter AS paid_at__quarter
-                  , subq_0.paid_at__year AS paid_at__year
-                  , subq_0.paid_at__extract_year AS paid_at__extract_year
-                  , subq_0.paid_at__extract_quarter AS paid_at__extract_quarter
-                  , subq_0.paid_at__extract_month AS paid_at__extract_month
-                  , subq_0.paid_at__extract_day AS paid_at__extract_day
-                  , subq_0.paid_at__extract_dow AS paid_at__extract_dow
-                  , subq_0.paid_at__extract_doy AS paid_at__extract_doy
-                  , subq_0.booking__ds__day AS booking__ds__day
-                  , subq_0.booking__ds__week AS booking__ds__week
-                  , subq_0.booking__ds__month AS booking__ds__month
-                  , subq_0.booking__ds__quarter AS booking__ds__quarter
-                  , subq_0.booking__ds__year AS booking__ds__year
-                  , subq_0.booking__ds__extract_year AS booking__ds__extract_year
-                  , subq_0.booking__ds__extract_quarter AS booking__ds__extract_quarter
-                  , subq_0.booking__ds__extract_month AS booking__ds__extract_month
-                  , subq_0.booking__ds__extract_day AS booking__ds__extract_day
-                  , subq_0.booking__ds__extract_dow AS booking__ds__extract_dow
-                  , subq_0.booking__ds__extract_doy AS booking__ds__extract_doy
-                  , subq_0.booking__ds_partitioned__day AS booking__ds_partitioned__day
-                  , subq_0.booking__ds_partitioned__week AS booking__ds_partitioned__week
-                  , subq_0.booking__ds_partitioned__month AS booking__ds_partitioned__month
-                  , subq_0.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
-                  , subq_0.booking__ds_partitioned__year AS booking__ds_partitioned__year
-                  , subq_0.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
-                  , subq_0.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
-                  , subq_0.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
-                  , subq_0.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
-                  , subq_0.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
-                  , subq_0.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
-                  , subq_0.booking__paid_at__day AS booking__paid_at__day
-                  , subq_0.booking__paid_at__week AS booking__paid_at__week
-                  , subq_0.booking__paid_at__month AS booking__paid_at__month
-                  , subq_0.booking__paid_at__quarter AS booking__paid_at__quarter
-                  , subq_0.booking__paid_at__year AS booking__paid_at__year
-                  , subq_0.booking__paid_at__extract_year AS booking__paid_at__extract_year
-                  , subq_0.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
-                  , subq_0.booking__paid_at__extract_month AS booking__paid_at__extract_month
-                  , subq_0.booking__paid_at__extract_day AS booking__paid_at__extract_day
-                  , subq_0.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
-                  , subq_0.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
-                  , subq_0.ds__day AS metric_time__day
-                  , subq_0.ds__week AS metric_time__week
-                  , subq_0.ds__month AS metric_time__month
-                  , subq_0.ds__quarter AS metric_time__quarter
-                  , subq_0.ds__year AS metric_time__year
-                  , subq_0.ds__extract_year AS metric_time__extract_year
-                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_0.ds__extract_month AS metric_time__extract_month
-                  , subq_0.ds__extract_day AS metric_time__extract_day
-                  , subq_0.ds__extract_dow AS metric_time__extract_dow
-                  , subq_0.ds__extract_doy AS metric_time__extract_doy
-                  , subq_0.listing AS listing
-                  , subq_0.guest AS guest
-                  , subq_0.host AS host
-                  , subq_0.booking__listing AS booking__listing
-                  , subq_0.booking__guest AS booking__guest
-                  , subq_0.booking__host AS booking__host
-                  , subq_0.is_instant AS is_instant
-                  , subq_0.booking__is_instant AS booking__is_instant
-                  , subq_0.__bookings AS __bookings
-                  , subq_0.__average_booking_value AS __average_booking_value
-                  , subq_0.__instant_bookings AS __instant_bookings
-                  , subq_0.__booking_value AS __booking_value
-                  , subq_0.__max_booking_value AS __max_booking_value
-                  , subq_0.__min_booking_value AS __min_booking_value
-                  , subq_0.__instant_booking_value AS __instant_booking_value
-                  , subq_0.__average_instant_booking_value AS __average_instant_booking_value
-                  , subq_0.__booking_value_for_non_null_listing_id AS __booking_value_for_non_null_listing_id
-                  , subq_0.__bookers AS __bookers
-                  , subq_0.__referred_bookings AS __referred_bookings
-                  , subq_0.__median_booking_value AS __median_booking_value
-                  , subq_0.__booking_value_p99 AS __booking_value_p99
-                  , subq_0.__discrete_booking_value_p99 AS __discrete_booking_value_p99
-                  , subq_0.__approximate_continuous_booking_value_p99 AS __approximate_continuous_booking_value_p99
-                  , subq_0.__approximate_discrete_booking_value_p99 AS __approximate_discrete_booking_value_p99
-                  , subq_0.__bookings_join_to_time_spine AS __bookings_join_to_time_spine
-                  , subq_0.__bookings_fill_nulls_with_0_without_time_spine AS __bookings_fill_nulls_with_0_without_time_spine
-                  , subq_0.__bookings_fill_nulls_with_0 AS __bookings_fill_nulls_with_0
-                  , subq_0.__instant_bookings_with_measure_filter AS __instant_bookings_with_measure_filter
-                  , subq_0.__bookings_join_to_time_spine_with_tiered_filters AS __bookings_join_to_time_spine_with_tiered_filters
-                  , subq_0.__bookers_fill_nulls_with_0_join_to_timespine AS __bookers_fill_nulls_with_0_join_to_timespine
-                  , subq_1.alien_day AS metric_time__alien_day
-                FROM (
-                  -- Read Elements From Semantic Model 'bookings_source'
-                  SELECT
-                    1 AS __bookings
-                    , bookings_source_src_28000.booking_value AS __average_booking_value
-                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS __instant_bookings
-                    , bookings_source_src_28000.booking_value AS __booking_value
-                    , bookings_source_src_28000.booking_value AS __max_booking_value
-                    , bookings_source_src_28000.booking_value AS __min_booking_value
-                    , bookings_source_src_28000.booking_value AS __instant_booking_value
-                    , bookings_source_src_28000.booking_value AS __average_instant_booking_value
-                    , bookings_source_src_28000.booking_value AS __booking_value_for_non_null_listing_id
-                    , bookings_source_src_28000.guest_id AS __bookers
-                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS __referred_bookings
-                    , bookings_source_src_28000.booking_value AS __median_booking_value
-                    , bookings_source_src_28000.booking_value AS __booking_value_p99
-                    , bookings_source_src_28000.booking_value AS __discrete_booking_value_p99
-                    , bookings_source_src_28000.booking_value AS __approximate_continuous_booking_value_p99
-                    , bookings_source_src_28000.booking_value AS __approximate_discrete_booking_value_p99
-                    , 1 AS __bookings_join_to_time_spine
-                    , 1 AS __bookings_fill_nulls_with_0_without_time_spine
-                    , 1 AS __bookings_fill_nulls_with_0
-                    , 1 AS __instant_bookings_with_measure_filter
-                    , 1 AS __bookings_join_to_time_spine_with_tiered_filters
-                    , bookings_source_src_28000.guest_id AS __bookers_fill_nulls_with_0_join_to_timespine
-                    , bookings_source_src_28000.booking_value AS __booking_payments
-                    , bookings_source_src_28000.is_instant
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                    , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS ds__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                    , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS ds_partitioned__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                    , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS paid_at__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                    , bookings_source_src_28000.is_instant AS booking__is_instant
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                    , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS booking__ds__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                    , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS booking__ds_partitioned__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                    , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS booking__paid_at__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                    , bookings_source_src_28000.listing_id AS listing
-                    , bookings_source_src_28000.guest_id AS guest
-                    , bookings_source_src_28000.host_id AS host
-                    , bookings_source_src_28000.listing_id AS booking__listing
-                    , bookings_source_src_28000.guest_id AS booking__guest
-                    , bookings_source_src_28000.host_id AS booking__host
-                  FROM ***************************.fct_bookings bookings_source_src_28000
-                ) subq_0
-                LEFT OUTER JOIN
-                  ***************************.mf_time_spine subq_1
-                ON
-                  subq_0.ds__day = subq_1.ds
-              ) subq_2
-            ) subq_3
-            WHERE metric_time__alien_day = '2020-01-01'
-          ) subq_4
-        ) subq_5
+                  1 AS __bookings
+                  , bookings_source_src_28000.booking_value AS __average_booking_value
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS __instant_bookings
+                  , bookings_source_src_28000.booking_value AS __booking_value
+                  , bookings_source_src_28000.booking_value AS __max_booking_value
+                  , bookings_source_src_28000.booking_value AS __min_booking_value
+                  , bookings_source_src_28000.booking_value AS __instant_booking_value
+                  , bookings_source_src_28000.booking_value AS __average_instant_booking_value
+                  , bookings_source_src_28000.booking_value AS __booking_value_for_non_null_listing_id
+                  , bookings_source_src_28000.guest_id AS __bookers
+                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS __referred_bookings
+                  , bookings_source_src_28000.booking_value AS __median_booking_value
+                  , bookings_source_src_28000.booking_value AS __booking_value_p99
+                  , bookings_source_src_28000.booking_value AS __discrete_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS __approximate_continuous_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS __approximate_discrete_booking_value_p99
+                  , 1 AS __bookings_join_to_time_spine
+                  , 1 AS __bookings_fill_nulls_with_0_without_time_spine
+                  , 1 AS __bookings_fill_nulls_with_0
+                  , 1 AS __instant_bookings_with_measure_filter
+                  , 1 AS __bookings_join_to_time_spine_with_tiered_filters
+                  , bookings_source_src_28000.guest_id AS __bookers_fill_nulls_with_0_join_to_timespine
+                  , bookings_source_src_28000.booking_value AS __booking_payments
+                  , bookings_source_src_28000.is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                  , bookings_source_src_28000.is_instant AS booking__is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS booking__ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS booking__ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS booking__paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                  , bookings_source_src_28000.listing_id AS listing
+                  , bookings_source_src_28000.guest_id AS guest
+                  , bookings_source_src_28000.host_id AS host
+                  , bookings_source_src_28000.listing_id AS booking__listing
+                  , bookings_source_src_28000.guest_id AS booking__guest
+                  , bookings_source_src_28000.host_id AS booking__host
+                FROM ***************************.fct_bookings bookings_source_src_28000
+              ) subq_0
+              LEFT OUTER JOIN
+                ***************************.mf_time_spine subq_1
+              ON
+                subq_0.ds__day = subq_1.ds
+            ) subq_2
+          ) subq_3
+        ) subq_4
         GROUP BY
-          subq_5.metric_time__day
-      ) subq_6
+          subq_4.metric_time__day
+      ) subq_5
       ON
-        DATEADD(day, -5, subq_11.metric_time__day) = subq_6.metric_time__day
-    ) subq_12
-  ) subq_13
-) subq_14
+        DATEADD(day, -5, subq_10.metric_time__day) = subq_5.metric_time__day
+    ) subq_11
+  ) subq_12
+) subq_13

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Redshift/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Redshift/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0_optimized.sql
@@ -11,8 +11,8 @@ FROM (
   -- Join to Time Spine Dataset
   -- Compute Metrics via Expressions
   SELECT
-    subq_26.metric_time__day AS metric_time__day
-    , subq_21.__bookings AS bookings_5_days_ago
+    subq_24.metric_time__day AS metric_time__day
+    , subq_19.__bookings AS bookings_5_days_ago
   FROM (
     -- Constrain Output with WHERE
     -- Select: ['metric_time__day']
@@ -26,40 +26,32 @@ FROM (
         ds AS metric_time__day
         , alien_day AS metric_time__alien_day
       FROM ***************************.mf_time_spine time_spine_src_28006
-    ) subq_24
+    ) subq_22
     WHERE metric_time__alien_day = '2020-01-01'
-  ) subq_26
+  ) subq_24
   INNER JOIN (
-    -- Constrain Output with WHERE
+    -- Metric Time Dimension 'ds'
+    -- Join to Custom Granularity Dataset
+    -- Select: ['__bookings', 'metric_time__day']
     -- Select: ['__bookings', 'metric_time__day']
     -- Aggregate Inputs for Simple Metrics
     SELECT
-      metric_time__day
-      , SUM(bookings) AS __bookings
+      subq_14.ds__day AS metric_time__day
+      , SUM(subq_14.__bookings) AS __bookings
     FROM (
-      -- Metric Time Dimension 'ds'
-      -- Join to Custom Granularity Dataset
-      -- Select: ['__bookings', 'metric_time__day', 'metric_time__alien_day']
+      -- Read Elements From Semantic Model 'bookings_source'
       SELECT
-        subq_16.alien_day AS metric_time__alien_day
-        , subq_15.ds__day AS metric_time__day
-        , subq_15.__bookings AS bookings
-      FROM (
-        -- Read Elements From Semantic Model 'bookings_source'
-        SELECT
-          1 AS __bookings
-          , DATE_TRUNC('day', ds) AS ds__day
-        FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_15
-      LEFT OUTER JOIN
-        ***************************.mf_time_spine subq_16
-      ON
-        subq_15.ds__day = subq_16.ds
-    ) subq_18
-    WHERE metric_time__alien_day = '2020-01-01'
+        1 AS __bookings
+        , DATE_TRUNC('day', ds) AS ds__day
+      FROM ***************************.fct_bookings bookings_source_src_28000
+    ) subq_14
+    LEFT OUTER JOIN
+      ***************************.mf_time_spine subq_15
+    ON
+      subq_14.ds__day = subq_15.ds
     GROUP BY
-      metric_time__day
-  ) subq_21
+      subq_14.ds__day
+  ) subq_19
   ON
-    DATEADD(day, -5, subq_26.metric_time__day) = subq_21.metric_time__day
-) subq_28
+    DATEADD(day, -5, subq_24.metric_time__day) = subq_19.metric_time__day
+) subq_26

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Snowflake/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Snowflake/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
@@ -4,52 +4,52 @@ sql_engine: Snowflake
 ---
 -- Write to DataTable
 SELECT
-  subq_14.metric_time__day
-  , subq_14.bookings_5_day_lag
+  subq_13.metric_time__day
+  , subq_13.bookings_5_day_lag
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_13.metric_time__day
+    subq_12.metric_time__day
     , bookings_5_days_ago AS bookings_5_day_lag
   FROM (
     -- Compute Metrics via Expressions
     SELECT
-      subq_12.metric_time__day
-      , subq_12.__bookings AS bookings_5_days_ago
+      subq_11.metric_time__day
+      , subq_11.__bookings AS bookings_5_days_ago
     FROM (
       -- Join to Time Spine Dataset
       SELECT
-        subq_11.metric_time__day AS metric_time__day
-        , subq_6.__bookings AS __bookings
+        subq_10.metric_time__day AS metric_time__day
+        , subq_5.__bookings AS __bookings
       FROM (
         -- Select: ['metric_time__day']
         SELECT
-          subq_10.metric_time__day
+          subq_9.metric_time__day
         FROM (
           -- Constrain Output with WHERE
           SELECT
-            subq_9.metric_time__day
-            , subq_9.metric_time__alien_day
+            subq_8.metric_time__day
+            , subq_8.metric_time__alien_day
           FROM (
             -- Select: ['metric_time__day', 'metric_time__alien_day']
             SELECT
-              subq_8.metric_time__day
-              , subq_8.metric_time__alien_day
+              subq_7.metric_time__day
+              , subq_7.metric_time__alien_day
             FROM (
               -- Change Column Aliases
               SELECT
-                subq_7.ds__day AS metric_time__day
-                , subq_7.ds__week
-                , subq_7.ds__month
-                , subq_7.ds__quarter
-                , subq_7.ds__year
-                , subq_7.ds__extract_year
-                , subq_7.ds__extract_quarter
-                , subq_7.ds__extract_month
-                , subq_7.ds__extract_day
-                , subq_7.ds__extract_dow
-                , subq_7.ds__extract_doy
-                , subq_7.ds__alien_day AS metric_time__alien_day
+                subq_6.ds__day AS metric_time__day
+                , subq_6.ds__week
+                , subq_6.ds__month
+                , subq_6.ds__quarter
+                , subq_6.ds__year
+                , subq_6.ds__extract_year
+                , subq_6.ds__extract_quarter
+                , subq_6.ds__extract_month
+                , subq_6.ds__extract_day
+                , subq_6.ds__extract_dow
+                , subq_6.ds__extract_doy
+                , subq_6.ds__alien_day AS metric_time__alien_day
               FROM (
                 -- Read From Time Spine 'mf_time_spine'
                 SELECT
@@ -66,262 +66,253 @@ FROM (
                   , EXTRACT(doy FROM time_spine_src_28006.ds) AS ds__extract_doy
                   , time_spine_src_28006.alien_day AS ds__alien_day
                 FROM ***************************.mf_time_spine time_spine_src_28006
-              ) subq_7
-            ) subq_8
-          ) subq_9
+              ) subq_6
+            ) subq_7
+          ) subq_8
           WHERE metric_time__alien_day = '2020-01-01'
-        ) subq_10
-      ) subq_11
+        ) subq_9
+      ) subq_10
       INNER JOIN (
         -- Aggregate Inputs for Simple Metrics
         SELECT
-          subq_5.metric_time__day
-          , SUM(subq_5.__bookings) AS __bookings
+          subq_4.metric_time__day
+          , SUM(subq_4.__bookings) AS __bookings
         FROM (
           -- Select: ['__bookings', 'metric_time__day']
           SELECT
-            subq_4.metric_time__day
-            , subq_4.__bookings
+            subq_3.metric_time__day
+            , subq_3.__bookings
           FROM (
-            -- Constrain Output with WHERE
+            -- Select: ['__bookings', 'metric_time__day']
             SELECT
-              subq_3.bookings AS __bookings
-              , subq_3.metric_time__alien_day
-              , subq_3.metric_time__day
+              subq_2.metric_time__day
+              , subq_2.__bookings
             FROM (
-              -- Select: ['__bookings', 'metric_time__day', 'metric_time__alien_day']
+              -- Metric Time Dimension 'ds'
+              -- Join to Custom Granularity Dataset
               SELECT
-                subq_2.metric_time__alien_day
-                , subq_2.metric_time__day
-                , subq_2.__bookings AS bookings
+                subq_0.ds__day AS ds__day
+                , subq_0.ds__week AS ds__week
+                , subq_0.ds__month AS ds__month
+                , subq_0.ds__quarter AS ds__quarter
+                , subq_0.ds__year AS ds__year
+                , subq_0.ds__extract_year AS ds__extract_year
+                , subq_0.ds__extract_quarter AS ds__extract_quarter
+                , subq_0.ds__extract_month AS ds__extract_month
+                , subq_0.ds__extract_day AS ds__extract_day
+                , subq_0.ds__extract_dow AS ds__extract_dow
+                , subq_0.ds__extract_doy AS ds__extract_doy
+                , subq_0.ds_partitioned__day AS ds_partitioned__day
+                , subq_0.ds_partitioned__week AS ds_partitioned__week
+                , subq_0.ds_partitioned__month AS ds_partitioned__month
+                , subq_0.ds_partitioned__quarter AS ds_partitioned__quarter
+                , subq_0.ds_partitioned__year AS ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year AS ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month AS ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day AS ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+                , subq_0.paid_at__day AS paid_at__day
+                , subq_0.paid_at__week AS paid_at__week
+                , subq_0.paid_at__month AS paid_at__month
+                , subq_0.paid_at__quarter AS paid_at__quarter
+                , subq_0.paid_at__year AS paid_at__year
+                , subq_0.paid_at__extract_year AS paid_at__extract_year
+                , subq_0.paid_at__extract_quarter AS paid_at__extract_quarter
+                , subq_0.paid_at__extract_month AS paid_at__extract_month
+                , subq_0.paid_at__extract_day AS paid_at__extract_day
+                , subq_0.paid_at__extract_dow AS paid_at__extract_dow
+                , subq_0.paid_at__extract_doy AS paid_at__extract_doy
+                , subq_0.booking__ds__day AS booking__ds__day
+                , subq_0.booking__ds__week AS booking__ds__week
+                , subq_0.booking__ds__month AS booking__ds__month
+                , subq_0.booking__ds__quarter AS booking__ds__quarter
+                , subq_0.booking__ds__year AS booking__ds__year
+                , subq_0.booking__ds__extract_year AS booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter AS booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month AS booking__ds__extract_month
+                , subq_0.booking__ds__extract_day AS booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow AS booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy AS booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day AS booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week AS booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month AS booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year AS booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day AS booking__paid_at__day
+                , subq_0.booking__paid_at__week AS booking__paid_at__week
+                , subq_0.booking__paid_at__month AS booking__paid_at__month
+                , subq_0.booking__paid_at__quarter AS booking__paid_at__quarter
+                , subq_0.booking__paid_at__year AS booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year AS booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month AS booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day AS booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing AS listing
+                , subq_0.guest AS guest
+                , subq_0.host AS host
+                , subq_0.booking__listing AS booking__listing
+                , subq_0.booking__guest AS booking__guest
+                , subq_0.booking__host AS booking__host
+                , subq_0.is_instant AS is_instant
+                , subq_0.booking__is_instant AS booking__is_instant
+                , subq_0.__bookings AS __bookings
+                , subq_0.__average_booking_value AS __average_booking_value
+                , subq_0.__instant_bookings AS __instant_bookings
+                , subq_0.__booking_value AS __booking_value
+                , subq_0.__max_booking_value AS __max_booking_value
+                , subq_0.__min_booking_value AS __min_booking_value
+                , subq_0.__instant_booking_value AS __instant_booking_value
+                , subq_0.__average_instant_booking_value AS __average_instant_booking_value
+                , subq_0.__booking_value_for_non_null_listing_id AS __booking_value_for_non_null_listing_id
+                , subq_0.__bookers AS __bookers
+                , subq_0.__referred_bookings AS __referred_bookings
+                , subq_0.__median_booking_value AS __median_booking_value
+                , subq_0.__booking_value_p99 AS __booking_value_p99
+                , subq_0.__discrete_booking_value_p99 AS __discrete_booking_value_p99
+                , subq_0.__approximate_continuous_booking_value_p99 AS __approximate_continuous_booking_value_p99
+                , subq_0.__approximate_discrete_booking_value_p99 AS __approximate_discrete_booking_value_p99
+                , subq_0.__bookings_join_to_time_spine AS __bookings_join_to_time_spine
+                , subq_0.__bookings_fill_nulls_with_0_without_time_spine AS __bookings_fill_nulls_with_0_without_time_spine
+                , subq_0.__bookings_fill_nulls_with_0 AS __bookings_fill_nulls_with_0
+                , subq_0.__instant_bookings_with_measure_filter AS __instant_bookings_with_measure_filter
+                , subq_0.__bookings_join_to_time_spine_with_tiered_filters AS __bookings_join_to_time_spine_with_tiered_filters
+                , subq_0.__bookers_fill_nulls_with_0_join_to_timespine AS __bookers_fill_nulls_with_0_join_to_timespine
+                , subq_1.alien_day AS metric_time__alien_day
               FROM (
-                -- Metric Time Dimension 'ds'
-                -- Join to Custom Granularity Dataset
+                -- Read Elements From Semantic Model 'bookings_source'
                 SELECT
-                  subq_0.ds__day AS ds__day
-                  , subq_0.ds__week AS ds__week
-                  , subq_0.ds__month AS ds__month
-                  , subq_0.ds__quarter AS ds__quarter
-                  , subq_0.ds__year AS ds__year
-                  , subq_0.ds__extract_year AS ds__extract_year
-                  , subq_0.ds__extract_quarter AS ds__extract_quarter
-                  , subq_0.ds__extract_month AS ds__extract_month
-                  , subq_0.ds__extract_day AS ds__extract_day
-                  , subq_0.ds__extract_dow AS ds__extract_dow
-                  , subq_0.ds__extract_doy AS ds__extract_doy
-                  , subq_0.ds_partitioned__day AS ds_partitioned__day
-                  , subq_0.ds_partitioned__week AS ds_partitioned__week
-                  , subq_0.ds_partitioned__month AS ds_partitioned__month
-                  , subq_0.ds_partitioned__quarter AS ds_partitioned__quarter
-                  , subq_0.ds_partitioned__year AS ds_partitioned__year
-                  , subq_0.ds_partitioned__extract_year AS ds_partitioned__extract_year
-                  , subq_0.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
-                  , subq_0.ds_partitioned__extract_month AS ds_partitioned__extract_month
-                  , subq_0.ds_partitioned__extract_day AS ds_partitioned__extract_day
-                  , subq_0.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
-                  , subq_0.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
-                  , subq_0.paid_at__day AS paid_at__day
-                  , subq_0.paid_at__week AS paid_at__week
-                  , subq_0.paid_at__month AS paid_at__month
-                  , subq_0.paid_at__quarter AS paid_at__quarter
-                  , subq_0.paid_at__year AS paid_at__year
-                  , subq_0.paid_at__extract_year AS paid_at__extract_year
-                  , subq_0.paid_at__extract_quarter AS paid_at__extract_quarter
-                  , subq_0.paid_at__extract_month AS paid_at__extract_month
-                  , subq_0.paid_at__extract_day AS paid_at__extract_day
-                  , subq_0.paid_at__extract_dow AS paid_at__extract_dow
-                  , subq_0.paid_at__extract_doy AS paid_at__extract_doy
-                  , subq_0.booking__ds__day AS booking__ds__day
-                  , subq_0.booking__ds__week AS booking__ds__week
-                  , subq_0.booking__ds__month AS booking__ds__month
-                  , subq_0.booking__ds__quarter AS booking__ds__quarter
-                  , subq_0.booking__ds__year AS booking__ds__year
-                  , subq_0.booking__ds__extract_year AS booking__ds__extract_year
-                  , subq_0.booking__ds__extract_quarter AS booking__ds__extract_quarter
-                  , subq_0.booking__ds__extract_month AS booking__ds__extract_month
-                  , subq_0.booking__ds__extract_day AS booking__ds__extract_day
-                  , subq_0.booking__ds__extract_dow AS booking__ds__extract_dow
-                  , subq_0.booking__ds__extract_doy AS booking__ds__extract_doy
-                  , subq_0.booking__ds_partitioned__day AS booking__ds_partitioned__day
-                  , subq_0.booking__ds_partitioned__week AS booking__ds_partitioned__week
-                  , subq_0.booking__ds_partitioned__month AS booking__ds_partitioned__month
-                  , subq_0.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
-                  , subq_0.booking__ds_partitioned__year AS booking__ds_partitioned__year
-                  , subq_0.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
-                  , subq_0.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
-                  , subq_0.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
-                  , subq_0.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
-                  , subq_0.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
-                  , subq_0.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
-                  , subq_0.booking__paid_at__day AS booking__paid_at__day
-                  , subq_0.booking__paid_at__week AS booking__paid_at__week
-                  , subq_0.booking__paid_at__month AS booking__paid_at__month
-                  , subq_0.booking__paid_at__quarter AS booking__paid_at__quarter
-                  , subq_0.booking__paid_at__year AS booking__paid_at__year
-                  , subq_0.booking__paid_at__extract_year AS booking__paid_at__extract_year
-                  , subq_0.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
-                  , subq_0.booking__paid_at__extract_month AS booking__paid_at__extract_month
-                  , subq_0.booking__paid_at__extract_day AS booking__paid_at__extract_day
-                  , subq_0.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
-                  , subq_0.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
-                  , subq_0.ds__day AS metric_time__day
-                  , subq_0.ds__week AS metric_time__week
-                  , subq_0.ds__month AS metric_time__month
-                  , subq_0.ds__quarter AS metric_time__quarter
-                  , subq_0.ds__year AS metric_time__year
-                  , subq_0.ds__extract_year AS metric_time__extract_year
-                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_0.ds__extract_month AS metric_time__extract_month
-                  , subq_0.ds__extract_day AS metric_time__extract_day
-                  , subq_0.ds__extract_dow AS metric_time__extract_dow
-                  , subq_0.ds__extract_doy AS metric_time__extract_doy
-                  , subq_0.listing AS listing
-                  , subq_0.guest AS guest
-                  , subq_0.host AS host
-                  , subq_0.booking__listing AS booking__listing
-                  , subq_0.booking__guest AS booking__guest
-                  , subq_0.booking__host AS booking__host
-                  , subq_0.is_instant AS is_instant
-                  , subq_0.booking__is_instant AS booking__is_instant
-                  , subq_0.__bookings AS __bookings
-                  , subq_0.__average_booking_value AS __average_booking_value
-                  , subq_0.__instant_bookings AS __instant_bookings
-                  , subq_0.__booking_value AS __booking_value
-                  , subq_0.__max_booking_value AS __max_booking_value
-                  , subq_0.__min_booking_value AS __min_booking_value
-                  , subq_0.__instant_booking_value AS __instant_booking_value
-                  , subq_0.__average_instant_booking_value AS __average_instant_booking_value
-                  , subq_0.__booking_value_for_non_null_listing_id AS __booking_value_for_non_null_listing_id
-                  , subq_0.__bookers AS __bookers
-                  , subq_0.__referred_bookings AS __referred_bookings
-                  , subq_0.__median_booking_value AS __median_booking_value
-                  , subq_0.__booking_value_p99 AS __booking_value_p99
-                  , subq_0.__discrete_booking_value_p99 AS __discrete_booking_value_p99
-                  , subq_0.__approximate_continuous_booking_value_p99 AS __approximate_continuous_booking_value_p99
-                  , subq_0.__approximate_discrete_booking_value_p99 AS __approximate_discrete_booking_value_p99
-                  , subq_0.__bookings_join_to_time_spine AS __bookings_join_to_time_spine
-                  , subq_0.__bookings_fill_nulls_with_0_without_time_spine AS __bookings_fill_nulls_with_0_without_time_spine
-                  , subq_0.__bookings_fill_nulls_with_0 AS __bookings_fill_nulls_with_0
-                  , subq_0.__instant_bookings_with_measure_filter AS __instant_bookings_with_measure_filter
-                  , subq_0.__bookings_join_to_time_spine_with_tiered_filters AS __bookings_join_to_time_spine_with_tiered_filters
-                  , subq_0.__bookers_fill_nulls_with_0_join_to_timespine AS __bookers_fill_nulls_with_0_join_to_timespine
-                  , subq_1.alien_day AS metric_time__alien_day
-                FROM (
-                  -- Read Elements From Semantic Model 'bookings_source'
-                  SELECT
-                    1 AS __bookings
-                    , bookings_source_src_28000.booking_value AS __average_booking_value
-                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS __instant_bookings
-                    , bookings_source_src_28000.booking_value AS __booking_value
-                    , bookings_source_src_28000.booking_value AS __max_booking_value
-                    , bookings_source_src_28000.booking_value AS __min_booking_value
-                    , bookings_source_src_28000.booking_value AS __instant_booking_value
-                    , bookings_source_src_28000.booking_value AS __average_instant_booking_value
-                    , bookings_source_src_28000.booking_value AS __booking_value_for_non_null_listing_id
-                    , bookings_source_src_28000.guest_id AS __bookers
-                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS __referred_bookings
-                    , bookings_source_src_28000.booking_value AS __median_booking_value
-                    , bookings_source_src_28000.booking_value AS __booking_value_p99
-                    , bookings_source_src_28000.booking_value AS __discrete_booking_value_p99
-                    , bookings_source_src_28000.booking_value AS __approximate_continuous_booking_value_p99
-                    , bookings_source_src_28000.booking_value AS __approximate_discrete_booking_value_p99
-                    , 1 AS __bookings_join_to_time_spine
-                    , 1 AS __bookings_fill_nulls_with_0_without_time_spine
-                    , 1 AS __bookings_fill_nulls_with_0
-                    , 1 AS __instant_bookings_with_measure_filter
-                    , 1 AS __bookings_join_to_time_spine_with_tiered_filters
-                    , bookings_source_src_28000.guest_id AS __bookers_fill_nulls_with_0_join_to_timespine
-                    , bookings_source_src_28000.booking_value AS __booking_payments
-                    , bookings_source_src_28000.is_instant
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                    , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS ds__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                    , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                    , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                    , bookings_source_src_28000.is_instant AS booking__is_instant
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                    , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                    , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                    , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                    , bookings_source_src_28000.listing_id AS listing
-                    , bookings_source_src_28000.guest_id AS guest
-                    , bookings_source_src_28000.host_id AS host
-                    , bookings_source_src_28000.listing_id AS booking__listing
-                    , bookings_source_src_28000.guest_id AS booking__guest
-                    , bookings_source_src_28000.host_id AS booking__host
-                  FROM ***************************.fct_bookings bookings_source_src_28000
-                ) subq_0
-                LEFT OUTER JOIN
-                  ***************************.mf_time_spine subq_1
-                ON
-                  subq_0.ds__day = subq_1.ds
-              ) subq_2
-            ) subq_3
-            WHERE metric_time__alien_day = '2020-01-01'
-          ) subq_4
-        ) subq_5
+                  1 AS __bookings
+                  , bookings_source_src_28000.booking_value AS __average_booking_value
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS __instant_bookings
+                  , bookings_source_src_28000.booking_value AS __booking_value
+                  , bookings_source_src_28000.booking_value AS __max_booking_value
+                  , bookings_source_src_28000.booking_value AS __min_booking_value
+                  , bookings_source_src_28000.booking_value AS __instant_booking_value
+                  , bookings_source_src_28000.booking_value AS __average_instant_booking_value
+                  , bookings_source_src_28000.booking_value AS __booking_value_for_non_null_listing_id
+                  , bookings_source_src_28000.guest_id AS __bookers
+                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS __referred_bookings
+                  , bookings_source_src_28000.booking_value AS __median_booking_value
+                  , bookings_source_src_28000.booking_value AS __booking_value_p99
+                  , bookings_source_src_28000.booking_value AS __discrete_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS __approximate_continuous_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS __approximate_discrete_booking_value_p99
+                  , 1 AS __bookings_join_to_time_spine
+                  , 1 AS __bookings_fill_nulls_with_0_without_time_spine
+                  , 1 AS __bookings_fill_nulls_with_0
+                  , 1 AS __instant_bookings_with_measure_filter
+                  , 1 AS __bookings_join_to_time_spine_with_tiered_filters
+                  , bookings_source_src_28000.guest_id AS __bookers_fill_nulls_with_0_join_to_timespine
+                  , bookings_source_src_28000.booking_value AS __booking_payments
+                  , bookings_source_src_28000.is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                  , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                  , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                  , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                  , bookings_source_src_28000.is_instant AS booking__is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                  , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                  , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                  , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                  , bookings_source_src_28000.listing_id AS listing
+                  , bookings_source_src_28000.guest_id AS guest
+                  , bookings_source_src_28000.host_id AS host
+                  , bookings_source_src_28000.listing_id AS booking__listing
+                  , bookings_source_src_28000.guest_id AS booking__guest
+                  , bookings_source_src_28000.host_id AS booking__host
+                FROM ***************************.fct_bookings bookings_source_src_28000
+              ) subq_0
+              LEFT OUTER JOIN
+                ***************************.mf_time_spine subq_1
+              ON
+                subq_0.ds__day = subq_1.ds
+            ) subq_2
+          ) subq_3
+        ) subq_4
         GROUP BY
-          subq_5.metric_time__day
-      ) subq_6
+          subq_4.metric_time__day
+      ) subq_5
       ON
-        DATEADD(day, -5, subq_11.metric_time__day) = subq_6.metric_time__day
-    ) subq_12
-  ) subq_13
-) subq_14
+        DATEADD(day, -5, subq_10.metric_time__day) = subq_5.metric_time__day
+    ) subq_11
+  ) subq_12
+) subq_13

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Snowflake/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Snowflake/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0_optimized.sql
@@ -11,8 +11,8 @@ FROM (
   -- Join to Time Spine Dataset
   -- Compute Metrics via Expressions
   SELECT
-    subq_26.metric_time__day AS metric_time__day
-    , subq_21.__bookings AS bookings_5_days_ago
+    subq_24.metric_time__day AS metric_time__day
+    , subq_19.__bookings AS bookings_5_days_ago
   FROM (
     -- Constrain Output with WHERE
     -- Select: ['metric_time__day']
@@ -26,40 +26,32 @@ FROM (
         ds AS metric_time__day
         , alien_day AS metric_time__alien_day
       FROM ***************************.mf_time_spine time_spine_src_28006
-    ) subq_24
+    ) subq_22
     WHERE metric_time__alien_day = '2020-01-01'
-  ) subq_26
+  ) subq_24
   INNER JOIN (
-    -- Constrain Output with WHERE
+    -- Metric Time Dimension 'ds'
+    -- Join to Custom Granularity Dataset
+    -- Select: ['__bookings', 'metric_time__day']
     -- Select: ['__bookings', 'metric_time__day']
     -- Aggregate Inputs for Simple Metrics
     SELECT
-      metric_time__day
-      , SUM(bookings) AS __bookings
+      subq_14.ds__day AS metric_time__day
+      , SUM(subq_14.__bookings) AS __bookings
     FROM (
-      -- Metric Time Dimension 'ds'
-      -- Join to Custom Granularity Dataset
-      -- Select: ['__bookings', 'metric_time__day', 'metric_time__alien_day']
+      -- Read Elements From Semantic Model 'bookings_source'
       SELECT
-        subq_16.alien_day AS metric_time__alien_day
-        , subq_15.ds__day AS metric_time__day
-        , subq_15.__bookings AS bookings
-      FROM (
-        -- Read Elements From Semantic Model 'bookings_source'
-        SELECT
-          1 AS __bookings
-          , DATE_TRUNC('day', ds) AS ds__day
-        FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_15
-      LEFT OUTER JOIN
-        ***************************.mf_time_spine subq_16
-      ON
-        subq_15.ds__day = subq_16.ds
-    ) subq_18
-    WHERE metric_time__alien_day = '2020-01-01'
+        1 AS __bookings
+        , DATE_TRUNC('day', ds) AS ds__day
+      FROM ***************************.fct_bookings bookings_source_src_28000
+    ) subq_14
+    LEFT OUTER JOIN
+      ***************************.mf_time_spine subq_15
+    ON
+      subq_14.ds__day = subq_15.ds
     GROUP BY
-      metric_time__day
-  ) subq_21
+      subq_14.ds__day
+  ) subq_19
   ON
-    DATEADD(day, -5, subq_26.metric_time__day) = subq_21.metric_time__day
-) subq_28
+    DATEADD(day, -5, subq_24.metric_time__day) = subq_19.metric_time__day
+) subq_26

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Trino/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Trino/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0.sql
@@ -4,52 +4,52 @@ sql_engine: Trino
 ---
 -- Write to DataTable
 SELECT
-  subq_14.metric_time__day
-  , subq_14.bookings_5_day_lag
+  subq_13.metric_time__day
+  , subq_13.bookings_5_day_lag
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_13.metric_time__day
+    subq_12.metric_time__day
     , bookings_5_days_ago AS bookings_5_day_lag
   FROM (
     -- Compute Metrics via Expressions
     SELECT
-      subq_12.metric_time__day
-      , subq_12.__bookings AS bookings_5_days_ago
+      subq_11.metric_time__day
+      , subq_11.__bookings AS bookings_5_days_ago
     FROM (
       -- Join to Time Spine Dataset
       SELECT
-        subq_11.metric_time__day AS metric_time__day
-        , subq_6.__bookings AS __bookings
+        subq_10.metric_time__day AS metric_time__day
+        , subq_5.__bookings AS __bookings
       FROM (
         -- Select: ['metric_time__day']
         SELECT
-          subq_10.metric_time__day
+          subq_9.metric_time__day
         FROM (
           -- Constrain Output with WHERE
           SELECT
-            subq_9.metric_time__day
-            , subq_9.metric_time__alien_day
+            subq_8.metric_time__day
+            , subq_8.metric_time__alien_day
           FROM (
             -- Select: ['metric_time__day', 'metric_time__alien_day']
             SELECT
-              subq_8.metric_time__day
-              , subq_8.metric_time__alien_day
+              subq_7.metric_time__day
+              , subq_7.metric_time__alien_day
             FROM (
               -- Change Column Aliases
               SELECT
-                subq_7.ds__day AS metric_time__day
-                , subq_7.ds__week
-                , subq_7.ds__month
-                , subq_7.ds__quarter
-                , subq_7.ds__year
-                , subq_7.ds__extract_year
-                , subq_7.ds__extract_quarter
-                , subq_7.ds__extract_month
-                , subq_7.ds__extract_day
-                , subq_7.ds__extract_dow
-                , subq_7.ds__extract_doy
-                , subq_7.ds__alien_day AS metric_time__alien_day
+                subq_6.ds__day AS metric_time__day
+                , subq_6.ds__week
+                , subq_6.ds__month
+                , subq_6.ds__quarter
+                , subq_6.ds__year
+                , subq_6.ds__extract_year
+                , subq_6.ds__extract_quarter
+                , subq_6.ds__extract_month
+                , subq_6.ds__extract_day
+                , subq_6.ds__extract_dow
+                , subq_6.ds__extract_doy
+                , subq_6.ds__alien_day AS metric_time__alien_day
               FROM (
                 -- Read From Time Spine 'mf_time_spine'
                 SELECT
@@ -66,262 +66,253 @@ FROM (
                   , EXTRACT(doy FROM time_spine_src_28006.ds) AS ds__extract_doy
                   , time_spine_src_28006.alien_day AS ds__alien_day
                 FROM ***************************.mf_time_spine time_spine_src_28006
-              ) subq_7
-            ) subq_8
-          ) subq_9
+              ) subq_6
+            ) subq_7
+          ) subq_8
           WHERE metric_time__alien_day = '2020-01-01'
-        ) subq_10
-      ) subq_11
+        ) subq_9
+      ) subq_10
       INNER JOIN (
         -- Aggregate Inputs for Simple Metrics
         SELECT
-          subq_5.metric_time__day
-          , SUM(subq_5.__bookings) AS __bookings
+          subq_4.metric_time__day
+          , SUM(subq_4.__bookings) AS __bookings
         FROM (
           -- Select: ['__bookings', 'metric_time__day']
           SELECT
-            subq_4.metric_time__day
-            , subq_4.__bookings
+            subq_3.metric_time__day
+            , subq_3.__bookings
           FROM (
-            -- Constrain Output with WHERE
+            -- Select: ['__bookings', 'metric_time__day']
             SELECT
-              subq_3.bookings AS __bookings
-              , subq_3.metric_time__alien_day
-              , subq_3.metric_time__day
+              subq_2.metric_time__day
+              , subq_2.__bookings
             FROM (
-              -- Select: ['__bookings', 'metric_time__day', 'metric_time__alien_day']
+              -- Metric Time Dimension 'ds'
+              -- Join to Custom Granularity Dataset
               SELECT
-                subq_2.metric_time__alien_day
-                , subq_2.metric_time__day
-                , subq_2.__bookings AS bookings
+                subq_0.ds__day AS ds__day
+                , subq_0.ds__week AS ds__week
+                , subq_0.ds__month AS ds__month
+                , subq_0.ds__quarter AS ds__quarter
+                , subq_0.ds__year AS ds__year
+                , subq_0.ds__extract_year AS ds__extract_year
+                , subq_0.ds__extract_quarter AS ds__extract_quarter
+                , subq_0.ds__extract_month AS ds__extract_month
+                , subq_0.ds__extract_day AS ds__extract_day
+                , subq_0.ds__extract_dow AS ds__extract_dow
+                , subq_0.ds__extract_doy AS ds__extract_doy
+                , subq_0.ds_partitioned__day AS ds_partitioned__day
+                , subq_0.ds_partitioned__week AS ds_partitioned__week
+                , subq_0.ds_partitioned__month AS ds_partitioned__month
+                , subq_0.ds_partitioned__quarter AS ds_partitioned__quarter
+                , subq_0.ds_partitioned__year AS ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year AS ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month AS ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day AS ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+                , subq_0.paid_at__day AS paid_at__day
+                , subq_0.paid_at__week AS paid_at__week
+                , subq_0.paid_at__month AS paid_at__month
+                , subq_0.paid_at__quarter AS paid_at__quarter
+                , subq_0.paid_at__year AS paid_at__year
+                , subq_0.paid_at__extract_year AS paid_at__extract_year
+                , subq_0.paid_at__extract_quarter AS paid_at__extract_quarter
+                , subq_0.paid_at__extract_month AS paid_at__extract_month
+                , subq_0.paid_at__extract_day AS paid_at__extract_day
+                , subq_0.paid_at__extract_dow AS paid_at__extract_dow
+                , subq_0.paid_at__extract_doy AS paid_at__extract_doy
+                , subq_0.booking__ds__day AS booking__ds__day
+                , subq_0.booking__ds__week AS booking__ds__week
+                , subq_0.booking__ds__month AS booking__ds__month
+                , subq_0.booking__ds__quarter AS booking__ds__quarter
+                , subq_0.booking__ds__year AS booking__ds__year
+                , subq_0.booking__ds__extract_year AS booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter AS booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month AS booking__ds__extract_month
+                , subq_0.booking__ds__extract_day AS booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow AS booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy AS booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day AS booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week AS booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month AS booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year AS booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day AS booking__paid_at__day
+                , subq_0.booking__paid_at__week AS booking__paid_at__week
+                , subq_0.booking__paid_at__month AS booking__paid_at__month
+                , subq_0.booking__paid_at__quarter AS booking__paid_at__quarter
+                , subq_0.booking__paid_at__year AS booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year AS booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month AS booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day AS booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing AS listing
+                , subq_0.guest AS guest
+                , subq_0.host AS host
+                , subq_0.booking__listing AS booking__listing
+                , subq_0.booking__guest AS booking__guest
+                , subq_0.booking__host AS booking__host
+                , subq_0.is_instant AS is_instant
+                , subq_0.booking__is_instant AS booking__is_instant
+                , subq_0.__bookings AS __bookings
+                , subq_0.__average_booking_value AS __average_booking_value
+                , subq_0.__instant_bookings AS __instant_bookings
+                , subq_0.__booking_value AS __booking_value
+                , subq_0.__max_booking_value AS __max_booking_value
+                , subq_0.__min_booking_value AS __min_booking_value
+                , subq_0.__instant_booking_value AS __instant_booking_value
+                , subq_0.__average_instant_booking_value AS __average_instant_booking_value
+                , subq_0.__booking_value_for_non_null_listing_id AS __booking_value_for_non_null_listing_id
+                , subq_0.__bookers AS __bookers
+                , subq_0.__referred_bookings AS __referred_bookings
+                , subq_0.__median_booking_value AS __median_booking_value
+                , subq_0.__booking_value_p99 AS __booking_value_p99
+                , subq_0.__discrete_booking_value_p99 AS __discrete_booking_value_p99
+                , subq_0.__approximate_continuous_booking_value_p99 AS __approximate_continuous_booking_value_p99
+                , subq_0.__approximate_discrete_booking_value_p99 AS __approximate_discrete_booking_value_p99
+                , subq_0.__bookings_join_to_time_spine AS __bookings_join_to_time_spine
+                , subq_0.__bookings_fill_nulls_with_0_without_time_spine AS __bookings_fill_nulls_with_0_without_time_spine
+                , subq_0.__bookings_fill_nulls_with_0 AS __bookings_fill_nulls_with_0
+                , subq_0.__instant_bookings_with_measure_filter AS __instant_bookings_with_measure_filter
+                , subq_0.__bookings_join_to_time_spine_with_tiered_filters AS __bookings_join_to_time_spine_with_tiered_filters
+                , subq_0.__bookers_fill_nulls_with_0_join_to_timespine AS __bookers_fill_nulls_with_0_join_to_timespine
+                , subq_1.alien_day AS metric_time__alien_day
               FROM (
-                -- Metric Time Dimension 'ds'
-                -- Join to Custom Granularity Dataset
+                -- Read Elements From Semantic Model 'bookings_source'
                 SELECT
-                  subq_0.ds__day AS ds__day
-                  , subq_0.ds__week AS ds__week
-                  , subq_0.ds__month AS ds__month
-                  , subq_0.ds__quarter AS ds__quarter
-                  , subq_0.ds__year AS ds__year
-                  , subq_0.ds__extract_year AS ds__extract_year
-                  , subq_0.ds__extract_quarter AS ds__extract_quarter
-                  , subq_0.ds__extract_month AS ds__extract_month
-                  , subq_0.ds__extract_day AS ds__extract_day
-                  , subq_0.ds__extract_dow AS ds__extract_dow
-                  , subq_0.ds__extract_doy AS ds__extract_doy
-                  , subq_0.ds_partitioned__day AS ds_partitioned__day
-                  , subq_0.ds_partitioned__week AS ds_partitioned__week
-                  , subq_0.ds_partitioned__month AS ds_partitioned__month
-                  , subq_0.ds_partitioned__quarter AS ds_partitioned__quarter
-                  , subq_0.ds_partitioned__year AS ds_partitioned__year
-                  , subq_0.ds_partitioned__extract_year AS ds_partitioned__extract_year
-                  , subq_0.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
-                  , subq_0.ds_partitioned__extract_month AS ds_partitioned__extract_month
-                  , subq_0.ds_partitioned__extract_day AS ds_partitioned__extract_day
-                  , subq_0.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
-                  , subq_0.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
-                  , subq_0.paid_at__day AS paid_at__day
-                  , subq_0.paid_at__week AS paid_at__week
-                  , subq_0.paid_at__month AS paid_at__month
-                  , subq_0.paid_at__quarter AS paid_at__quarter
-                  , subq_0.paid_at__year AS paid_at__year
-                  , subq_0.paid_at__extract_year AS paid_at__extract_year
-                  , subq_0.paid_at__extract_quarter AS paid_at__extract_quarter
-                  , subq_0.paid_at__extract_month AS paid_at__extract_month
-                  , subq_0.paid_at__extract_day AS paid_at__extract_day
-                  , subq_0.paid_at__extract_dow AS paid_at__extract_dow
-                  , subq_0.paid_at__extract_doy AS paid_at__extract_doy
-                  , subq_0.booking__ds__day AS booking__ds__day
-                  , subq_0.booking__ds__week AS booking__ds__week
-                  , subq_0.booking__ds__month AS booking__ds__month
-                  , subq_0.booking__ds__quarter AS booking__ds__quarter
-                  , subq_0.booking__ds__year AS booking__ds__year
-                  , subq_0.booking__ds__extract_year AS booking__ds__extract_year
-                  , subq_0.booking__ds__extract_quarter AS booking__ds__extract_quarter
-                  , subq_0.booking__ds__extract_month AS booking__ds__extract_month
-                  , subq_0.booking__ds__extract_day AS booking__ds__extract_day
-                  , subq_0.booking__ds__extract_dow AS booking__ds__extract_dow
-                  , subq_0.booking__ds__extract_doy AS booking__ds__extract_doy
-                  , subq_0.booking__ds_partitioned__day AS booking__ds_partitioned__day
-                  , subq_0.booking__ds_partitioned__week AS booking__ds_partitioned__week
-                  , subq_0.booking__ds_partitioned__month AS booking__ds_partitioned__month
-                  , subq_0.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
-                  , subq_0.booking__ds_partitioned__year AS booking__ds_partitioned__year
-                  , subq_0.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
-                  , subq_0.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
-                  , subq_0.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
-                  , subq_0.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
-                  , subq_0.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
-                  , subq_0.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
-                  , subq_0.booking__paid_at__day AS booking__paid_at__day
-                  , subq_0.booking__paid_at__week AS booking__paid_at__week
-                  , subq_0.booking__paid_at__month AS booking__paid_at__month
-                  , subq_0.booking__paid_at__quarter AS booking__paid_at__quarter
-                  , subq_0.booking__paid_at__year AS booking__paid_at__year
-                  , subq_0.booking__paid_at__extract_year AS booking__paid_at__extract_year
-                  , subq_0.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
-                  , subq_0.booking__paid_at__extract_month AS booking__paid_at__extract_month
-                  , subq_0.booking__paid_at__extract_day AS booking__paid_at__extract_day
-                  , subq_0.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
-                  , subq_0.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
-                  , subq_0.ds__day AS metric_time__day
-                  , subq_0.ds__week AS metric_time__week
-                  , subq_0.ds__month AS metric_time__month
-                  , subq_0.ds__quarter AS metric_time__quarter
-                  , subq_0.ds__year AS metric_time__year
-                  , subq_0.ds__extract_year AS metric_time__extract_year
-                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_0.ds__extract_month AS metric_time__extract_month
-                  , subq_0.ds__extract_day AS metric_time__extract_day
-                  , subq_0.ds__extract_dow AS metric_time__extract_dow
-                  , subq_0.ds__extract_doy AS metric_time__extract_doy
-                  , subq_0.listing AS listing
-                  , subq_0.guest AS guest
-                  , subq_0.host AS host
-                  , subq_0.booking__listing AS booking__listing
-                  , subq_0.booking__guest AS booking__guest
-                  , subq_0.booking__host AS booking__host
-                  , subq_0.is_instant AS is_instant
-                  , subq_0.booking__is_instant AS booking__is_instant
-                  , subq_0.__bookings AS __bookings
-                  , subq_0.__average_booking_value AS __average_booking_value
-                  , subq_0.__instant_bookings AS __instant_bookings
-                  , subq_0.__booking_value AS __booking_value
-                  , subq_0.__max_booking_value AS __max_booking_value
-                  , subq_0.__min_booking_value AS __min_booking_value
-                  , subq_0.__instant_booking_value AS __instant_booking_value
-                  , subq_0.__average_instant_booking_value AS __average_instant_booking_value
-                  , subq_0.__booking_value_for_non_null_listing_id AS __booking_value_for_non_null_listing_id
-                  , subq_0.__bookers AS __bookers
-                  , subq_0.__referred_bookings AS __referred_bookings
-                  , subq_0.__median_booking_value AS __median_booking_value
-                  , subq_0.__booking_value_p99 AS __booking_value_p99
-                  , subq_0.__discrete_booking_value_p99 AS __discrete_booking_value_p99
-                  , subq_0.__approximate_continuous_booking_value_p99 AS __approximate_continuous_booking_value_p99
-                  , subq_0.__approximate_discrete_booking_value_p99 AS __approximate_discrete_booking_value_p99
-                  , subq_0.__bookings_join_to_time_spine AS __bookings_join_to_time_spine
-                  , subq_0.__bookings_fill_nulls_with_0_without_time_spine AS __bookings_fill_nulls_with_0_without_time_spine
-                  , subq_0.__bookings_fill_nulls_with_0 AS __bookings_fill_nulls_with_0
-                  , subq_0.__instant_bookings_with_measure_filter AS __instant_bookings_with_measure_filter
-                  , subq_0.__bookings_join_to_time_spine_with_tiered_filters AS __bookings_join_to_time_spine_with_tiered_filters
-                  , subq_0.__bookers_fill_nulls_with_0_join_to_timespine AS __bookers_fill_nulls_with_0_join_to_timespine
-                  , subq_1.alien_day AS metric_time__alien_day
-                FROM (
-                  -- Read Elements From Semantic Model 'bookings_source'
-                  SELECT
-                    1 AS __bookings
-                    , bookings_source_src_28000.booking_value AS __average_booking_value
-                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS __instant_bookings
-                    , bookings_source_src_28000.booking_value AS __booking_value
-                    , bookings_source_src_28000.booking_value AS __max_booking_value
-                    , bookings_source_src_28000.booking_value AS __min_booking_value
-                    , bookings_source_src_28000.booking_value AS __instant_booking_value
-                    , bookings_source_src_28000.booking_value AS __average_instant_booking_value
-                    , bookings_source_src_28000.booking_value AS __booking_value_for_non_null_listing_id
-                    , bookings_source_src_28000.guest_id AS __bookers
-                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS __referred_bookings
-                    , bookings_source_src_28000.booking_value AS __median_booking_value
-                    , bookings_source_src_28000.booking_value AS __booking_value_p99
-                    , bookings_source_src_28000.booking_value AS __discrete_booking_value_p99
-                    , bookings_source_src_28000.booking_value AS __approximate_continuous_booking_value_p99
-                    , bookings_source_src_28000.booking_value AS __approximate_discrete_booking_value_p99
-                    , 1 AS __bookings_join_to_time_spine
-                    , 1 AS __bookings_fill_nulls_with_0_without_time_spine
-                    , 1 AS __bookings_fill_nulls_with_0
-                    , 1 AS __instant_bookings_with_measure_filter
-                    , 1 AS __bookings_join_to_time_spine_with_tiered_filters
-                    , bookings_source_src_28000.guest_id AS __bookers_fill_nulls_with_0_join_to_timespine
-                    , bookings_source_src_28000.booking_value AS __booking_payments
-                    , bookings_source_src_28000.is_instant
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                    , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS ds__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                    , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                    , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                    , bookings_source_src_28000.is_instant AS booking__is_instant
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                    , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                    , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                    , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                    , bookings_source_src_28000.listing_id AS listing
-                    , bookings_source_src_28000.guest_id AS guest
-                    , bookings_source_src_28000.host_id AS host
-                    , bookings_source_src_28000.listing_id AS booking__listing
-                    , bookings_source_src_28000.guest_id AS booking__guest
-                    , bookings_source_src_28000.host_id AS booking__host
-                  FROM ***************************.fct_bookings bookings_source_src_28000
-                ) subq_0
-                LEFT OUTER JOIN
-                  ***************************.mf_time_spine subq_1
-                ON
-                  subq_0.ds__day = subq_1.ds
-              ) subq_2
-            ) subq_3
-            WHERE metric_time__alien_day = '2020-01-01'
-          ) subq_4
-        ) subq_5
+                  1 AS __bookings
+                  , bookings_source_src_28000.booking_value AS __average_booking_value
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS __instant_bookings
+                  , bookings_source_src_28000.booking_value AS __booking_value
+                  , bookings_source_src_28000.booking_value AS __max_booking_value
+                  , bookings_source_src_28000.booking_value AS __min_booking_value
+                  , bookings_source_src_28000.booking_value AS __instant_booking_value
+                  , bookings_source_src_28000.booking_value AS __average_instant_booking_value
+                  , bookings_source_src_28000.booking_value AS __booking_value_for_non_null_listing_id
+                  , bookings_source_src_28000.guest_id AS __bookers
+                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS __referred_bookings
+                  , bookings_source_src_28000.booking_value AS __median_booking_value
+                  , bookings_source_src_28000.booking_value AS __booking_value_p99
+                  , bookings_source_src_28000.booking_value AS __discrete_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS __approximate_continuous_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS __approximate_discrete_booking_value_p99
+                  , 1 AS __bookings_join_to_time_spine
+                  , 1 AS __bookings_fill_nulls_with_0_without_time_spine
+                  , 1 AS __bookings_fill_nulls_with_0
+                  , 1 AS __instant_bookings_with_measure_filter
+                  , 1 AS __bookings_join_to_time_spine_with_tiered_filters
+                  , bookings_source_src_28000.guest_id AS __bookers_fill_nulls_with_0_join_to_timespine
+                  , bookings_source_src_28000.booking_value AS __booking_payments
+                  , bookings_source_src_28000.is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                  , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                  , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                  , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                  , bookings_source_src_28000.is_instant AS booking__is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                  , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                  , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                  , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                  , bookings_source_src_28000.listing_id AS listing
+                  , bookings_source_src_28000.guest_id AS guest
+                  , bookings_source_src_28000.host_id AS host
+                  , bookings_source_src_28000.listing_id AS booking__listing
+                  , bookings_source_src_28000.guest_id AS booking__guest
+                  , bookings_source_src_28000.host_id AS booking__host
+                FROM ***************************.fct_bookings bookings_source_src_28000
+              ) subq_0
+              LEFT OUTER JOIN
+                ***************************.mf_time_spine subq_1
+              ON
+                subq_0.ds__day = subq_1.ds
+            ) subq_2
+          ) subq_3
+        ) subq_4
         GROUP BY
-          subq_5.metric_time__day
-      ) subq_6
+          subq_4.metric_time__day
+      ) subq_5
       ON
-        DATE_ADD('day', -5, subq_11.metric_time__day) = subq_6.metric_time__day
-    ) subq_12
-  ) subq_13
-) subq_14
+        DATE_ADD('day', -5, subq_10.metric_time__day) = subq_5.metric_time__day
+    ) subq_11
+  ) subq_12
+) subq_13

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Trino/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/Trino/test_offset_metric_with_custom_granularity_filter_not_in_group_by__plan0_optimized.sql
@@ -11,8 +11,8 @@ FROM (
   -- Join to Time Spine Dataset
   -- Compute Metrics via Expressions
   SELECT
-    subq_26.metric_time__day AS metric_time__day
-    , subq_21.__bookings AS bookings_5_days_ago
+    subq_24.metric_time__day AS metric_time__day
+    , subq_19.__bookings AS bookings_5_days_ago
   FROM (
     -- Constrain Output with WHERE
     -- Select: ['metric_time__day']
@@ -26,40 +26,32 @@ FROM (
         ds AS metric_time__day
         , alien_day AS metric_time__alien_day
       FROM ***************************.mf_time_spine time_spine_src_28006
-    ) subq_24
+    ) subq_22
     WHERE metric_time__alien_day = '2020-01-01'
-  ) subq_26
+  ) subq_24
   INNER JOIN (
-    -- Constrain Output with WHERE
+    -- Metric Time Dimension 'ds'
+    -- Join to Custom Granularity Dataset
+    -- Select: ['__bookings', 'metric_time__day']
     -- Select: ['__bookings', 'metric_time__day']
     -- Aggregate Inputs for Simple Metrics
     SELECT
-      metric_time__day
-      , SUM(bookings) AS __bookings
+      subq_14.ds__day AS metric_time__day
+      , SUM(subq_14.__bookings) AS __bookings
     FROM (
-      -- Metric Time Dimension 'ds'
-      -- Join to Custom Granularity Dataset
-      -- Select: ['__bookings', 'metric_time__day', 'metric_time__alien_day']
+      -- Read Elements From Semantic Model 'bookings_source'
       SELECT
-        subq_16.alien_day AS metric_time__alien_day
-        , subq_15.ds__day AS metric_time__day
-        , subq_15.__bookings AS bookings
-      FROM (
-        -- Read Elements From Semantic Model 'bookings_source'
-        SELECT
-          1 AS __bookings
-          , DATE_TRUNC('day', ds) AS ds__day
-        FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_15
-      LEFT OUTER JOIN
-        ***************************.mf_time_spine subq_16
-      ON
-        subq_15.ds__day = subq_16.ds
-    ) subq_18
-    WHERE metric_time__alien_day = '2020-01-01'
+        1 AS __bookings
+        , DATE_TRUNC('day', ds) AS ds__day
+      FROM ***************************.fct_bookings bookings_source_src_28000
+    ) subq_14
+    LEFT OUTER JOIN
+      ***************************.mf_time_spine subq_15
+    ON
+      subq_14.ds__day = subq_15.ds
     GROUP BY
-      metric_time__day
-  ) subq_21
+      subq_14.ds__day
+  ) subq_19
   ON
-    DATE_ADD('day', -5, subq_26.metric_time__day) = subq_21.metric_time__day
-) subq_28
+    DATE_ADD('day', -5, subq_24.metric_time__day) = subq_19.metric_time__day
+) subq_26

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_offset_to_grain_metric_filter_and_query_have_different_granularities__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_offset_to_grain_metric_filter_and_query_have_different_granularities__dfp_0.xml
@@ -104,64 +104,27 @@ docstring:
                             <!--     time_granularity=ExpandedTimeGranularity(name='month', base_granularity=MONTH), -->
                             <!--   )                                                                                 -->
                             <!-- distinct = False -->
-                            <WhereFilterNode>
-                                <!-- description = 'Filter Output with WHERE' -->
-                                <!-- node_id = NodeId(id_str='wcc_0') -->
-                                <!-- filter_spec =                                    -->
-                                <!--   WhereFilterSpec(                               -->
-                                <!--     where_sql="metric_time__day = '2020-01-01'", -->
-                                <!--     bind_parameters=SqlBindParameterSet(),       -->
-                                <!--     element_set=GroupByItemSet(                  -->
-                                <!--       annotated_specs=(                          -->
-                                <!--         AnnotatedSpec(                           -->
-                                <!--           element_type=TIME_DIMENSION,           -->
-                                <!--           element_name='metric_time',            -->
-                                <!--           time_grain=ExpandedTimeGranularity(    -->
-                                <!--             name='day',                          -->
-                                <!--             base_granularity=DAY,                -->
-                                <!--           ),                                     -->
-                                <!--           element_properties=(METRIC_TIME,),     -->
-                                <!--           origin_semantic_model_names=(          -->
-                                <!--             'bookings_source',                   -->
-                                <!--           ),                                     -->
-                                <!--           derived_from_semantic_model_names=(    -->
-                                <!--             'bookings_source',                   -->
-                                <!--           ),                                     -->
-                                <!--         ),                                       -->
-                                <!--       ),                                         -->
-                                <!--     ),                                           -->
-                                <!--   )                                              -->
-                                <SelectorNode>
-                                    <!-- description =                                                        -->
-                                    <!--   "Select: ['__bookings', 'metric_time__month', 'metric_time__day']" -->
-                                    <!-- node_id = NodeId(id_str='pfe_0') -->
-                                    <!-- include_spec = SimpleMetricInputSpec(element_name='bookings') -->
-                                    <!-- include_spec =                                -->
-                                    <!--   TimeDimensionSpec(                          -->
-                                    <!--     element_name='metric_time',               -->
-                                    <!--     time_granularity=ExpandedTimeGranularity( -->
-                                    <!--       name='month',                           -->
-                                    <!--       base_granularity=MONTH,                 -->
-                                    <!--     ),                                        -->
-                                    <!--   )                                           -->
-                                    <!-- include_spec =                                                                  -->
-                                    <!--   TimeDimensionSpec(                                                            -->
-                                    <!--     element_name='metric_time',                                                 -->
-                                    <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
-                                    <!--   )                                                                             -->
-                                    <!-- distinct = False -->
-                                    <MetricTimeDimensionTransformNode>
-                                        <!-- description = "Metric Time Dimension 'ds'" -->
-                                        <!-- node_id = NodeId(id_str='sma_28009') -->
-                                        <!-- aggregation_time_dimension = 'ds' -->
-                                        <ReadSqlSourceNode>
-                                            <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
-                                            <!-- node_id = NodeId(id_str='rss_28020') -->
-                                            <!-- data_set = SemanticModelDataSet('bookings_source') -->
-                                        </ReadSqlSourceNode>
-                                    </MetricTimeDimensionTransformNode>
-                                </SelectorNode>
-                            </WhereFilterNode>
+                            <SelectorNode>
+                                <!-- description = "Select: ['__bookings', 'metric_time__month']" -->
+                                <!-- node_id = NodeId(id_str='pfe_0') -->
+                                <!-- include_spec = SimpleMetricInputSpec(element_name='bookings') -->
+                                <!-- include_spec =                                                                      -->
+                                <!--   TimeDimensionSpec(                                                                -->
+                                <!--     element_name='metric_time',                                                     -->
+                                <!--     time_granularity=ExpandedTimeGranularity(name='month', base_granularity=MONTH), -->
+                                <!--   )                                                                                 -->
+                                <!-- distinct = False -->
+                                <MetricTimeDimensionTransformNode>
+                                    <!-- description = "Metric Time Dimension 'ds'" -->
+                                    <!-- node_id = NodeId(id_str='sma_28009') -->
+                                    <!-- aggregation_time_dimension = 'ds' -->
+                                    <ReadSqlSourceNode>
+                                        <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
+                                        <!-- node_id = NodeId(id_str='rss_28020') -->
+                                        <!-- data_set = SemanticModelDataSet('bookings_source') -->
+                                    </ReadSqlSourceNode>
+                                </MetricTimeDimensionTransformNode>
+                            </SelectorNode>
                         </SelectorNode>
                     </AggregateSimpleMetricInputsNode>
                     <SelectorNode>
@@ -175,7 +138,7 @@ docstring:
                         <!-- distinct = True -->
                         <WhereFilterNode>
                             <!-- description = 'Filter Output with WHERE' -->
-                            <!-- node_id = NodeId(id_str='wcc_1') -->
+                            <!-- node_id = NodeId(id_str='wcc_0') -->
                             <!-- filter_spec =                                               -->
                             <!--   WhereFilterSpec(                                          -->
                             <!--     where_sql="metric_time__day = '2020-01-01'",            -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_offset_window_metric_filter_and_query_have_different_granularities__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_offset_window_metric_filter_and_query_have_different_granularities__dfp_0.xml
@@ -89,66 +89,50 @@ docstring:
                             <!--     time_granularity=ExpandedTimeGranularity(name='month', base_granularity=MONTH), -->
                             <!--   )                                                                                 -->
                             <!-- distinct = False -->
-                            <WhereFilterNode>
-                                <!-- description = 'Filter Output with WHERE' -->
-                                <!-- node_id = NodeId(id_str='wcc_0') -->
-                                <!-- filter_spec =                                    -->
-                                <!--   WhereFilterSpec(                               -->
-                                <!--     where_sql="metric_time__day = '2020-01-01'", -->
-                                <!--     bind_parameters=SqlBindParameterSet(),       -->
-                                <!--     element_set=GroupByItemSet(                  -->
-                                <!--       annotated_specs=(                          -->
-                                <!--         AnnotatedSpec(                           -->
-                                <!--           element_type=TIME_DIMENSION,           -->
-                                <!--           element_name='metric_time',            -->
-                                <!--           time_grain=ExpandedTimeGranularity(    -->
-                                <!--             name='day',                          -->
-                                <!--             base_granularity=DAY,                -->
-                                <!--           ),                                     -->
-                                <!--           element_properties=(METRIC_TIME,),     -->
-                                <!--           origin_semantic_model_names=(          -->
-                                <!--             'bookings_source',                   -->
-                                <!--           ),                                     -->
-                                <!--           derived_from_semantic_model_names=(    -->
-                                <!--             'bookings_source',                   -->
-                                <!--           ),                                     -->
-                                <!--         ),                                       -->
-                                <!--       ),                                         -->
-                                <!--     ),                                           -->
-                                <!--   )                                              -->
-                                <SelectorNode>
-                                    <!-- description =                                                             -->
-                                    <!--   "Select: ['__booking_value', 'metric_time__month', 'metric_time__day']" -->
-                                    <!-- node_id = NodeId(id_str='pfe_2') -->
-                                    <!-- include_spec = SimpleMetricInputSpec(element_name='booking_value') -->
-                                    <!-- include_spec =                                -->
-                                    <!--   TimeDimensionSpec(                          -->
-                                    <!--     element_name='metric_time',               -->
-                                    <!--     time_granularity=ExpandedTimeGranularity( -->
-                                    <!--       name='month',                           -->
-                                    <!--       base_granularity=MONTH,                 -->
-                                    <!--     ),                                        -->
-                                    <!--   )                                           -->
-                                    <!-- include_spec =                                                                  -->
+                            <SelectorNode>
+                                <!-- description = "Select: ['__booking_value', 'metric_time__month']" -->
+                                <!-- node_id = NodeId(id_str='pfe_2') -->
+                                <!-- include_spec = SimpleMetricInputSpec(element_name='booking_value') -->
+                                <!-- include_spec =                                                                      -->
+                                <!--   TimeDimensionSpec(                                                                -->
+                                <!--     element_name='metric_time',                                                     -->
+                                <!--     time_granularity=ExpandedTimeGranularity(name='month', base_granularity=MONTH), -->
+                                <!--   )                                                                                 -->
+                                <!-- distinct = False -->
+                                <JoinToTimeSpineNode>
+                                    <!-- description = 'Join to Time Spine Dataset' -->
+                                    <!-- node_id = NodeId(id_str='jts_0') -->
+                                    <!-- requested_agg_time_dimension_specs =            -->
+                                    <!--   (                                             -->
+                                    <!--     TimeDimensionSpec(                          -->
+                                    <!--       element_name='metric_time',               -->
+                                    <!--       time_granularity=ExpandedTimeGranularity( -->
+                                    <!--         name='month',                           -->
+                                    <!--         base_granularity=MONTH,                 -->
+                                    <!--       ),                                        -->
+                                    <!--     ),                                          -->
+                                    <!--   )                                             -->
+                                    <!-- join_on_time_dimension_spec =                                                   -->
                                     <!--   TimeDimensionSpec(                                                            -->
                                     <!--     element_name='metric_time',                                                 -->
                                     <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
                                     <!--   )                                                                             -->
-                                    <!-- distinct = False -->
-                                    <JoinToTimeSpineNode>
-                                        <!-- description = 'Join to Time Spine Dataset' -->
-                                        <!-- node_id = NodeId(id_str='jts_0') -->
-                                        <!-- requested_agg_time_dimension_specs =            -->
-                                        <!--   (                                             -->
-                                        <!--     TimeDimensionSpec(                          -->
-                                        <!--       element_name='metric_time',               -->
-                                        <!--       time_granularity=ExpandedTimeGranularity( -->
-                                        <!--         name='month',                           -->
-                                        <!--         base_granularity=MONTH,                 -->
-                                        <!--       ),                                        -->
-                                        <!--     ),                                          -->
-                                        <!--   )                                             -->
-                                        <!-- join_on_time_dimension_spec =                 -->
+                                    <!-- join_type = INNER -->
+                                    <!-- standard_offset_window = TimeWindow(count=1, granularity='week') -->
+                                    <MetricTimeDimensionTransformNode>
+                                        <!-- description = "Metric Time Dimension 'ds'" -->
+                                        <!-- node_id = NodeId(id_str='sma_28009') -->
+                                        <!-- aggregation_time_dimension = 'ds' -->
+                                        <ReadSqlSourceNode>
+                                            <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
+                                            <!-- node_id = NodeId(id_str='rss_28020') -->
+                                            <!-- data_set = SemanticModelDataSet('bookings_source') -->
+                                        </ReadSqlSourceNode>
+                                    </MetricTimeDimensionTransformNode>
+                                    <SelectorNode>
+                                        <!-- description = "Select: ['metric_time__day', 'metric_time__month']" -->
+                                        <!-- node_id = NodeId(id_str='pfe_1') -->
+                                        <!-- include_spec =                                -->
                                         <!--   TimeDimensionSpec(                          -->
                                         <!--     element_name='metric_time',               -->
                                         <!--     time_granularity=ExpandedTimeGranularity( -->
@@ -156,38 +140,42 @@ docstring:
                                         <!--       base_granularity=DAY,                   -->
                                         <!--     ),                                        -->
                                         <!--   )                                           -->
-                                        <!-- join_type = INNER -->
-                                        <!-- standard_offset_window = TimeWindow(count=1, granularity='week') -->
-                                        <MetricTimeDimensionTransformNode>
-                                            <!-- description = "Metric Time Dimension 'ds'" -->
-                                            <!-- node_id = NodeId(id_str='sma_28009') -->
-                                            <!-- aggregation_time_dimension = 'ds' -->
-                                            <ReadSqlSourceNode>
-                                                <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
-                                                <!-- node_id = NodeId(id_str='rss_28020') -->
-                                                <!-- data_set = SemanticModelDataSet('bookings_source') -->
-                                            </ReadSqlSourceNode>
-                                        </MetricTimeDimensionTransformNode>
-                                        <SelectorNode>
-                                            <!-- description = "Select: ['metric_time__day', 'metric_time__month']" -->
-                                            <!-- node_id = NodeId(id_str='pfe_1') -->
-                                            <!-- include_spec =                                -->
-                                            <!--   TimeDimensionSpec(                          -->
-                                            <!--     element_name='metric_time',               -->
-                                            <!--     time_granularity=ExpandedTimeGranularity( -->
-                                            <!--       name='day',                             -->
-                                            <!--       base_granularity=DAY,                   -->
-                                            <!--     ),                                        -->
-                                            <!--   )                                           -->
-                                            <!-- include_spec =                                -->
-                                            <!--   TimeDimensionSpec(                          -->
-                                            <!--     element_name='metric_time',               -->
-                                            <!--     time_granularity=ExpandedTimeGranularity( -->
-                                            <!--       name='month',                           -->
-                                            <!--       base_granularity=MONTH,                 -->
-                                            <!--     ),                                        -->
-                                            <!--   )                                           -->
-                                            <!-- distinct = False -->
+                                        <!-- include_spec =                                -->
+                                        <!--   TimeDimensionSpec(                          -->
+                                        <!--     element_name='metric_time',               -->
+                                        <!--     time_granularity=ExpandedTimeGranularity( -->
+                                        <!--       name='month',                           -->
+                                        <!--       base_granularity=MONTH,                 -->
+                                        <!--     ),                                        -->
+                                        <!--   )                                           -->
+                                        <!-- distinct = False -->
+                                        <WhereFilterNode>
+                                            <!-- description = 'Filter Output with WHERE' -->
+                                            <!-- node_id = NodeId(id_str='wcc_0') -->
+                                            <!-- filter_spec =                                    -->
+                                            <!--   WhereFilterSpec(                               -->
+                                            <!--     where_sql="metric_time__day = '2020-01-01'", -->
+                                            <!--     bind_parameters=SqlBindParameterSet(),       -->
+                                            <!--     element_set=GroupByItemSet(                  -->
+                                            <!--       annotated_specs=(                          -->
+                                            <!--         AnnotatedSpec(                           -->
+                                            <!--           element_type=TIME_DIMENSION,           -->
+                                            <!--           element_name='metric_time',            -->
+                                            <!--           time_grain=ExpandedTimeGranularity(    -->
+                                            <!--             name='day',                          -->
+                                            <!--             base_granularity=DAY,                -->
+                                            <!--           ),                                     -->
+                                            <!--           element_properties=(METRIC_TIME,),     -->
+                                            <!--           origin_semantic_model_names=(          -->
+                                            <!--             'bookings_source',                   -->
+                                            <!--           ),                                     -->
+                                            <!--           derived_from_semantic_model_names=(    -->
+                                            <!--             'bookings_source',                   -->
+                                            <!--           ),                                     -->
+                                            <!--         ),                                       -->
+                                            <!--       ),                                         -->
+                                            <!--     ),                                           -->
+                                            <!--   )                                              -->
                                             <SelectorNode>
                                                 <!-- description = "Select: ['metric_time__day', 'metric_time__month']" -->
                                                 <!-- node_id = NodeId(id_str='pfe_0') -->
@@ -253,10 +241,10 @@ docstring:
                                                     </ReadSqlSourceNode>
                                                 </AliasSpecsNode>
                                             </SelectorNode>
-                                        </SelectorNode>
-                                    </JoinToTimeSpineNode>
-                                </SelectorNode>
-                            </WhereFilterNode>
+                                        </WhereFilterNode>
+                                    </SelectorNode>
+                                </JoinToTimeSpineNode>
+                            </SelectorNode>
                         </SelectorNode>
                     </AggregateSimpleMetricInputsNode>
                 </ComputeMetricsNode>

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
@@ -4,19 +4,19 @@ sql_engine: BigQuery
 ---
 -- Write to DataTable
 SELECT
-  subq_20.metric_time__day
-  , subq_20.bookings_growth_2_weeks
+  subq_19.metric_time__day
+  , subq_19.bookings_growth_2_weeks
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_19.metric_time__day
+    subq_18.metric_time__day
     , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
   FROM (
     -- Combine Aggregated Outputs
     SELECT
-      COALESCE(subq_6.metric_time__day, subq_18.metric_time__day) AS metric_time__day
+      COALESCE(subq_6.metric_time__day, subq_17.metric_time__day) AS metric_time__day
       , MAX(subq_6.bookings) AS bookings
-      , MAX(subq_18.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+      , MAX(subq_17.bookings_2_weeks_ago) AS bookings_2_weeks_ago
     FROM (
       -- Compute Metrics via Expressions
       SELECT
@@ -266,40 +266,40 @@ FROM (
     FULL OUTER JOIN (
       -- Compute Metrics via Expressions
       SELECT
-        subq_17.metric_time__day
-        , subq_17.__bookings AS bookings_2_weeks_ago
+        subq_16.metric_time__day
+        , subq_16.__bookings AS bookings_2_weeks_ago
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_16.metric_time__day AS metric_time__day
-          , subq_11.__bookings AS __bookings
+          subq_15.metric_time__day AS metric_time__day
+          , subq_10.__bookings AS __bookings
         FROM (
           -- Select: ['metric_time__day']
           SELECT
-            subq_15.metric_time__day
+            subq_14.metric_time__day
           FROM (
             -- Constrain Output with WHERE
             SELECT
-              subq_14.metric_time__day
+              subq_13.metric_time__day
             FROM (
               -- Select: ['metric_time__day']
               SELECT
-                subq_13.metric_time__day
+                subq_12.metric_time__day
               FROM (
                 -- Change Column Aliases
                 SELECT
-                  subq_12.ds__day AS metric_time__day
-                  , subq_12.ds__week
-                  , subq_12.ds__month
-                  , subq_12.ds__quarter
-                  , subq_12.ds__year
-                  , subq_12.ds__extract_year
-                  , subq_12.ds__extract_quarter
-                  , subq_12.ds__extract_month
-                  , subq_12.ds__extract_day
-                  , subq_12.ds__extract_dow
-                  , subq_12.ds__extract_doy
-                  , subq_12.ds__alien_day
+                  subq_11.ds__day AS metric_time__day
+                  , subq_11.ds__week
+                  , subq_11.ds__month
+                  , subq_11.ds__quarter
+                  , subq_11.ds__year
+                  , subq_11.ds__extract_year
+                  , subq_11.ds__extract_quarter
+                  , subq_11.ds__extract_month
+                  , subq_11.ds__extract_day
+                  , subq_11.ds__extract_dow
+                  , subq_11.ds__extract_doy
+                  , subq_11.ds__alien_day
                 FROM (
                   -- Read From Time Spine 'mf_time_spine'
                   SELECT
@@ -316,259 +316,252 @@ FROM (
                     , EXTRACT(dayofyear FROM time_spine_src_28006.ds) AS ds__extract_doy
                     , time_spine_src_28006.alien_day AS ds__alien_day
                   FROM ***************************.mf_time_spine time_spine_src_28006
-                ) subq_12
-              ) subq_13
-            ) subq_14
+                ) subq_11
+              ) subq_12
+            ) subq_13
             WHERE metric_time__day = '2020-01-01' or metric_time__day = '2020-01-14'
-          ) subq_15
-        ) subq_16
+          ) subq_14
+        ) subq_15
         INNER JOIN (
           -- Aggregate Inputs for Simple Metrics
           SELECT
-            subq_10.metric_time__day
-            , SUM(subq_10.__bookings) AS __bookings
+            subq_9.metric_time__day
+            , SUM(subq_9.__bookings) AS __bookings
           FROM (
             -- Select: ['__bookings', 'metric_time__day']
             SELECT
-              subq_9.metric_time__day
-              , subq_9.__bookings
+              subq_8.metric_time__day
+              , subq_8.__bookings
             FROM (
-              -- Constrain Output with WHERE
+              -- Select: ['__bookings', 'metric_time__day']
               SELECT
-                subq_8.bookings AS __bookings
-                , subq_8.metric_time__day
+                subq_7.metric_time__day
+                , subq_7.__bookings
               FROM (
-                -- Select: ['__bookings', 'metric_time__day']
+                -- Metric Time Dimension 'ds'
                 SELECT
-                  subq_7.metric_time__day
-                  , subq_7.__bookings AS bookings
+                  subq_0.ds__day
+                  , subq_0.ds__week
+                  , subq_0.ds__month
+                  , subq_0.ds__quarter
+                  , subq_0.ds__year
+                  , subq_0.ds__extract_year
+                  , subq_0.ds__extract_quarter
+                  , subq_0.ds__extract_month
+                  , subq_0.ds__extract_day
+                  , subq_0.ds__extract_dow
+                  , subq_0.ds__extract_doy
+                  , subq_0.ds_partitioned__day
+                  , subq_0.ds_partitioned__week
+                  , subq_0.ds_partitioned__month
+                  , subq_0.ds_partitioned__quarter
+                  , subq_0.ds_partitioned__year
+                  , subq_0.ds_partitioned__extract_year
+                  , subq_0.ds_partitioned__extract_quarter
+                  , subq_0.ds_partitioned__extract_month
+                  , subq_0.ds_partitioned__extract_day
+                  , subq_0.ds_partitioned__extract_dow
+                  , subq_0.ds_partitioned__extract_doy
+                  , subq_0.paid_at__day
+                  , subq_0.paid_at__week
+                  , subq_0.paid_at__month
+                  , subq_0.paid_at__quarter
+                  , subq_0.paid_at__year
+                  , subq_0.paid_at__extract_year
+                  , subq_0.paid_at__extract_quarter
+                  , subq_0.paid_at__extract_month
+                  , subq_0.paid_at__extract_day
+                  , subq_0.paid_at__extract_dow
+                  , subq_0.paid_at__extract_doy
+                  , subq_0.booking__ds__day
+                  , subq_0.booking__ds__week
+                  , subq_0.booking__ds__month
+                  , subq_0.booking__ds__quarter
+                  , subq_0.booking__ds__year
+                  , subq_0.booking__ds__extract_year
+                  , subq_0.booking__ds__extract_quarter
+                  , subq_0.booking__ds__extract_month
+                  , subq_0.booking__ds__extract_day
+                  , subq_0.booking__ds__extract_dow
+                  , subq_0.booking__ds__extract_doy
+                  , subq_0.booking__ds_partitioned__day
+                  , subq_0.booking__ds_partitioned__week
+                  , subq_0.booking__ds_partitioned__month
+                  , subq_0.booking__ds_partitioned__quarter
+                  , subq_0.booking__ds_partitioned__year
+                  , subq_0.booking__ds_partitioned__extract_year
+                  , subq_0.booking__ds_partitioned__extract_quarter
+                  , subq_0.booking__ds_partitioned__extract_month
+                  , subq_0.booking__ds_partitioned__extract_day
+                  , subq_0.booking__ds_partitioned__extract_dow
+                  , subq_0.booking__ds_partitioned__extract_doy
+                  , subq_0.booking__paid_at__day
+                  , subq_0.booking__paid_at__week
+                  , subq_0.booking__paid_at__month
+                  , subq_0.booking__paid_at__quarter
+                  , subq_0.booking__paid_at__year
+                  , subq_0.booking__paid_at__extract_year
+                  , subq_0.booking__paid_at__extract_quarter
+                  , subq_0.booking__paid_at__extract_month
+                  , subq_0.booking__paid_at__extract_day
+                  , subq_0.booking__paid_at__extract_dow
+                  , subq_0.booking__paid_at__extract_doy
+                  , subq_0.ds__day AS metric_time__day
+                  , subq_0.ds__week AS metric_time__week
+                  , subq_0.ds__month AS metric_time__month
+                  , subq_0.ds__quarter AS metric_time__quarter
+                  , subq_0.ds__year AS metric_time__year
+                  , subq_0.ds__extract_year AS metric_time__extract_year
+                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_0.ds__extract_month AS metric_time__extract_month
+                  , subq_0.ds__extract_day AS metric_time__extract_day
+                  , subq_0.ds__extract_dow AS metric_time__extract_dow
+                  , subq_0.ds__extract_doy AS metric_time__extract_doy
+                  , subq_0.listing
+                  , subq_0.guest
+                  , subq_0.host
+                  , subq_0.booking__listing
+                  , subq_0.booking__guest
+                  , subq_0.booking__host
+                  , subq_0.is_instant
+                  , subq_0.booking__is_instant
+                  , subq_0.__bookings
+                  , subq_0.__average_booking_value
+                  , subq_0.__instant_bookings
+                  , subq_0.__booking_value
+                  , subq_0.__max_booking_value
+                  , subq_0.__min_booking_value
+                  , subq_0.__instant_booking_value
+                  , subq_0.__average_instant_booking_value
+                  , subq_0.__booking_value_for_non_null_listing_id
+                  , subq_0.__bookers
+                  , subq_0.__referred_bookings
+                  , subq_0.__median_booking_value
+                  , subq_0.__booking_value_p99
+                  , subq_0.__discrete_booking_value_p99
+                  , subq_0.__approximate_continuous_booking_value_p99
+                  , subq_0.__approximate_discrete_booking_value_p99
+                  , subq_0.__bookings_join_to_time_spine
+                  , subq_0.__bookings_fill_nulls_with_0_without_time_spine
+                  , subq_0.__bookings_fill_nulls_with_0
+                  , subq_0.__instant_bookings_with_measure_filter
+                  , subq_0.__bookings_join_to_time_spine_with_tiered_filters
+                  , subq_0.__bookers_fill_nulls_with_0_join_to_timespine
                 FROM (
-                  -- Metric Time Dimension 'ds'
+                  -- Read Elements From Semantic Model 'bookings_source'
                   SELECT
-                    subq_0.ds__day
-                    , subq_0.ds__week
-                    , subq_0.ds__month
-                    , subq_0.ds__quarter
-                    , subq_0.ds__year
-                    , subq_0.ds__extract_year
-                    , subq_0.ds__extract_quarter
-                    , subq_0.ds__extract_month
-                    , subq_0.ds__extract_day
-                    , subq_0.ds__extract_dow
-                    , subq_0.ds__extract_doy
-                    , subq_0.ds_partitioned__day
-                    , subq_0.ds_partitioned__week
-                    , subq_0.ds_partitioned__month
-                    , subq_0.ds_partitioned__quarter
-                    , subq_0.ds_partitioned__year
-                    , subq_0.ds_partitioned__extract_year
-                    , subq_0.ds_partitioned__extract_quarter
-                    , subq_0.ds_partitioned__extract_month
-                    , subq_0.ds_partitioned__extract_day
-                    , subq_0.ds_partitioned__extract_dow
-                    , subq_0.ds_partitioned__extract_doy
-                    , subq_0.paid_at__day
-                    , subq_0.paid_at__week
-                    , subq_0.paid_at__month
-                    , subq_0.paid_at__quarter
-                    , subq_0.paid_at__year
-                    , subq_0.paid_at__extract_year
-                    , subq_0.paid_at__extract_quarter
-                    , subq_0.paid_at__extract_month
-                    , subq_0.paid_at__extract_day
-                    , subq_0.paid_at__extract_dow
-                    , subq_0.paid_at__extract_doy
-                    , subq_0.booking__ds__day
-                    , subq_0.booking__ds__week
-                    , subq_0.booking__ds__month
-                    , subq_0.booking__ds__quarter
-                    , subq_0.booking__ds__year
-                    , subq_0.booking__ds__extract_year
-                    , subq_0.booking__ds__extract_quarter
-                    , subq_0.booking__ds__extract_month
-                    , subq_0.booking__ds__extract_day
-                    , subq_0.booking__ds__extract_dow
-                    , subq_0.booking__ds__extract_doy
-                    , subq_0.booking__ds_partitioned__day
-                    , subq_0.booking__ds_partitioned__week
-                    , subq_0.booking__ds_partitioned__month
-                    , subq_0.booking__ds_partitioned__quarter
-                    , subq_0.booking__ds_partitioned__year
-                    , subq_0.booking__ds_partitioned__extract_year
-                    , subq_0.booking__ds_partitioned__extract_quarter
-                    , subq_0.booking__ds_partitioned__extract_month
-                    , subq_0.booking__ds_partitioned__extract_day
-                    , subq_0.booking__ds_partitioned__extract_dow
-                    , subq_0.booking__ds_partitioned__extract_doy
-                    , subq_0.booking__paid_at__day
-                    , subq_0.booking__paid_at__week
-                    , subq_0.booking__paid_at__month
-                    , subq_0.booking__paid_at__quarter
-                    , subq_0.booking__paid_at__year
-                    , subq_0.booking__paid_at__extract_year
-                    , subq_0.booking__paid_at__extract_quarter
-                    , subq_0.booking__paid_at__extract_month
-                    , subq_0.booking__paid_at__extract_day
-                    , subq_0.booking__paid_at__extract_dow
-                    , subq_0.booking__paid_at__extract_doy
-                    , subq_0.ds__day AS metric_time__day
-                    , subq_0.ds__week AS metric_time__week
-                    , subq_0.ds__month AS metric_time__month
-                    , subq_0.ds__quarter AS metric_time__quarter
-                    , subq_0.ds__year AS metric_time__year
-                    , subq_0.ds__extract_year AS metric_time__extract_year
-                    , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                    , subq_0.ds__extract_month AS metric_time__extract_month
-                    , subq_0.ds__extract_day AS metric_time__extract_day
-                    , subq_0.ds__extract_dow AS metric_time__extract_dow
-                    , subq_0.ds__extract_doy AS metric_time__extract_doy
-                    , subq_0.listing
-                    , subq_0.guest
-                    , subq_0.host
-                    , subq_0.booking__listing
-                    , subq_0.booking__guest
-                    , subq_0.booking__host
-                    , subq_0.is_instant
-                    , subq_0.booking__is_instant
-                    , subq_0.__bookings
-                    , subq_0.__average_booking_value
-                    , subq_0.__instant_bookings
-                    , subq_0.__booking_value
-                    , subq_0.__max_booking_value
-                    , subq_0.__min_booking_value
-                    , subq_0.__instant_booking_value
-                    , subq_0.__average_instant_booking_value
-                    , subq_0.__booking_value_for_non_null_listing_id
-                    , subq_0.__bookers
-                    , subq_0.__referred_bookings
-                    , subq_0.__median_booking_value
-                    , subq_0.__booking_value_p99
-                    , subq_0.__discrete_booking_value_p99
-                    , subq_0.__approximate_continuous_booking_value_p99
-                    , subq_0.__approximate_discrete_booking_value_p99
-                    , subq_0.__bookings_join_to_time_spine
-                    , subq_0.__bookings_fill_nulls_with_0_without_time_spine
-                    , subq_0.__bookings_fill_nulls_with_0
-                    , subq_0.__instant_bookings_with_measure_filter
-                    , subq_0.__bookings_join_to_time_spine_with_tiered_filters
-                    , subq_0.__bookers_fill_nulls_with_0_join_to_timespine
-                  FROM (
-                    -- Read Elements From Semantic Model 'bookings_source'
-                    SELECT
-                      1 AS __bookings
-                      , bookings_source_src_28000.booking_value AS __average_booking_value
-                      , CASE WHEN is_instant THEN 1 ELSE 0 END AS __instant_bookings
-                      , bookings_source_src_28000.booking_value AS __booking_value
-                      , bookings_source_src_28000.booking_value AS __max_booking_value
-                      , bookings_source_src_28000.booking_value AS __min_booking_value
-                      , bookings_source_src_28000.booking_value AS __instant_booking_value
-                      , bookings_source_src_28000.booking_value AS __average_instant_booking_value
-                      , bookings_source_src_28000.booking_value AS __booking_value_for_non_null_listing_id
-                      , bookings_source_src_28000.guest_id AS __bookers
-                      , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS __referred_bookings
-                      , bookings_source_src_28000.booking_value AS __median_booking_value
-                      , bookings_source_src_28000.booking_value AS __booking_value_p99
-                      , bookings_source_src_28000.booking_value AS __discrete_booking_value_p99
-                      , bookings_source_src_28000.booking_value AS __approximate_continuous_booking_value_p99
-                      , bookings_source_src_28000.booking_value AS __approximate_discrete_booking_value_p99
-                      , 1 AS __bookings_join_to_time_spine
-                      , 1 AS __bookings_fill_nulls_with_0_without_time_spine
-                      , 1 AS __bookings_fill_nulls_with_0
-                      , 1 AS __instant_bookings_with_measure_filter
-                      , 1 AS __bookings_join_to_time_spine_with_tiered_filters
-                      , bookings_source_src_28000.guest_id AS __bookers_fill_nulls_with_0_join_to_timespine
-                      , bookings_source_src_28000.booking_value AS __booking_payments
-                      , bookings_source_src_28000.is_instant
-                      , DATETIME_TRUNC(bookings_source_src_28000.ds, day) AS ds__day
-                      , DATETIME_TRUNC(bookings_source_src_28000.ds, isoweek) AS ds__week
-                      , DATETIME_TRUNC(bookings_source_src_28000.ds, month) AS ds__month
-                      , DATETIME_TRUNC(bookings_source_src_28000.ds, quarter) AS ds__quarter
-                      , DATETIME_TRUNC(bookings_source_src_28000.ds, year) AS ds__year
-                      , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                      , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS ds__extract_dow
-                      , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                      , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS ds_partitioned__day
-                      , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS ds_partitioned__week
-                      , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS ds_partitioned__month
-                      , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS ds_partitioned__quarter
-                      , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS ds_partitioned__year
-                      , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                      , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS ds_partitioned__extract_dow
-                      , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                      , DATETIME_TRUNC(bookings_source_src_28000.paid_at, day) AS paid_at__day
-                      , DATETIME_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS paid_at__week
-                      , DATETIME_TRUNC(bookings_source_src_28000.paid_at, month) AS paid_at__month
-                      , DATETIME_TRUNC(bookings_source_src_28000.paid_at, quarter) AS paid_at__quarter
-                      , DATETIME_TRUNC(bookings_source_src_28000.paid_at, year) AS paid_at__year
-                      , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                      , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS paid_at__extract_dow
-                      , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                      , bookings_source_src_28000.is_instant AS booking__is_instant
-                      , DATETIME_TRUNC(bookings_source_src_28000.ds, day) AS booking__ds__day
-                      , DATETIME_TRUNC(bookings_source_src_28000.ds, isoweek) AS booking__ds__week
-                      , DATETIME_TRUNC(bookings_source_src_28000.ds, month) AS booking__ds__month
-                      , DATETIME_TRUNC(bookings_source_src_28000.ds, quarter) AS booking__ds__quarter
-                      , DATETIME_TRUNC(bookings_source_src_28000.ds, year) AS booking__ds__year
-                      , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                      , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS booking__ds__extract_dow
-                      , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                      , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS booking__ds_partitioned__day
-                      , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS booking__ds_partitioned__week
-                      , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS booking__ds_partitioned__month
-                      , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
-                      , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS booking__ds_partitioned__year
-                      , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                      , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS booking__ds_partitioned__extract_dow
-                      , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                      , DATETIME_TRUNC(bookings_source_src_28000.paid_at, day) AS booking__paid_at__day
-                      , DATETIME_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS booking__paid_at__week
-                      , DATETIME_TRUNC(bookings_source_src_28000.paid_at, month) AS booking__paid_at__month
-                      , DATETIME_TRUNC(bookings_source_src_28000.paid_at, quarter) AS booking__paid_at__quarter
-                      , DATETIME_TRUNC(bookings_source_src_28000.paid_at, year) AS booking__paid_at__year
-                      , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                      , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS booking__paid_at__extract_dow
-                      , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                      , bookings_source_src_28000.listing_id AS listing
-                      , bookings_source_src_28000.guest_id AS guest
-                      , bookings_source_src_28000.host_id AS host
-                      , bookings_source_src_28000.listing_id AS booking__listing
-                      , bookings_source_src_28000.guest_id AS booking__guest
-                      , bookings_source_src_28000.host_id AS booking__host
-                    FROM ***************************.fct_bookings bookings_source_src_28000
-                  ) subq_0
-                ) subq_7
-              ) subq_8
-              WHERE metric_time__day = '2020-01-01' or metric_time__day = '2020-01-14'
-            ) subq_9
-          ) subq_10
+                    1 AS __bookings
+                    , bookings_source_src_28000.booking_value AS __average_booking_value
+                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS __instant_bookings
+                    , bookings_source_src_28000.booking_value AS __booking_value
+                    , bookings_source_src_28000.booking_value AS __max_booking_value
+                    , bookings_source_src_28000.booking_value AS __min_booking_value
+                    , bookings_source_src_28000.booking_value AS __instant_booking_value
+                    , bookings_source_src_28000.booking_value AS __average_instant_booking_value
+                    , bookings_source_src_28000.booking_value AS __booking_value_for_non_null_listing_id
+                    , bookings_source_src_28000.guest_id AS __bookers
+                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS __referred_bookings
+                    , bookings_source_src_28000.booking_value AS __median_booking_value
+                    , bookings_source_src_28000.booking_value AS __booking_value_p99
+                    , bookings_source_src_28000.booking_value AS __discrete_booking_value_p99
+                    , bookings_source_src_28000.booking_value AS __approximate_continuous_booking_value_p99
+                    , bookings_source_src_28000.booking_value AS __approximate_discrete_booking_value_p99
+                    , 1 AS __bookings_join_to_time_spine
+                    , 1 AS __bookings_fill_nulls_with_0_without_time_spine
+                    , 1 AS __bookings_fill_nulls_with_0
+                    , 1 AS __instant_bookings_with_measure_filter
+                    , 1 AS __bookings_join_to_time_spine_with_tiered_filters
+                    , bookings_source_src_28000.guest_id AS __bookers_fill_nulls_with_0_join_to_timespine
+                    , bookings_source_src_28000.booking_value AS __booking_payments
+                    , bookings_source_src_28000.is_instant
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds, day) AS ds__day
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds, isoweek) AS ds__week
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds, month) AS ds__month
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds, quarter) AS ds__quarter
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds, year) AS ds__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                    , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS ds__extract_dow
+                    , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS ds_partitioned__day
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS ds_partitioned__week
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS ds_partitioned__month
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS ds_partitioned__quarter
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                    , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS ds_partitioned__extract_dow
+                    , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, day) AS paid_at__day
+                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS paid_at__week
+                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, month) AS paid_at__month
+                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, quarter) AS paid_at__quarter
+                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, year) AS paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                    , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS paid_at__extract_dow
+                    , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                    , bookings_source_src_28000.is_instant AS booking__is_instant
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds, day) AS booking__ds__day
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds, isoweek) AS booking__ds__week
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds, month) AS booking__ds__month
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds, quarter) AS booking__ds__quarter
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds, year) AS booking__ds__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                    , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS booking__ds__extract_dow
+                    , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS booking__ds_partitioned__day
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS booking__ds_partitioned__week
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS booking__ds_partitioned__month
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS booking__ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                    , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS booking__ds_partitioned__extract_dow
+                    , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, day) AS booking__paid_at__day
+                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS booking__paid_at__week
+                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, month) AS booking__paid_at__month
+                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, quarter) AS booking__paid_at__quarter
+                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, year) AS booking__paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                    , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS booking__paid_at__extract_dow
+                    , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                    , bookings_source_src_28000.listing_id AS listing
+                    , bookings_source_src_28000.guest_id AS guest
+                    , bookings_source_src_28000.host_id AS host
+                    , bookings_source_src_28000.listing_id AS booking__listing
+                    , bookings_source_src_28000.guest_id AS booking__guest
+                    , bookings_source_src_28000.host_id AS booking__host
+                  FROM ***************************.fct_bookings bookings_source_src_28000
+                ) subq_0
+              ) subq_7
+            ) subq_8
+          ) subq_9
           GROUP BY
             metric_time__day
-        ) subq_11
+        ) subq_10
         ON
-          DATE_SUB(CAST(subq_16.metric_time__day AS DATETIME), INTERVAL 14 day) = subq_11.metric_time__day
-      ) subq_17
-    ) subq_18
+          DATE_SUB(CAST(subq_15.metric_time__day AS DATETIME), INTERVAL 14 day) = subq_10.metric_time__day
+      ) subq_16
+    ) subq_17
     ON
-      subq_6.metric_time__day = subq_18.metric_time__day
+      subq_6.metric_time__day = subq_17.metric_time__day
     GROUP BY
       metric_time__day
-  ) subq_19
-) subq_20
+  ) subq_18
+) subq_19

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_derived_metric_with_offset_window_and_time_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_derived_metric_with_offset_window_and_time_filter__plan0_optimized.sql
@@ -19,9 +19,9 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_27.metric_time__day, subq_39.metric_time__day) AS metric_time__day
-    , MAX(subq_27.bookings) AS bookings
-    , MAX(subq_39.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+    COALESCE(subq_26.metric_time__day, subq_37.metric_time__day) AS metric_time__day
+    , MAX(subq_26.bookings) AS bookings
+    , MAX(subq_37.bookings_2_weeks_ago) AS bookings_2_weeks_ago
   FROM (
     -- Constrain Output with WHERE
     -- Select: ['__bookings', 'metric_time__day']
@@ -37,17 +37,17 @@ FROM (
         metric_time__day
         , __bookings AS bookings
       FROM sma_28009_cte
-    ) subq_23
+    ) subq_22
     WHERE metric_time__day = '2020-01-01' or metric_time__day = '2020-01-14'
     GROUP BY
       metric_time__day
-  ) subq_27
+  ) subq_26
   FULL OUTER JOIN (
     -- Join to Time Spine Dataset
     -- Compute Metrics via Expressions
     SELECT
-      subq_37.metric_time__day AS metric_time__day
-      , subq_32.__bookings AS bookings_2_weeks_ago
+      subq_35.metric_time__day AS metric_time__day
+      , subq_30.__bookings AS bookings_2_weeks_ago
     FROM (
       -- Constrain Output with WHERE
       -- Select: ['metric_time__day']
@@ -60,33 +60,26 @@ FROM (
         SELECT
           ds AS metric_time__day
         FROM ***************************.mf_time_spine time_spine_src_28006
-      ) subq_35
+      ) subq_33
       WHERE metric_time__day = '2020-01-01' or metric_time__day = '2020-01-14'
-    ) subq_37
+    ) subq_35
     INNER JOIN (
-      -- Constrain Output with WHERE
+      -- Read From CTE For node_id=sma_28009
+      -- Select: ['__bookings', 'metric_time__day']
       -- Select: ['__bookings', 'metric_time__day']
       -- Aggregate Inputs for Simple Metrics
       SELECT
         metric_time__day
-        , SUM(bookings) AS __bookings
-      FROM (
-        -- Read From CTE For node_id=sma_28009
-        -- Select: ['__bookings', 'metric_time__day']
-        SELECT
-          metric_time__day
-          , __bookings AS bookings
-        FROM sma_28009_cte
-      ) subq_29
-      WHERE metric_time__day = '2020-01-01' or metric_time__day = '2020-01-14'
+        , SUM(__bookings) AS __bookings
+      FROM sma_28009_cte
       GROUP BY
         metric_time__day
-    ) subq_32
+    ) subq_30
     ON
-      DATE_SUB(CAST(subq_37.metric_time__day AS DATETIME), INTERVAL 14 day) = subq_32.metric_time__day
-  ) subq_39
+      DATE_SUB(CAST(subq_35.metric_time__day AS DATETIME), INTERVAL 14 day) = subq_30.metric_time__day
+  ) subq_37
   ON
-    subq_27.metric_time__day = subq_39.metric_time__day
+    subq_26.metric_time__day = subq_37.metric_time__day
   GROUP BY
     metric_time__day
-) subq_40
+) subq_38

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0.sql
@@ -6,52 +6,52 @@ sql_engine: BigQuery
 ---
 -- Write to DataTable
 SELECT
-  subq_13.metric_time__month
-  , subq_13.bookings_at_start_of_month
+  subq_12.metric_time__month
+  , subq_12.bookings_at_start_of_month
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_12.metric_time__month
+    subq_11.metric_time__month
     , bookings_start_of_month AS bookings_at_start_of_month
   FROM (
     -- Compute Metrics via Expressions
     SELECT
-      subq_11.metric_time__month
-      , subq_11.__bookings AS bookings_start_of_month
+      subq_10.metric_time__month
+      , subq_10.__bookings AS bookings_start_of_month
     FROM (
       -- Join to Time Spine Dataset
       SELECT
-        subq_10.metric_time__month AS metric_time__month
-        , subq_5.__bookings AS __bookings
+        subq_9.metric_time__month AS metric_time__month
+        , subq_4.__bookings AS __bookings
       FROM (
         -- Select: ['metric_time__month']
         SELECT
-          subq_9.metric_time__month
+          subq_8.metric_time__month
         FROM (
           -- Constrain Output with WHERE
           SELECT
-            subq_8.metric_time__day
-            , subq_8.metric_time__month
+            subq_7.metric_time__day
+            , subq_7.metric_time__month
           FROM (
             -- Select: ['metric_time__month', 'metric_time__day']
             SELECT
-              subq_7.metric_time__day
-              , subq_7.metric_time__month
+              subq_6.metric_time__day
+              , subq_6.metric_time__month
             FROM (
               -- Change Column Aliases
               SELECT
-                subq_6.ds__day AS metric_time__day
-                , subq_6.ds__week
-                , subq_6.ds__month AS metric_time__month
-                , subq_6.ds__quarter
-                , subq_6.ds__year
-                , subq_6.ds__extract_year
-                , subq_6.ds__extract_quarter
-                , subq_6.ds__extract_month
-                , subq_6.ds__extract_day
-                , subq_6.ds__extract_dow
-                , subq_6.ds__extract_doy
-                , subq_6.ds__alien_day
+                subq_5.ds__day AS metric_time__day
+                , subq_5.ds__week
+                , subq_5.ds__month AS metric_time__month
+                , subq_5.ds__quarter
+                , subq_5.ds__year
+                , subq_5.ds__extract_year
+                , subq_5.ds__extract_quarter
+                , subq_5.ds__extract_month
+                , subq_5.ds__extract_day
+                , subq_5.ds__extract_dow
+                , subq_5.ds__extract_doy
+                , subq_5.ds__alien_day
               FROM (
                 -- Read From Time Spine 'mf_time_spine'
                 SELECT
@@ -68,258 +68,249 @@ FROM (
                   , EXTRACT(dayofyear FROM time_spine_src_28006.ds) AS ds__extract_doy
                   , time_spine_src_28006.alien_day AS ds__alien_day
                 FROM ***************************.mf_time_spine time_spine_src_28006
-              ) subq_6
-            ) subq_7
-          ) subq_8
+              ) subq_5
+            ) subq_6
+          ) subq_7
           WHERE metric_time__day = '2020-01-01'
-        ) subq_9
+        ) subq_8
         GROUP BY
           metric_time__month
-      ) subq_10
+      ) subq_9
       INNER JOIN (
         -- Aggregate Inputs for Simple Metrics
         SELECT
-          subq_4.metric_time__month
-          , SUM(subq_4.__bookings) AS __bookings
+          subq_3.metric_time__month
+          , SUM(subq_3.__bookings) AS __bookings
         FROM (
           -- Select: ['__bookings', 'metric_time__month']
           SELECT
-            subq_3.metric_time__month
-            , subq_3.__bookings
+            subq_2.metric_time__month
+            , subq_2.__bookings
           FROM (
-            -- Constrain Output with WHERE
+            -- Select: ['__bookings', 'metric_time__month']
             SELECT
-              subq_2.bookings AS __bookings
-              , subq_2.metric_time__day
-              , subq_2.metric_time__month
+              subq_1.metric_time__month
+              , subq_1.__bookings
             FROM (
-              -- Select: ['__bookings', 'metric_time__month', 'metric_time__day']
+              -- Metric Time Dimension 'ds'
               SELECT
-                subq_1.metric_time__day
-                , subq_1.metric_time__month
-                , subq_1.__bookings AS bookings
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.__bookings
+                , subq_0.__average_booking_value
+                , subq_0.__instant_bookings
+                , subq_0.__booking_value
+                , subq_0.__max_booking_value
+                , subq_0.__min_booking_value
+                , subq_0.__instant_booking_value
+                , subq_0.__average_instant_booking_value
+                , subq_0.__booking_value_for_non_null_listing_id
+                , subq_0.__bookers
+                , subq_0.__referred_bookings
+                , subq_0.__median_booking_value
+                , subq_0.__booking_value_p99
+                , subq_0.__discrete_booking_value_p99
+                , subq_0.__approximate_continuous_booking_value_p99
+                , subq_0.__approximate_discrete_booking_value_p99
+                , subq_0.__bookings_join_to_time_spine
+                , subq_0.__bookings_fill_nulls_with_0_without_time_spine
+                , subq_0.__bookings_fill_nulls_with_0
+                , subq_0.__instant_bookings_with_measure_filter
+                , subq_0.__bookings_join_to_time_spine_with_tiered_filters
+                , subq_0.__bookers_fill_nulls_with_0_join_to_timespine
               FROM (
-                -- Metric Time Dimension 'ds'
+                -- Read Elements From Semantic Model 'bookings_source'
                 SELECT
-                  subq_0.ds__day
-                  , subq_0.ds__week
-                  , subq_0.ds__month
-                  , subq_0.ds__quarter
-                  , subq_0.ds__year
-                  , subq_0.ds__extract_year
-                  , subq_0.ds__extract_quarter
-                  , subq_0.ds__extract_month
-                  , subq_0.ds__extract_day
-                  , subq_0.ds__extract_dow
-                  , subq_0.ds__extract_doy
-                  , subq_0.ds_partitioned__day
-                  , subq_0.ds_partitioned__week
-                  , subq_0.ds_partitioned__month
-                  , subq_0.ds_partitioned__quarter
-                  , subq_0.ds_partitioned__year
-                  , subq_0.ds_partitioned__extract_year
-                  , subq_0.ds_partitioned__extract_quarter
-                  , subq_0.ds_partitioned__extract_month
-                  , subq_0.ds_partitioned__extract_day
-                  , subq_0.ds_partitioned__extract_dow
-                  , subq_0.ds_partitioned__extract_doy
-                  , subq_0.paid_at__day
-                  , subq_0.paid_at__week
-                  , subq_0.paid_at__month
-                  , subq_0.paid_at__quarter
-                  , subq_0.paid_at__year
-                  , subq_0.paid_at__extract_year
-                  , subq_0.paid_at__extract_quarter
-                  , subq_0.paid_at__extract_month
-                  , subq_0.paid_at__extract_day
-                  , subq_0.paid_at__extract_dow
-                  , subq_0.paid_at__extract_doy
-                  , subq_0.booking__ds__day
-                  , subq_0.booking__ds__week
-                  , subq_0.booking__ds__month
-                  , subq_0.booking__ds__quarter
-                  , subq_0.booking__ds__year
-                  , subq_0.booking__ds__extract_year
-                  , subq_0.booking__ds__extract_quarter
-                  , subq_0.booking__ds__extract_month
-                  , subq_0.booking__ds__extract_day
-                  , subq_0.booking__ds__extract_dow
-                  , subq_0.booking__ds__extract_doy
-                  , subq_0.booking__ds_partitioned__day
-                  , subq_0.booking__ds_partitioned__week
-                  , subq_0.booking__ds_partitioned__month
-                  , subq_0.booking__ds_partitioned__quarter
-                  , subq_0.booking__ds_partitioned__year
-                  , subq_0.booking__ds_partitioned__extract_year
-                  , subq_0.booking__ds_partitioned__extract_quarter
-                  , subq_0.booking__ds_partitioned__extract_month
-                  , subq_0.booking__ds_partitioned__extract_day
-                  , subq_0.booking__ds_partitioned__extract_dow
-                  , subq_0.booking__ds_partitioned__extract_doy
-                  , subq_0.booking__paid_at__day
-                  , subq_0.booking__paid_at__week
-                  , subq_0.booking__paid_at__month
-                  , subq_0.booking__paid_at__quarter
-                  , subq_0.booking__paid_at__year
-                  , subq_0.booking__paid_at__extract_year
-                  , subq_0.booking__paid_at__extract_quarter
-                  , subq_0.booking__paid_at__extract_month
-                  , subq_0.booking__paid_at__extract_day
-                  , subq_0.booking__paid_at__extract_dow
-                  , subq_0.booking__paid_at__extract_doy
-                  , subq_0.ds__day AS metric_time__day
-                  , subq_0.ds__week AS metric_time__week
-                  , subq_0.ds__month AS metric_time__month
-                  , subq_0.ds__quarter AS metric_time__quarter
-                  , subq_0.ds__year AS metric_time__year
-                  , subq_0.ds__extract_year AS metric_time__extract_year
-                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_0.ds__extract_month AS metric_time__extract_month
-                  , subq_0.ds__extract_day AS metric_time__extract_day
-                  , subq_0.ds__extract_dow AS metric_time__extract_dow
-                  , subq_0.ds__extract_doy AS metric_time__extract_doy
-                  , subq_0.listing
-                  , subq_0.guest
-                  , subq_0.host
-                  , subq_0.booking__listing
-                  , subq_0.booking__guest
-                  , subq_0.booking__host
-                  , subq_0.is_instant
-                  , subq_0.booking__is_instant
-                  , subq_0.__bookings
-                  , subq_0.__average_booking_value
-                  , subq_0.__instant_bookings
-                  , subq_0.__booking_value
-                  , subq_0.__max_booking_value
-                  , subq_0.__min_booking_value
-                  , subq_0.__instant_booking_value
-                  , subq_0.__average_instant_booking_value
-                  , subq_0.__booking_value_for_non_null_listing_id
-                  , subq_0.__bookers
-                  , subq_0.__referred_bookings
-                  , subq_0.__median_booking_value
-                  , subq_0.__booking_value_p99
-                  , subq_0.__discrete_booking_value_p99
-                  , subq_0.__approximate_continuous_booking_value_p99
-                  , subq_0.__approximate_discrete_booking_value_p99
-                  , subq_0.__bookings_join_to_time_spine
-                  , subq_0.__bookings_fill_nulls_with_0_without_time_spine
-                  , subq_0.__bookings_fill_nulls_with_0
-                  , subq_0.__instant_bookings_with_measure_filter
-                  , subq_0.__bookings_join_to_time_spine_with_tiered_filters
-                  , subq_0.__bookers_fill_nulls_with_0_join_to_timespine
-                FROM (
-                  -- Read Elements From Semantic Model 'bookings_source'
-                  SELECT
-                    1 AS __bookings
-                    , bookings_source_src_28000.booking_value AS __average_booking_value
-                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS __instant_bookings
-                    , bookings_source_src_28000.booking_value AS __booking_value
-                    , bookings_source_src_28000.booking_value AS __max_booking_value
-                    , bookings_source_src_28000.booking_value AS __min_booking_value
-                    , bookings_source_src_28000.booking_value AS __instant_booking_value
-                    , bookings_source_src_28000.booking_value AS __average_instant_booking_value
-                    , bookings_source_src_28000.booking_value AS __booking_value_for_non_null_listing_id
-                    , bookings_source_src_28000.guest_id AS __bookers
-                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS __referred_bookings
-                    , bookings_source_src_28000.booking_value AS __median_booking_value
-                    , bookings_source_src_28000.booking_value AS __booking_value_p99
-                    , bookings_source_src_28000.booking_value AS __discrete_booking_value_p99
-                    , bookings_source_src_28000.booking_value AS __approximate_continuous_booking_value_p99
-                    , bookings_source_src_28000.booking_value AS __approximate_discrete_booking_value_p99
-                    , 1 AS __bookings_join_to_time_spine
-                    , 1 AS __bookings_fill_nulls_with_0_without_time_spine
-                    , 1 AS __bookings_fill_nulls_with_0
-                    , 1 AS __instant_bookings_with_measure_filter
-                    , 1 AS __bookings_join_to_time_spine_with_tiered_filters
-                    , bookings_source_src_28000.guest_id AS __bookers_fill_nulls_with_0_join_to_timespine
-                    , bookings_source_src_28000.booking_value AS __booking_payments
-                    , bookings_source_src_28000.is_instant
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds, day) AS ds__day
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds, isoweek) AS ds__week
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds, month) AS ds__month
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds, quarter) AS ds__quarter
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds, year) AS ds__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                    , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS ds__extract_dow
-                    , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS ds_partitioned__day
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS ds_partitioned__week
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS ds_partitioned__month
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS ds_partitioned__quarter
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS ds_partitioned__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                    , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS ds_partitioned__extract_dow
-                    , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, day) AS paid_at__day
-                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS paid_at__week
-                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, month) AS paid_at__month
-                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, quarter) AS paid_at__quarter
-                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, year) AS paid_at__year
-                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                    , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS paid_at__extract_dow
-                    , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                    , bookings_source_src_28000.is_instant AS booking__is_instant
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds, day) AS booking__ds__day
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds, isoweek) AS booking__ds__week
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds, month) AS booking__ds__month
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds, quarter) AS booking__ds__quarter
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds, year) AS booking__ds__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                    , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS booking__ds__extract_dow
-                    , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS booking__ds_partitioned__day
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS booking__ds_partitioned__week
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS booking__ds_partitioned__month
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS booking__ds_partitioned__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                    , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS booking__ds_partitioned__extract_dow
-                    , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, day) AS booking__paid_at__day
-                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS booking__paid_at__week
-                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, month) AS booking__paid_at__month
-                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, quarter) AS booking__paid_at__quarter
-                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, year) AS booking__paid_at__year
-                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                    , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS booking__paid_at__extract_dow
-                    , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                    , bookings_source_src_28000.listing_id AS listing
-                    , bookings_source_src_28000.guest_id AS guest
-                    , bookings_source_src_28000.host_id AS host
-                    , bookings_source_src_28000.listing_id AS booking__listing
-                    , bookings_source_src_28000.guest_id AS booking__guest
-                    , bookings_source_src_28000.host_id AS booking__host
-                  FROM ***************************.fct_bookings bookings_source_src_28000
-                ) subq_0
-              ) subq_1
-            ) subq_2
-            WHERE metric_time__day = '2020-01-01'
-          ) subq_3
-        ) subq_4
+                  1 AS __bookings
+                  , bookings_source_src_28000.booking_value AS __average_booking_value
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS __instant_bookings
+                  , bookings_source_src_28000.booking_value AS __booking_value
+                  , bookings_source_src_28000.booking_value AS __max_booking_value
+                  , bookings_source_src_28000.booking_value AS __min_booking_value
+                  , bookings_source_src_28000.booking_value AS __instant_booking_value
+                  , bookings_source_src_28000.booking_value AS __average_instant_booking_value
+                  , bookings_source_src_28000.booking_value AS __booking_value_for_non_null_listing_id
+                  , bookings_source_src_28000.guest_id AS __bookers
+                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS __referred_bookings
+                  , bookings_source_src_28000.booking_value AS __median_booking_value
+                  , bookings_source_src_28000.booking_value AS __booking_value_p99
+                  , bookings_source_src_28000.booking_value AS __discrete_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS __approximate_continuous_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS __approximate_discrete_booking_value_p99
+                  , 1 AS __bookings_join_to_time_spine
+                  , 1 AS __bookings_fill_nulls_with_0_without_time_spine
+                  , 1 AS __bookings_fill_nulls_with_0
+                  , 1 AS __instant_bookings_with_measure_filter
+                  , 1 AS __bookings_join_to_time_spine_with_tiered_filters
+                  , bookings_source_src_28000.guest_id AS __bookers_fill_nulls_with_0_join_to_timespine
+                  , bookings_source_src_28000.booking_value AS __booking_payments
+                  , bookings_source_src_28000.is_instant
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds, day) AS ds__day
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds, isoweek) AS ds__week
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds, month) AS ds__month
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds, quarter) AS ds__quarter
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds, year) AS ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                  , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS ds__extract_dow
+                  , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS ds_partitioned__day
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS ds_partitioned__week
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS ds_partitioned__month
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS ds_partitioned__quarter
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                  , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS ds_partitioned__extract_dow
+                  , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, day) AS paid_at__day
+                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS paid_at__week
+                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, month) AS paid_at__month
+                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, quarter) AS paid_at__quarter
+                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, year) AS paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                  , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS paid_at__extract_dow
+                  , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                  , bookings_source_src_28000.is_instant AS booking__is_instant
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds, day) AS booking__ds__day
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds, isoweek) AS booking__ds__week
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds, month) AS booking__ds__month
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds, quarter) AS booking__ds__quarter
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds, year) AS booking__ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                  , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS booking__ds__extract_dow
+                  , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS booking__ds_partitioned__day
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS booking__ds_partitioned__week
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS booking__ds_partitioned__month
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS booking__ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                  , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS booking__ds_partitioned__extract_dow
+                  , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, day) AS booking__paid_at__day
+                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS booking__paid_at__week
+                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, month) AS booking__paid_at__month
+                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, quarter) AS booking__paid_at__quarter
+                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, year) AS booking__paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                  , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS booking__paid_at__extract_dow
+                  , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                  , bookings_source_src_28000.listing_id AS listing
+                  , bookings_source_src_28000.guest_id AS guest
+                  , bookings_source_src_28000.host_id AS host
+                  , bookings_source_src_28000.listing_id AS booking__listing
+                  , bookings_source_src_28000.guest_id AS booking__guest
+                  , bookings_source_src_28000.host_id AS booking__host
+                FROM ***************************.fct_bookings bookings_source_src_28000
+              ) subq_0
+            ) subq_1
+          ) subq_2
+        ) subq_3
         GROUP BY
           metric_time__month
-      ) subq_5
+      ) subq_4
       ON
-        DATETIME_TRUNC(subq_10.metric_time__month, month) = subq_5.metric_time__month
-    ) subq_11
-  ) subq_12
-) subq_13
+        DATETIME_TRUNC(subq_9.metric_time__month, month) = subq_4.metric_time__month
+    ) subq_10
+  ) subq_11
+) subq_12

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
@@ -13,8 +13,8 @@ FROM (
   -- Join to Time Spine Dataset
   -- Compute Metrics via Expressions
   SELECT
-    subq_24.metric_time__month AS metric_time__month
-    , subq_19.__bookings AS bookings_start_of_month
+    subq_22.metric_time__month AS metric_time__month
+    , subq_17.__bookings AS bookings_start_of_month
   FROM (
     -- Constrain Output with WHERE
     -- Select: ['metric_time__month']
@@ -28,32 +28,29 @@ FROM (
         ds AS metric_time__day
         , DATETIME_TRUNC(ds, month) AS metric_time__month
       FROM ***************************.mf_time_spine time_spine_src_28006
-    ) subq_22
+    ) subq_20
     WHERE metric_time__day = '2020-01-01'
     GROUP BY
       metric_time__month
-  ) subq_24
+  ) subq_22
   INNER JOIN (
-    -- Constrain Output with WHERE
-    -- Select: ['__bookings', 'metric_time__month']
     -- Aggregate Inputs for Simple Metrics
     SELECT
       metric_time__month
-      , SUM(bookings) AS __bookings
+      , SUM(__bookings) AS __bookings
     FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
-      -- Select: ['__bookings', 'metric_time__month', 'metric_time__day']
+      -- Select: ['__bookings', 'metric_time__month']
+      -- Select: ['__bookings', 'metric_time__month']
       SELECT
-        DATETIME_TRUNC(ds, day) AS metric_time__day
-        , DATETIME_TRUNC(ds, month) AS metric_time__month
-        , 1 AS bookings
+        DATETIME_TRUNC(ds, month) AS metric_time__month
+        , 1 AS __bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
     ) subq_16
-    WHERE metric_time__day = '2020-01-01'
     GROUP BY
       metric_time__month
-  ) subq_19
+  ) subq_17
   ON
-    DATETIME_TRUNC(subq_24.metric_time__month, month) = subq_19.metric_time__month
-) subq_26
+    DATETIME_TRUNC(subq_22.metric_time__month, month) = subq_17.metric_time__month
+) subq_24

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_offset_window_metric_filter_and_query_have_different_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_offset_window_metric_filter_and_query_have_different_granularities__plan0.sql
@@ -35,129 +35,127 @@ FROM (
             subq_8.metric_time__month
             , subq_8.__booking_value
           FROM (
-            -- Constrain Output with WHERE
+            -- Select: ['__booking_value', 'metric_time__month']
             SELECT
-              subq_7.booking_value AS __booking_value
-              , subq_7.metric_time__day
-              , subq_7.metric_time__month
+              subq_7.metric_time__month
+              , subq_7.__booking_value
             FROM (
-              -- Select: ['__booking_value', 'metric_time__month', 'metric_time__day']
+              -- Join to Time Spine Dataset
               SELECT
-                subq_6.metric_time__day
-                , subq_6.metric_time__month
-                , subq_6.__booking_value AS booking_value
+                subq_6.metric_time__day AS metric_time__day
+                , subq_6.metric_time__month AS metric_time__month
+                , subq_1.ds__day AS ds__day
+                , subq_1.ds__week AS ds__week
+                , subq_1.ds__month AS ds__month
+                , subq_1.ds__quarter AS ds__quarter
+                , subq_1.ds__year AS ds__year
+                , subq_1.ds__extract_year AS ds__extract_year
+                , subq_1.ds__extract_quarter AS ds__extract_quarter
+                , subq_1.ds__extract_month AS ds__extract_month
+                , subq_1.ds__extract_day AS ds__extract_day
+                , subq_1.ds__extract_dow AS ds__extract_dow
+                , subq_1.ds__extract_doy AS ds__extract_doy
+                , subq_1.ds_partitioned__day AS ds_partitioned__day
+                , subq_1.ds_partitioned__week AS ds_partitioned__week
+                , subq_1.ds_partitioned__month AS ds_partitioned__month
+                , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
+                , subq_1.ds_partitioned__year AS ds_partitioned__year
+                , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
+                , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+                , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
+                , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
+                , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+                , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+                , subq_1.paid_at__day AS paid_at__day
+                , subq_1.paid_at__week AS paid_at__week
+                , subq_1.paid_at__month AS paid_at__month
+                , subq_1.paid_at__quarter AS paid_at__quarter
+                , subq_1.paid_at__year AS paid_at__year
+                , subq_1.paid_at__extract_year AS paid_at__extract_year
+                , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
+                , subq_1.paid_at__extract_month AS paid_at__extract_month
+                , subq_1.paid_at__extract_day AS paid_at__extract_day
+                , subq_1.paid_at__extract_dow AS paid_at__extract_dow
+                , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+                , subq_1.booking__ds__day AS booking__ds__day
+                , subq_1.booking__ds__week AS booking__ds__week
+                , subq_1.booking__ds__month AS booking__ds__month
+                , subq_1.booking__ds__quarter AS booking__ds__quarter
+                , subq_1.booking__ds__year AS booking__ds__year
+                , subq_1.booking__ds__extract_year AS booking__ds__extract_year
+                , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
+                , subq_1.booking__ds__extract_month AS booking__ds__extract_month
+                , subq_1.booking__ds__extract_day AS booking__ds__extract_day
+                , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
+                , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
+                , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
+                , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
+                , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
+                , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+                , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
+                , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+                , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+                , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+                , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+                , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+                , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+                , subq_1.booking__paid_at__day AS booking__paid_at__day
+                , subq_1.booking__paid_at__week AS booking__paid_at__week
+                , subq_1.booking__paid_at__month AS booking__paid_at__month
+                , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
+                , subq_1.booking__paid_at__year AS booking__paid_at__year
+                , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
+                , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+                , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
+                , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
+                , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+                , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                , subq_1.metric_time__week AS metric_time__week
+                , subq_1.metric_time__quarter AS metric_time__quarter
+                , subq_1.metric_time__year AS metric_time__year
+                , subq_1.metric_time__extract_year AS metric_time__extract_year
+                , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+                , subq_1.metric_time__extract_month AS metric_time__extract_month
+                , subq_1.metric_time__extract_day AS metric_time__extract_day
+                , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+                , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+                , subq_1.listing AS listing
+                , subq_1.guest AS guest
+                , subq_1.host AS host
+                , subq_1.booking__listing AS booking__listing
+                , subq_1.booking__guest AS booking__guest
+                , subq_1.booking__host AS booking__host
+                , subq_1.is_instant AS is_instant
+                , subq_1.booking__is_instant AS booking__is_instant
+                , subq_1.__bookings AS __bookings
+                , subq_1.__average_booking_value AS __average_booking_value
+                , subq_1.__instant_bookings AS __instant_bookings
+                , subq_1.__booking_value AS __booking_value
+                , subq_1.__max_booking_value AS __max_booking_value
+                , subq_1.__min_booking_value AS __min_booking_value
+                , subq_1.__instant_booking_value AS __instant_booking_value
+                , subq_1.__average_instant_booking_value AS __average_instant_booking_value
+                , subq_1.__booking_value_for_non_null_listing_id AS __booking_value_for_non_null_listing_id
+                , subq_1.__bookers AS __bookers
+                , subq_1.__referred_bookings AS __referred_bookings
+                , subq_1.__median_booking_value AS __median_booking_value
+                , subq_1.__booking_value_p99 AS __booking_value_p99
+                , subq_1.__discrete_booking_value_p99 AS __discrete_booking_value_p99
+                , subq_1.__approximate_continuous_booking_value_p99 AS __approximate_continuous_booking_value_p99
+                , subq_1.__approximate_discrete_booking_value_p99 AS __approximate_discrete_booking_value_p99
+                , subq_1.__bookings_join_to_time_spine AS __bookings_join_to_time_spine
+                , subq_1.__bookings_fill_nulls_with_0_without_time_spine AS __bookings_fill_nulls_with_0_without_time_spine
+                , subq_1.__bookings_fill_nulls_with_0 AS __bookings_fill_nulls_with_0
+                , subq_1.__instant_bookings_with_measure_filter AS __instant_bookings_with_measure_filter
+                , subq_1.__bookings_join_to_time_spine_with_tiered_filters AS __bookings_join_to_time_spine_with_tiered_filters
+                , subq_1.__bookers_fill_nulls_with_0_join_to_timespine AS __bookers_fill_nulls_with_0_join_to_timespine
               FROM (
-                -- Join to Time Spine Dataset
+                -- Select: ['metric_time__day', 'metric_time__month']
                 SELECT
-                  subq_5.metric_time__day AS metric_time__day
-                  , subq_5.metric_time__month AS metric_time__month
-                  , subq_1.ds__day AS ds__day
-                  , subq_1.ds__week AS ds__week
-                  , subq_1.ds__month AS ds__month
-                  , subq_1.ds__quarter AS ds__quarter
-                  , subq_1.ds__year AS ds__year
-                  , subq_1.ds__extract_year AS ds__extract_year
-                  , subq_1.ds__extract_quarter AS ds__extract_quarter
-                  , subq_1.ds__extract_month AS ds__extract_month
-                  , subq_1.ds__extract_day AS ds__extract_day
-                  , subq_1.ds__extract_dow AS ds__extract_dow
-                  , subq_1.ds__extract_doy AS ds__extract_doy
-                  , subq_1.ds_partitioned__day AS ds_partitioned__day
-                  , subq_1.ds_partitioned__week AS ds_partitioned__week
-                  , subq_1.ds_partitioned__month AS ds_partitioned__month
-                  , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
-                  , subq_1.ds_partitioned__year AS ds_partitioned__year
-                  , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
-                  , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
-                  , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
-                  , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
-                  , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
-                  , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
-                  , subq_1.paid_at__day AS paid_at__day
-                  , subq_1.paid_at__week AS paid_at__week
-                  , subq_1.paid_at__month AS paid_at__month
-                  , subq_1.paid_at__quarter AS paid_at__quarter
-                  , subq_1.paid_at__year AS paid_at__year
-                  , subq_1.paid_at__extract_year AS paid_at__extract_year
-                  , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
-                  , subq_1.paid_at__extract_month AS paid_at__extract_month
-                  , subq_1.paid_at__extract_day AS paid_at__extract_day
-                  , subq_1.paid_at__extract_dow AS paid_at__extract_dow
-                  , subq_1.paid_at__extract_doy AS paid_at__extract_doy
-                  , subq_1.booking__ds__day AS booking__ds__day
-                  , subq_1.booking__ds__week AS booking__ds__week
-                  , subq_1.booking__ds__month AS booking__ds__month
-                  , subq_1.booking__ds__quarter AS booking__ds__quarter
-                  , subq_1.booking__ds__year AS booking__ds__year
-                  , subq_1.booking__ds__extract_year AS booking__ds__extract_year
-                  , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
-                  , subq_1.booking__ds__extract_month AS booking__ds__extract_month
-                  , subq_1.booking__ds__extract_day AS booking__ds__extract_day
-                  , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
-                  , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
-                  , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
-                  , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
-                  , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
-                  , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
-                  , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
-                  , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
-                  , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
-                  , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
-                  , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
-                  , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
-                  , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
-                  , subq_1.booking__paid_at__day AS booking__paid_at__day
-                  , subq_1.booking__paid_at__week AS booking__paid_at__week
-                  , subq_1.booking__paid_at__month AS booking__paid_at__month
-                  , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
-                  , subq_1.booking__paid_at__year AS booking__paid_at__year
-                  , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
-                  , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
-                  , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
-                  , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
-                  , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
-                  , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
-                  , subq_1.metric_time__week AS metric_time__week
-                  , subq_1.metric_time__quarter AS metric_time__quarter
-                  , subq_1.metric_time__year AS metric_time__year
-                  , subq_1.metric_time__extract_year AS metric_time__extract_year
-                  , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
-                  , subq_1.metric_time__extract_month AS metric_time__extract_month
-                  , subq_1.metric_time__extract_day AS metric_time__extract_day
-                  , subq_1.metric_time__extract_dow AS metric_time__extract_dow
-                  , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-                  , subq_1.listing AS listing
-                  , subq_1.guest AS guest
-                  , subq_1.host AS host
-                  , subq_1.booking__listing AS booking__listing
-                  , subq_1.booking__guest AS booking__guest
-                  , subq_1.booking__host AS booking__host
-                  , subq_1.is_instant AS is_instant
-                  , subq_1.booking__is_instant AS booking__is_instant
-                  , subq_1.__bookings AS __bookings
-                  , subq_1.__average_booking_value AS __average_booking_value
-                  , subq_1.__instant_bookings AS __instant_bookings
-                  , subq_1.__booking_value AS __booking_value
-                  , subq_1.__max_booking_value AS __max_booking_value
-                  , subq_1.__min_booking_value AS __min_booking_value
-                  , subq_1.__instant_booking_value AS __instant_booking_value
-                  , subq_1.__average_instant_booking_value AS __average_instant_booking_value
-                  , subq_1.__booking_value_for_non_null_listing_id AS __booking_value_for_non_null_listing_id
-                  , subq_1.__bookers AS __bookers
-                  , subq_1.__referred_bookings AS __referred_bookings
-                  , subq_1.__median_booking_value AS __median_booking_value
-                  , subq_1.__booking_value_p99 AS __booking_value_p99
-                  , subq_1.__discrete_booking_value_p99 AS __discrete_booking_value_p99
-                  , subq_1.__approximate_continuous_booking_value_p99 AS __approximate_continuous_booking_value_p99
-                  , subq_1.__approximate_discrete_booking_value_p99 AS __approximate_discrete_booking_value_p99
-                  , subq_1.__bookings_join_to_time_spine AS __bookings_join_to_time_spine
-                  , subq_1.__bookings_fill_nulls_with_0_without_time_spine AS __bookings_fill_nulls_with_0_without_time_spine
-                  , subq_1.__bookings_fill_nulls_with_0 AS __bookings_fill_nulls_with_0
-                  , subq_1.__instant_bookings_with_measure_filter AS __instant_bookings_with_measure_filter
-                  , subq_1.__bookings_join_to_time_spine_with_tiered_filters AS __bookings_join_to_time_spine_with_tiered_filters
-                  , subq_1.__bookers_fill_nulls_with_0_join_to_timespine AS __bookers_fill_nulls_with_0_join_to_timespine
+                  subq_5.metric_time__day
+                  , subq_5.metric_time__month
                 FROM (
-                  -- Select: ['metric_time__day', 'metric_time__month']
+                  -- Constrain Output with WHERE
                   SELECT
                     subq_4.metric_time__day
                     , subq_4.metric_time__month
@@ -200,225 +198,225 @@ FROM (
                       ) subq_2
                     ) subq_3
                   ) subq_4
+                  WHERE metric_time__day = '2020-01-01'
                 ) subq_5
-                INNER JOIN (
-                  -- Metric Time Dimension 'ds'
-                  SELECT
-                    subq_0.ds__day
-                    , subq_0.ds__week
-                    , subq_0.ds__month
-                    , subq_0.ds__quarter
-                    , subq_0.ds__year
-                    , subq_0.ds__extract_year
-                    , subq_0.ds__extract_quarter
-                    , subq_0.ds__extract_month
-                    , subq_0.ds__extract_day
-                    , subq_0.ds__extract_dow
-                    , subq_0.ds__extract_doy
-                    , subq_0.ds_partitioned__day
-                    , subq_0.ds_partitioned__week
-                    , subq_0.ds_partitioned__month
-                    , subq_0.ds_partitioned__quarter
-                    , subq_0.ds_partitioned__year
-                    , subq_0.ds_partitioned__extract_year
-                    , subq_0.ds_partitioned__extract_quarter
-                    , subq_0.ds_partitioned__extract_month
-                    , subq_0.ds_partitioned__extract_day
-                    , subq_0.ds_partitioned__extract_dow
-                    , subq_0.ds_partitioned__extract_doy
-                    , subq_0.paid_at__day
-                    , subq_0.paid_at__week
-                    , subq_0.paid_at__month
-                    , subq_0.paid_at__quarter
-                    , subq_0.paid_at__year
-                    , subq_0.paid_at__extract_year
-                    , subq_0.paid_at__extract_quarter
-                    , subq_0.paid_at__extract_month
-                    , subq_0.paid_at__extract_day
-                    , subq_0.paid_at__extract_dow
-                    , subq_0.paid_at__extract_doy
-                    , subq_0.booking__ds__day
-                    , subq_0.booking__ds__week
-                    , subq_0.booking__ds__month
-                    , subq_0.booking__ds__quarter
-                    , subq_0.booking__ds__year
-                    , subq_0.booking__ds__extract_year
-                    , subq_0.booking__ds__extract_quarter
-                    , subq_0.booking__ds__extract_month
-                    , subq_0.booking__ds__extract_day
-                    , subq_0.booking__ds__extract_dow
-                    , subq_0.booking__ds__extract_doy
-                    , subq_0.booking__ds_partitioned__day
-                    , subq_0.booking__ds_partitioned__week
-                    , subq_0.booking__ds_partitioned__month
-                    , subq_0.booking__ds_partitioned__quarter
-                    , subq_0.booking__ds_partitioned__year
-                    , subq_0.booking__ds_partitioned__extract_year
-                    , subq_0.booking__ds_partitioned__extract_quarter
-                    , subq_0.booking__ds_partitioned__extract_month
-                    , subq_0.booking__ds_partitioned__extract_day
-                    , subq_0.booking__ds_partitioned__extract_dow
-                    , subq_0.booking__ds_partitioned__extract_doy
-                    , subq_0.booking__paid_at__day
-                    , subq_0.booking__paid_at__week
-                    , subq_0.booking__paid_at__month
-                    , subq_0.booking__paid_at__quarter
-                    , subq_0.booking__paid_at__year
-                    , subq_0.booking__paid_at__extract_year
-                    , subq_0.booking__paid_at__extract_quarter
-                    , subq_0.booking__paid_at__extract_month
-                    , subq_0.booking__paid_at__extract_day
-                    , subq_0.booking__paid_at__extract_dow
-                    , subq_0.booking__paid_at__extract_doy
-                    , subq_0.ds__day AS metric_time__day
-                    , subq_0.ds__week AS metric_time__week
-                    , subq_0.ds__month AS metric_time__month
-                    , subq_0.ds__quarter AS metric_time__quarter
-                    , subq_0.ds__year AS metric_time__year
-                    , subq_0.ds__extract_year AS metric_time__extract_year
-                    , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                    , subq_0.ds__extract_month AS metric_time__extract_month
-                    , subq_0.ds__extract_day AS metric_time__extract_day
-                    , subq_0.ds__extract_dow AS metric_time__extract_dow
-                    , subq_0.ds__extract_doy AS metric_time__extract_doy
-                    , subq_0.listing
-                    , subq_0.guest
-                    , subq_0.host
-                    , subq_0.booking__listing
-                    , subq_0.booking__guest
-                    , subq_0.booking__host
-                    , subq_0.is_instant
-                    , subq_0.booking__is_instant
-                    , subq_0.__bookings
-                    , subq_0.__average_booking_value
-                    , subq_0.__instant_bookings
-                    , subq_0.__booking_value
-                    , subq_0.__max_booking_value
-                    , subq_0.__min_booking_value
-                    , subq_0.__instant_booking_value
-                    , subq_0.__average_instant_booking_value
-                    , subq_0.__booking_value_for_non_null_listing_id
-                    , subq_0.__bookers
-                    , subq_0.__referred_bookings
-                    , subq_0.__median_booking_value
-                    , subq_0.__booking_value_p99
-                    , subq_0.__discrete_booking_value_p99
-                    , subq_0.__approximate_continuous_booking_value_p99
-                    , subq_0.__approximate_discrete_booking_value_p99
-                    , subq_0.__bookings_join_to_time_spine
-                    , subq_0.__bookings_fill_nulls_with_0_without_time_spine
-                    , subq_0.__bookings_fill_nulls_with_0
-                    , subq_0.__instant_bookings_with_measure_filter
-                    , subq_0.__bookings_join_to_time_spine_with_tiered_filters
-                    , subq_0.__bookers_fill_nulls_with_0_join_to_timespine
-                  FROM (
-                    -- Read Elements From Semantic Model 'bookings_source'
-                    SELECT
-                      1 AS __bookings
-                      , bookings_source_src_28000.booking_value AS __average_booking_value
-                      , CASE WHEN is_instant THEN 1 ELSE 0 END AS __instant_bookings
-                      , bookings_source_src_28000.booking_value AS __booking_value
-                      , bookings_source_src_28000.booking_value AS __max_booking_value
-                      , bookings_source_src_28000.booking_value AS __min_booking_value
-                      , bookings_source_src_28000.booking_value AS __instant_booking_value
-                      , bookings_source_src_28000.booking_value AS __average_instant_booking_value
-                      , bookings_source_src_28000.booking_value AS __booking_value_for_non_null_listing_id
-                      , bookings_source_src_28000.guest_id AS __bookers
-                      , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS __referred_bookings
-                      , bookings_source_src_28000.booking_value AS __median_booking_value
-                      , bookings_source_src_28000.booking_value AS __booking_value_p99
-                      , bookings_source_src_28000.booking_value AS __discrete_booking_value_p99
-                      , bookings_source_src_28000.booking_value AS __approximate_continuous_booking_value_p99
-                      , bookings_source_src_28000.booking_value AS __approximate_discrete_booking_value_p99
-                      , 1 AS __bookings_join_to_time_spine
-                      , 1 AS __bookings_fill_nulls_with_0_without_time_spine
-                      , 1 AS __bookings_fill_nulls_with_0
-                      , 1 AS __instant_bookings_with_measure_filter
-                      , 1 AS __bookings_join_to_time_spine_with_tiered_filters
-                      , bookings_source_src_28000.guest_id AS __bookers_fill_nulls_with_0_join_to_timespine
-                      , bookings_source_src_28000.booking_value AS __booking_payments
-                      , bookings_source_src_28000.is_instant
-                      , DATETIME_TRUNC(bookings_source_src_28000.ds, day) AS ds__day
-                      , DATETIME_TRUNC(bookings_source_src_28000.ds, isoweek) AS ds__week
-                      , DATETIME_TRUNC(bookings_source_src_28000.ds, month) AS ds__month
-                      , DATETIME_TRUNC(bookings_source_src_28000.ds, quarter) AS ds__quarter
-                      , DATETIME_TRUNC(bookings_source_src_28000.ds, year) AS ds__year
-                      , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                      , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS ds__extract_dow
-                      , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                      , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS ds_partitioned__day
-                      , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS ds_partitioned__week
-                      , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS ds_partitioned__month
-                      , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS ds_partitioned__quarter
-                      , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS ds_partitioned__year
-                      , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                      , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS ds_partitioned__extract_dow
-                      , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                      , DATETIME_TRUNC(bookings_source_src_28000.paid_at, day) AS paid_at__day
-                      , DATETIME_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS paid_at__week
-                      , DATETIME_TRUNC(bookings_source_src_28000.paid_at, month) AS paid_at__month
-                      , DATETIME_TRUNC(bookings_source_src_28000.paid_at, quarter) AS paid_at__quarter
-                      , DATETIME_TRUNC(bookings_source_src_28000.paid_at, year) AS paid_at__year
-                      , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                      , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS paid_at__extract_dow
-                      , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                      , bookings_source_src_28000.is_instant AS booking__is_instant
-                      , DATETIME_TRUNC(bookings_source_src_28000.ds, day) AS booking__ds__day
-                      , DATETIME_TRUNC(bookings_source_src_28000.ds, isoweek) AS booking__ds__week
-                      , DATETIME_TRUNC(bookings_source_src_28000.ds, month) AS booking__ds__month
-                      , DATETIME_TRUNC(bookings_source_src_28000.ds, quarter) AS booking__ds__quarter
-                      , DATETIME_TRUNC(bookings_source_src_28000.ds, year) AS booking__ds__year
-                      , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                      , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS booking__ds__extract_dow
-                      , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                      , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS booking__ds_partitioned__day
-                      , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS booking__ds_partitioned__week
-                      , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS booking__ds_partitioned__month
-                      , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
-                      , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS booking__ds_partitioned__year
-                      , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                      , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS booking__ds_partitioned__extract_dow
-                      , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                      , DATETIME_TRUNC(bookings_source_src_28000.paid_at, day) AS booking__paid_at__day
-                      , DATETIME_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS booking__paid_at__week
-                      , DATETIME_TRUNC(bookings_source_src_28000.paid_at, month) AS booking__paid_at__month
-                      , DATETIME_TRUNC(bookings_source_src_28000.paid_at, quarter) AS booking__paid_at__quarter
-                      , DATETIME_TRUNC(bookings_source_src_28000.paid_at, year) AS booking__paid_at__year
-                      , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                      , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS booking__paid_at__extract_dow
-                      , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                      , bookings_source_src_28000.listing_id AS listing
-                      , bookings_source_src_28000.guest_id AS guest
-                      , bookings_source_src_28000.host_id AS host
-                      , bookings_source_src_28000.listing_id AS booking__listing
-                      , bookings_source_src_28000.guest_id AS booking__guest
-                      , bookings_source_src_28000.host_id AS booking__host
-                    FROM ***************************.fct_bookings bookings_source_src_28000
-                  ) subq_0
-                ) subq_1
-                ON
-                  DATE_SUB(CAST(subq_5.metric_time__day AS DATETIME), INTERVAL 1 week) = subq_1.metric_time__day
               ) subq_6
+              INNER JOIN (
+                -- Metric Time Dimension 'ds'
+                SELECT
+                  subq_0.ds__day
+                  , subq_0.ds__week
+                  , subq_0.ds__month
+                  , subq_0.ds__quarter
+                  , subq_0.ds__year
+                  , subq_0.ds__extract_year
+                  , subq_0.ds__extract_quarter
+                  , subq_0.ds__extract_month
+                  , subq_0.ds__extract_day
+                  , subq_0.ds__extract_dow
+                  , subq_0.ds__extract_doy
+                  , subq_0.ds_partitioned__day
+                  , subq_0.ds_partitioned__week
+                  , subq_0.ds_partitioned__month
+                  , subq_0.ds_partitioned__quarter
+                  , subq_0.ds_partitioned__year
+                  , subq_0.ds_partitioned__extract_year
+                  , subq_0.ds_partitioned__extract_quarter
+                  , subq_0.ds_partitioned__extract_month
+                  , subq_0.ds_partitioned__extract_day
+                  , subq_0.ds_partitioned__extract_dow
+                  , subq_0.ds_partitioned__extract_doy
+                  , subq_0.paid_at__day
+                  , subq_0.paid_at__week
+                  , subq_0.paid_at__month
+                  , subq_0.paid_at__quarter
+                  , subq_0.paid_at__year
+                  , subq_0.paid_at__extract_year
+                  , subq_0.paid_at__extract_quarter
+                  , subq_0.paid_at__extract_month
+                  , subq_0.paid_at__extract_day
+                  , subq_0.paid_at__extract_dow
+                  , subq_0.paid_at__extract_doy
+                  , subq_0.booking__ds__day
+                  , subq_0.booking__ds__week
+                  , subq_0.booking__ds__month
+                  , subq_0.booking__ds__quarter
+                  , subq_0.booking__ds__year
+                  , subq_0.booking__ds__extract_year
+                  , subq_0.booking__ds__extract_quarter
+                  , subq_0.booking__ds__extract_month
+                  , subq_0.booking__ds__extract_day
+                  , subq_0.booking__ds__extract_dow
+                  , subq_0.booking__ds__extract_doy
+                  , subq_0.booking__ds_partitioned__day
+                  , subq_0.booking__ds_partitioned__week
+                  , subq_0.booking__ds_partitioned__month
+                  , subq_0.booking__ds_partitioned__quarter
+                  , subq_0.booking__ds_partitioned__year
+                  , subq_0.booking__ds_partitioned__extract_year
+                  , subq_0.booking__ds_partitioned__extract_quarter
+                  , subq_0.booking__ds_partitioned__extract_month
+                  , subq_0.booking__ds_partitioned__extract_day
+                  , subq_0.booking__ds_partitioned__extract_dow
+                  , subq_0.booking__ds_partitioned__extract_doy
+                  , subq_0.booking__paid_at__day
+                  , subq_0.booking__paid_at__week
+                  , subq_0.booking__paid_at__month
+                  , subq_0.booking__paid_at__quarter
+                  , subq_0.booking__paid_at__year
+                  , subq_0.booking__paid_at__extract_year
+                  , subq_0.booking__paid_at__extract_quarter
+                  , subq_0.booking__paid_at__extract_month
+                  , subq_0.booking__paid_at__extract_day
+                  , subq_0.booking__paid_at__extract_dow
+                  , subq_0.booking__paid_at__extract_doy
+                  , subq_0.ds__day AS metric_time__day
+                  , subq_0.ds__week AS metric_time__week
+                  , subq_0.ds__month AS metric_time__month
+                  , subq_0.ds__quarter AS metric_time__quarter
+                  , subq_0.ds__year AS metric_time__year
+                  , subq_0.ds__extract_year AS metric_time__extract_year
+                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_0.ds__extract_month AS metric_time__extract_month
+                  , subq_0.ds__extract_day AS metric_time__extract_day
+                  , subq_0.ds__extract_dow AS metric_time__extract_dow
+                  , subq_0.ds__extract_doy AS metric_time__extract_doy
+                  , subq_0.listing
+                  , subq_0.guest
+                  , subq_0.host
+                  , subq_0.booking__listing
+                  , subq_0.booking__guest
+                  , subq_0.booking__host
+                  , subq_0.is_instant
+                  , subq_0.booking__is_instant
+                  , subq_0.__bookings
+                  , subq_0.__average_booking_value
+                  , subq_0.__instant_bookings
+                  , subq_0.__booking_value
+                  , subq_0.__max_booking_value
+                  , subq_0.__min_booking_value
+                  , subq_0.__instant_booking_value
+                  , subq_0.__average_instant_booking_value
+                  , subq_0.__booking_value_for_non_null_listing_id
+                  , subq_0.__bookers
+                  , subq_0.__referred_bookings
+                  , subq_0.__median_booking_value
+                  , subq_0.__booking_value_p99
+                  , subq_0.__discrete_booking_value_p99
+                  , subq_0.__approximate_continuous_booking_value_p99
+                  , subq_0.__approximate_discrete_booking_value_p99
+                  , subq_0.__bookings_join_to_time_spine
+                  , subq_0.__bookings_fill_nulls_with_0_without_time_spine
+                  , subq_0.__bookings_fill_nulls_with_0
+                  , subq_0.__instant_bookings_with_measure_filter
+                  , subq_0.__bookings_join_to_time_spine_with_tiered_filters
+                  , subq_0.__bookers_fill_nulls_with_0_join_to_timespine
+                FROM (
+                  -- Read Elements From Semantic Model 'bookings_source'
+                  SELECT
+                    1 AS __bookings
+                    , bookings_source_src_28000.booking_value AS __average_booking_value
+                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS __instant_bookings
+                    , bookings_source_src_28000.booking_value AS __booking_value
+                    , bookings_source_src_28000.booking_value AS __max_booking_value
+                    , bookings_source_src_28000.booking_value AS __min_booking_value
+                    , bookings_source_src_28000.booking_value AS __instant_booking_value
+                    , bookings_source_src_28000.booking_value AS __average_instant_booking_value
+                    , bookings_source_src_28000.booking_value AS __booking_value_for_non_null_listing_id
+                    , bookings_source_src_28000.guest_id AS __bookers
+                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS __referred_bookings
+                    , bookings_source_src_28000.booking_value AS __median_booking_value
+                    , bookings_source_src_28000.booking_value AS __booking_value_p99
+                    , bookings_source_src_28000.booking_value AS __discrete_booking_value_p99
+                    , bookings_source_src_28000.booking_value AS __approximate_continuous_booking_value_p99
+                    , bookings_source_src_28000.booking_value AS __approximate_discrete_booking_value_p99
+                    , 1 AS __bookings_join_to_time_spine
+                    , 1 AS __bookings_fill_nulls_with_0_without_time_spine
+                    , 1 AS __bookings_fill_nulls_with_0
+                    , 1 AS __instant_bookings_with_measure_filter
+                    , 1 AS __bookings_join_to_time_spine_with_tiered_filters
+                    , bookings_source_src_28000.guest_id AS __bookers_fill_nulls_with_0_join_to_timespine
+                    , bookings_source_src_28000.booking_value AS __booking_payments
+                    , bookings_source_src_28000.is_instant
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds, day) AS ds__day
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds, isoweek) AS ds__week
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds, month) AS ds__month
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds, quarter) AS ds__quarter
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds, year) AS ds__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                    , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS ds__extract_dow
+                    , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS ds_partitioned__day
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS ds_partitioned__week
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS ds_partitioned__month
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS ds_partitioned__quarter
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                    , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS ds_partitioned__extract_dow
+                    , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, day) AS paid_at__day
+                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS paid_at__week
+                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, month) AS paid_at__month
+                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, quarter) AS paid_at__quarter
+                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, year) AS paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                    , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS paid_at__extract_dow
+                    , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                    , bookings_source_src_28000.is_instant AS booking__is_instant
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds, day) AS booking__ds__day
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds, isoweek) AS booking__ds__week
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds, month) AS booking__ds__month
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds, quarter) AS booking__ds__quarter
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds, year) AS booking__ds__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                    , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS booking__ds__extract_dow
+                    , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS booking__ds_partitioned__day
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS booking__ds_partitioned__week
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS booking__ds_partitioned__month
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS booking__ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                    , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS booking__ds_partitioned__extract_dow
+                    , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, day) AS booking__paid_at__day
+                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS booking__paid_at__week
+                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, month) AS booking__paid_at__month
+                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, quarter) AS booking__paid_at__quarter
+                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, year) AS booking__paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                    , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS booking__paid_at__extract_dow
+                    , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                    , bookings_source_src_28000.listing_id AS listing
+                    , bookings_source_src_28000.guest_id AS guest
+                    , bookings_source_src_28000.host_id AS host
+                    , bookings_source_src_28000.listing_id AS booking__listing
+                    , bookings_source_src_28000.guest_id AS booking__guest
+                    , bookings_source_src_28000.host_id AS booking__host
+                  FROM ***************************.fct_bookings bookings_source_src_28000
+                ) subq_0
+              ) subq_1
+              ON
+                DATE_SUB(CAST(subq_6.metric_time__day AS DATETIME), INTERVAL 1 week) = subq_1.metric_time__day
             ) subq_7
-            WHERE metric_time__day = '2020-01-01'
           ) subq_8
         ) subq_9
         GROUP BY

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_offset_window_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/BigQuery/test_offset_window_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
@@ -27,27 +27,35 @@ FROM (
     , MAX(subq_31.booking_value) AS booking_value
     , MAX(subq_37.bookers) AS bookers
   FROM (
-    -- Constrain Output with WHERE
+    -- Join to Time Spine Dataset
+    -- Select: ['__booking_value', 'metric_time__month']
     -- Select: ['__booking_value', 'metric_time__month']
     -- Aggregate Inputs for Simple Metrics
     -- Compute Metrics via Expressions
     SELECT
-      metric_time__month
-      , SUM(booking_value) AS booking_value
+      subq_26.metric_time__month AS metric_time__month
+      , SUM(sma_28009_cte.__booking_value) AS booking_value
     FROM (
-      -- Join to Time Spine Dataset
-      -- Select: ['__booking_value', 'metric_time__month', 'metric_time__day']
+      -- Constrain Output with WHERE
+      -- Select: ['metric_time__day', 'metric_time__month']
       SELECT
-        time_spine_src_28006.ds AS metric_time__day
-        , DATETIME_TRUNC(time_spine_src_28006.ds, month) AS metric_time__month
-        , sma_28009_cte.__booking_value AS booking_value
-      FROM ***************************.mf_time_spine time_spine_src_28006
-      INNER JOIN
-        sma_28009_cte
-      ON
-        DATE_SUB(CAST(time_spine_src_28006.ds AS DATETIME), INTERVAL 1 week) = sma_28009_cte.metric_time__day
-    ) subq_27
-    WHERE metric_time__day = '2020-01-01'
+        metric_time__day
+        , metric_time__month
+      FROM (
+        -- Read From Time Spine 'mf_time_spine'
+        -- Change Column Aliases
+        -- Select: ['metric_time__day', 'metric_time__month']
+        SELECT
+          ds AS metric_time__day
+          , DATETIME_TRUNC(ds, month) AS metric_time__month
+        FROM ***************************.mf_time_spine time_spine_src_28006
+      ) subq_24
+      WHERE metric_time__day = '2020-01-01'
+    ) subq_26
+    INNER JOIN
+      sma_28009_cte
+    ON
+      DATE_SUB(CAST(subq_26.metric_time__day AS DATETIME), INTERVAL 1 week) = sma_28009_cte.metric_time__day
     GROUP BY
       metric_time__month
   ) subq_31

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
@@ -4,19 +4,19 @@ sql_engine: Databricks
 ---
 -- Write to DataTable
 SELECT
-  subq_20.metric_time__day
-  , subq_20.bookings_growth_2_weeks
+  subq_19.metric_time__day
+  , subq_19.bookings_growth_2_weeks
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_19.metric_time__day
+    subq_18.metric_time__day
     , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
   FROM (
     -- Combine Aggregated Outputs
     SELECT
-      COALESCE(subq_6.metric_time__day, subq_18.metric_time__day) AS metric_time__day
+      COALESCE(subq_6.metric_time__day, subq_17.metric_time__day) AS metric_time__day
       , MAX(subq_6.bookings) AS bookings
-      , MAX(subq_18.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+      , MAX(subq_17.bookings_2_weeks_ago) AS bookings_2_weeks_ago
     FROM (
       -- Compute Metrics via Expressions
       SELECT
@@ -266,40 +266,40 @@ FROM (
     FULL OUTER JOIN (
       -- Compute Metrics via Expressions
       SELECT
-        subq_17.metric_time__day
-        , subq_17.__bookings AS bookings_2_weeks_ago
+        subq_16.metric_time__day
+        , subq_16.__bookings AS bookings_2_weeks_ago
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_16.metric_time__day AS metric_time__day
-          , subq_11.__bookings AS __bookings
+          subq_15.metric_time__day AS metric_time__day
+          , subq_10.__bookings AS __bookings
         FROM (
           -- Select: ['metric_time__day']
           SELECT
-            subq_15.metric_time__day
+            subq_14.metric_time__day
           FROM (
             -- Constrain Output with WHERE
             SELECT
-              subq_14.metric_time__day
+              subq_13.metric_time__day
             FROM (
               -- Select: ['metric_time__day']
               SELECT
-                subq_13.metric_time__day
+                subq_12.metric_time__day
               FROM (
                 -- Change Column Aliases
                 SELECT
-                  subq_12.ds__day AS metric_time__day
-                  , subq_12.ds__week
-                  , subq_12.ds__month
-                  , subq_12.ds__quarter
-                  , subq_12.ds__year
-                  , subq_12.ds__extract_year
-                  , subq_12.ds__extract_quarter
-                  , subq_12.ds__extract_month
-                  , subq_12.ds__extract_day
-                  , subq_12.ds__extract_dow
-                  , subq_12.ds__extract_doy
-                  , subq_12.ds__alien_day
+                  subq_11.ds__day AS metric_time__day
+                  , subq_11.ds__week
+                  , subq_11.ds__month
+                  , subq_11.ds__quarter
+                  , subq_11.ds__year
+                  , subq_11.ds__extract_year
+                  , subq_11.ds__extract_quarter
+                  , subq_11.ds__extract_month
+                  , subq_11.ds__extract_day
+                  , subq_11.ds__extract_dow
+                  , subq_11.ds__extract_doy
+                  , subq_11.ds__alien_day
                 FROM (
                   -- Read From Time Spine 'mf_time_spine'
                   SELECT
@@ -316,259 +316,252 @@ FROM (
                     , EXTRACT(doy FROM time_spine_src_28006.ds) AS ds__extract_doy
                     , time_spine_src_28006.alien_day AS ds__alien_day
                   FROM ***************************.mf_time_spine time_spine_src_28006
-                ) subq_12
-              ) subq_13
-            ) subq_14
+                ) subq_11
+              ) subq_12
+            ) subq_13
             WHERE metric_time__day = '2020-01-01' or metric_time__day = '2020-01-14'
-          ) subq_15
-        ) subq_16
+          ) subq_14
+        ) subq_15
         INNER JOIN (
           -- Aggregate Inputs for Simple Metrics
           SELECT
-            subq_10.metric_time__day
-            , SUM(subq_10.__bookings) AS __bookings
+            subq_9.metric_time__day
+            , SUM(subq_9.__bookings) AS __bookings
           FROM (
             -- Select: ['__bookings', 'metric_time__day']
             SELECT
-              subq_9.metric_time__day
-              , subq_9.__bookings
+              subq_8.metric_time__day
+              , subq_8.__bookings
             FROM (
-              -- Constrain Output with WHERE
+              -- Select: ['__bookings', 'metric_time__day']
               SELECT
-                subq_8.bookings AS __bookings
-                , subq_8.metric_time__day
+                subq_7.metric_time__day
+                , subq_7.__bookings
               FROM (
-                -- Select: ['__bookings', 'metric_time__day']
+                -- Metric Time Dimension 'ds'
                 SELECT
-                  subq_7.metric_time__day
-                  , subq_7.__bookings AS bookings
+                  subq_0.ds__day
+                  , subq_0.ds__week
+                  , subq_0.ds__month
+                  , subq_0.ds__quarter
+                  , subq_0.ds__year
+                  , subq_0.ds__extract_year
+                  , subq_0.ds__extract_quarter
+                  , subq_0.ds__extract_month
+                  , subq_0.ds__extract_day
+                  , subq_0.ds__extract_dow
+                  , subq_0.ds__extract_doy
+                  , subq_0.ds_partitioned__day
+                  , subq_0.ds_partitioned__week
+                  , subq_0.ds_partitioned__month
+                  , subq_0.ds_partitioned__quarter
+                  , subq_0.ds_partitioned__year
+                  , subq_0.ds_partitioned__extract_year
+                  , subq_0.ds_partitioned__extract_quarter
+                  , subq_0.ds_partitioned__extract_month
+                  , subq_0.ds_partitioned__extract_day
+                  , subq_0.ds_partitioned__extract_dow
+                  , subq_0.ds_partitioned__extract_doy
+                  , subq_0.paid_at__day
+                  , subq_0.paid_at__week
+                  , subq_0.paid_at__month
+                  , subq_0.paid_at__quarter
+                  , subq_0.paid_at__year
+                  , subq_0.paid_at__extract_year
+                  , subq_0.paid_at__extract_quarter
+                  , subq_0.paid_at__extract_month
+                  , subq_0.paid_at__extract_day
+                  , subq_0.paid_at__extract_dow
+                  , subq_0.paid_at__extract_doy
+                  , subq_0.booking__ds__day
+                  , subq_0.booking__ds__week
+                  , subq_0.booking__ds__month
+                  , subq_0.booking__ds__quarter
+                  , subq_0.booking__ds__year
+                  , subq_0.booking__ds__extract_year
+                  , subq_0.booking__ds__extract_quarter
+                  , subq_0.booking__ds__extract_month
+                  , subq_0.booking__ds__extract_day
+                  , subq_0.booking__ds__extract_dow
+                  , subq_0.booking__ds__extract_doy
+                  , subq_0.booking__ds_partitioned__day
+                  , subq_0.booking__ds_partitioned__week
+                  , subq_0.booking__ds_partitioned__month
+                  , subq_0.booking__ds_partitioned__quarter
+                  , subq_0.booking__ds_partitioned__year
+                  , subq_0.booking__ds_partitioned__extract_year
+                  , subq_0.booking__ds_partitioned__extract_quarter
+                  , subq_0.booking__ds_partitioned__extract_month
+                  , subq_0.booking__ds_partitioned__extract_day
+                  , subq_0.booking__ds_partitioned__extract_dow
+                  , subq_0.booking__ds_partitioned__extract_doy
+                  , subq_0.booking__paid_at__day
+                  , subq_0.booking__paid_at__week
+                  , subq_0.booking__paid_at__month
+                  , subq_0.booking__paid_at__quarter
+                  , subq_0.booking__paid_at__year
+                  , subq_0.booking__paid_at__extract_year
+                  , subq_0.booking__paid_at__extract_quarter
+                  , subq_0.booking__paid_at__extract_month
+                  , subq_0.booking__paid_at__extract_day
+                  , subq_0.booking__paid_at__extract_dow
+                  , subq_0.booking__paid_at__extract_doy
+                  , subq_0.ds__day AS metric_time__day
+                  , subq_0.ds__week AS metric_time__week
+                  , subq_0.ds__month AS metric_time__month
+                  , subq_0.ds__quarter AS metric_time__quarter
+                  , subq_0.ds__year AS metric_time__year
+                  , subq_0.ds__extract_year AS metric_time__extract_year
+                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_0.ds__extract_month AS metric_time__extract_month
+                  , subq_0.ds__extract_day AS metric_time__extract_day
+                  , subq_0.ds__extract_dow AS metric_time__extract_dow
+                  , subq_0.ds__extract_doy AS metric_time__extract_doy
+                  , subq_0.listing
+                  , subq_0.guest
+                  , subq_0.host
+                  , subq_0.booking__listing
+                  , subq_0.booking__guest
+                  , subq_0.booking__host
+                  , subq_0.is_instant
+                  , subq_0.booking__is_instant
+                  , subq_0.__bookings
+                  , subq_0.__average_booking_value
+                  , subq_0.__instant_bookings
+                  , subq_0.__booking_value
+                  , subq_0.__max_booking_value
+                  , subq_0.__min_booking_value
+                  , subq_0.__instant_booking_value
+                  , subq_0.__average_instant_booking_value
+                  , subq_0.__booking_value_for_non_null_listing_id
+                  , subq_0.__bookers
+                  , subq_0.__referred_bookings
+                  , subq_0.__median_booking_value
+                  , subq_0.__booking_value_p99
+                  , subq_0.__discrete_booking_value_p99
+                  , subq_0.__approximate_continuous_booking_value_p99
+                  , subq_0.__approximate_discrete_booking_value_p99
+                  , subq_0.__bookings_join_to_time_spine
+                  , subq_0.__bookings_fill_nulls_with_0_without_time_spine
+                  , subq_0.__bookings_fill_nulls_with_0
+                  , subq_0.__instant_bookings_with_measure_filter
+                  , subq_0.__bookings_join_to_time_spine_with_tiered_filters
+                  , subq_0.__bookers_fill_nulls_with_0_join_to_timespine
                 FROM (
-                  -- Metric Time Dimension 'ds'
+                  -- Read Elements From Semantic Model 'bookings_source'
                   SELECT
-                    subq_0.ds__day
-                    , subq_0.ds__week
-                    , subq_0.ds__month
-                    , subq_0.ds__quarter
-                    , subq_0.ds__year
-                    , subq_0.ds__extract_year
-                    , subq_0.ds__extract_quarter
-                    , subq_0.ds__extract_month
-                    , subq_0.ds__extract_day
-                    , subq_0.ds__extract_dow
-                    , subq_0.ds__extract_doy
-                    , subq_0.ds_partitioned__day
-                    , subq_0.ds_partitioned__week
-                    , subq_0.ds_partitioned__month
-                    , subq_0.ds_partitioned__quarter
-                    , subq_0.ds_partitioned__year
-                    , subq_0.ds_partitioned__extract_year
-                    , subq_0.ds_partitioned__extract_quarter
-                    , subq_0.ds_partitioned__extract_month
-                    , subq_0.ds_partitioned__extract_day
-                    , subq_0.ds_partitioned__extract_dow
-                    , subq_0.ds_partitioned__extract_doy
-                    , subq_0.paid_at__day
-                    , subq_0.paid_at__week
-                    , subq_0.paid_at__month
-                    , subq_0.paid_at__quarter
-                    , subq_0.paid_at__year
-                    , subq_0.paid_at__extract_year
-                    , subq_0.paid_at__extract_quarter
-                    , subq_0.paid_at__extract_month
-                    , subq_0.paid_at__extract_day
-                    , subq_0.paid_at__extract_dow
-                    , subq_0.paid_at__extract_doy
-                    , subq_0.booking__ds__day
-                    , subq_0.booking__ds__week
-                    , subq_0.booking__ds__month
-                    , subq_0.booking__ds__quarter
-                    , subq_0.booking__ds__year
-                    , subq_0.booking__ds__extract_year
-                    , subq_0.booking__ds__extract_quarter
-                    , subq_0.booking__ds__extract_month
-                    , subq_0.booking__ds__extract_day
-                    , subq_0.booking__ds__extract_dow
-                    , subq_0.booking__ds__extract_doy
-                    , subq_0.booking__ds_partitioned__day
-                    , subq_0.booking__ds_partitioned__week
-                    , subq_0.booking__ds_partitioned__month
-                    , subq_0.booking__ds_partitioned__quarter
-                    , subq_0.booking__ds_partitioned__year
-                    , subq_0.booking__ds_partitioned__extract_year
-                    , subq_0.booking__ds_partitioned__extract_quarter
-                    , subq_0.booking__ds_partitioned__extract_month
-                    , subq_0.booking__ds_partitioned__extract_day
-                    , subq_0.booking__ds_partitioned__extract_dow
-                    , subq_0.booking__ds_partitioned__extract_doy
-                    , subq_0.booking__paid_at__day
-                    , subq_0.booking__paid_at__week
-                    , subq_0.booking__paid_at__month
-                    , subq_0.booking__paid_at__quarter
-                    , subq_0.booking__paid_at__year
-                    , subq_0.booking__paid_at__extract_year
-                    , subq_0.booking__paid_at__extract_quarter
-                    , subq_0.booking__paid_at__extract_month
-                    , subq_0.booking__paid_at__extract_day
-                    , subq_0.booking__paid_at__extract_dow
-                    , subq_0.booking__paid_at__extract_doy
-                    , subq_0.ds__day AS metric_time__day
-                    , subq_0.ds__week AS metric_time__week
-                    , subq_0.ds__month AS metric_time__month
-                    , subq_0.ds__quarter AS metric_time__quarter
-                    , subq_0.ds__year AS metric_time__year
-                    , subq_0.ds__extract_year AS metric_time__extract_year
-                    , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                    , subq_0.ds__extract_month AS metric_time__extract_month
-                    , subq_0.ds__extract_day AS metric_time__extract_day
-                    , subq_0.ds__extract_dow AS metric_time__extract_dow
-                    , subq_0.ds__extract_doy AS metric_time__extract_doy
-                    , subq_0.listing
-                    , subq_0.guest
-                    , subq_0.host
-                    , subq_0.booking__listing
-                    , subq_0.booking__guest
-                    , subq_0.booking__host
-                    , subq_0.is_instant
-                    , subq_0.booking__is_instant
-                    , subq_0.__bookings
-                    , subq_0.__average_booking_value
-                    , subq_0.__instant_bookings
-                    , subq_0.__booking_value
-                    , subq_0.__max_booking_value
-                    , subq_0.__min_booking_value
-                    , subq_0.__instant_booking_value
-                    , subq_0.__average_instant_booking_value
-                    , subq_0.__booking_value_for_non_null_listing_id
-                    , subq_0.__bookers
-                    , subq_0.__referred_bookings
-                    , subq_0.__median_booking_value
-                    , subq_0.__booking_value_p99
-                    , subq_0.__discrete_booking_value_p99
-                    , subq_0.__approximate_continuous_booking_value_p99
-                    , subq_0.__approximate_discrete_booking_value_p99
-                    , subq_0.__bookings_join_to_time_spine
-                    , subq_0.__bookings_fill_nulls_with_0_without_time_spine
-                    , subq_0.__bookings_fill_nulls_with_0
-                    , subq_0.__instant_bookings_with_measure_filter
-                    , subq_0.__bookings_join_to_time_spine_with_tiered_filters
-                    , subq_0.__bookers_fill_nulls_with_0_join_to_timespine
-                  FROM (
-                    -- Read Elements From Semantic Model 'bookings_source'
-                    SELECT
-                      1 AS __bookings
-                      , bookings_source_src_28000.booking_value AS __average_booking_value
-                      , CASE WHEN is_instant THEN 1 ELSE 0 END AS __instant_bookings
-                      , bookings_source_src_28000.booking_value AS __booking_value
-                      , bookings_source_src_28000.booking_value AS __max_booking_value
-                      , bookings_source_src_28000.booking_value AS __min_booking_value
-                      , bookings_source_src_28000.booking_value AS __instant_booking_value
-                      , bookings_source_src_28000.booking_value AS __average_instant_booking_value
-                      , bookings_source_src_28000.booking_value AS __booking_value_for_non_null_listing_id
-                      , bookings_source_src_28000.guest_id AS __bookers
-                      , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS __referred_bookings
-                      , bookings_source_src_28000.booking_value AS __median_booking_value
-                      , bookings_source_src_28000.booking_value AS __booking_value_p99
-                      , bookings_source_src_28000.booking_value AS __discrete_booking_value_p99
-                      , bookings_source_src_28000.booking_value AS __approximate_continuous_booking_value_p99
-                      , bookings_source_src_28000.booking_value AS __approximate_discrete_booking_value_p99
-                      , 1 AS __bookings_join_to_time_spine
-                      , 1 AS __bookings_fill_nulls_with_0_without_time_spine
-                      , 1 AS __bookings_fill_nulls_with_0
-                      , 1 AS __instant_bookings_with_measure_filter
-                      , 1 AS __bookings_join_to_time_spine_with_tiered_filters
-                      , bookings_source_src_28000.guest_id AS __bookers_fill_nulls_with_0_join_to_timespine
-                      , bookings_source_src_28000.booking_value AS __booking_payments
-                      , bookings_source_src_28000.is_instant
-                      , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                      , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                      , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS ds__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                      , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                      , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                      , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                      , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                      , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                      , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                      , bookings_source_src_28000.is_instant AS booking__is_instant
-                      , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                      , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                      , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                      , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                      , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                      , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                      , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                      , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                      , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                      , bookings_source_src_28000.listing_id AS listing
-                      , bookings_source_src_28000.guest_id AS guest
-                      , bookings_source_src_28000.host_id AS host
-                      , bookings_source_src_28000.listing_id AS booking__listing
-                      , bookings_source_src_28000.guest_id AS booking__guest
-                      , bookings_source_src_28000.host_id AS booking__host
-                    FROM ***************************.fct_bookings bookings_source_src_28000
-                  ) subq_0
-                ) subq_7
-              ) subq_8
-              WHERE metric_time__day = '2020-01-01' or metric_time__day = '2020-01-14'
-            ) subq_9
-          ) subq_10
+                    1 AS __bookings
+                    , bookings_source_src_28000.booking_value AS __average_booking_value
+                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS __instant_bookings
+                    , bookings_source_src_28000.booking_value AS __booking_value
+                    , bookings_source_src_28000.booking_value AS __max_booking_value
+                    , bookings_source_src_28000.booking_value AS __min_booking_value
+                    , bookings_source_src_28000.booking_value AS __instant_booking_value
+                    , bookings_source_src_28000.booking_value AS __average_instant_booking_value
+                    , bookings_source_src_28000.booking_value AS __booking_value_for_non_null_listing_id
+                    , bookings_source_src_28000.guest_id AS __bookers
+                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS __referred_bookings
+                    , bookings_source_src_28000.booking_value AS __median_booking_value
+                    , bookings_source_src_28000.booking_value AS __booking_value_p99
+                    , bookings_source_src_28000.booking_value AS __discrete_booking_value_p99
+                    , bookings_source_src_28000.booking_value AS __approximate_continuous_booking_value_p99
+                    , bookings_source_src_28000.booking_value AS __approximate_discrete_booking_value_p99
+                    , 1 AS __bookings_join_to_time_spine
+                    , 1 AS __bookings_fill_nulls_with_0_without_time_spine
+                    , 1 AS __bookings_fill_nulls_with_0
+                    , 1 AS __instant_bookings_with_measure_filter
+                    , 1 AS __bookings_join_to_time_spine_with_tiered_filters
+                    , bookings_source_src_28000.guest_id AS __bookers_fill_nulls_with_0_join_to_timespine
+                    , bookings_source_src_28000.booking_value AS __booking_payments
+                    , bookings_source_src_28000.is_instant
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                    , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                    , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                    , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                    , bookings_source_src_28000.is_instant AS booking__is_instant
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                    , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                    , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                    , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                    , bookings_source_src_28000.listing_id AS listing
+                    , bookings_source_src_28000.guest_id AS guest
+                    , bookings_source_src_28000.host_id AS host
+                    , bookings_source_src_28000.listing_id AS booking__listing
+                    , bookings_source_src_28000.guest_id AS booking__guest
+                    , bookings_source_src_28000.host_id AS booking__host
+                  FROM ***************************.fct_bookings bookings_source_src_28000
+                ) subq_0
+              ) subq_7
+            ) subq_8
+          ) subq_9
           GROUP BY
-            subq_10.metric_time__day
-        ) subq_11
+            subq_9.metric_time__day
+        ) subq_10
         ON
-          DATEADD(day, -14, subq_16.metric_time__day) = subq_11.metric_time__day
-      ) subq_17
-    ) subq_18
+          DATEADD(day, -14, subq_15.metric_time__day) = subq_10.metric_time__day
+      ) subq_16
+    ) subq_17
     ON
-      subq_6.metric_time__day = subq_18.metric_time__day
+      subq_6.metric_time__day = subq_17.metric_time__day
     GROUP BY
-      COALESCE(subq_6.metric_time__day, subq_18.metric_time__day)
-  ) subq_19
-) subq_20
+      COALESCE(subq_6.metric_time__day, subq_17.metric_time__day)
+  ) subq_18
+) subq_19

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_derived_metric_with_offset_window_and_time_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_derived_metric_with_offset_window_and_time_filter__plan0_optimized.sql
@@ -19,9 +19,9 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_27.metric_time__day, subq_39.metric_time__day) AS metric_time__day
-    , MAX(subq_27.bookings) AS bookings
-    , MAX(subq_39.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+    COALESCE(subq_26.metric_time__day, subq_37.metric_time__day) AS metric_time__day
+    , MAX(subq_26.bookings) AS bookings
+    , MAX(subq_37.bookings_2_weeks_ago) AS bookings_2_weeks_ago
   FROM (
     -- Constrain Output with WHERE
     -- Select: ['__bookings', 'metric_time__day']
@@ -37,17 +37,17 @@ FROM (
         metric_time__day
         , __bookings AS bookings
       FROM sma_28009_cte
-    ) subq_23
+    ) subq_22
     WHERE metric_time__day = '2020-01-01' or metric_time__day = '2020-01-14'
     GROUP BY
       metric_time__day
-  ) subq_27
+  ) subq_26
   FULL OUTER JOIN (
     -- Join to Time Spine Dataset
     -- Compute Metrics via Expressions
     SELECT
-      subq_37.metric_time__day AS metric_time__day
-      , subq_32.__bookings AS bookings_2_weeks_ago
+      subq_35.metric_time__day AS metric_time__day
+      , subq_30.__bookings AS bookings_2_weeks_ago
     FROM (
       -- Constrain Output with WHERE
       -- Select: ['metric_time__day']
@@ -60,33 +60,26 @@ FROM (
         SELECT
           ds AS metric_time__day
         FROM ***************************.mf_time_spine time_spine_src_28006
-      ) subq_35
+      ) subq_33
       WHERE metric_time__day = '2020-01-01' or metric_time__day = '2020-01-14'
-    ) subq_37
+    ) subq_35
     INNER JOIN (
-      -- Constrain Output with WHERE
+      -- Read From CTE For node_id=sma_28009
+      -- Select: ['__bookings', 'metric_time__day']
       -- Select: ['__bookings', 'metric_time__day']
       -- Aggregate Inputs for Simple Metrics
       SELECT
         metric_time__day
-        , SUM(bookings) AS __bookings
-      FROM (
-        -- Read From CTE For node_id=sma_28009
-        -- Select: ['__bookings', 'metric_time__day']
-        SELECT
-          metric_time__day
-          , __bookings AS bookings
-        FROM sma_28009_cte
-      ) subq_29
-      WHERE metric_time__day = '2020-01-01' or metric_time__day = '2020-01-14'
+        , SUM(__bookings) AS __bookings
+      FROM sma_28009_cte
       GROUP BY
         metric_time__day
-    ) subq_32
+    ) subq_30
     ON
-      DATEADD(day, -14, subq_37.metric_time__day) = subq_32.metric_time__day
-  ) subq_39
+      DATEADD(day, -14, subq_35.metric_time__day) = subq_30.metric_time__day
+  ) subq_37
   ON
-    subq_27.metric_time__day = subq_39.metric_time__day
+    subq_26.metric_time__day = subq_37.metric_time__day
   GROUP BY
-    COALESCE(subq_27.metric_time__day, subq_39.metric_time__day)
-) subq_40
+    COALESCE(subq_26.metric_time__day, subq_37.metric_time__day)
+) subq_38

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0.sql
@@ -6,52 +6,52 @@ sql_engine: Databricks
 ---
 -- Write to DataTable
 SELECT
-  subq_13.metric_time__month
-  , subq_13.bookings_at_start_of_month
+  subq_12.metric_time__month
+  , subq_12.bookings_at_start_of_month
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_12.metric_time__month
+    subq_11.metric_time__month
     , bookings_start_of_month AS bookings_at_start_of_month
   FROM (
     -- Compute Metrics via Expressions
     SELECT
-      subq_11.metric_time__month
-      , subq_11.__bookings AS bookings_start_of_month
+      subq_10.metric_time__month
+      , subq_10.__bookings AS bookings_start_of_month
     FROM (
       -- Join to Time Spine Dataset
       SELECT
-        subq_10.metric_time__month AS metric_time__month
-        , subq_5.__bookings AS __bookings
+        subq_9.metric_time__month AS metric_time__month
+        , subq_4.__bookings AS __bookings
       FROM (
         -- Select: ['metric_time__month']
         SELECT
-          subq_9.metric_time__month
+          subq_8.metric_time__month
         FROM (
           -- Constrain Output with WHERE
           SELECT
-            subq_8.metric_time__day
-            , subq_8.metric_time__month
+            subq_7.metric_time__day
+            , subq_7.metric_time__month
           FROM (
             -- Select: ['metric_time__month', 'metric_time__day']
             SELECT
-              subq_7.metric_time__day
-              , subq_7.metric_time__month
+              subq_6.metric_time__day
+              , subq_6.metric_time__month
             FROM (
               -- Change Column Aliases
               SELECT
-                subq_6.ds__day AS metric_time__day
-                , subq_6.ds__week
-                , subq_6.ds__month AS metric_time__month
-                , subq_6.ds__quarter
-                , subq_6.ds__year
-                , subq_6.ds__extract_year
-                , subq_6.ds__extract_quarter
-                , subq_6.ds__extract_month
-                , subq_6.ds__extract_day
-                , subq_6.ds__extract_dow
-                , subq_6.ds__extract_doy
-                , subq_6.ds__alien_day
+                subq_5.ds__day AS metric_time__day
+                , subq_5.ds__week
+                , subq_5.ds__month AS metric_time__month
+                , subq_5.ds__quarter
+                , subq_5.ds__year
+                , subq_5.ds__extract_year
+                , subq_5.ds__extract_quarter
+                , subq_5.ds__extract_month
+                , subq_5.ds__extract_day
+                , subq_5.ds__extract_dow
+                , subq_5.ds__extract_doy
+                , subq_5.ds__alien_day
               FROM (
                 -- Read From Time Spine 'mf_time_spine'
                 SELECT
@@ -68,258 +68,249 @@ FROM (
                   , EXTRACT(doy FROM time_spine_src_28006.ds) AS ds__extract_doy
                   , time_spine_src_28006.alien_day AS ds__alien_day
                 FROM ***************************.mf_time_spine time_spine_src_28006
-              ) subq_6
-            ) subq_7
-          ) subq_8
+              ) subq_5
+            ) subq_6
+          ) subq_7
           WHERE metric_time__day = '2020-01-01'
-        ) subq_9
+        ) subq_8
         GROUP BY
-          subq_9.metric_time__month
-      ) subq_10
+          subq_8.metric_time__month
+      ) subq_9
       INNER JOIN (
         -- Aggregate Inputs for Simple Metrics
         SELECT
-          subq_4.metric_time__month
-          , SUM(subq_4.__bookings) AS __bookings
+          subq_3.metric_time__month
+          , SUM(subq_3.__bookings) AS __bookings
         FROM (
           -- Select: ['__bookings', 'metric_time__month']
           SELECT
-            subq_3.metric_time__month
-            , subq_3.__bookings
+            subq_2.metric_time__month
+            , subq_2.__bookings
           FROM (
-            -- Constrain Output with WHERE
+            -- Select: ['__bookings', 'metric_time__month']
             SELECT
-              subq_2.bookings AS __bookings
-              , subq_2.metric_time__day
-              , subq_2.metric_time__month
+              subq_1.metric_time__month
+              , subq_1.__bookings
             FROM (
-              -- Select: ['__bookings', 'metric_time__month', 'metric_time__day']
+              -- Metric Time Dimension 'ds'
               SELECT
-                subq_1.metric_time__day
-                , subq_1.metric_time__month
-                , subq_1.__bookings AS bookings
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.__bookings
+                , subq_0.__average_booking_value
+                , subq_0.__instant_bookings
+                , subq_0.__booking_value
+                , subq_0.__max_booking_value
+                , subq_0.__min_booking_value
+                , subq_0.__instant_booking_value
+                , subq_0.__average_instant_booking_value
+                , subq_0.__booking_value_for_non_null_listing_id
+                , subq_0.__bookers
+                , subq_0.__referred_bookings
+                , subq_0.__median_booking_value
+                , subq_0.__booking_value_p99
+                , subq_0.__discrete_booking_value_p99
+                , subq_0.__approximate_continuous_booking_value_p99
+                , subq_0.__approximate_discrete_booking_value_p99
+                , subq_0.__bookings_join_to_time_spine
+                , subq_0.__bookings_fill_nulls_with_0_without_time_spine
+                , subq_0.__bookings_fill_nulls_with_0
+                , subq_0.__instant_bookings_with_measure_filter
+                , subq_0.__bookings_join_to_time_spine_with_tiered_filters
+                , subq_0.__bookers_fill_nulls_with_0_join_to_timespine
               FROM (
-                -- Metric Time Dimension 'ds'
+                -- Read Elements From Semantic Model 'bookings_source'
                 SELECT
-                  subq_0.ds__day
-                  , subq_0.ds__week
-                  , subq_0.ds__month
-                  , subq_0.ds__quarter
-                  , subq_0.ds__year
-                  , subq_0.ds__extract_year
-                  , subq_0.ds__extract_quarter
-                  , subq_0.ds__extract_month
-                  , subq_0.ds__extract_day
-                  , subq_0.ds__extract_dow
-                  , subq_0.ds__extract_doy
-                  , subq_0.ds_partitioned__day
-                  , subq_0.ds_partitioned__week
-                  , subq_0.ds_partitioned__month
-                  , subq_0.ds_partitioned__quarter
-                  , subq_0.ds_partitioned__year
-                  , subq_0.ds_partitioned__extract_year
-                  , subq_0.ds_partitioned__extract_quarter
-                  , subq_0.ds_partitioned__extract_month
-                  , subq_0.ds_partitioned__extract_day
-                  , subq_0.ds_partitioned__extract_dow
-                  , subq_0.ds_partitioned__extract_doy
-                  , subq_0.paid_at__day
-                  , subq_0.paid_at__week
-                  , subq_0.paid_at__month
-                  , subq_0.paid_at__quarter
-                  , subq_0.paid_at__year
-                  , subq_0.paid_at__extract_year
-                  , subq_0.paid_at__extract_quarter
-                  , subq_0.paid_at__extract_month
-                  , subq_0.paid_at__extract_day
-                  , subq_0.paid_at__extract_dow
-                  , subq_0.paid_at__extract_doy
-                  , subq_0.booking__ds__day
-                  , subq_0.booking__ds__week
-                  , subq_0.booking__ds__month
-                  , subq_0.booking__ds__quarter
-                  , subq_0.booking__ds__year
-                  , subq_0.booking__ds__extract_year
-                  , subq_0.booking__ds__extract_quarter
-                  , subq_0.booking__ds__extract_month
-                  , subq_0.booking__ds__extract_day
-                  , subq_0.booking__ds__extract_dow
-                  , subq_0.booking__ds__extract_doy
-                  , subq_0.booking__ds_partitioned__day
-                  , subq_0.booking__ds_partitioned__week
-                  , subq_0.booking__ds_partitioned__month
-                  , subq_0.booking__ds_partitioned__quarter
-                  , subq_0.booking__ds_partitioned__year
-                  , subq_0.booking__ds_partitioned__extract_year
-                  , subq_0.booking__ds_partitioned__extract_quarter
-                  , subq_0.booking__ds_partitioned__extract_month
-                  , subq_0.booking__ds_partitioned__extract_day
-                  , subq_0.booking__ds_partitioned__extract_dow
-                  , subq_0.booking__ds_partitioned__extract_doy
-                  , subq_0.booking__paid_at__day
-                  , subq_0.booking__paid_at__week
-                  , subq_0.booking__paid_at__month
-                  , subq_0.booking__paid_at__quarter
-                  , subq_0.booking__paid_at__year
-                  , subq_0.booking__paid_at__extract_year
-                  , subq_0.booking__paid_at__extract_quarter
-                  , subq_0.booking__paid_at__extract_month
-                  , subq_0.booking__paid_at__extract_day
-                  , subq_0.booking__paid_at__extract_dow
-                  , subq_0.booking__paid_at__extract_doy
-                  , subq_0.ds__day AS metric_time__day
-                  , subq_0.ds__week AS metric_time__week
-                  , subq_0.ds__month AS metric_time__month
-                  , subq_0.ds__quarter AS metric_time__quarter
-                  , subq_0.ds__year AS metric_time__year
-                  , subq_0.ds__extract_year AS metric_time__extract_year
-                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_0.ds__extract_month AS metric_time__extract_month
-                  , subq_0.ds__extract_day AS metric_time__extract_day
-                  , subq_0.ds__extract_dow AS metric_time__extract_dow
-                  , subq_0.ds__extract_doy AS metric_time__extract_doy
-                  , subq_0.listing
-                  , subq_0.guest
-                  , subq_0.host
-                  , subq_0.booking__listing
-                  , subq_0.booking__guest
-                  , subq_0.booking__host
-                  , subq_0.is_instant
-                  , subq_0.booking__is_instant
-                  , subq_0.__bookings
-                  , subq_0.__average_booking_value
-                  , subq_0.__instant_bookings
-                  , subq_0.__booking_value
-                  , subq_0.__max_booking_value
-                  , subq_0.__min_booking_value
-                  , subq_0.__instant_booking_value
-                  , subq_0.__average_instant_booking_value
-                  , subq_0.__booking_value_for_non_null_listing_id
-                  , subq_0.__bookers
-                  , subq_0.__referred_bookings
-                  , subq_0.__median_booking_value
-                  , subq_0.__booking_value_p99
-                  , subq_0.__discrete_booking_value_p99
-                  , subq_0.__approximate_continuous_booking_value_p99
-                  , subq_0.__approximate_discrete_booking_value_p99
-                  , subq_0.__bookings_join_to_time_spine
-                  , subq_0.__bookings_fill_nulls_with_0_without_time_spine
-                  , subq_0.__bookings_fill_nulls_with_0
-                  , subq_0.__instant_bookings_with_measure_filter
-                  , subq_0.__bookings_join_to_time_spine_with_tiered_filters
-                  , subq_0.__bookers_fill_nulls_with_0_join_to_timespine
-                FROM (
-                  -- Read Elements From Semantic Model 'bookings_source'
-                  SELECT
-                    1 AS __bookings
-                    , bookings_source_src_28000.booking_value AS __average_booking_value
-                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS __instant_bookings
-                    , bookings_source_src_28000.booking_value AS __booking_value
-                    , bookings_source_src_28000.booking_value AS __max_booking_value
-                    , bookings_source_src_28000.booking_value AS __min_booking_value
-                    , bookings_source_src_28000.booking_value AS __instant_booking_value
-                    , bookings_source_src_28000.booking_value AS __average_instant_booking_value
-                    , bookings_source_src_28000.booking_value AS __booking_value_for_non_null_listing_id
-                    , bookings_source_src_28000.guest_id AS __bookers
-                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS __referred_bookings
-                    , bookings_source_src_28000.booking_value AS __median_booking_value
-                    , bookings_source_src_28000.booking_value AS __booking_value_p99
-                    , bookings_source_src_28000.booking_value AS __discrete_booking_value_p99
-                    , bookings_source_src_28000.booking_value AS __approximate_continuous_booking_value_p99
-                    , bookings_source_src_28000.booking_value AS __approximate_discrete_booking_value_p99
-                    , 1 AS __bookings_join_to_time_spine
-                    , 1 AS __bookings_fill_nulls_with_0_without_time_spine
-                    , 1 AS __bookings_fill_nulls_with_0
-                    , 1 AS __instant_bookings_with_measure_filter
-                    , 1 AS __bookings_join_to_time_spine_with_tiered_filters
-                    , bookings_source_src_28000.guest_id AS __bookers_fill_nulls_with_0_join_to_timespine
-                    , bookings_source_src_28000.booking_value AS __booking_payments
-                    , bookings_source_src_28000.is_instant
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                    , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS ds__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                    , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                    , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                    , bookings_source_src_28000.is_instant AS booking__is_instant
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                    , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                    , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                    , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                    , bookings_source_src_28000.listing_id AS listing
-                    , bookings_source_src_28000.guest_id AS guest
-                    , bookings_source_src_28000.host_id AS host
-                    , bookings_source_src_28000.listing_id AS booking__listing
-                    , bookings_source_src_28000.guest_id AS booking__guest
-                    , bookings_source_src_28000.host_id AS booking__host
-                  FROM ***************************.fct_bookings bookings_source_src_28000
-                ) subq_0
-              ) subq_1
-            ) subq_2
-            WHERE metric_time__day = '2020-01-01'
-          ) subq_3
-        ) subq_4
+                  1 AS __bookings
+                  , bookings_source_src_28000.booking_value AS __average_booking_value
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS __instant_bookings
+                  , bookings_source_src_28000.booking_value AS __booking_value
+                  , bookings_source_src_28000.booking_value AS __max_booking_value
+                  , bookings_source_src_28000.booking_value AS __min_booking_value
+                  , bookings_source_src_28000.booking_value AS __instant_booking_value
+                  , bookings_source_src_28000.booking_value AS __average_instant_booking_value
+                  , bookings_source_src_28000.booking_value AS __booking_value_for_non_null_listing_id
+                  , bookings_source_src_28000.guest_id AS __bookers
+                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS __referred_bookings
+                  , bookings_source_src_28000.booking_value AS __median_booking_value
+                  , bookings_source_src_28000.booking_value AS __booking_value_p99
+                  , bookings_source_src_28000.booking_value AS __discrete_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS __approximate_continuous_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS __approximate_discrete_booking_value_p99
+                  , 1 AS __bookings_join_to_time_spine
+                  , 1 AS __bookings_fill_nulls_with_0_without_time_spine
+                  , 1 AS __bookings_fill_nulls_with_0
+                  , 1 AS __instant_bookings_with_measure_filter
+                  , 1 AS __bookings_join_to_time_spine_with_tiered_filters
+                  , bookings_source_src_28000.guest_id AS __bookers_fill_nulls_with_0_join_to_timespine
+                  , bookings_source_src_28000.booking_value AS __booking_payments
+                  , bookings_source_src_28000.is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                  , bookings_source_src_28000.is_instant AS booking__is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                  , bookings_source_src_28000.listing_id AS listing
+                  , bookings_source_src_28000.guest_id AS guest
+                  , bookings_source_src_28000.host_id AS host
+                  , bookings_source_src_28000.listing_id AS booking__listing
+                  , bookings_source_src_28000.guest_id AS booking__guest
+                  , bookings_source_src_28000.host_id AS booking__host
+                FROM ***************************.fct_bookings bookings_source_src_28000
+              ) subq_0
+            ) subq_1
+          ) subq_2
+        ) subq_3
         GROUP BY
-          subq_4.metric_time__month
-      ) subq_5
+          subq_3.metric_time__month
+      ) subq_4
       ON
-        DATE_TRUNC('month', subq_10.metric_time__month) = subq_5.metric_time__month
-    ) subq_11
-  ) subq_12
-) subq_13
+        DATE_TRUNC('month', subq_9.metric_time__month) = subq_4.metric_time__month
+    ) subq_10
+  ) subq_11
+) subq_12

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
@@ -13,8 +13,8 @@ FROM (
   -- Join to Time Spine Dataset
   -- Compute Metrics via Expressions
   SELECT
-    subq_24.metric_time__month AS metric_time__month
-    , subq_19.__bookings AS bookings_start_of_month
+    subq_22.metric_time__month AS metric_time__month
+    , subq_17.__bookings AS bookings_start_of_month
   FROM (
     -- Constrain Output with WHERE
     -- Select: ['metric_time__month']
@@ -28,32 +28,29 @@ FROM (
         ds AS metric_time__day
         , DATE_TRUNC('month', ds) AS metric_time__month
       FROM ***************************.mf_time_spine time_spine_src_28006
-    ) subq_22
+    ) subq_20
     WHERE metric_time__day = '2020-01-01'
     GROUP BY
       metric_time__month
-  ) subq_24
+  ) subq_22
   INNER JOIN (
-    -- Constrain Output with WHERE
-    -- Select: ['__bookings', 'metric_time__month']
     -- Aggregate Inputs for Simple Metrics
     SELECT
       metric_time__month
-      , SUM(bookings) AS __bookings
+      , SUM(__bookings) AS __bookings
     FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
-      -- Select: ['__bookings', 'metric_time__month', 'metric_time__day']
+      -- Select: ['__bookings', 'metric_time__month']
+      -- Select: ['__bookings', 'metric_time__month']
       SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , DATE_TRUNC('month', ds) AS metric_time__month
-        , 1 AS bookings
+        DATE_TRUNC('month', ds) AS metric_time__month
+        , 1 AS __bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
     ) subq_16
-    WHERE metric_time__day = '2020-01-01'
     GROUP BY
       metric_time__month
-  ) subq_19
+  ) subq_17
   ON
-    DATE_TRUNC('month', subq_24.metric_time__month) = subq_19.metric_time__month
-) subq_26
+    DATE_TRUNC('month', subq_22.metric_time__month) = subq_17.metric_time__month
+) subq_24

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_offset_window_metric_filter_and_query_have_different_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_offset_window_metric_filter_and_query_have_different_granularities__plan0.sql
@@ -35,129 +35,127 @@ FROM (
             subq_8.metric_time__month
             , subq_8.__booking_value
           FROM (
-            -- Constrain Output with WHERE
+            -- Select: ['__booking_value', 'metric_time__month']
             SELECT
-              subq_7.booking_value AS __booking_value
-              , subq_7.metric_time__day
-              , subq_7.metric_time__month
+              subq_7.metric_time__month
+              , subq_7.__booking_value
             FROM (
-              -- Select: ['__booking_value', 'metric_time__month', 'metric_time__day']
+              -- Join to Time Spine Dataset
               SELECT
-                subq_6.metric_time__day
-                , subq_6.metric_time__month
-                , subq_6.__booking_value AS booking_value
+                subq_6.metric_time__day AS metric_time__day
+                , subq_6.metric_time__month AS metric_time__month
+                , subq_1.ds__day AS ds__day
+                , subq_1.ds__week AS ds__week
+                , subq_1.ds__month AS ds__month
+                , subq_1.ds__quarter AS ds__quarter
+                , subq_1.ds__year AS ds__year
+                , subq_1.ds__extract_year AS ds__extract_year
+                , subq_1.ds__extract_quarter AS ds__extract_quarter
+                , subq_1.ds__extract_month AS ds__extract_month
+                , subq_1.ds__extract_day AS ds__extract_day
+                , subq_1.ds__extract_dow AS ds__extract_dow
+                , subq_1.ds__extract_doy AS ds__extract_doy
+                , subq_1.ds_partitioned__day AS ds_partitioned__day
+                , subq_1.ds_partitioned__week AS ds_partitioned__week
+                , subq_1.ds_partitioned__month AS ds_partitioned__month
+                , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
+                , subq_1.ds_partitioned__year AS ds_partitioned__year
+                , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
+                , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+                , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
+                , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
+                , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+                , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+                , subq_1.paid_at__day AS paid_at__day
+                , subq_1.paid_at__week AS paid_at__week
+                , subq_1.paid_at__month AS paid_at__month
+                , subq_1.paid_at__quarter AS paid_at__quarter
+                , subq_1.paid_at__year AS paid_at__year
+                , subq_1.paid_at__extract_year AS paid_at__extract_year
+                , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
+                , subq_1.paid_at__extract_month AS paid_at__extract_month
+                , subq_1.paid_at__extract_day AS paid_at__extract_day
+                , subq_1.paid_at__extract_dow AS paid_at__extract_dow
+                , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+                , subq_1.booking__ds__day AS booking__ds__day
+                , subq_1.booking__ds__week AS booking__ds__week
+                , subq_1.booking__ds__month AS booking__ds__month
+                , subq_1.booking__ds__quarter AS booking__ds__quarter
+                , subq_1.booking__ds__year AS booking__ds__year
+                , subq_1.booking__ds__extract_year AS booking__ds__extract_year
+                , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
+                , subq_1.booking__ds__extract_month AS booking__ds__extract_month
+                , subq_1.booking__ds__extract_day AS booking__ds__extract_day
+                , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
+                , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
+                , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
+                , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
+                , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
+                , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+                , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
+                , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+                , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+                , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+                , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+                , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+                , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+                , subq_1.booking__paid_at__day AS booking__paid_at__day
+                , subq_1.booking__paid_at__week AS booking__paid_at__week
+                , subq_1.booking__paid_at__month AS booking__paid_at__month
+                , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
+                , subq_1.booking__paid_at__year AS booking__paid_at__year
+                , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
+                , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+                , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
+                , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
+                , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+                , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                , subq_1.metric_time__week AS metric_time__week
+                , subq_1.metric_time__quarter AS metric_time__quarter
+                , subq_1.metric_time__year AS metric_time__year
+                , subq_1.metric_time__extract_year AS metric_time__extract_year
+                , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+                , subq_1.metric_time__extract_month AS metric_time__extract_month
+                , subq_1.metric_time__extract_day AS metric_time__extract_day
+                , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+                , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+                , subq_1.listing AS listing
+                , subq_1.guest AS guest
+                , subq_1.host AS host
+                , subq_1.booking__listing AS booking__listing
+                , subq_1.booking__guest AS booking__guest
+                , subq_1.booking__host AS booking__host
+                , subq_1.is_instant AS is_instant
+                , subq_1.booking__is_instant AS booking__is_instant
+                , subq_1.__bookings AS __bookings
+                , subq_1.__average_booking_value AS __average_booking_value
+                , subq_1.__instant_bookings AS __instant_bookings
+                , subq_1.__booking_value AS __booking_value
+                , subq_1.__max_booking_value AS __max_booking_value
+                , subq_1.__min_booking_value AS __min_booking_value
+                , subq_1.__instant_booking_value AS __instant_booking_value
+                , subq_1.__average_instant_booking_value AS __average_instant_booking_value
+                , subq_1.__booking_value_for_non_null_listing_id AS __booking_value_for_non_null_listing_id
+                , subq_1.__bookers AS __bookers
+                , subq_1.__referred_bookings AS __referred_bookings
+                , subq_1.__median_booking_value AS __median_booking_value
+                , subq_1.__booking_value_p99 AS __booking_value_p99
+                , subq_1.__discrete_booking_value_p99 AS __discrete_booking_value_p99
+                , subq_1.__approximate_continuous_booking_value_p99 AS __approximate_continuous_booking_value_p99
+                , subq_1.__approximate_discrete_booking_value_p99 AS __approximate_discrete_booking_value_p99
+                , subq_1.__bookings_join_to_time_spine AS __bookings_join_to_time_spine
+                , subq_1.__bookings_fill_nulls_with_0_without_time_spine AS __bookings_fill_nulls_with_0_without_time_spine
+                , subq_1.__bookings_fill_nulls_with_0 AS __bookings_fill_nulls_with_0
+                , subq_1.__instant_bookings_with_measure_filter AS __instant_bookings_with_measure_filter
+                , subq_1.__bookings_join_to_time_spine_with_tiered_filters AS __bookings_join_to_time_spine_with_tiered_filters
+                , subq_1.__bookers_fill_nulls_with_0_join_to_timespine AS __bookers_fill_nulls_with_0_join_to_timespine
               FROM (
-                -- Join to Time Spine Dataset
+                -- Select: ['metric_time__day', 'metric_time__month']
                 SELECT
-                  subq_5.metric_time__day AS metric_time__day
-                  , subq_5.metric_time__month AS metric_time__month
-                  , subq_1.ds__day AS ds__day
-                  , subq_1.ds__week AS ds__week
-                  , subq_1.ds__month AS ds__month
-                  , subq_1.ds__quarter AS ds__quarter
-                  , subq_1.ds__year AS ds__year
-                  , subq_1.ds__extract_year AS ds__extract_year
-                  , subq_1.ds__extract_quarter AS ds__extract_quarter
-                  , subq_1.ds__extract_month AS ds__extract_month
-                  , subq_1.ds__extract_day AS ds__extract_day
-                  , subq_1.ds__extract_dow AS ds__extract_dow
-                  , subq_1.ds__extract_doy AS ds__extract_doy
-                  , subq_1.ds_partitioned__day AS ds_partitioned__day
-                  , subq_1.ds_partitioned__week AS ds_partitioned__week
-                  , subq_1.ds_partitioned__month AS ds_partitioned__month
-                  , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
-                  , subq_1.ds_partitioned__year AS ds_partitioned__year
-                  , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
-                  , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
-                  , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
-                  , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
-                  , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
-                  , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
-                  , subq_1.paid_at__day AS paid_at__day
-                  , subq_1.paid_at__week AS paid_at__week
-                  , subq_1.paid_at__month AS paid_at__month
-                  , subq_1.paid_at__quarter AS paid_at__quarter
-                  , subq_1.paid_at__year AS paid_at__year
-                  , subq_1.paid_at__extract_year AS paid_at__extract_year
-                  , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
-                  , subq_1.paid_at__extract_month AS paid_at__extract_month
-                  , subq_1.paid_at__extract_day AS paid_at__extract_day
-                  , subq_1.paid_at__extract_dow AS paid_at__extract_dow
-                  , subq_1.paid_at__extract_doy AS paid_at__extract_doy
-                  , subq_1.booking__ds__day AS booking__ds__day
-                  , subq_1.booking__ds__week AS booking__ds__week
-                  , subq_1.booking__ds__month AS booking__ds__month
-                  , subq_1.booking__ds__quarter AS booking__ds__quarter
-                  , subq_1.booking__ds__year AS booking__ds__year
-                  , subq_1.booking__ds__extract_year AS booking__ds__extract_year
-                  , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
-                  , subq_1.booking__ds__extract_month AS booking__ds__extract_month
-                  , subq_1.booking__ds__extract_day AS booking__ds__extract_day
-                  , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
-                  , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
-                  , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
-                  , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
-                  , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
-                  , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
-                  , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
-                  , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
-                  , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
-                  , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
-                  , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
-                  , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
-                  , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
-                  , subq_1.booking__paid_at__day AS booking__paid_at__day
-                  , subq_1.booking__paid_at__week AS booking__paid_at__week
-                  , subq_1.booking__paid_at__month AS booking__paid_at__month
-                  , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
-                  , subq_1.booking__paid_at__year AS booking__paid_at__year
-                  , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
-                  , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
-                  , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
-                  , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
-                  , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
-                  , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
-                  , subq_1.metric_time__week AS metric_time__week
-                  , subq_1.metric_time__quarter AS metric_time__quarter
-                  , subq_1.metric_time__year AS metric_time__year
-                  , subq_1.metric_time__extract_year AS metric_time__extract_year
-                  , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
-                  , subq_1.metric_time__extract_month AS metric_time__extract_month
-                  , subq_1.metric_time__extract_day AS metric_time__extract_day
-                  , subq_1.metric_time__extract_dow AS metric_time__extract_dow
-                  , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-                  , subq_1.listing AS listing
-                  , subq_1.guest AS guest
-                  , subq_1.host AS host
-                  , subq_1.booking__listing AS booking__listing
-                  , subq_1.booking__guest AS booking__guest
-                  , subq_1.booking__host AS booking__host
-                  , subq_1.is_instant AS is_instant
-                  , subq_1.booking__is_instant AS booking__is_instant
-                  , subq_1.__bookings AS __bookings
-                  , subq_1.__average_booking_value AS __average_booking_value
-                  , subq_1.__instant_bookings AS __instant_bookings
-                  , subq_1.__booking_value AS __booking_value
-                  , subq_1.__max_booking_value AS __max_booking_value
-                  , subq_1.__min_booking_value AS __min_booking_value
-                  , subq_1.__instant_booking_value AS __instant_booking_value
-                  , subq_1.__average_instant_booking_value AS __average_instant_booking_value
-                  , subq_1.__booking_value_for_non_null_listing_id AS __booking_value_for_non_null_listing_id
-                  , subq_1.__bookers AS __bookers
-                  , subq_1.__referred_bookings AS __referred_bookings
-                  , subq_1.__median_booking_value AS __median_booking_value
-                  , subq_1.__booking_value_p99 AS __booking_value_p99
-                  , subq_1.__discrete_booking_value_p99 AS __discrete_booking_value_p99
-                  , subq_1.__approximate_continuous_booking_value_p99 AS __approximate_continuous_booking_value_p99
-                  , subq_1.__approximate_discrete_booking_value_p99 AS __approximate_discrete_booking_value_p99
-                  , subq_1.__bookings_join_to_time_spine AS __bookings_join_to_time_spine
-                  , subq_1.__bookings_fill_nulls_with_0_without_time_spine AS __bookings_fill_nulls_with_0_without_time_spine
-                  , subq_1.__bookings_fill_nulls_with_0 AS __bookings_fill_nulls_with_0
-                  , subq_1.__instant_bookings_with_measure_filter AS __instant_bookings_with_measure_filter
-                  , subq_1.__bookings_join_to_time_spine_with_tiered_filters AS __bookings_join_to_time_spine_with_tiered_filters
-                  , subq_1.__bookers_fill_nulls_with_0_join_to_timespine AS __bookers_fill_nulls_with_0_join_to_timespine
+                  subq_5.metric_time__day
+                  , subq_5.metric_time__month
                 FROM (
-                  -- Select: ['metric_time__day', 'metric_time__month']
+                  -- Constrain Output with WHERE
                   SELECT
                     subq_4.metric_time__day
                     , subq_4.metric_time__month
@@ -200,225 +198,225 @@ FROM (
                       ) subq_2
                     ) subq_3
                   ) subq_4
+                  WHERE metric_time__day = '2020-01-01'
                 ) subq_5
-                INNER JOIN (
-                  -- Metric Time Dimension 'ds'
-                  SELECT
-                    subq_0.ds__day
-                    , subq_0.ds__week
-                    , subq_0.ds__month
-                    , subq_0.ds__quarter
-                    , subq_0.ds__year
-                    , subq_0.ds__extract_year
-                    , subq_0.ds__extract_quarter
-                    , subq_0.ds__extract_month
-                    , subq_0.ds__extract_day
-                    , subq_0.ds__extract_dow
-                    , subq_0.ds__extract_doy
-                    , subq_0.ds_partitioned__day
-                    , subq_0.ds_partitioned__week
-                    , subq_0.ds_partitioned__month
-                    , subq_0.ds_partitioned__quarter
-                    , subq_0.ds_partitioned__year
-                    , subq_0.ds_partitioned__extract_year
-                    , subq_0.ds_partitioned__extract_quarter
-                    , subq_0.ds_partitioned__extract_month
-                    , subq_0.ds_partitioned__extract_day
-                    , subq_0.ds_partitioned__extract_dow
-                    , subq_0.ds_partitioned__extract_doy
-                    , subq_0.paid_at__day
-                    , subq_0.paid_at__week
-                    , subq_0.paid_at__month
-                    , subq_0.paid_at__quarter
-                    , subq_0.paid_at__year
-                    , subq_0.paid_at__extract_year
-                    , subq_0.paid_at__extract_quarter
-                    , subq_0.paid_at__extract_month
-                    , subq_0.paid_at__extract_day
-                    , subq_0.paid_at__extract_dow
-                    , subq_0.paid_at__extract_doy
-                    , subq_0.booking__ds__day
-                    , subq_0.booking__ds__week
-                    , subq_0.booking__ds__month
-                    , subq_0.booking__ds__quarter
-                    , subq_0.booking__ds__year
-                    , subq_0.booking__ds__extract_year
-                    , subq_0.booking__ds__extract_quarter
-                    , subq_0.booking__ds__extract_month
-                    , subq_0.booking__ds__extract_day
-                    , subq_0.booking__ds__extract_dow
-                    , subq_0.booking__ds__extract_doy
-                    , subq_0.booking__ds_partitioned__day
-                    , subq_0.booking__ds_partitioned__week
-                    , subq_0.booking__ds_partitioned__month
-                    , subq_0.booking__ds_partitioned__quarter
-                    , subq_0.booking__ds_partitioned__year
-                    , subq_0.booking__ds_partitioned__extract_year
-                    , subq_0.booking__ds_partitioned__extract_quarter
-                    , subq_0.booking__ds_partitioned__extract_month
-                    , subq_0.booking__ds_partitioned__extract_day
-                    , subq_0.booking__ds_partitioned__extract_dow
-                    , subq_0.booking__ds_partitioned__extract_doy
-                    , subq_0.booking__paid_at__day
-                    , subq_0.booking__paid_at__week
-                    , subq_0.booking__paid_at__month
-                    , subq_0.booking__paid_at__quarter
-                    , subq_0.booking__paid_at__year
-                    , subq_0.booking__paid_at__extract_year
-                    , subq_0.booking__paid_at__extract_quarter
-                    , subq_0.booking__paid_at__extract_month
-                    , subq_0.booking__paid_at__extract_day
-                    , subq_0.booking__paid_at__extract_dow
-                    , subq_0.booking__paid_at__extract_doy
-                    , subq_0.ds__day AS metric_time__day
-                    , subq_0.ds__week AS metric_time__week
-                    , subq_0.ds__month AS metric_time__month
-                    , subq_0.ds__quarter AS metric_time__quarter
-                    , subq_0.ds__year AS metric_time__year
-                    , subq_0.ds__extract_year AS metric_time__extract_year
-                    , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                    , subq_0.ds__extract_month AS metric_time__extract_month
-                    , subq_0.ds__extract_day AS metric_time__extract_day
-                    , subq_0.ds__extract_dow AS metric_time__extract_dow
-                    , subq_0.ds__extract_doy AS metric_time__extract_doy
-                    , subq_0.listing
-                    , subq_0.guest
-                    , subq_0.host
-                    , subq_0.booking__listing
-                    , subq_0.booking__guest
-                    , subq_0.booking__host
-                    , subq_0.is_instant
-                    , subq_0.booking__is_instant
-                    , subq_0.__bookings
-                    , subq_0.__average_booking_value
-                    , subq_0.__instant_bookings
-                    , subq_0.__booking_value
-                    , subq_0.__max_booking_value
-                    , subq_0.__min_booking_value
-                    , subq_0.__instant_booking_value
-                    , subq_0.__average_instant_booking_value
-                    , subq_0.__booking_value_for_non_null_listing_id
-                    , subq_0.__bookers
-                    , subq_0.__referred_bookings
-                    , subq_0.__median_booking_value
-                    , subq_0.__booking_value_p99
-                    , subq_0.__discrete_booking_value_p99
-                    , subq_0.__approximate_continuous_booking_value_p99
-                    , subq_0.__approximate_discrete_booking_value_p99
-                    , subq_0.__bookings_join_to_time_spine
-                    , subq_0.__bookings_fill_nulls_with_0_without_time_spine
-                    , subq_0.__bookings_fill_nulls_with_0
-                    , subq_0.__instant_bookings_with_measure_filter
-                    , subq_0.__bookings_join_to_time_spine_with_tiered_filters
-                    , subq_0.__bookers_fill_nulls_with_0_join_to_timespine
-                  FROM (
-                    -- Read Elements From Semantic Model 'bookings_source'
-                    SELECT
-                      1 AS __bookings
-                      , bookings_source_src_28000.booking_value AS __average_booking_value
-                      , CASE WHEN is_instant THEN 1 ELSE 0 END AS __instant_bookings
-                      , bookings_source_src_28000.booking_value AS __booking_value
-                      , bookings_source_src_28000.booking_value AS __max_booking_value
-                      , bookings_source_src_28000.booking_value AS __min_booking_value
-                      , bookings_source_src_28000.booking_value AS __instant_booking_value
-                      , bookings_source_src_28000.booking_value AS __average_instant_booking_value
-                      , bookings_source_src_28000.booking_value AS __booking_value_for_non_null_listing_id
-                      , bookings_source_src_28000.guest_id AS __bookers
-                      , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS __referred_bookings
-                      , bookings_source_src_28000.booking_value AS __median_booking_value
-                      , bookings_source_src_28000.booking_value AS __booking_value_p99
-                      , bookings_source_src_28000.booking_value AS __discrete_booking_value_p99
-                      , bookings_source_src_28000.booking_value AS __approximate_continuous_booking_value_p99
-                      , bookings_source_src_28000.booking_value AS __approximate_discrete_booking_value_p99
-                      , 1 AS __bookings_join_to_time_spine
-                      , 1 AS __bookings_fill_nulls_with_0_without_time_spine
-                      , 1 AS __bookings_fill_nulls_with_0
-                      , 1 AS __instant_bookings_with_measure_filter
-                      , 1 AS __bookings_join_to_time_spine_with_tiered_filters
-                      , bookings_source_src_28000.guest_id AS __bookers_fill_nulls_with_0_join_to_timespine
-                      , bookings_source_src_28000.booking_value AS __booking_payments
-                      , bookings_source_src_28000.is_instant
-                      , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                      , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                      , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS ds__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                      , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                      , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                      , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                      , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                      , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                      , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                      , bookings_source_src_28000.is_instant AS booking__is_instant
-                      , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                      , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                      , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                      , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                      , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                      , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                      , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                      , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                      , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                      , bookings_source_src_28000.listing_id AS listing
-                      , bookings_source_src_28000.guest_id AS guest
-                      , bookings_source_src_28000.host_id AS host
-                      , bookings_source_src_28000.listing_id AS booking__listing
-                      , bookings_source_src_28000.guest_id AS booking__guest
-                      , bookings_source_src_28000.host_id AS booking__host
-                    FROM ***************************.fct_bookings bookings_source_src_28000
-                  ) subq_0
-                ) subq_1
-                ON
-                  DATEADD(week, -1, subq_5.metric_time__day) = subq_1.metric_time__day
               ) subq_6
+              INNER JOIN (
+                -- Metric Time Dimension 'ds'
+                SELECT
+                  subq_0.ds__day
+                  , subq_0.ds__week
+                  , subq_0.ds__month
+                  , subq_0.ds__quarter
+                  , subq_0.ds__year
+                  , subq_0.ds__extract_year
+                  , subq_0.ds__extract_quarter
+                  , subq_0.ds__extract_month
+                  , subq_0.ds__extract_day
+                  , subq_0.ds__extract_dow
+                  , subq_0.ds__extract_doy
+                  , subq_0.ds_partitioned__day
+                  , subq_0.ds_partitioned__week
+                  , subq_0.ds_partitioned__month
+                  , subq_0.ds_partitioned__quarter
+                  , subq_0.ds_partitioned__year
+                  , subq_0.ds_partitioned__extract_year
+                  , subq_0.ds_partitioned__extract_quarter
+                  , subq_0.ds_partitioned__extract_month
+                  , subq_0.ds_partitioned__extract_day
+                  , subq_0.ds_partitioned__extract_dow
+                  , subq_0.ds_partitioned__extract_doy
+                  , subq_0.paid_at__day
+                  , subq_0.paid_at__week
+                  , subq_0.paid_at__month
+                  , subq_0.paid_at__quarter
+                  , subq_0.paid_at__year
+                  , subq_0.paid_at__extract_year
+                  , subq_0.paid_at__extract_quarter
+                  , subq_0.paid_at__extract_month
+                  , subq_0.paid_at__extract_day
+                  , subq_0.paid_at__extract_dow
+                  , subq_0.paid_at__extract_doy
+                  , subq_0.booking__ds__day
+                  , subq_0.booking__ds__week
+                  , subq_0.booking__ds__month
+                  , subq_0.booking__ds__quarter
+                  , subq_0.booking__ds__year
+                  , subq_0.booking__ds__extract_year
+                  , subq_0.booking__ds__extract_quarter
+                  , subq_0.booking__ds__extract_month
+                  , subq_0.booking__ds__extract_day
+                  , subq_0.booking__ds__extract_dow
+                  , subq_0.booking__ds__extract_doy
+                  , subq_0.booking__ds_partitioned__day
+                  , subq_0.booking__ds_partitioned__week
+                  , subq_0.booking__ds_partitioned__month
+                  , subq_0.booking__ds_partitioned__quarter
+                  , subq_0.booking__ds_partitioned__year
+                  , subq_0.booking__ds_partitioned__extract_year
+                  , subq_0.booking__ds_partitioned__extract_quarter
+                  , subq_0.booking__ds_partitioned__extract_month
+                  , subq_0.booking__ds_partitioned__extract_day
+                  , subq_0.booking__ds_partitioned__extract_dow
+                  , subq_0.booking__ds_partitioned__extract_doy
+                  , subq_0.booking__paid_at__day
+                  , subq_0.booking__paid_at__week
+                  , subq_0.booking__paid_at__month
+                  , subq_0.booking__paid_at__quarter
+                  , subq_0.booking__paid_at__year
+                  , subq_0.booking__paid_at__extract_year
+                  , subq_0.booking__paid_at__extract_quarter
+                  , subq_0.booking__paid_at__extract_month
+                  , subq_0.booking__paid_at__extract_day
+                  , subq_0.booking__paid_at__extract_dow
+                  , subq_0.booking__paid_at__extract_doy
+                  , subq_0.ds__day AS metric_time__day
+                  , subq_0.ds__week AS metric_time__week
+                  , subq_0.ds__month AS metric_time__month
+                  , subq_0.ds__quarter AS metric_time__quarter
+                  , subq_0.ds__year AS metric_time__year
+                  , subq_0.ds__extract_year AS metric_time__extract_year
+                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_0.ds__extract_month AS metric_time__extract_month
+                  , subq_0.ds__extract_day AS metric_time__extract_day
+                  , subq_0.ds__extract_dow AS metric_time__extract_dow
+                  , subq_0.ds__extract_doy AS metric_time__extract_doy
+                  , subq_0.listing
+                  , subq_0.guest
+                  , subq_0.host
+                  , subq_0.booking__listing
+                  , subq_0.booking__guest
+                  , subq_0.booking__host
+                  , subq_0.is_instant
+                  , subq_0.booking__is_instant
+                  , subq_0.__bookings
+                  , subq_0.__average_booking_value
+                  , subq_0.__instant_bookings
+                  , subq_0.__booking_value
+                  , subq_0.__max_booking_value
+                  , subq_0.__min_booking_value
+                  , subq_0.__instant_booking_value
+                  , subq_0.__average_instant_booking_value
+                  , subq_0.__booking_value_for_non_null_listing_id
+                  , subq_0.__bookers
+                  , subq_0.__referred_bookings
+                  , subq_0.__median_booking_value
+                  , subq_0.__booking_value_p99
+                  , subq_0.__discrete_booking_value_p99
+                  , subq_0.__approximate_continuous_booking_value_p99
+                  , subq_0.__approximate_discrete_booking_value_p99
+                  , subq_0.__bookings_join_to_time_spine
+                  , subq_0.__bookings_fill_nulls_with_0_without_time_spine
+                  , subq_0.__bookings_fill_nulls_with_0
+                  , subq_0.__instant_bookings_with_measure_filter
+                  , subq_0.__bookings_join_to_time_spine_with_tiered_filters
+                  , subq_0.__bookers_fill_nulls_with_0_join_to_timespine
+                FROM (
+                  -- Read Elements From Semantic Model 'bookings_source'
+                  SELECT
+                    1 AS __bookings
+                    , bookings_source_src_28000.booking_value AS __average_booking_value
+                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS __instant_bookings
+                    , bookings_source_src_28000.booking_value AS __booking_value
+                    , bookings_source_src_28000.booking_value AS __max_booking_value
+                    , bookings_source_src_28000.booking_value AS __min_booking_value
+                    , bookings_source_src_28000.booking_value AS __instant_booking_value
+                    , bookings_source_src_28000.booking_value AS __average_instant_booking_value
+                    , bookings_source_src_28000.booking_value AS __booking_value_for_non_null_listing_id
+                    , bookings_source_src_28000.guest_id AS __bookers
+                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS __referred_bookings
+                    , bookings_source_src_28000.booking_value AS __median_booking_value
+                    , bookings_source_src_28000.booking_value AS __booking_value_p99
+                    , bookings_source_src_28000.booking_value AS __discrete_booking_value_p99
+                    , bookings_source_src_28000.booking_value AS __approximate_continuous_booking_value_p99
+                    , bookings_source_src_28000.booking_value AS __approximate_discrete_booking_value_p99
+                    , 1 AS __bookings_join_to_time_spine
+                    , 1 AS __bookings_fill_nulls_with_0_without_time_spine
+                    , 1 AS __bookings_fill_nulls_with_0
+                    , 1 AS __instant_bookings_with_measure_filter
+                    , 1 AS __bookings_join_to_time_spine_with_tiered_filters
+                    , bookings_source_src_28000.guest_id AS __bookers_fill_nulls_with_0_join_to_timespine
+                    , bookings_source_src_28000.booking_value AS __booking_payments
+                    , bookings_source_src_28000.is_instant
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                    , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                    , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                    , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                    , bookings_source_src_28000.is_instant AS booking__is_instant
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                    , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                    , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                    , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                    , bookings_source_src_28000.listing_id AS listing
+                    , bookings_source_src_28000.guest_id AS guest
+                    , bookings_source_src_28000.host_id AS host
+                    , bookings_source_src_28000.listing_id AS booking__listing
+                    , bookings_source_src_28000.guest_id AS booking__guest
+                    , bookings_source_src_28000.host_id AS booking__host
+                  FROM ***************************.fct_bookings bookings_source_src_28000
+                ) subq_0
+              ) subq_1
+              ON
+                DATEADD(week, -1, subq_6.metric_time__day) = subq_1.metric_time__day
             ) subq_7
-            WHERE metric_time__day = '2020-01-01'
           ) subq_8
         ) subq_9
         GROUP BY

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_offset_window_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Databricks/test_offset_window_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
@@ -27,29 +27,37 @@ FROM (
     , MAX(subq_31.booking_value) AS booking_value
     , MAX(subq_37.bookers) AS bookers
   FROM (
-    -- Constrain Output with WHERE
+    -- Join to Time Spine Dataset
+    -- Select: ['__booking_value', 'metric_time__month']
     -- Select: ['__booking_value', 'metric_time__month']
     -- Aggregate Inputs for Simple Metrics
     -- Compute Metrics via Expressions
     SELECT
-      metric_time__month
-      , SUM(booking_value) AS booking_value
+      subq_26.metric_time__month AS metric_time__month
+      , SUM(sma_28009_cte.__booking_value) AS booking_value
     FROM (
-      -- Join to Time Spine Dataset
-      -- Select: ['__booking_value', 'metric_time__month', 'metric_time__day']
+      -- Constrain Output with WHERE
+      -- Select: ['metric_time__day', 'metric_time__month']
       SELECT
-        time_spine_src_28006.ds AS metric_time__day
-        , DATE_TRUNC('month', time_spine_src_28006.ds) AS metric_time__month
-        , sma_28009_cte.__booking_value AS booking_value
-      FROM ***************************.mf_time_spine time_spine_src_28006
-      INNER JOIN
-        sma_28009_cte
-      ON
-        DATEADD(week, -1, time_spine_src_28006.ds) = sma_28009_cte.metric_time__day
-    ) subq_27
-    WHERE metric_time__day = '2020-01-01'
+        metric_time__day
+        , metric_time__month
+      FROM (
+        -- Read From Time Spine 'mf_time_spine'
+        -- Change Column Aliases
+        -- Select: ['metric_time__day', 'metric_time__month']
+        SELECT
+          ds AS metric_time__day
+          , DATE_TRUNC('month', ds) AS metric_time__month
+        FROM ***************************.mf_time_spine time_spine_src_28006
+      ) subq_24
+      WHERE metric_time__day = '2020-01-01'
+    ) subq_26
+    INNER JOIN
+      sma_28009_cte
+    ON
+      DATEADD(week, -1, subq_26.metric_time__day) = sma_28009_cte.metric_time__day
     GROUP BY
-      metric_time__month
+      subq_26.metric_time__month
   ) subq_31
   FULL OUTER JOIN (
     -- Constrain Output with WHERE

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
@@ -4,19 +4,19 @@ sql_engine: DuckDB
 ---
 -- Write to DataTable
 SELECT
-  subq_20.metric_time__day
-  , subq_20.bookings_growth_2_weeks
+  subq_19.metric_time__day
+  , subq_19.bookings_growth_2_weeks
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_19.metric_time__day
+    subq_18.metric_time__day
     , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
   FROM (
     -- Combine Aggregated Outputs
     SELECT
-      COALESCE(subq_6.metric_time__day, subq_18.metric_time__day) AS metric_time__day
+      COALESCE(subq_6.metric_time__day, subq_17.metric_time__day) AS metric_time__day
       , MAX(subq_6.bookings) AS bookings
-      , MAX(subq_18.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+      , MAX(subq_17.bookings_2_weeks_ago) AS bookings_2_weeks_ago
     FROM (
       -- Compute Metrics via Expressions
       SELECT
@@ -266,40 +266,40 @@ FROM (
     FULL OUTER JOIN (
       -- Compute Metrics via Expressions
       SELECT
-        subq_17.metric_time__day
-        , subq_17.__bookings AS bookings_2_weeks_ago
+        subq_16.metric_time__day
+        , subq_16.__bookings AS bookings_2_weeks_ago
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_16.metric_time__day AS metric_time__day
-          , subq_11.__bookings AS __bookings
+          subq_15.metric_time__day AS metric_time__day
+          , subq_10.__bookings AS __bookings
         FROM (
           -- Select: ['metric_time__day']
           SELECT
-            subq_15.metric_time__day
+            subq_14.metric_time__day
           FROM (
             -- Constrain Output with WHERE
             SELECT
-              subq_14.metric_time__day
+              subq_13.metric_time__day
             FROM (
               -- Select: ['metric_time__day']
               SELECT
-                subq_13.metric_time__day
+                subq_12.metric_time__day
               FROM (
                 -- Change Column Aliases
                 SELECT
-                  subq_12.ds__day AS metric_time__day
-                  , subq_12.ds__week
-                  , subq_12.ds__month
-                  , subq_12.ds__quarter
-                  , subq_12.ds__year
-                  , subq_12.ds__extract_year
-                  , subq_12.ds__extract_quarter
-                  , subq_12.ds__extract_month
-                  , subq_12.ds__extract_day
-                  , subq_12.ds__extract_dow
-                  , subq_12.ds__extract_doy
-                  , subq_12.ds__alien_day
+                  subq_11.ds__day AS metric_time__day
+                  , subq_11.ds__week
+                  , subq_11.ds__month
+                  , subq_11.ds__quarter
+                  , subq_11.ds__year
+                  , subq_11.ds__extract_year
+                  , subq_11.ds__extract_quarter
+                  , subq_11.ds__extract_month
+                  , subq_11.ds__extract_day
+                  , subq_11.ds__extract_dow
+                  , subq_11.ds__extract_doy
+                  , subq_11.ds__alien_day
                 FROM (
                   -- Read From Time Spine 'mf_time_spine'
                   SELECT
@@ -316,259 +316,252 @@ FROM (
                     , EXTRACT(doy FROM time_spine_src_28006.ds) AS ds__extract_doy
                     , time_spine_src_28006.alien_day AS ds__alien_day
                   FROM ***************************.mf_time_spine time_spine_src_28006
-                ) subq_12
-              ) subq_13
-            ) subq_14
+                ) subq_11
+              ) subq_12
+            ) subq_13
             WHERE metric_time__day = '2020-01-01' or metric_time__day = '2020-01-14'
-          ) subq_15
-        ) subq_16
+          ) subq_14
+        ) subq_15
         INNER JOIN (
           -- Aggregate Inputs for Simple Metrics
           SELECT
-            subq_10.metric_time__day
-            , SUM(subq_10.__bookings) AS __bookings
+            subq_9.metric_time__day
+            , SUM(subq_9.__bookings) AS __bookings
           FROM (
             -- Select: ['__bookings', 'metric_time__day']
             SELECT
-              subq_9.metric_time__day
-              , subq_9.__bookings
+              subq_8.metric_time__day
+              , subq_8.__bookings
             FROM (
-              -- Constrain Output with WHERE
+              -- Select: ['__bookings', 'metric_time__day']
               SELECT
-                subq_8.bookings AS __bookings
-                , subq_8.metric_time__day
+                subq_7.metric_time__day
+                , subq_7.__bookings
               FROM (
-                -- Select: ['__bookings', 'metric_time__day']
+                -- Metric Time Dimension 'ds'
                 SELECT
-                  subq_7.metric_time__day
-                  , subq_7.__bookings AS bookings
+                  subq_0.ds__day
+                  , subq_0.ds__week
+                  , subq_0.ds__month
+                  , subq_0.ds__quarter
+                  , subq_0.ds__year
+                  , subq_0.ds__extract_year
+                  , subq_0.ds__extract_quarter
+                  , subq_0.ds__extract_month
+                  , subq_0.ds__extract_day
+                  , subq_0.ds__extract_dow
+                  , subq_0.ds__extract_doy
+                  , subq_0.ds_partitioned__day
+                  , subq_0.ds_partitioned__week
+                  , subq_0.ds_partitioned__month
+                  , subq_0.ds_partitioned__quarter
+                  , subq_0.ds_partitioned__year
+                  , subq_0.ds_partitioned__extract_year
+                  , subq_0.ds_partitioned__extract_quarter
+                  , subq_0.ds_partitioned__extract_month
+                  , subq_0.ds_partitioned__extract_day
+                  , subq_0.ds_partitioned__extract_dow
+                  , subq_0.ds_partitioned__extract_doy
+                  , subq_0.paid_at__day
+                  , subq_0.paid_at__week
+                  , subq_0.paid_at__month
+                  , subq_0.paid_at__quarter
+                  , subq_0.paid_at__year
+                  , subq_0.paid_at__extract_year
+                  , subq_0.paid_at__extract_quarter
+                  , subq_0.paid_at__extract_month
+                  , subq_0.paid_at__extract_day
+                  , subq_0.paid_at__extract_dow
+                  , subq_0.paid_at__extract_doy
+                  , subq_0.booking__ds__day
+                  , subq_0.booking__ds__week
+                  , subq_0.booking__ds__month
+                  , subq_0.booking__ds__quarter
+                  , subq_0.booking__ds__year
+                  , subq_0.booking__ds__extract_year
+                  , subq_0.booking__ds__extract_quarter
+                  , subq_0.booking__ds__extract_month
+                  , subq_0.booking__ds__extract_day
+                  , subq_0.booking__ds__extract_dow
+                  , subq_0.booking__ds__extract_doy
+                  , subq_0.booking__ds_partitioned__day
+                  , subq_0.booking__ds_partitioned__week
+                  , subq_0.booking__ds_partitioned__month
+                  , subq_0.booking__ds_partitioned__quarter
+                  , subq_0.booking__ds_partitioned__year
+                  , subq_0.booking__ds_partitioned__extract_year
+                  , subq_0.booking__ds_partitioned__extract_quarter
+                  , subq_0.booking__ds_partitioned__extract_month
+                  , subq_0.booking__ds_partitioned__extract_day
+                  , subq_0.booking__ds_partitioned__extract_dow
+                  , subq_0.booking__ds_partitioned__extract_doy
+                  , subq_0.booking__paid_at__day
+                  , subq_0.booking__paid_at__week
+                  , subq_0.booking__paid_at__month
+                  , subq_0.booking__paid_at__quarter
+                  , subq_0.booking__paid_at__year
+                  , subq_0.booking__paid_at__extract_year
+                  , subq_0.booking__paid_at__extract_quarter
+                  , subq_0.booking__paid_at__extract_month
+                  , subq_0.booking__paid_at__extract_day
+                  , subq_0.booking__paid_at__extract_dow
+                  , subq_0.booking__paid_at__extract_doy
+                  , subq_0.ds__day AS metric_time__day
+                  , subq_0.ds__week AS metric_time__week
+                  , subq_0.ds__month AS metric_time__month
+                  , subq_0.ds__quarter AS metric_time__quarter
+                  , subq_0.ds__year AS metric_time__year
+                  , subq_0.ds__extract_year AS metric_time__extract_year
+                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_0.ds__extract_month AS metric_time__extract_month
+                  , subq_0.ds__extract_day AS metric_time__extract_day
+                  , subq_0.ds__extract_dow AS metric_time__extract_dow
+                  , subq_0.ds__extract_doy AS metric_time__extract_doy
+                  , subq_0.listing
+                  , subq_0.guest
+                  , subq_0.host
+                  , subq_0.booking__listing
+                  , subq_0.booking__guest
+                  , subq_0.booking__host
+                  , subq_0.is_instant
+                  , subq_0.booking__is_instant
+                  , subq_0.__bookings
+                  , subq_0.__average_booking_value
+                  , subq_0.__instant_bookings
+                  , subq_0.__booking_value
+                  , subq_0.__max_booking_value
+                  , subq_0.__min_booking_value
+                  , subq_0.__instant_booking_value
+                  , subq_0.__average_instant_booking_value
+                  , subq_0.__booking_value_for_non_null_listing_id
+                  , subq_0.__bookers
+                  , subq_0.__referred_bookings
+                  , subq_0.__median_booking_value
+                  , subq_0.__booking_value_p99
+                  , subq_0.__discrete_booking_value_p99
+                  , subq_0.__approximate_continuous_booking_value_p99
+                  , subq_0.__approximate_discrete_booking_value_p99
+                  , subq_0.__bookings_join_to_time_spine
+                  , subq_0.__bookings_fill_nulls_with_0_without_time_spine
+                  , subq_0.__bookings_fill_nulls_with_0
+                  , subq_0.__instant_bookings_with_measure_filter
+                  , subq_0.__bookings_join_to_time_spine_with_tiered_filters
+                  , subq_0.__bookers_fill_nulls_with_0_join_to_timespine
                 FROM (
-                  -- Metric Time Dimension 'ds'
+                  -- Read Elements From Semantic Model 'bookings_source'
                   SELECT
-                    subq_0.ds__day
-                    , subq_0.ds__week
-                    , subq_0.ds__month
-                    , subq_0.ds__quarter
-                    , subq_0.ds__year
-                    , subq_0.ds__extract_year
-                    , subq_0.ds__extract_quarter
-                    , subq_0.ds__extract_month
-                    , subq_0.ds__extract_day
-                    , subq_0.ds__extract_dow
-                    , subq_0.ds__extract_doy
-                    , subq_0.ds_partitioned__day
-                    , subq_0.ds_partitioned__week
-                    , subq_0.ds_partitioned__month
-                    , subq_0.ds_partitioned__quarter
-                    , subq_0.ds_partitioned__year
-                    , subq_0.ds_partitioned__extract_year
-                    , subq_0.ds_partitioned__extract_quarter
-                    , subq_0.ds_partitioned__extract_month
-                    , subq_0.ds_partitioned__extract_day
-                    , subq_0.ds_partitioned__extract_dow
-                    , subq_0.ds_partitioned__extract_doy
-                    , subq_0.paid_at__day
-                    , subq_0.paid_at__week
-                    , subq_0.paid_at__month
-                    , subq_0.paid_at__quarter
-                    , subq_0.paid_at__year
-                    , subq_0.paid_at__extract_year
-                    , subq_0.paid_at__extract_quarter
-                    , subq_0.paid_at__extract_month
-                    , subq_0.paid_at__extract_day
-                    , subq_0.paid_at__extract_dow
-                    , subq_0.paid_at__extract_doy
-                    , subq_0.booking__ds__day
-                    , subq_0.booking__ds__week
-                    , subq_0.booking__ds__month
-                    , subq_0.booking__ds__quarter
-                    , subq_0.booking__ds__year
-                    , subq_0.booking__ds__extract_year
-                    , subq_0.booking__ds__extract_quarter
-                    , subq_0.booking__ds__extract_month
-                    , subq_0.booking__ds__extract_day
-                    , subq_0.booking__ds__extract_dow
-                    , subq_0.booking__ds__extract_doy
-                    , subq_0.booking__ds_partitioned__day
-                    , subq_0.booking__ds_partitioned__week
-                    , subq_0.booking__ds_partitioned__month
-                    , subq_0.booking__ds_partitioned__quarter
-                    , subq_0.booking__ds_partitioned__year
-                    , subq_0.booking__ds_partitioned__extract_year
-                    , subq_0.booking__ds_partitioned__extract_quarter
-                    , subq_0.booking__ds_partitioned__extract_month
-                    , subq_0.booking__ds_partitioned__extract_day
-                    , subq_0.booking__ds_partitioned__extract_dow
-                    , subq_0.booking__ds_partitioned__extract_doy
-                    , subq_0.booking__paid_at__day
-                    , subq_0.booking__paid_at__week
-                    , subq_0.booking__paid_at__month
-                    , subq_0.booking__paid_at__quarter
-                    , subq_0.booking__paid_at__year
-                    , subq_0.booking__paid_at__extract_year
-                    , subq_0.booking__paid_at__extract_quarter
-                    , subq_0.booking__paid_at__extract_month
-                    , subq_0.booking__paid_at__extract_day
-                    , subq_0.booking__paid_at__extract_dow
-                    , subq_0.booking__paid_at__extract_doy
-                    , subq_0.ds__day AS metric_time__day
-                    , subq_0.ds__week AS metric_time__week
-                    , subq_0.ds__month AS metric_time__month
-                    , subq_0.ds__quarter AS metric_time__quarter
-                    , subq_0.ds__year AS metric_time__year
-                    , subq_0.ds__extract_year AS metric_time__extract_year
-                    , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                    , subq_0.ds__extract_month AS metric_time__extract_month
-                    , subq_0.ds__extract_day AS metric_time__extract_day
-                    , subq_0.ds__extract_dow AS metric_time__extract_dow
-                    , subq_0.ds__extract_doy AS metric_time__extract_doy
-                    , subq_0.listing
-                    , subq_0.guest
-                    , subq_0.host
-                    , subq_0.booking__listing
-                    , subq_0.booking__guest
-                    , subq_0.booking__host
-                    , subq_0.is_instant
-                    , subq_0.booking__is_instant
-                    , subq_0.__bookings
-                    , subq_0.__average_booking_value
-                    , subq_0.__instant_bookings
-                    , subq_0.__booking_value
-                    , subq_0.__max_booking_value
-                    , subq_0.__min_booking_value
-                    , subq_0.__instant_booking_value
-                    , subq_0.__average_instant_booking_value
-                    , subq_0.__booking_value_for_non_null_listing_id
-                    , subq_0.__bookers
-                    , subq_0.__referred_bookings
-                    , subq_0.__median_booking_value
-                    , subq_0.__booking_value_p99
-                    , subq_0.__discrete_booking_value_p99
-                    , subq_0.__approximate_continuous_booking_value_p99
-                    , subq_0.__approximate_discrete_booking_value_p99
-                    , subq_0.__bookings_join_to_time_spine
-                    , subq_0.__bookings_fill_nulls_with_0_without_time_spine
-                    , subq_0.__bookings_fill_nulls_with_0
-                    , subq_0.__instant_bookings_with_measure_filter
-                    , subq_0.__bookings_join_to_time_spine_with_tiered_filters
-                    , subq_0.__bookers_fill_nulls_with_0_join_to_timespine
-                  FROM (
-                    -- Read Elements From Semantic Model 'bookings_source'
-                    SELECT
-                      1 AS __bookings
-                      , bookings_source_src_28000.booking_value AS __average_booking_value
-                      , CASE WHEN is_instant THEN 1 ELSE 0 END AS __instant_bookings
-                      , bookings_source_src_28000.booking_value AS __booking_value
-                      , bookings_source_src_28000.booking_value AS __max_booking_value
-                      , bookings_source_src_28000.booking_value AS __min_booking_value
-                      , bookings_source_src_28000.booking_value AS __instant_booking_value
-                      , bookings_source_src_28000.booking_value AS __average_instant_booking_value
-                      , bookings_source_src_28000.booking_value AS __booking_value_for_non_null_listing_id
-                      , bookings_source_src_28000.guest_id AS __bookers
-                      , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS __referred_bookings
-                      , bookings_source_src_28000.booking_value AS __median_booking_value
-                      , bookings_source_src_28000.booking_value AS __booking_value_p99
-                      , bookings_source_src_28000.booking_value AS __discrete_booking_value_p99
-                      , bookings_source_src_28000.booking_value AS __approximate_continuous_booking_value_p99
-                      , bookings_source_src_28000.booking_value AS __approximate_discrete_booking_value_p99
-                      , 1 AS __bookings_join_to_time_spine
-                      , 1 AS __bookings_fill_nulls_with_0_without_time_spine
-                      , 1 AS __bookings_fill_nulls_with_0
-                      , 1 AS __instant_bookings_with_measure_filter
-                      , 1 AS __bookings_join_to_time_spine_with_tiered_filters
-                      , bookings_source_src_28000.guest_id AS __bookers_fill_nulls_with_0_join_to_timespine
-                      , bookings_source_src_28000.booking_value AS __booking_payments
-                      , bookings_source_src_28000.is_instant
-                      , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                      , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                      , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                      , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                      , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                      , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                      , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                      , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                      , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                      , bookings_source_src_28000.is_instant AS booking__is_instant
-                      , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                      , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                      , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                      , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                      , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                      , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                      , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                      , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                      , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                      , bookings_source_src_28000.listing_id AS listing
-                      , bookings_source_src_28000.guest_id AS guest
-                      , bookings_source_src_28000.host_id AS host
-                      , bookings_source_src_28000.listing_id AS booking__listing
-                      , bookings_source_src_28000.guest_id AS booking__guest
-                      , bookings_source_src_28000.host_id AS booking__host
-                    FROM ***************************.fct_bookings bookings_source_src_28000
-                  ) subq_0
-                ) subq_7
-              ) subq_8
-              WHERE metric_time__day = '2020-01-01' or metric_time__day = '2020-01-14'
-            ) subq_9
-          ) subq_10
+                    1 AS __bookings
+                    , bookings_source_src_28000.booking_value AS __average_booking_value
+                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS __instant_bookings
+                    , bookings_source_src_28000.booking_value AS __booking_value
+                    , bookings_source_src_28000.booking_value AS __max_booking_value
+                    , bookings_source_src_28000.booking_value AS __min_booking_value
+                    , bookings_source_src_28000.booking_value AS __instant_booking_value
+                    , bookings_source_src_28000.booking_value AS __average_instant_booking_value
+                    , bookings_source_src_28000.booking_value AS __booking_value_for_non_null_listing_id
+                    , bookings_source_src_28000.guest_id AS __bookers
+                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS __referred_bookings
+                    , bookings_source_src_28000.booking_value AS __median_booking_value
+                    , bookings_source_src_28000.booking_value AS __booking_value_p99
+                    , bookings_source_src_28000.booking_value AS __discrete_booking_value_p99
+                    , bookings_source_src_28000.booking_value AS __approximate_continuous_booking_value_p99
+                    , bookings_source_src_28000.booking_value AS __approximate_discrete_booking_value_p99
+                    , 1 AS __bookings_join_to_time_spine
+                    , 1 AS __bookings_fill_nulls_with_0_without_time_spine
+                    , 1 AS __bookings_fill_nulls_with_0
+                    , 1 AS __instant_bookings_with_measure_filter
+                    , 1 AS __bookings_join_to_time_spine_with_tiered_filters
+                    , bookings_source_src_28000.guest_id AS __bookers_fill_nulls_with_0_join_to_timespine
+                    , bookings_source_src_28000.booking_value AS __booking_payments
+                    , bookings_source_src_28000.is_instant
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                    , bookings_source_src_28000.is_instant AS booking__is_instant
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                    , bookings_source_src_28000.listing_id AS listing
+                    , bookings_source_src_28000.guest_id AS guest
+                    , bookings_source_src_28000.host_id AS host
+                    , bookings_source_src_28000.listing_id AS booking__listing
+                    , bookings_source_src_28000.guest_id AS booking__guest
+                    , bookings_source_src_28000.host_id AS booking__host
+                  FROM ***************************.fct_bookings bookings_source_src_28000
+                ) subq_0
+              ) subq_7
+            ) subq_8
+          ) subq_9
           GROUP BY
-            subq_10.metric_time__day
-        ) subq_11
+            subq_9.metric_time__day
+        ) subq_10
         ON
-          subq_16.metric_time__day - INTERVAL 14 day = subq_11.metric_time__day
-      ) subq_17
-    ) subq_18
+          subq_15.metric_time__day - INTERVAL 14 day = subq_10.metric_time__day
+      ) subq_16
+    ) subq_17
     ON
-      subq_6.metric_time__day = subq_18.metric_time__day
+      subq_6.metric_time__day = subq_17.metric_time__day
     GROUP BY
-      COALESCE(subq_6.metric_time__day, subq_18.metric_time__day)
-  ) subq_19
-) subq_20
+      COALESCE(subq_6.metric_time__day, subq_17.metric_time__day)
+  ) subq_18
+) subq_19

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_derived_metric_with_offset_window_and_time_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_derived_metric_with_offset_window_and_time_filter__plan0_optimized.sql
@@ -19,9 +19,9 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_27.metric_time__day, subq_39.metric_time__day) AS metric_time__day
-    , MAX(subq_27.bookings) AS bookings
-    , MAX(subq_39.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+    COALESCE(subq_26.metric_time__day, subq_37.metric_time__day) AS metric_time__day
+    , MAX(subq_26.bookings) AS bookings
+    , MAX(subq_37.bookings_2_weeks_ago) AS bookings_2_weeks_ago
   FROM (
     -- Constrain Output with WHERE
     -- Select: ['__bookings', 'metric_time__day']
@@ -37,17 +37,17 @@ FROM (
         metric_time__day
         , __bookings AS bookings
       FROM sma_28009_cte
-    ) subq_23
+    ) subq_22
     WHERE metric_time__day = '2020-01-01' or metric_time__day = '2020-01-14'
     GROUP BY
       metric_time__day
-  ) subq_27
+  ) subq_26
   FULL OUTER JOIN (
     -- Join to Time Spine Dataset
     -- Compute Metrics via Expressions
     SELECT
-      subq_37.metric_time__day AS metric_time__day
-      , subq_32.__bookings AS bookings_2_weeks_ago
+      subq_35.metric_time__day AS metric_time__day
+      , subq_30.__bookings AS bookings_2_weeks_ago
     FROM (
       -- Constrain Output with WHERE
       -- Select: ['metric_time__day']
@@ -60,33 +60,26 @@ FROM (
         SELECT
           ds AS metric_time__day
         FROM ***************************.mf_time_spine time_spine_src_28006
-      ) subq_35
+      ) subq_33
       WHERE metric_time__day = '2020-01-01' or metric_time__day = '2020-01-14'
-    ) subq_37
+    ) subq_35
     INNER JOIN (
-      -- Constrain Output with WHERE
+      -- Read From CTE For node_id=sma_28009
+      -- Select: ['__bookings', 'metric_time__day']
       -- Select: ['__bookings', 'metric_time__day']
       -- Aggregate Inputs for Simple Metrics
       SELECT
         metric_time__day
-        , SUM(bookings) AS __bookings
-      FROM (
-        -- Read From CTE For node_id=sma_28009
-        -- Select: ['__bookings', 'metric_time__day']
-        SELECT
-          metric_time__day
-          , __bookings AS bookings
-        FROM sma_28009_cte
-      ) subq_29
-      WHERE metric_time__day = '2020-01-01' or metric_time__day = '2020-01-14'
+        , SUM(__bookings) AS __bookings
+      FROM sma_28009_cte
       GROUP BY
         metric_time__day
-    ) subq_32
+    ) subq_30
     ON
-      subq_37.metric_time__day - INTERVAL 14 day = subq_32.metric_time__day
-  ) subq_39
+      subq_35.metric_time__day - INTERVAL 14 day = subq_30.metric_time__day
+  ) subq_37
   ON
-    subq_27.metric_time__day = subq_39.metric_time__day
+    subq_26.metric_time__day = subq_37.metric_time__day
   GROUP BY
-    COALESCE(subq_27.metric_time__day, subq_39.metric_time__day)
-) subq_40
+    COALESCE(subq_26.metric_time__day, subq_37.metric_time__day)
+) subq_38

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0.sql
@@ -6,52 +6,52 @@ sql_engine: DuckDB
 ---
 -- Write to DataTable
 SELECT
-  subq_13.metric_time__month
-  , subq_13.bookings_at_start_of_month
+  subq_12.metric_time__month
+  , subq_12.bookings_at_start_of_month
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_12.metric_time__month
+    subq_11.metric_time__month
     , bookings_start_of_month AS bookings_at_start_of_month
   FROM (
     -- Compute Metrics via Expressions
     SELECT
-      subq_11.metric_time__month
-      , subq_11.__bookings AS bookings_start_of_month
+      subq_10.metric_time__month
+      , subq_10.__bookings AS bookings_start_of_month
     FROM (
       -- Join to Time Spine Dataset
       SELECT
-        subq_10.metric_time__month AS metric_time__month
-        , subq_5.__bookings AS __bookings
+        subq_9.metric_time__month AS metric_time__month
+        , subq_4.__bookings AS __bookings
       FROM (
         -- Select: ['metric_time__month']
         SELECT
-          subq_9.metric_time__month
+          subq_8.metric_time__month
         FROM (
           -- Constrain Output with WHERE
           SELECT
-            subq_8.metric_time__day
-            , subq_8.metric_time__month
+            subq_7.metric_time__day
+            , subq_7.metric_time__month
           FROM (
             -- Select: ['metric_time__month', 'metric_time__day']
             SELECT
-              subq_7.metric_time__day
-              , subq_7.metric_time__month
+              subq_6.metric_time__day
+              , subq_6.metric_time__month
             FROM (
               -- Change Column Aliases
               SELECT
-                subq_6.ds__day AS metric_time__day
-                , subq_6.ds__week
-                , subq_6.ds__month AS metric_time__month
-                , subq_6.ds__quarter
-                , subq_6.ds__year
-                , subq_6.ds__extract_year
-                , subq_6.ds__extract_quarter
-                , subq_6.ds__extract_month
-                , subq_6.ds__extract_day
-                , subq_6.ds__extract_dow
-                , subq_6.ds__extract_doy
-                , subq_6.ds__alien_day
+                subq_5.ds__day AS metric_time__day
+                , subq_5.ds__week
+                , subq_5.ds__month AS metric_time__month
+                , subq_5.ds__quarter
+                , subq_5.ds__year
+                , subq_5.ds__extract_year
+                , subq_5.ds__extract_quarter
+                , subq_5.ds__extract_month
+                , subq_5.ds__extract_day
+                , subq_5.ds__extract_dow
+                , subq_5.ds__extract_doy
+                , subq_5.ds__alien_day
               FROM (
                 -- Read From Time Spine 'mf_time_spine'
                 SELECT
@@ -68,258 +68,249 @@ FROM (
                   , EXTRACT(doy FROM time_spine_src_28006.ds) AS ds__extract_doy
                   , time_spine_src_28006.alien_day AS ds__alien_day
                 FROM ***************************.mf_time_spine time_spine_src_28006
-              ) subq_6
-            ) subq_7
-          ) subq_8
+              ) subq_5
+            ) subq_6
+          ) subq_7
           WHERE metric_time__day = '2020-01-01'
-        ) subq_9
+        ) subq_8
         GROUP BY
-          subq_9.metric_time__month
-      ) subq_10
+          subq_8.metric_time__month
+      ) subq_9
       INNER JOIN (
         -- Aggregate Inputs for Simple Metrics
         SELECT
-          subq_4.metric_time__month
-          , SUM(subq_4.__bookings) AS __bookings
+          subq_3.metric_time__month
+          , SUM(subq_3.__bookings) AS __bookings
         FROM (
           -- Select: ['__bookings', 'metric_time__month']
           SELECT
-            subq_3.metric_time__month
-            , subq_3.__bookings
+            subq_2.metric_time__month
+            , subq_2.__bookings
           FROM (
-            -- Constrain Output with WHERE
+            -- Select: ['__bookings', 'metric_time__month']
             SELECT
-              subq_2.bookings AS __bookings
-              , subq_2.metric_time__day
-              , subq_2.metric_time__month
+              subq_1.metric_time__month
+              , subq_1.__bookings
             FROM (
-              -- Select: ['__bookings', 'metric_time__month', 'metric_time__day']
+              -- Metric Time Dimension 'ds'
               SELECT
-                subq_1.metric_time__day
-                , subq_1.metric_time__month
-                , subq_1.__bookings AS bookings
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.__bookings
+                , subq_0.__average_booking_value
+                , subq_0.__instant_bookings
+                , subq_0.__booking_value
+                , subq_0.__max_booking_value
+                , subq_0.__min_booking_value
+                , subq_0.__instant_booking_value
+                , subq_0.__average_instant_booking_value
+                , subq_0.__booking_value_for_non_null_listing_id
+                , subq_0.__bookers
+                , subq_0.__referred_bookings
+                , subq_0.__median_booking_value
+                , subq_0.__booking_value_p99
+                , subq_0.__discrete_booking_value_p99
+                , subq_0.__approximate_continuous_booking_value_p99
+                , subq_0.__approximate_discrete_booking_value_p99
+                , subq_0.__bookings_join_to_time_spine
+                , subq_0.__bookings_fill_nulls_with_0_without_time_spine
+                , subq_0.__bookings_fill_nulls_with_0
+                , subq_0.__instant_bookings_with_measure_filter
+                , subq_0.__bookings_join_to_time_spine_with_tiered_filters
+                , subq_0.__bookers_fill_nulls_with_0_join_to_timespine
               FROM (
-                -- Metric Time Dimension 'ds'
+                -- Read Elements From Semantic Model 'bookings_source'
                 SELECT
-                  subq_0.ds__day
-                  , subq_0.ds__week
-                  , subq_0.ds__month
-                  , subq_0.ds__quarter
-                  , subq_0.ds__year
-                  , subq_0.ds__extract_year
-                  , subq_0.ds__extract_quarter
-                  , subq_0.ds__extract_month
-                  , subq_0.ds__extract_day
-                  , subq_0.ds__extract_dow
-                  , subq_0.ds__extract_doy
-                  , subq_0.ds_partitioned__day
-                  , subq_0.ds_partitioned__week
-                  , subq_0.ds_partitioned__month
-                  , subq_0.ds_partitioned__quarter
-                  , subq_0.ds_partitioned__year
-                  , subq_0.ds_partitioned__extract_year
-                  , subq_0.ds_partitioned__extract_quarter
-                  , subq_0.ds_partitioned__extract_month
-                  , subq_0.ds_partitioned__extract_day
-                  , subq_0.ds_partitioned__extract_dow
-                  , subq_0.ds_partitioned__extract_doy
-                  , subq_0.paid_at__day
-                  , subq_0.paid_at__week
-                  , subq_0.paid_at__month
-                  , subq_0.paid_at__quarter
-                  , subq_0.paid_at__year
-                  , subq_0.paid_at__extract_year
-                  , subq_0.paid_at__extract_quarter
-                  , subq_0.paid_at__extract_month
-                  , subq_0.paid_at__extract_day
-                  , subq_0.paid_at__extract_dow
-                  , subq_0.paid_at__extract_doy
-                  , subq_0.booking__ds__day
-                  , subq_0.booking__ds__week
-                  , subq_0.booking__ds__month
-                  , subq_0.booking__ds__quarter
-                  , subq_0.booking__ds__year
-                  , subq_0.booking__ds__extract_year
-                  , subq_0.booking__ds__extract_quarter
-                  , subq_0.booking__ds__extract_month
-                  , subq_0.booking__ds__extract_day
-                  , subq_0.booking__ds__extract_dow
-                  , subq_0.booking__ds__extract_doy
-                  , subq_0.booking__ds_partitioned__day
-                  , subq_0.booking__ds_partitioned__week
-                  , subq_0.booking__ds_partitioned__month
-                  , subq_0.booking__ds_partitioned__quarter
-                  , subq_0.booking__ds_partitioned__year
-                  , subq_0.booking__ds_partitioned__extract_year
-                  , subq_0.booking__ds_partitioned__extract_quarter
-                  , subq_0.booking__ds_partitioned__extract_month
-                  , subq_0.booking__ds_partitioned__extract_day
-                  , subq_0.booking__ds_partitioned__extract_dow
-                  , subq_0.booking__ds_partitioned__extract_doy
-                  , subq_0.booking__paid_at__day
-                  , subq_0.booking__paid_at__week
-                  , subq_0.booking__paid_at__month
-                  , subq_0.booking__paid_at__quarter
-                  , subq_0.booking__paid_at__year
-                  , subq_0.booking__paid_at__extract_year
-                  , subq_0.booking__paid_at__extract_quarter
-                  , subq_0.booking__paid_at__extract_month
-                  , subq_0.booking__paid_at__extract_day
-                  , subq_0.booking__paid_at__extract_dow
-                  , subq_0.booking__paid_at__extract_doy
-                  , subq_0.ds__day AS metric_time__day
-                  , subq_0.ds__week AS metric_time__week
-                  , subq_0.ds__month AS metric_time__month
-                  , subq_0.ds__quarter AS metric_time__quarter
-                  , subq_0.ds__year AS metric_time__year
-                  , subq_0.ds__extract_year AS metric_time__extract_year
-                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_0.ds__extract_month AS metric_time__extract_month
-                  , subq_0.ds__extract_day AS metric_time__extract_day
-                  , subq_0.ds__extract_dow AS metric_time__extract_dow
-                  , subq_0.ds__extract_doy AS metric_time__extract_doy
-                  , subq_0.listing
-                  , subq_0.guest
-                  , subq_0.host
-                  , subq_0.booking__listing
-                  , subq_0.booking__guest
-                  , subq_0.booking__host
-                  , subq_0.is_instant
-                  , subq_0.booking__is_instant
-                  , subq_0.__bookings
-                  , subq_0.__average_booking_value
-                  , subq_0.__instant_bookings
-                  , subq_0.__booking_value
-                  , subq_0.__max_booking_value
-                  , subq_0.__min_booking_value
-                  , subq_0.__instant_booking_value
-                  , subq_0.__average_instant_booking_value
-                  , subq_0.__booking_value_for_non_null_listing_id
-                  , subq_0.__bookers
-                  , subq_0.__referred_bookings
-                  , subq_0.__median_booking_value
-                  , subq_0.__booking_value_p99
-                  , subq_0.__discrete_booking_value_p99
-                  , subq_0.__approximate_continuous_booking_value_p99
-                  , subq_0.__approximate_discrete_booking_value_p99
-                  , subq_0.__bookings_join_to_time_spine
-                  , subq_0.__bookings_fill_nulls_with_0_without_time_spine
-                  , subq_0.__bookings_fill_nulls_with_0
-                  , subq_0.__instant_bookings_with_measure_filter
-                  , subq_0.__bookings_join_to_time_spine_with_tiered_filters
-                  , subq_0.__bookers_fill_nulls_with_0_join_to_timespine
-                FROM (
-                  -- Read Elements From Semantic Model 'bookings_source'
-                  SELECT
-                    1 AS __bookings
-                    , bookings_source_src_28000.booking_value AS __average_booking_value
-                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS __instant_bookings
-                    , bookings_source_src_28000.booking_value AS __booking_value
-                    , bookings_source_src_28000.booking_value AS __max_booking_value
-                    , bookings_source_src_28000.booking_value AS __min_booking_value
-                    , bookings_source_src_28000.booking_value AS __instant_booking_value
-                    , bookings_source_src_28000.booking_value AS __average_instant_booking_value
-                    , bookings_source_src_28000.booking_value AS __booking_value_for_non_null_listing_id
-                    , bookings_source_src_28000.guest_id AS __bookers
-                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS __referred_bookings
-                    , bookings_source_src_28000.booking_value AS __median_booking_value
-                    , bookings_source_src_28000.booking_value AS __booking_value_p99
-                    , bookings_source_src_28000.booking_value AS __discrete_booking_value_p99
-                    , bookings_source_src_28000.booking_value AS __approximate_continuous_booking_value_p99
-                    , bookings_source_src_28000.booking_value AS __approximate_discrete_booking_value_p99
-                    , 1 AS __bookings_join_to_time_spine
-                    , 1 AS __bookings_fill_nulls_with_0_without_time_spine
-                    , 1 AS __bookings_fill_nulls_with_0
-                    , 1 AS __instant_bookings_with_measure_filter
-                    , 1 AS __bookings_join_to_time_spine_with_tiered_filters
-                    , bookings_source_src_28000.guest_id AS __bookers_fill_nulls_with_0_join_to_timespine
-                    , bookings_source_src_28000.booking_value AS __booking_payments
-                    , bookings_source_src_28000.is_instant
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                    , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                    , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                    , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                    , bookings_source_src_28000.is_instant AS booking__is_instant
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                    , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                    , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                    , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                    , bookings_source_src_28000.listing_id AS listing
-                    , bookings_source_src_28000.guest_id AS guest
-                    , bookings_source_src_28000.host_id AS host
-                    , bookings_source_src_28000.listing_id AS booking__listing
-                    , bookings_source_src_28000.guest_id AS booking__guest
-                    , bookings_source_src_28000.host_id AS booking__host
-                  FROM ***************************.fct_bookings bookings_source_src_28000
-                ) subq_0
-              ) subq_1
-            ) subq_2
-            WHERE metric_time__day = '2020-01-01'
-          ) subq_3
-        ) subq_4
+                  1 AS __bookings
+                  , bookings_source_src_28000.booking_value AS __average_booking_value
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS __instant_bookings
+                  , bookings_source_src_28000.booking_value AS __booking_value
+                  , bookings_source_src_28000.booking_value AS __max_booking_value
+                  , bookings_source_src_28000.booking_value AS __min_booking_value
+                  , bookings_source_src_28000.booking_value AS __instant_booking_value
+                  , bookings_source_src_28000.booking_value AS __average_instant_booking_value
+                  , bookings_source_src_28000.booking_value AS __booking_value_for_non_null_listing_id
+                  , bookings_source_src_28000.guest_id AS __bookers
+                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS __referred_bookings
+                  , bookings_source_src_28000.booking_value AS __median_booking_value
+                  , bookings_source_src_28000.booking_value AS __booking_value_p99
+                  , bookings_source_src_28000.booking_value AS __discrete_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS __approximate_continuous_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS __approximate_discrete_booking_value_p99
+                  , 1 AS __bookings_join_to_time_spine
+                  , 1 AS __bookings_fill_nulls_with_0_without_time_spine
+                  , 1 AS __bookings_fill_nulls_with_0
+                  , 1 AS __instant_bookings_with_measure_filter
+                  , 1 AS __bookings_join_to_time_spine_with_tiered_filters
+                  , bookings_source_src_28000.guest_id AS __bookers_fill_nulls_with_0_join_to_timespine
+                  , bookings_source_src_28000.booking_value AS __booking_payments
+                  , bookings_source_src_28000.is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                  , bookings_source_src_28000.is_instant AS booking__is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                  , bookings_source_src_28000.listing_id AS listing
+                  , bookings_source_src_28000.guest_id AS guest
+                  , bookings_source_src_28000.host_id AS host
+                  , bookings_source_src_28000.listing_id AS booking__listing
+                  , bookings_source_src_28000.guest_id AS booking__guest
+                  , bookings_source_src_28000.host_id AS booking__host
+                FROM ***************************.fct_bookings bookings_source_src_28000
+              ) subq_0
+            ) subq_1
+          ) subq_2
+        ) subq_3
         GROUP BY
-          subq_4.metric_time__month
-      ) subq_5
+          subq_3.metric_time__month
+      ) subq_4
       ON
-        DATE_TRUNC('month', subq_10.metric_time__month) = subq_5.metric_time__month
-    ) subq_11
-  ) subq_12
-) subq_13
+        DATE_TRUNC('month', subq_9.metric_time__month) = subq_4.metric_time__month
+    ) subq_10
+  ) subq_11
+) subq_12

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
@@ -13,8 +13,8 @@ FROM (
   -- Join to Time Spine Dataset
   -- Compute Metrics via Expressions
   SELECT
-    subq_24.metric_time__month AS metric_time__month
-    , subq_19.__bookings AS bookings_start_of_month
+    subq_22.metric_time__month AS metric_time__month
+    , subq_17.__bookings AS bookings_start_of_month
   FROM (
     -- Constrain Output with WHERE
     -- Select: ['metric_time__month']
@@ -28,32 +28,29 @@ FROM (
         ds AS metric_time__day
         , DATE_TRUNC('month', ds) AS metric_time__month
       FROM ***************************.mf_time_spine time_spine_src_28006
-    ) subq_22
+    ) subq_20
     WHERE metric_time__day = '2020-01-01'
     GROUP BY
       metric_time__month
-  ) subq_24
+  ) subq_22
   INNER JOIN (
-    -- Constrain Output with WHERE
-    -- Select: ['__bookings', 'metric_time__month']
     -- Aggregate Inputs for Simple Metrics
     SELECT
       metric_time__month
-      , SUM(bookings) AS __bookings
+      , SUM(__bookings) AS __bookings
     FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
-      -- Select: ['__bookings', 'metric_time__month', 'metric_time__day']
+      -- Select: ['__bookings', 'metric_time__month']
+      -- Select: ['__bookings', 'metric_time__month']
       SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , DATE_TRUNC('month', ds) AS metric_time__month
-        , 1 AS bookings
+        DATE_TRUNC('month', ds) AS metric_time__month
+        , 1 AS __bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
     ) subq_16
-    WHERE metric_time__day = '2020-01-01'
     GROUP BY
       metric_time__month
-  ) subq_19
+  ) subq_17
   ON
-    DATE_TRUNC('month', subq_24.metric_time__month) = subq_19.metric_time__month
-) subq_26
+    DATE_TRUNC('month', subq_22.metric_time__month) = subq_17.metric_time__month
+) subq_24

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_offset_window_metric_filter_and_query_have_different_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_offset_window_metric_filter_and_query_have_different_granularities__plan0.sql
@@ -35,129 +35,127 @@ FROM (
             subq_8.metric_time__month
             , subq_8.__booking_value
           FROM (
-            -- Constrain Output with WHERE
+            -- Select: ['__booking_value', 'metric_time__month']
             SELECT
-              subq_7.booking_value AS __booking_value
-              , subq_7.metric_time__day
-              , subq_7.metric_time__month
+              subq_7.metric_time__month
+              , subq_7.__booking_value
             FROM (
-              -- Select: ['__booking_value', 'metric_time__month', 'metric_time__day']
+              -- Join to Time Spine Dataset
               SELECT
-                subq_6.metric_time__day
-                , subq_6.metric_time__month
-                , subq_6.__booking_value AS booking_value
+                subq_6.metric_time__day AS metric_time__day
+                , subq_6.metric_time__month AS metric_time__month
+                , subq_1.ds__day AS ds__day
+                , subq_1.ds__week AS ds__week
+                , subq_1.ds__month AS ds__month
+                , subq_1.ds__quarter AS ds__quarter
+                , subq_1.ds__year AS ds__year
+                , subq_1.ds__extract_year AS ds__extract_year
+                , subq_1.ds__extract_quarter AS ds__extract_quarter
+                , subq_1.ds__extract_month AS ds__extract_month
+                , subq_1.ds__extract_day AS ds__extract_day
+                , subq_1.ds__extract_dow AS ds__extract_dow
+                , subq_1.ds__extract_doy AS ds__extract_doy
+                , subq_1.ds_partitioned__day AS ds_partitioned__day
+                , subq_1.ds_partitioned__week AS ds_partitioned__week
+                , subq_1.ds_partitioned__month AS ds_partitioned__month
+                , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
+                , subq_1.ds_partitioned__year AS ds_partitioned__year
+                , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
+                , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+                , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
+                , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
+                , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+                , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+                , subq_1.paid_at__day AS paid_at__day
+                , subq_1.paid_at__week AS paid_at__week
+                , subq_1.paid_at__month AS paid_at__month
+                , subq_1.paid_at__quarter AS paid_at__quarter
+                , subq_1.paid_at__year AS paid_at__year
+                , subq_1.paid_at__extract_year AS paid_at__extract_year
+                , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
+                , subq_1.paid_at__extract_month AS paid_at__extract_month
+                , subq_1.paid_at__extract_day AS paid_at__extract_day
+                , subq_1.paid_at__extract_dow AS paid_at__extract_dow
+                , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+                , subq_1.booking__ds__day AS booking__ds__day
+                , subq_1.booking__ds__week AS booking__ds__week
+                , subq_1.booking__ds__month AS booking__ds__month
+                , subq_1.booking__ds__quarter AS booking__ds__quarter
+                , subq_1.booking__ds__year AS booking__ds__year
+                , subq_1.booking__ds__extract_year AS booking__ds__extract_year
+                , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
+                , subq_1.booking__ds__extract_month AS booking__ds__extract_month
+                , subq_1.booking__ds__extract_day AS booking__ds__extract_day
+                , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
+                , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
+                , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
+                , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
+                , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
+                , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+                , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
+                , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+                , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+                , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+                , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+                , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+                , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+                , subq_1.booking__paid_at__day AS booking__paid_at__day
+                , subq_1.booking__paid_at__week AS booking__paid_at__week
+                , subq_1.booking__paid_at__month AS booking__paid_at__month
+                , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
+                , subq_1.booking__paid_at__year AS booking__paid_at__year
+                , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
+                , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+                , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
+                , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
+                , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+                , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                , subq_1.metric_time__week AS metric_time__week
+                , subq_1.metric_time__quarter AS metric_time__quarter
+                , subq_1.metric_time__year AS metric_time__year
+                , subq_1.metric_time__extract_year AS metric_time__extract_year
+                , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+                , subq_1.metric_time__extract_month AS metric_time__extract_month
+                , subq_1.metric_time__extract_day AS metric_time__extract_day
+                , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+                , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+                , subq_1.listing AS listing
+                , subq_1.guest AS guest
+                , subq_1.host AS host
+                , subq_1.booking__listing AS booking__listing
+                , subq_1.booking__guest AS booking__guest
+                , subq_1.booking__host AS booking__host
+                , subq_1.is_instant AS is_instant
+                , subq_1.booking__is_instant AS booking__is_instant
+                , subq_1.__bookings AS __bookings
+                , subq_1.__average_booking_value AS __average_booking_value
+                , subq_1.__instant_bookings AS __instant_bookings
+                , subq_1.__booking_value AS __booking_value
+                , subq_1.__max_booking_value AS __max_booking_value
+                , subq_1.__min_booking_value AS __min_booking_value
+                , subq_1.__instant_booking_value AS __instant_booking_value
+                , subq_1.__average_instant_booking_value AS __average_instant_booking_value
+                , subq_1.__booking_value_for_non_null_listing_id AS __booking_value_for_non_null_listing_id
+                , subq_1.__bookers AS __bookers
+                , subq_1.__referred_bookings AS __referred_bookings
+                , subq_1.__median_booking_value AS __median_booking_value
+                , subq_1.__booking_value_p99 AS __booking_value_p99
+                , subq_1.__discrete_booking_value_p99 AS __discrete_booking_value_p99
+                , subq_1.__approximate_continuous_booking_value_p99 AS __approximate_continuous_booking_value_p99
+                , subq_1.__approximate_discrete_booking_value_p99 AS __approximate_discrete_booking_value_p99
+                , subq_1.__bookings_join_to_time_spine AS __bookings_join_to_time_spine
+                , subq_1.__bookings_fill_nulls_with_0_without_time_spine AS __bookings_fill_nulls_with_0_without_time_spine
+                , subq_1.__bookings_fill_nulls_with_0 AS __bookings_fill_nulls_with_0
+                , subq_1.__instant_bookings_with_measure_filter AS __instant_bookings_with_measure_filter
+                , subq_1.__bookings_join_to_time_spine_with_tiered_filters AS __bookings_join_to_time_spine_with_tiered_filters
+                , subq_1.__bookers_fill_nulls_with_0_join_to_timespine AS __bookers_fill_nulls_with_0_join_to_timespine
               FROM (
-                -- Join to Time Spine Dataset
+                -- Select: ['metric_time__day', 'metric_time__month']
                 SELECT
-                  subq_5.metric_time__day AS metric_time__day
-                  , subq_5.metric_time__month AS metric_time__month
-                  , subq_1.ds__day AS ds__day
-                  , subq_1.ds__week AS ds__week
-                  , subq_1.ds__month AS ds__month
-                  , subq_1.ds__quarter AS ds__quarter
-                  , subq_1.ds__year AS ds__year
-                  , subq_1.ds__extract_year AS ds__extract_year
-                  , subq_1.ds__extract_quarter AS ds__extract_quarter
-                  , subq_1.ds__extract_month AS ds__extract_month
-                  , subq_1.ds__extract_day AS ds__extract_day
-                  , subq_1.ds__extract_dow AS ds__extract_dow
-                  , subq_1.ds__extract_doy AS ds__extract_doy
-                  , subq_1.ds_partitioned__day AS ds_partitioned__day
-                  , subq_1.ds_partitioned__week AS ds_partitioned__week
-                  , subq_1.ds_partitioned__month AS ds_partitioned__month
-                  , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
-                  , subq_1.ds_partitioned__year AS ds_partitioned__year
-                  , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
-                  , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
-                  , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
-                  , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
-                  , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
-                  , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
-                  , subq_1.paid_at__day AS paid_at__day
-                  , subq_1.paid_at__week AS paid_at__week
-                  , subq_1.paid_at__month AS paid_at__month
-                  , subq_1.paid_at__quarter AS paid_at__quarter
-                  , subq_1.paid_at__year AS paid_at__year
-                  , subq_1.paid_at__extract_year AS paid_at__extract_year
-                  , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
-                  , subq_1.paid_at__extract_month AS paid_at__extract_month
-                  , subq_1.paid_at__extract_day AS paid_at__extract_day
-                  , subq_1.paid_at__extract_dow AS paid_at__extract_dow
-                  , subq_1.paid_at__extract_doy AS paid_at__extract_doy
-                  , subq_1.booking__ds__day AS booking__ds__day
-                  , subq_1.booking__ds__week AS booking__ds__week
-                  , subq_1.booking__ds__month AS booking__ds__month
-                  , subq_1.booking__ds__quarter AS booking__ds__quarter
-                  , subq_1.booking__ds__year AS booking__ds__year
-                  , subq_1.booking__ds__extract_year AS booking__ds__extract_year
-                  , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
-                  , subq_1.booking__ds__extract_month AS booking__ds__extract_month
-                  , subq_1.booking__ds__extract_day AS booking__ds__extract_day
-                  , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
-                  , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
-                  , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
-                  , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
-                  , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
-                  , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
-                  , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
-                  , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
-                  , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
-                  , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
-                  , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
-                  , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
-                  , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
-                  , subq_1.booking__paid_at__day AS booking__paid_at__day
-                  , subq_1.booking__paid_at__week AS booking__paid_at__week
-                  , subq_1.booking__paid_at__month AS booking__paid_at__month
-                  , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
-                  , subq_1.booking__paid_at__year AS booking__paid_at__year
-                  , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
-                  , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
-                  , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
-                  , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
-                  , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
-                  , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
-                  , subq_1.metric_time__week AS metric_time__week
-                  , subq_1.metric_time__quarter AS metric_time__quarter
-                  , subq_1.metric_time__year AS metric_time__year
-                  , subq_1.metric_time__extract_year AS metric_time__extract_year
-                  , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
-                  , subq_1.metric_time__extract_month AS metric_time__extract_month
-                  , subq_1.metric_time__extract_day AS metric_time__extract_day
-                  , subq_1.metric_time__extract_dow AS metric_time__extract_dow
-                  , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-                  , subq_1.listing AS listing
-                  , subq_1.guest AS guest
-                  , subq_1.host AS host
-                  , subq_1.booking__listing AS booking__listing
-                  , subq_1.booking__guest AS booking__guest
-                  , subq_1.booking__host AS booking__host
-                  , subq_1.is_instant AS is_instant
-                  , subq_1.booking__is_instant AS booking__is_instant
-                  , subq_1.__bookings AS __bookings
-                  , subq_1.__average_booking_value AS __average_booking_value
-                  , subq_1.__instant_bookings AS __instant_bookings
-                  , subq_1.__booking_value AS __booking_value
-                  , subq_1.__max_booking_value AS __max_booking_value
-                  , subq_1.__min_booking_value AS __min_booking_value
-                  , subq_1.__instant_booking_value AS __instant_booking_value
-                  , subq_1.__average_instant_booking_value AS __average_instant_booking_value
-                  , subq_1.__booking_value_for_non_null_listing_id AS __booking_value_for_non_null_listing_id
-                  , subq_1.__bookers AS __bookers
-                  , subq_1.__referred_bookings AS __referred_bookings
-                  , subq_1.__median_booking_value AS __median_booking_value
-                  , subq_1.__booking_value_p99 AS __booking_value_p99
-                  , subq_1.__discrete_booking_value_p99 AS __discrete_booking_value_p99
-                  , subq_1.__approximate_continuous_booking_value_p99 AS __approximate_continuous_booking_value_p99
-                  , subq_1.__approximate_discrete_booking_value_p99 AS __approximate_discrete_booking_value_p99
-                  , subq_1.__bookings_join_to_time_spine AS __bookings_join_to_time_spine
-                  , subq_1.__bookings_fill_nulls_with_0_without_time_spine AS __bookings_fill_nulls_with_0_without_time_spine
-                  , subq_1.__bookings_fill_nulls_with_0 AS __bookings_fill_nulls_with_0
-                  , subq_1.__instant_bookings_with_measure_filter AS __instant_bookings_with_measure_filter
-                  , subq_1.__bookings_join_to_time_spine_with_tiered_filters AS __bookings_join_to_time_spine_with_tiered_filters
-                  , subq_1.__bookers_fill_nulls_with_0_join_to_timespine AS __bookers_fill_nulls_with_0_join_to_timespine
+                  subq_5.metric_time__day
+                  , subq_5.metric_time__month
                 FROM (
-                  -- Select: ['metric_time__day', 'metric_time__month']
+                  -- Constrain Output with WHERE
                   SELECT
                     subq_4.metric_time__day
                     , subq_4.metric_time__month
@@ -200,225 +198,225 @@ FROM (
                       ) subq_2
                     ) subq_3
                   ) subq_4
+                  WHERE metric_time__day = '2020-01-01'
                 ) subq_5
-                INNER JOIN (
-                  -- Metric Time Dimension 'ds'
-                  SELECT
-                    subq_0.ds__day
-                    , subq_0.ds__week
-                    , subq_0.ds__month
-                    , subq_0.ds__quarter
-                    , subq_0.ds__year
-                    , subq_0.ds__extract_year
-                    , subq_0.ds__extract_quarter
-                    , subq_0.ds__extract_month
-                    , subq_0.ds__extract_day
-                    , subq_0.ds__extract_dow
-                    , subq_0.ds__extract_doy
-                    , subq_0.ds_partitioned__day
-                    , subq_0.ds_partitioned__week
-                    , subq_0.ds_partitioned__month
-                    , subq_0.ds_partitioned__quarter
-                    , subq_0.ds_partitioned__year
-                    , subq_0.ds_partitioned__extract_year
-                    , subq_0.ds_partitioned__extract_quarter
-                    , subq_0.ds_partitioned__extract_month
-                    , subq_0.ds_partitioned__extract_day
-                    , subq_0.ds_partitioned__extract_dow
-                    , subq_0.ds_partitioned__extract_doy
-                    , subq_0.paid_at__day
-                    , subq_0.paid_at__week
-                    , subq_0.paid_at__month
-                    , subq_0.paid_at__quarter
-                    , subq_0.paid_at__year
-                    , subq_0.paid_at__extract_year
-                    , subq_0.paid_at__extract_quarter
-                    , subq_0.paid_at__extract_month
-                    , subq_0.paid_at__extract_day
-                    , subq_0.paid_at__extract_dow
-                    , subq_0.paid_at__extract_doy
-                    , subq_0.booking__ds__day
-                    , subq_0.booking__ds__week
-                    , subq_0.booking__ds__month
-                    , subq_0.booking__ds__quarter
-                    , subq_0.booking__ds__year
-                    , subq_0.booking__ds__extract_year
-                    , subq_0.booking__ds__extract_quarter
-                    , subq_0.booking__ds__extract_month
-                    , subq_0.booking__ds__extract_day
-                    , subq_0.booking__ds__extract_dow
-                    , subq_0.booking__ds__extract_doy
-                    , subq_0.booking__ds_partitioned__day
-                    , subq_0.booking__ds_partitioned__week
-                    , subq_0.booking__ds_partitioned__month
-                    , subq_0.booking__ds_partitioned__quarter
-                    , subq_0.booking__ds_partitioned__year
-                    , subq_0.booking__ds_partitioned__extract_year
-                    , subq_0.booking__ds_partitioned__extract_quarter
-                    , subq_0.booking__ds_partitioned__extract_month
-                    , subq_0.booking__ds_partitioned__extract_day
-                    , subq_0.booking__ds_partitioned__extract_dow
-                    , subq_0.booking__ds_partitioned__extract_doy
-                    , subq_0.booking__paid_at__day
-                    , subq_0.booking__paid_at__week
-                    , subq_0.booking__paid_at__month
-                    , subq_0.booking__paid_at__quarter
-                    , subq_0.booking__paid_at__year
-                    , subq_0.booking__paid_at__extract_year
-                    , subq_0.booking__paid_at__extract_quarter
-                    , subq_0.booking__paid_at__extract_month
-                    , subq_0.booking__paid_at__extract_day
-                    , subq_0.booking__paid_at__extract_dow
-                    , subq_0.booking__paid_at__extract_doy
-                    , subq_0.ds__day AS metric_time__day
-                    , subq_0.ds__week AS metric_time__week
-                    , subq_0.ds__month AS metric_time__month
-                    , subq_0.ds__quarter AS metric_time__quarter
-                    , subq_0.ds__year AS metric_time__year
-                    , subq_0.ds__extract_year AS metric_time__extract_year
-                    , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                    , subq_0.ds__extract_month AS metric_time__extract_month
-                    , subq_0.ds__extract_day AS metric_time__extract_day
-                    , subq_0.ds__extract_dow AS metric_time__extract_dow
-                    , subq_0.ds__extract_doy AS metric_time__extract_doy
-                    , subq_0.listing
-                    , subq_0.guest
-                    , subq_0.host
-                    , subq_0.booking__listing
-                    , subq_0.booking__guest
-                    , subq_0.booking__host
-                    , subq_0.is_instant
-                    , subq_0.booking__is_instant
-                    , subq_0.__bookings
-                    , subq_0.__average_booking_value
-                    , subq_0.__instant_bookings
-                    , subq_0.__booking_value
-                    , subq_0.__max_booking_value
-                    , subq_0.__min_booking_value
-                    , subq_0.__instant_booking_value
-                    , subq_0.__average_instant_booking_value
-                    , subq_0.__booking_value_for_non_null_listing_id
-                    , subq_0.__bookers
-                    , subq_0.__referred_bookings
-                    , subq_0.__median_booking_value
-                    , subq_0.__booking_value_p99
-                    , subq_0.__discrete_booking_value_p99
-                    , subq_0.__approximate_continuous_booking_value_p99
-                    , subq_0.__approximate_discrete_booking_value_p99
-                    , subq_0.__bookings_join_to_time_spine
-                    , subq_0.__bookings_fill_nulls_with_0_without_time_spine
-                    , subq_0.__bookings_fill_nulls_with_0
-                    , subq_0.__instant_bookings_with_measure_filter
-                    , subq_0.__bookings_join_to_time_spine_with_tiered_filters
-                    , subq_0.__bookers_fill_nulls_with_0_join_to_timespine
-                  FROM (
-                    -- Read Elements From Semantic Model 'bookings_source'
-                    SELECT
-                      1 AS __bookings
-                      , bookings_source_src_28000.booking_value AS __average_booking_value
-                      , CASE WHEN is_instant THEN 1 ELSE 0 END AS __instant_bookings
-                      , bookings_source_src_28000.booking_value AS __booking_value
-                      , bookings_source_src_28000.booking_value AS __max_booking_value
-                      , bookings_source_src_28000.booking_value AS __min_booking_value
-                      , bookings_source_src_28000.booking_value AS __instant_booking_value
-                      , bookings_source_src_28000.booking_value AS __average_instant_booking_value
-                      , bookings_source_src_28000.booking_value AS __booking_value_for_non_null_listing_id
-                      , bookings_source_src_28000.guest_id AS __bookers
-                      , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS __referred_bookings
-                      , bookings_source_src_28000.booking_value AS __median_booking_value
-                      , bookings_source_src_28000.booking_value AS __booking_value_p99
-                      , bookings_source_src_28000.booking_value AS __discrete_booking_value_p99
-                      , bookings_source_src_28000.booking_value AS __approximate_continuous_booking_value_p99
-                      , bookings_source_src_28000.booking_value AS __approximate_discrete_booking_value_p99
-                      , 1 AS __bookings_join_to_time_spine
-                      , 1 AS __bookings_fill_nulls_with_0_without_time_spine
-                      , 1 AS __bookings_fill_nulls_with_0
-                      , 1 AS __instant_bookings_with_measure_filter
-                      , 1 AS __bookings_join_to_time_spine_with_tiered_filters
-                      , bookings_source_src_28000.guest_id AS __bookers_fill_nulls_with_0_join_to_timespine
-                      , bookings_source_src_28000.booking_value AS __booking_payments
-                      , bookings_source_src_28000.is_instant
-                      , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                      , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                      , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                      , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                      , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                      , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                      , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                      , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                      , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                      , bookings_source_src_28000.is_instant AS booking__is_instant
-                      , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                      , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                      , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                      , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                      , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                      , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                      , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                      , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                      , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                      , bookings_source_src_28000.listing_id AS listing
-                      , bookings_source_src_28000.guest_id AS guest
-                      , bookings_source_src_28000.host_id AS host
-                      , bookings_source_src_28000.listing_id AS booking__listing
-                      , bookings_source_src_28000.guest_id AS booking__guest
-                      , bookings_source_src_28000.host_id AS booking__host
-                    FROM ***************************.fct_bookings bookings_source_src_28000
-                  ) subq_0
-                ) subq_1
-                ON
-                  subq_5.metric_time__day - INTERVAL 1 week = subq_1.metric_time__day
               ) subq_6
+              INNER JOIN (
+                -- Metric Time Dimension 'ds'
+                SELECT
+                  subq_0.ds__day
+                  , subq_0.ds__week
+                  , subq_0.ds__month
+                  , subq_0.ds__quarter
+                  , subq_0.ds__year
+                  , subq_0.ds__extract_year
+                  , subq_0.ds__extract_quarter
+                  , subq_0.ds__extract_month
+                  , subq_0.ds__extract_day
+                  , subq_0.ds__extract_dow
+                  , subq_0.ds__extract_doy
+                  , subq_0.ds_partitioned__day
+                  , subq_0.ds_partitioned__week
+                  , subq_0.ds_partitioned__month
+                  , subq_0.ds_partitioned__quarter
+                  , subq_0.ds_partitioned__year
+                  , subq_0.ds_partitioned__extract_year
+                  , subq_0.ds_partitioned__extract_quarter
+                  , subq_0.ds_partitioned__extract_month
+                  , subq_0.ds_partitioned__extract_day
+                  , subq_0.ds_partitioned__extract_dow
+                  , subq_0.ds_partitioned__extract_doy
+                  , subq_0.paid_at__day
+                  , subq_0.paid_at__week
+                  , subq_0.paid_at__month
+                  , subq_0.paid_at__quarter
+                  , subq_0.paid_at__year
+                  , subq_0.paid_at__extract_year
+                  , subq_0.paid_at__extract_quarter
+                  , subq_0.paid_at__extract_month
+                  , subq_0.paid_at__extract_day
+                  , subq_0.paid_at__extract_dow
+                  , subq_0.paid_at__extract_doy
+                  , subq_0.booking__ds__day
+                  , subq_0.booking__ds__week
+                  , subq_0.booking__ds__month
+                  , subq_0.booking__ds__quarter
+                  , subq_0.booking__ds__year
+                  , subq_0.booking__ds__extract_year
+                  , subq_0.booking__ds__extract_quarter
+                  , subq_0.booking__ds__extract_month
+                  , subq_0.booking__ds__extract_day
+                  , subq_0.booking__ds__extract_dow
+                  , subq_0.booking__ds__extract_doy
+                  , subq_0.booking__ds_partitioned__day
+                  , subq_0.booking__ds_partitioned__week
+                  , subq_0.booking__ds_partitioned__month
+                  , subq_0.booking__ds_partitioned__quarter
+                  , subq_0.booking__ds_partitioned__year
+                  , subq_0.booking__ds_partitioned__extract_year
+                  , subq_0.booking__ds_partitioned__extract_quarter
+                  , subq_0.booking__ds_partitioned__extract_month
+                  , subq_0.booking__ds_partitioned__extract_day
+                  , subq_0.booking__ds_partitioned__extract_dow
+                  , subq_0.booking__ds_partitioned__extract_doy
+                  , subq_0.booking__paid_at__day
+                  , subq_0.booking__paid_at__week
+                  , subq_0.booking__paid_at__month
+                  , subq_0.booking__paid_at__quarter
+                  , subq_0.booking__paid_at__year
+                  , subq_0.booking__paid_at__extract_year
+                  , subq_0.booking__paid_at__extract_quarter
+                  , subq_0.booking__paid_at__extract_month
+                  , subq_0.booking__paid_at__extract_day
+                  , subq_0.booking__paid_at__extract_dow
+                  , subq_0.booking__paid_at__extract_doy
+                  , subq_0.ds__day AS metric_time__day
+                  , subq_0.ds__week AS metric_time__week
+                  , subq_0.ds__month AS metric_time__month
+                  , subq_0.ds__quarter AS metric_time__quarter
+                  , subq_0.ds__year AS metric_time__year
+                  , subq_0.ds__extract_year AS metric_time__extract_year
+                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_0.ds__extract_month AS metric_time__extract_month
+                  , subq_0.ds__extract_day AS metric_time__extract_day
+                  , subq_0.ds__extract_dow AS metric_time__extract_dow
+                  , subq_0.ds__extract_doy AS metric_time__extract_doy
+                  , subq_0.listing
+                  , subq_0.guest
+                  , subq_0.host
+                  , subq_0.booking__listing
+                  , subq_0.booking__guest
+                  , subq_0.booking__host
+                  , subq_0.is_instant
+                  , subq_0.booking__is_instant
+                  , subq_0.__bookings
+                  , subq_0.__average_booking_value
+                  , subq_0.__instant_bookings
+                  , subq_0.__booking_value
+                  , subq_0.__max_booking_value
+                  , subq_0.__min_booking_value
+                  , subq_0.__instant_booking_value
+                  , subq_0.__average_instant_booking_value
+                  , subq_0.__booking_value_for_non_null_listing_id
+                  , subq_0.__bookers
+                  , subq_0.__referred_bookings
+                  , subq_0.__median_booking_value
+                  , subq_0.__booking_value_p99
+                  , subq_0.__discrete_booking_value_p99
+                  , subq_0.__approximate_continuous_booking_value_p99
+                  , subq_0.__approximate_discrete_booking_value_p99
+                  , subq_0.__bookings_join_to_time_spine
+                  , subq_0.__bookings_fill_nulls_with_0_without_time_spine
+                  , subq_0.__bookings_fill_nulls_with_0
+                  , subq_0.__instant_bookings_with_measure_filter
+                  , subq_0.__bookings_join_to_time_spine_with_tiered_filters
+                  , subq_0.__bookers_fill_nulls_with_0_join_to_timespine
+                FROM (
+                  -- Read Elements From Semantic Model 'bookings_source'
+                  SELECT
+                    1 AS __bookings
+                    , bookings_source_src_28000.booking_value AS __average_booking_value
+                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS __instant_bookings
+                    , bookings_source_src_28000.booking_value AS __booking_value
+                    , bookings_source_src_28000.booking_value AS __max_booking_value
+                    , bookings_source_src_28000.booking_value AS __min_booking_value
+                    , bookings_source_src_28000.booking_value AS __instant_booking_value
+                    , bookings_source_src_28000.booking_value AS __average_instant_booking_value
+                    , bookings_source_src_28000.booking_value AS __booking_value_for_non_null_listing_id
+                    , bookings_source_src_28000.guest_id AS __bookers
+                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS __referred_bookings
+                    , bookings_source_src_28000.booking_value AS __median_booking_value
+                    , bookings_source_src_28000.booking_value AS __booking_value_p99
+                    , bookings_source_src_28000.booking_value AS __discrete_booking_value_p99
+                    , bookings_source_src_28000.booking_value AS __approximate_continuous_booking_value_p99
+                    , bookings_source_src_28000.booking_value AS __approximate_discrete_booking_value_p99
+                    , 1 AS __bookings_join_to_time_spine
+                    , 1 AS __bookings_fill_nulls_with_0_without_time_spine
+                    , 1 AS __bookings_fill_nulls_with_0
+                    , 1 AS __instant_bookings_with_measure_filter
+                    , 1 AS __bookings_join_to_time_spine_with_tiered_filters
+                    , bookings_source_src_28000.guest_id AS __bookers_fill_nulls_with_0_join_to_timespine
+                    , bookings_source_src_28000.booking_value AS __booking_payments
+                    , bookings_source_src_28000.is_instant
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                    , bookings_source_src_28000.is_instant AS booking__is_instant
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                    , bookings_source_src_28000.listing_id AS listing
+                    , bookings_source_src_28000.guest_id AS guest
+                    , bookings_source_src_28000.host_id AS host
+                    , bookings_source_src_28000.listing_id AS booking__listing
+                    , bookings_source_src_28000.guest_id AS booking__guest
+                    , bookings_source_src_28000.host_id AS booking__host
+                  FROM ***************************.fct_bookings bookings_source_src_28000
+                ) subq_0
+              ) subq_1
+              ON
+                subq_6.metric_time__day - INTERVAL 1 week = subq_1.metric_time__day
             ) subq_7
-            WHERE metric_time__day = '2020-01-01'
           ) subq_8
         ) subq_9
         GROUP BY

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_offset_window_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/DuckDB/test_offset_window_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
@@ -27,29 +27,37 @@ FROM (
     , MAX(subq_31.booking_value) AS booking_value
     , MAX(subq_37.bookers) AS bookers
   FROM (
-    -- Constrain Output with WHERE
+    -- Join to Time Spine Dataset
+    -- Select: ['__booking_value', 'metric_time__month']
     -- Select: ['__booking_value', 'metric_time__month']
     -- Aggregate Inputs for Simple Metrics
     -- Compute Metrics via Expressions
     SELECT
-      metric_time__month
-      , SUM(booking_value) AS booking_value
+      subq_26.metric_time__month AS metric_time__month
+      , SUM(sma_28009_cte.__booking_value) AS booking_value
     FROM (
-      -- Join to Time Spine Dataset
-      -- Select: ['__booking_value', 'metric_time__month', 'metric_time__day']
+      -- Constrain Output with WHERE
+      -- Select: ['metric_time__day', 'metric_time__month']
       SELECT
-        time_spine_src_28006.ds AS metric_time__day
-        , DATE_TRUNC('month', time_spine_src_28006.ds) AS metric_time__month
-        , sma_28009_cte.__booking_value AS booking_value
-      FROM ***************************.mf_time_spine time_spine_src_28006
-      INNER JOIN
-        sma_28009_cte
-      ON
-        time_spine_src_28006.ds - INTERVAL 1 week = sma_28009_cte.metric_time__day
-    ) subq_27
-    WHERE metric_time__day = '2020-01-01'
+        metric_time__day
+        , metric_time__month
+      FROM (
+        -- Read From Time Spine 'mf_time_spine'
+        -- Change Column Aliases
+        -- Select: ['metric_time__day', 'metric_time__month']
+        SELECT
+          ds AS metric_time__day
+          , DATE_TRUNC('month', ds) AS metric_time__month
+        FROM ***************************.mf_time_spine time_spine_src_28006
+      ) subq_24
+      WHERE metric_time__day = '2020-01-01'
+    ) subq_26
+    INNER JOIN
+      sma_28009_cte
+    ON
+      subq_26.metric_time__day - INTERVAL 1 week = sma_28009_cte.metric_time__day
     GROUP BY
-      metric_time__month
+      subq_26.metric_time__month
   ) subq_31
   FULL OUTER JOIN (
     -- Constrain Output with WHERE

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
@@ -4,19 +4,19 @@ sql_engine: Postgres
 ---
 -- Write to DataTable
 SELECT
-  subq_20.metric_time__day
-  , subq_20.bookings_growth_2_weeks
+  subq_19.metric_time__day
+  , subq_19.bookings_growth_2_weeks
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_19.metric_time__day
+    subq_18.metric_time__day
     , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
   FROM (
     -- Combine Aggregated Outputs
     SELECT
-      COALESCE(subq_6.metric_time__day, subq_18.metric_time__day) AS metric_time__day
+      COALESCE(subq_6.metric_time__day, subq_17.metric_time__day) AS metric_time__day
       , MAX(subq_6.bookings) AS bookings
-      , MAX(subq_18.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+      , MAX(subq_17.bookings_2_weeks_ago) AS bookings_2_weeks_ago
     FROM (
       -- Compute Metrics via Expressions
       SELECT
@@ -266,40 +266,40 @@ FROM (
     FULL OUTER JOIN (
       -- Compute Metrics via Expressions
       SELECT
-        subq_17.metric_time__day
-        , subq_17.__bookings AS bookings_2_weeks_ago
+        subq_16.metric_time__day
+        , subq_16.__bookings AS bookings_2_weeks_ago
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_16.metric_time__day AS metric_time__day
-          , subq_11.__bookings AS __bookings
+          subq_15.metric_time__day AS metric_time__day
+          , subq_10.__bookings AS __bookings
         FROM (
           -- Select: ['metric_time__day']
           SELECT
-            subq_15.metric_time__day
+            subq_14.metric_time__day
           FROM (
             -- Constrain Output with WHERE
             SELECT
-              subq_14.metric_time__day
+              subq_13.metric_time__day
             FROM (
               -- Select: ['metric_time__day']
               SELECT
-                subq_13.metric_time__day
+                subq_12.metric_time__day
               FROM (
                 -- Change Column Aliases
                 SELECT
-                  subq_12.ds__day AS metric_time__day
-                  , subq_12.ds__week
-                  , subq_12.ds__month
-                  , subq_12.ds__quarter
-                  , subq_12.ds__year
-                  , subq_12.ds__extract_year
-                  , subq_12.ds__extract_quarter
-                  , subq_12.ds__extract_month
-                  , subq_12.ds__extract_day
-                  , subq_12.ds__extract_dow
-                  , subq_12.ds__extract_doy
-                  , subq_12.ds__alien_day
+                  subq_11.ds__day AS metric_time__day
+                  , subq_11.ds__week
+                  , subq_11.ds__month
+                  , subq_11.ds__quarter
+                  , subq_11.ds__year
+                  , subq_11.ds__extract_year
+                  , subq_11.ds__extract_quarter
+                  , subq_11.ds__extract_month
+                  , subq_11.ds__extract_day
+                  , subq_11.ds__extract_dow
+                  , subq_11.ds__extract_doy
+                  , subq_11.ds__alien_day
                 FROM (
                   -- Read From Time Spine 'mf_time_spine'
                   SELECT
@@ -316,259 +316,252 @@ FROM (
                     , EXTRACT(doy FROM time_spine_src_28006.ds) AS ds__extract_doy
                     , time_spine_src_28006.alien_day AS ds__alien_day
                   FROM ***************************.mf_time_spine time_spine_src_28006
-                ) subq_12
-              ) subq_13
-            ) subq_14
+                ) subq_11
+              ) subq_12
+            ) subq_13
             WHERE metric_time__day = '2020-01-01' or metric_time__day = '2020-01-14'
-          ) subq_15
-        ) subq_16
+          ) subq_14
+        ) subq_15
         INNER JOIN (
           -- Aggregate Inputs for Simple Metrics
           SELECT
-            subq_10.metric_time__day
-            , SUM(subq_10.__bookings) AS __bookings
+            subq_9.metric_time__day
+            , SUM(subq_9.__bookings) AS __bookings
           FROM (
             -- Select: ['__bookings', 'metric_time__day']
             SELECT
-              subq_9.metric_time__day
-              , subq_9.__bookings
+              subq_8.metric_time__day
+              , subq_8.__bookings
             FROM (
-              -- Constrain Output with WHERE
+              -- Select: ['__bookings', 'metric_time__day']
               SELECT
-                subq_8.bookings AS __bookings
-                , subq_8.metric_time__day
+                subq_7.metric_time__day
+                , subq_7.__bookings
               FROM (
-                -- Select: ['__bookings', 'metric_time__day']
+                -- Metric Time Dimension 'ds'
                 SELECT
-                  subq_7.metric_time__day
-                  , subq_7.__bookings AS bookings
+                  subq_0.ds__day
+                  , subq_0.ds__week
+                  , subq_0.ds__month
+                  , subq_0.ds__quarter
+                  , subq_0.ds__year
+                  , subq_0.ds__extract_year
+                  , subq_0.ds__extract_quarter
+                  , subq_0.ds__extract_month
+                  , subq_0.ds__extract_day
+                  , subq_0.ds__extract_dow
+                  , subq_0.ds__extract_doy
+                  , subq_0.ds_partitioned__day
+                  , subq_0.ds_partitioned__week
+                  , subq_0.ds_partitioned__month
+                  , subq_0.ds_partitioned__quarter
+                  , subq_0.ds_partitioned__year
+                  , subq_0.ds_partitioned__extract_year
+                  , subq_0.ds_partitioned__extract_quarter
+                  , subq_0.ds_partitioned__extract_month
+                  , subq_0.ds_partitioned__extract_day
+                  , subq_0.ds_partitioned__extract_dow
+                  , subq_0.ds_partitioned__extract_doy
+                  , subq_0.paid_at__day
+                  , subq_0.paid_at__week
+                  , subq_0.paid_at__month
+                  , subq_0.paid_at__quarter
+                  , subq_0.paid_at__year
+                  , subq_0.paid_at__extract_year
+                  , subq_0.paid_at__extract_quarter
+                  , subq_0.paid_at__extract_month
+                  , subq_0.paid_at__extract_day
+                  , subq_0.paid_at__extract_dow
+                  , subq_0.paid_at__extract_doy
+                  , subq_0.booking__ds__day
+                  , subq_0.booking__ds__week
+                  , subq_0.booking__ds__month
+                  , subq_0.booking__ds__quarter
+                  , subq_0.booking__ds__year
+                  , subq_0.booking__ds__extract_year
+                  , subq_0.booking__ds__extract_quarter
+                  , subq_0.booking__ds__extract_month
+                  , subq_0.booking__ds__extract_day
+                  , subq_0.booking__ds__extract_dow
+                  , subq_0.booking__ds__extract_doy
+                  , subq_0.booking__ds_partitioned__day
+                  , subq_0.booking__ds_partitioned__week
+                  , subq_0.booking__ds_partitioned__month
+                  , subq_0.booking__ds_partitioned__quarter
+                  , subq_0.booking__ds_partitioned__year
+                  , subq_0.booking__ds_partitioned__extract_year
+                  , subq_0.booking__ds_partitioned__extract_quarter
+                  , subq_0.booking__ds_partitioned__extract_month
+                  , subq_0.booking__ds_partitioned__extract_day
+                  , subq_0.booking__ds_partitioned__extract_dow
+                  , subq_0.booking__ds_partitioned__extract_doy
+                  , subq_0.booking__paid_at__day
+                  , subq_0.booking__paid_at__week
+                  , subq_0.booking__paid_at__month
+                  , subq_0.booking__paid_at__quarter
+                  , subq_0.booking__paid_at__year
+                  , subq_0.booking__paid_at__extract_year
+                  , subq_0.booking__paid_at__extract_quarter
+                  , subq_0.booking__paid_at__extract_month
+                  , subq_0.booking__paid_at__extract_day
+                  , subq_0.booking__paid_at__extract_dow
+                  , subq_0.booking__paid_at__extract_doy
+                  , subq_0.ds__day AS metric_time__day
+                  , subq_0.ds__week AS metric_time__week
+                  , subq_0.ds__month AS metric_time__month
+                  , subq_0.ds__quarter AS metric_time__quarter
+                  , subq_0.ds__year AS metric_time__year
+                  , subq_0.ds__extract_year AS metric_time__extract_year
+                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_0.ds__extract_month AS metric_time__extract_month
+                  , subq_0.ds__extract_day AS metric_time__extract_day
+                  , subq_0.ds__extract_dow AS metric_time__extract_dow
+                  , subq_0.ds__extract_doy AS metric_time__extract_doy
+                  , subq_0.listing
+                  , subq_0.guest
+                  , subq_0.host
+                  , subq_0.booking__listing
+                  , subq_0.booking__guest
+                  , subq_0.booking__host
+                  , subq_0.is_instant
+                  , subq_0.booking__is_instant
+                  , subq_0.__bookings
+                  , subq_0.__average_booking_value
+                  , subq_0.__instant_bookings
+                  , subq_0.__booking_value
+                  , subq_0.__max_booking_value
+                  , subq_0.__min_booking_value
+                  , subq_0.__instant_booking_value
+                  , subq_0.__average_instant_booking_value
+                  , subq_0.__booking_value_for_non_null_listing_id
+                  , subq_0.__bookers
+                  , subq_0.__referred_bookings
+                  , subq_0.__median_booking_value
+                  , subq_0.__booking_value_p99
+                  , subq_0.__discrete_booking_value_p99
+                  , subq_0.__approximate_continuous_booking_value_p99
+                  , subq_0.__approximate_discrete_booking_value_p99
+                  , subq_0.__bookings_join_to_time_spine
+                  , subq_0.__bookings_fill_nulls_with_0_without_time_spine
+                  , subq_0.__bookings_fill_nulls_with_0
+                  , subq_0.__instant_bookings_with_measure_filter
+                  , subq_0.__bookings_join_to_time_spine_with_tiered_filters
+                  , subq_0.__bookers_fill_nulls_with_0_join_to_timespine
                 FROM (
-                  -- Metric Time Dimension 'ds'
+                  -- Read Elements From Semantic Model 'bookings_source'
                   SELECT
-                    subq_0.ds__day
-                    , subq_0.ds__week
-                    , subq_0.ds__month
-                    , subq_0.ds__quarter
-                    , subq_0.ds__year
-                    , subq_0.ds__extract_year
-                    , subq_0.ds__extract_quarter
-                    , subq_0.ds__extract_month
-                    , subq_0.ds__extract_day
-                    , subq_0.ds__extract_dow
-                    , subq_0.ds__extract_doy
-                    , subq_0.ds_partitioned__day
-                    , subq_0.ds_partitioned__week
-                    , subq_0.ds_partitioned__month
-                    , subq_0.ds_partitioned__quarter
-                    , subq_0.ds_partitioned__year
-                    , subq_0.ds_partitioned__extract_year
-                    , subq_0.ds_partitioned__extract_quarter
-                    , subq_0.ds_partitioned__extract_month
-                    , subq_0.ds_partitioned__extract_day
-                    , subq_0.ds_partitioned__extract_dow
-                    , subq_0.ds_partitioned__extract_doy
-                    , subq_0.paid_at__day
-                    , subq_0.paid_at__week
-                    , subq_0.paid_at__month
-                    , subq_0.paid_at__quarter
-                    , subq_0.paid_at__year
-                    , subq_0.paid_at__extract_year
-                    , subq_0.paid_at__extract_quarter
-                    , subq_0.paid_at__extract_month
-                    , subq_0.paid_at__extract_day
-                    , subq_0.paid_at__extract_dow
-                    , subq_0.paid_at__extract_doy
-                    , subq_0.booking__ds__day
-                    , subq_0.booking__ds__week
-                    , subq_0.booking__ds__month
-                    , subq_0.booking__ds__quarter
-                    , subq_0.booking__ds__year
-                    , subq_0.booking__ds__extract_year
-                    , subq_0.booking__ds__extract_quarter
-                    , subq_0.booking__ds__extract_month
-                    , subq_0.booking__ds__extract_day
-                    , subq_0.booking__ds__extract_dow
-                    , subq_0.booking__ds__extract_doy
-                    , subq_0.booking__ds_partitioned__day
-                    , subq_0.booking__ds_partitioned__week
-                    , subq_0.booking__ds_partitioned__month
-                    , subq_0.booking__ds_partitioned__quarter
-                    , subq_0.booking__ds_partitioned__year
-                    , subq_0.booking__ds_partitioned__extract_year
-                    , subq_0.booking__ds_partitioned__extract_quarter
-                    , subq_0.booking__ds_partitioned__extract_month
-                    , subq_0.booking__ds_partitioned__extract_day
-                    , subq_0.booking__ds_partitioned__extract_dow
-                    , subq_0.booking__ds_partitioned__extract_doy
-                    , subq_0.booking__paid_at__day
-                    , subq_0.booking__paid_at__week
-                    , subq_0.booking__paid_at__month
-                    , subq_0.booking__paid_at__quarter
-                    , subq_0.booking__paid_at__year
-                    , subq_0.booking__paid_at__extract_year
-                    , subq_0.booking__paid_at__extract_quarter
-                    , subq_0.booking__paid_at__extract_month
-                    , subq_0.booking__paid_at__extract_day
-                    , subq_0.booking__paid_at__extract_dow
-                    , subq_0.booking__paid_at__extract_doy
-                    , subq_0.ds__day AS metric_time__day
-                    , subq_0.ds__week AS metric_time__week
-                    , subq_0.ds__month AS metric_time__month
-                    , subq_0.ds__quarter AS metric_time__quarter
-                    , subq_0.ds__year AS metric_time__year
-                    , subq_0.ds__extract_year AS metric_time__extract_year
-                    , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                    , subq_0.ds__extract_month AS metric_time__extract_month
-                    , subq_0.ds__extract_day AS metric_time__extract_day
-                    , subq_0.ds__extract_dow AS metric_time__extract_dow
-                    , subq_0.ds__extract_doy AS metric_time__extract_doy
-                    , subq_0.listing
-                    , subq_0.guest
-                    , subq_0.host
-                    , subq_0.booking__listing
-                    , subq_0.booking__guest
-                    , subq_0.booking__host
-                    , subq_0.is_instant
-                    , subq_0.booking__is_instant
-                    , subq_0.__bookings
-                    , subq_0.__average_booking_value
-                    , subq_0.__instant_bookings
-                    , subq_0.__booking_value
-                    , subq_0.__max_booking_value
-                    , subq_0.__min_booking_value
-                    , subq_0.__instant_booking_value
-                    , subq_0.__average_instant_booking_value
-                    , subq_0.__booking_value_for_non_null_listing_id
-                    , subq_0.__bookers
-                    , subq_0.__referred_bookings
-                    , subq_0.__median_booking_value
-                    , subq_0.__booking_value_p99
-                    , subq_0.__discrete_booking_value_p99
-                    , subq_0.__approximate_continuous_booking_value_p99
-                    , subq_0.__approximate_discrete_booking_value_p99
-                    , subq_0.__bookings_join_to_time_spine
-                    , subq_0.__bookings_fill_nulls_with_0_without_time_spine
-                    , subq_0.__bookings_fill_nulls_with_0
-                    , subq_0.__instant_bookings_with_measure_filter
-                    , subq_0.__bookings_join_to_time_spine_with_tiered_filters
-                    , subq_0.__bookers_fill_nulls_with_0_join_to_timespine
-                  FROM (
-                    -- Read Elements From Semantic Model 'bookings_source'
-                    SELECT
-                      1 AS __bookings
-                      , bookings_source_src_28000.booking_value AS __average_booking_value
-                      , CASE WHEN is_instant THEN 1 ELSE 0 END AS __instant_bookings
-                      , bookings_source_src_28000.booking_value AS __booking_value
-                      , bookings_source_src_28000.booking_value AS __max_booking_value
-                      , bookings_source_src_28000.booking_value AS __min_booking_value
-                      , bookings_source_src_28000.booking_value AS __instant_booking_value
-                      , bookings_source_src_28000.booking_value AS __average_instant_booking_value
-                      , bookings_source_src_28000.booking_value AS __booking_value_for_non_null_listing_id
-                      , bookings_source_src_28000.guest_id AS __bookers
-                      , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS __referred_bookings
-                      , bookings_source_src_28000.booking_value AS __median_booking_value
-                      , bookings_source_src_28000.booking_value AS __booking_value_p99
-                      , bookings_source_src_28000.booking_value AS __discrete_booking_value_p99
-                      , bookings_source_src_28000.booking_value AS __approximate_continuous_booking_value_p99
-                      , bookings_source_src_28000.booking_value AS __approximate_discrete_booking_value_p99
-                      , 1 AS __bookings_join_to_time_spine
-                      , 1 AS __bookings_fill_nulls_with_0_without_time_spine
-                      , 1 AS __bookings_fill_nulls_with_0
-                      , 1 AS __instant_bookings_with_measure_filter
-                      , 1 AS __bookings_join_to_time_spine_with_tiered_filters
-                      , bookings_source_src_28000.guest_id AS __bookers_fill_nulls_with_0_join_to_timespine
-                      , bookings_source_src_28000.booking_value AS __booking_payments
-                      , bookings_source_src_28000.is_instant
-                      , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                      , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                      , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                      , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                      , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                      , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                      , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                      , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                      , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                      , bookings_source_src_28000.is_instant AS booking__is_instant
-                      , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                      , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                      , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                      , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                      , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                      , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                      , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                      , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                      , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                      , bookings_source_src_28000.listing_id AS listing
-                      , bookings_source_src_28000.guest_id AS guest
-                      , bookings_source_src_28000.host_id AS host
-                      , bookings_source_src_28000.listing_id AS booking__listing
-                      , bookings_source_src_28000.guest_id AS booking__guest
-                      , bookings_source_src_28000.host_id AS booking__host
-                    FROM ***************************.fct_bookings bookings_source_src_28000
-                  ) subq_0
-                ) subq_7
-              ) subq_8
-              WHERE metric_time__day = '2020-01-01' or metric_time__day = '2020-01-14'
-            ) subq_9
-          ) subq_10
+                    1 AS __bookings
+                    , bookings_source_src_28000.booking_value AS __average_booking_value
+                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS __instant_bookings
+                    , bookings_source_src_28000.booking_value AS __booking_value
+                    , bookings_source_src_28000.booking_value AS __max_booking_value
+                    , bookings_source_src_28000.booking_value AS __min_booking_value
+                    , bookings_source_src_28000.booking_value AS __instant_booking_value
+                    , bookings_source_src_28000.booking_value AS __average_instant_booking_value
+                    , bookings_source_src_28000.booking_value AS __booking_value_for_non_null_listing_id
+                    , bookings_source_src_28000.guest_id AS __bookers
+                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS __referred_bookings
+                    , bookings_source_src_28000.booking_value AS __median_booking_value
+                    , bookings_source_src_28000.booking_value AS __booking_value_p99
+                    , bookings_source_src_28000.booking_value AS __discrete_booking_value_p99
+                    , bookings_source_src_28000.booking_value AS __approximate_continuous_booking_value_p99
+                    , bookings_source_src_28000.booking_value AS __approximate_discrete_booking_value_p99
+                    , 1 AS __bookings_join_to_time_spine
+                    , 1 AS __bookings_fill_nulls_with_0_without_time_spine
+                    , 1 AS __bookings_fill_nulls_with_0
+                    , 1 AS __instant_bookings_with_measure_filter
+                    , 1 AS __bookings_join_to_time_spine_with_tiered_filters
+                    , bookings_source_src_28000.guest_id AS __bookers_fill_nulls_with_0_join_to_timespine
+                    , bookings_source_src_28000.booking_value AS __booking_payments
+                    , bookings_source_src_28000.is_instant
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                    , bookings_source_src_28000.is_instant AS booking__is_instant
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                    , bookings_source_src_28000.listing_id AS listing
+                    , bookings_source_src_28000.guest_id AS guest
+                    , bookings_source_src_28000.host_id AS host
+                    , bookings_source_src_28000.listing_id AS booking__listing
+                    , bookings_source_src_28000.guest_id AS booking__guest
+                    , bookings_source_src_28000.host_id AS booking__host
+                  FROM ***************************.fct_bookings bookings_source_src_28000
+                ) subq_0
+              ) subq_7
+            ) subq_8
+          ) subq_9
           GROUP BY
-            subq_10.metric_time__day
-        ) subq_11
+            subq_9.metric_time__day
+        ) subq_10
         ON
-          subq_16.metric_time__day - MAKE_INTERVAL(days => 14) = subq_11.metric_time__day
-      ) subq_17
-    ) subq_18
+          subq_15.metric_time__day - MAKE_INTERVAL(days => 14) = subq_10.metric_time__day
+      ) subq_16
+    ) subq_17
     ON
-      subq_6.metric_time__day = subq_18.metric_time__day
+      subq_6.metric_time__day = subq_17.metric_time__day
     GROUP BY
-      COALESCE(subq_6.metric_time__day, subq_18.metric_time__day)
-  ) subq_19
-) subq_20
+      COALESCE(subq_6.metric_time__day, subq_17.metric_time__day)
+  ) subq_18
+) subq_19

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_derived_metric_with_offset_window_and_time_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_derived_metric_with_offset_window_and_time_filter__plan0_optimized.sql
@@ -19,9 +19,9 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_27.metric_time__day, subq_39.metric_time__day) AS metric_time__day
-    , MAX(subq_27.bookings) AS bookings
-    , MAX(subq_39.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+    COALESCE(subq_26.metric_time__day, subq_37.metric_time__day) AS metric_time__day
+    , MAX(subq_26.bookings) AS bookings
+    , MAX(subq_37.bookings_2_weeks_ago) AS bookings_2_weeks_ago
   FROM (
     -- Constrain Output with WHERE
     -- Select: ['__bookings', 'metric_time__day']
@@ -37,17 +37,17 @@ FROM (
         metric_time__day
         , __bookings AS bookings
       FROM sma_28009_cte
-    ) subq_23
+    ) subq_22
     WHERE metric_time__day = '2020-01-01' or metric_time__day = '2020-01-14'
     GROUP BY
       metric_time__day
-  ) subq_27
+  ) subq_26
   FULL OUTER JOIN (
     -- Join to Time Spine Dataset
     -- Compute Metrics via Expressions
     SELECT
-      subq_37.metric_time__day AS metric_time__day
-      , subq_32.__bookings AS bookings_2_weeks_ago
+      subq_35.metric_time__day AS metric_time__day
+      , subq_30.__bookings AS bookings_2_weeks_ago
     FROM (
       -- Constrain Output with WHERE
       -- Select: ['metric_time__day']
@@ -60,33 +60,26 @@ FROM (
         SELECT
           ds AS metric_time__day
         FROM ***************************.mf_time_spine time_spine_src_28006
-      ) subq_35
+      ) subq_33
       WHERE metric_time__day = '2020-01-01' or metric_time__day = '2020-01-14'
-    ) subq_37
+    ) subq_35
     INNER JOIN (
-      -- Constrain Output with WHERE
+      -- Read From CTE For node_id=sma_28009
+      -- Select: ['__bookings', 'metric_time__day']
       -- Select: ['__bookings', 'metric_time__day']
       -- Aggregate Inputs for Simple Metrics
       SELECT
         metric_time__day
-        , SUM(bookings) AS __bookings
-      FROM (
-        -- Read From CTE For node_id=sma_28009
-        -- Select: ['__bookings', 'metric_time__day']
-        SELECT
-          metric_time__day
-          , __bookings AS bookings
-        FROM sma_28009_cte
-      ) subq_29
-      WHERE metric_time__day = '2020-01-01' or metric_time__day = '2020-01-14'
+        , SUM(__bookings) AS __bookings
+      FROM sma_28009_cte
       GROUP BY
         metric_time__day
-    ) subq_32
+    ) subq_30
     ON
-      subq_37.metric_time__day - MAKE_INTERVAL(days => 14) = subq_32.metric_time__day
-  ) subq_39
+      subq_35.metric_time__day - MAKE_INTERVAL(days => 14) = subq_30.metric_time__day
+  ) subq_37
   ON
-    subq_27.metric_time__day = subq_39.metric_time__day
+    subq_26.metric_time__day = subq_37.metric_time__day
   GROUP BY
-    COALESCE(subq_27.metric_time__day, subq_39.metric_time__day)
-) subq_40
+    COALESCE(subq_26.metric_time__day, subq_37.metric_time__day)
+) subq_38

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0.sql
@@ -6,52 +6,52 @@ sql_engine: Postgres
 ---
 -- Write to DataTable
 SELECT
-  subq_13.metric_time__month
-  , subq_13.bookings_at_start_of_month
+  subq_12.metric_time__month
+  , subq_12.bookings_at_start_of_month
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_12.metric_time__month
+    subq_11.metric_time__month
     , bookings_start_of_month AS bookings_at_start_of_month
   FROM (
     -- Compute Metrics via Expressions
     SELECT
-      subq_11.metric_time__month
-      , subq_11.__bookings AS bookings_start_of_month
+      subq_10.metric_time__month
+      , subq_10.__bookings AS bookings_start_of_month
     FROM (
       -- Join to Time Spine Dataset
       SELECT
-        subq_10.metric_time__month AS metric_time__month
-        , subq_5.__bookings AS __bookings
+        subq_9.metric_time__month AS metric_time__month
+        , subq_4.__bookings AS __bookings
       FROM (
         -- Select: ['metric_time__month']
         SELECT
-          subq_9.metric_time__month
+          subq_8.metric_time__month
         FROM (
           -- Constrain Output with WHERE
           SELECT
-            subq_8.metric_time__day
-            , subq_8.metric_time__month
+            subq_7.metric_time__day
+            , subq_7.metric_time__month
           FROM (
             -- Select: ['metric_time__month', 'metric_time__day']
             SELECT
-              subq_7.metric_time__day
-              , subq_7.metric_time__month
+              subq_6.metric_time__day
+              , subq_6.metric_time__month
             FROM (
               -- Change Column Aliases
               SELECT
-                subq_6.ds__day AS metric_time__day
-                , subq_6.ds__week
-                , subq_6.ds__month AS metric_time__month
-                , subq_6.ds__quarter
-                , subq_6.ds__year
-                , subq_6.ds__extract_year
-                , subq_6.ds__extract_quarter
-                , subq_6.ds__extract_month
-                , subq_6.ds__extract_day
-                , subq_6.ds__extract_dow
-                , subq_6.ds__extract_doy
-                , subq_6.ds__alien_day
+                subq_5.ds__day AS metric_time__day
+                , subq_5.ds__week
+                , subq_5.ds__month AS metric_time__month
+                , subq_5.ds__quarter
+                , subq_5.ds__year
+                , subq_5.ds__extract_year
+                , subq_5.ds__extract_quarter
+                , subq_5.ds__extract_month
+                , subq_5.ds__extract_day
+                , subq_5.ds__extract_dow
+                , subq_5.ds__extract_doy
+                , subq_5.ds__alien_day
               FROM (
                 -- Read From Time Spine 'mf_time_spine'
                 SELECT
@@ -68,258 +68,249 @@ FROM (
                   , EXTRACT(doy FROM time_spine_src_28006.ds) AS ds__extract_doy
                   , time_spine_src_28006.alien_day AS ds__alien_day
                 FROM ***************************.mf_time_spine time_spine_src_28006
-              ) subq_6
-            ) subq_7
-          ) subq_8
+              ) subq_5
+            ) subq_6
+          ) subq_7
           WHERE metric_time__day = '2020-01-01'
-        ) subq_9
+        ) subq_8
         GROUP BY
-          subq_9.metric_time__month
-      ) subq_10
+          subq_8.metric_time__month
+      ) subq_9
       INNER JOIN (
         -- Aggregate Inputs for Simple Metrics
         SELECT
-          subq_4.metric_time__month
-          , SUM(subq_4.__bookings) AS __bookings
+          subq_3.metric_time__month
+          , SUM(subq_3.__bookings) AS __bookings
         FROM (
           -- Select: ['__bookings', 'metric_time__month']
           SELECT
-            subq_3.metric_time__month
-            , subq_3.__bookings
+            subq_2.metric_time__month
+            , subq_2.__bookings
           FROM (
-            -- Constrain Output with WHERE
+            -- Select: ['__bookings', 'metric_time__month']
             SELECT
-              subq_2.bookings AS __bookings
-              , subq_2.metric_time__day
-              , subq_2.metric_time__month
+              subq_1.metric_time__month
+              , subq_1.__bookings
             FROM (
-              -- Select: ['__bookings', 'metric_time__month', 'metric_time__day']
+              -- Metric Time Dimension 'ds'
               SELECT
-                subq_1.metric_time__day
-                , subq_1.metric_time__month
-                , subq_1.__bookings AS bookings
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.__bookings
+                , subq_0.__average_booking_value
+                , subq_0.__instant_bookings
+                , subq_0.__booking_value
+                , subq_0.__max_booking_value
+                , subq_0.__min_booking_value
+                , subq_0.__instant_booking_value
+                , subq_0.__average_instant_booking_value
+                , subq_0.__booking_value_for_non_null_listing_id
+                , subq_0.__bookers
+                , subq_0.__referred_bookings
+                , subq_0.__median_booking_value
+                , subq_0.__booking_value_p99
+                , subq_0.__discrete_booking_value_p99
+                , subq_0.__approximate_continuous_booking_value_p99
+                , subq_0.__approximate_discrete_booking_value_p99
+                , subq_0.__bookings_join_to_time_spine
+                , subq_0.__bookings_fill_nulls_with_0_without_time_spine
+                , subq_0.__bookings_fill_nulls_with_0
+                , subq_0.__instant_bookings_with_measure_filter
+                , subq_0.__bookings_join_to_time_spine_with_tiered_filters
+                , subq_0.__bookers_fill_nulls_with_0_join_to_timespine
               FROM (
-                -- Metric Time Dimension 'ds'
+                -- Read Elements From Semantic Model 'bookings_source'
                 SELECT
-                  subq_0.ds__day
-                  , subq_0.ds__week
-                  , subq_0.ds__month
-                  , subq_0.ds__quarter
-                  , subq_0.ds__year
-                  , subq_0.ds__extract_year
-                  , subq_0.ds__extract_quarter
-                  , subq_0.ds__extract_month
-                  , subq_0.ds__extract_day
-                  , subq_0.ds__extract_dow
-                  , subq_0.ds__extract_doy
-                  , subq_0.ds_partitioned__day
-                  , subq_0.ds_partitioned__week
-                  , subq_0.ds_partitioned__month
-                  , subq_0.ds_partitioned__quarter
-                  , subq_0.ds_partitioned__year
-                  , subq_0.ds_partitioned__extract_year
-                  , subq_0.ds_partitioned__extract_quarter
-                  , subq_0.ds_partitioned__extract_month
-                  , subq_0.ds_partitioned__extract_day
-                  , subq_0.ds_partitioned__extract_dow
-                  , subq_0.ds_partitioned__extract_doy
-                  , subq_0.paid_at__day
-                  , subq_0.paid_at__week
-                  , subq_0.paid_at__month
-                  , subq_0.paid_at__quarter
-                  , subq_0.paid_at__year
-                  , subq_0.paid_at__extract_year
-                  , subq_0.paid_at__extract_quarter
-                  , subq_0.paid_at__extract_month
-                  , subq_0.paid_at__extract_day
-                  , subq_0.paid_at__extract_dow
-                  , subq_0.paid_at__extract_doy
-                  , subq_0.booking__ds__day
-                  , subq_0.booking__ds__week
-                  , subq_0.booking__ds__month
-                  , subq_0.booking__ds__quarter
-                  , subq_0.booking__ds__year
-                  , subq_0.booking__ds__extract_year
-                  , subq_0.booking__ds__extract_quarter
-                  , subq_0.booking__ds__extract_month
-                  , subq_0.booking__ds__extract_day
-                  , subq_0.booking__ds__extract_dow
-                  , subq_0.booking__ds__extract_doy
-                  , subq_0.booking__ds_partitioned__day
-                  , subq_0.booking__ds_partitioned__week
-                  , subq_0.booking__ds_partitioned__month
-                  , subq_0.booking__ds_partitioned__quarter
-                  , subq_0.booking__ds_partitioned__year
-                  , subq_0.booking__ds_partitioned__extract_year
-                  , subq_0.booking__ds_partitioned__extract_quarter
-                  , subq_0.booking__ds_partitioned__extract_month
-                  , subq_0.booking__ds_partitioned__extract_day
-                  , subq_0.booking__ds_partitioned__extract_dow
-                  , subq_0.booking__ds_partitioned__extract_doy
-                  , subq_0.booking__paid_at__day
-                  , subq_0.booking__paid_at__week
-                  , subq_0.booking__paid_at__month
-                  , subq_0.booking__paid_at__quarter
-                  , subq_0.booking__paid_at__year
-                  , subq_0.booking__paid_at__extract_year
-                  , subq_0.booking__paid_at__extract_quarter
-                  , subq_0.booking__paid_at__extract_month
-                  , subq_0.booking__paid_at__extract_day
-                  , subq_0.booking__paid_at__extract_dow
-                  , subq_0.booking__paid_at__extract_doy
-                  , subq_0.ds__day AS metric_time__day
-                  , subq_0.ds__week AS metric_time__week
-                  , subq_0.ds__month AS metric_time__month
-                  , subq_0.ds__quarter AS metric_time__quarter
-                  , subq_0.ds__year AS metric_time__year
-                  , subq_0.ds__extract_year AS metric_time__extract_year
-                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_0.ds__extract_month AS metric_time__extract_month
-                  , subq_0.ds__extract_day AS metric_time__extract_day
-                  , subq_0.ds__extract_dow AS metric_time__extract_dow
-                  , subq_0.ds__extract_doy AS metric_time__extract_doy
-                  , subq_0.listing
-                  , subq_0.guest
-                  , subq_0.host
-                  , subq_0.booking__listing
-                  , subq_0.booking__guest
-                  , subq_0.booking__host
-                  , subq_0.is_instant
-                  , subq_0.booking__is_instant
-                  , subq_0.__bookings
-                  , subq_0.__average_booking_value
-                  , subq_0.__instant_bookings
-                  , subq_0.__booking_value
-                  , subq_0.__max_booking_value
-                  , subq_0.__min_booking_value
-                  , subq_0.__instant_booking_value
-                  , subq_0.__average_instant_booking_value
-                  , subq_0.__booking_value_for_non_null_listing_id
-                  , subq_0.__bookers
-                  , subq_0.__referred_bookings
-                  , subq_0.__median_booking_value
-                  , subq_0.__booking_value_p99
-                  , subq_0.__discrete_booking_value_p99
-                  , subq_0.__approximate_continuous_booking_value_p99
-                  , subq_0.__approximate_discrete_booking_value_p99
-                  , subq_0.__bookings_join_to_time_spine
-                  , subq_0.__bookings_fill_nulls_with_0_without_time_spine
-                  , subq_0.__bookings_fill_nulls_with_0
-                  , subq_0.__instant_bookings_with_measure_filter
-                  , subq_0.__bookings_join_to_time_spine_with_tiered_filters
-                  , subq_0.__bookers_fill_nulls_with_0_join_to_timespine
-                FROM (
-                  -- Read Elements From Semantic Model 'bookings_source'
-                  SELECT
-                    1 AS __bookings
-                    , bookings_source_src_28000.booking_value AS __average_booking_value
-                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS __instant_bookings
-                    , bookings_source_src_28000.booking_value AS __booking_value
-                    , bookings_source_src_28000.booking_value AS __max_booking_value
-                    , bookings_source_src_28000.booking_value AS __min_booking_value
-                    , bookings_source_src_28000.booking_value AS __instant_booking_value
-                    , bookings_source_src_28000.booking_value AS __average_instant_booking_value
-                    , bookings_source_src_28000.booking_value AS __booking_value_for_non_null_listing_id
-                    , bookings_source_src_28000.guest_id AS __bookers
-                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS __referred_bookings
-                    , bookings_source_src_28000.booking_value AS __median_booking_value
-                    , bookings_source_src_28000.booking_value AS __booking_value_p99
-                    , bookings_source_src_28000.booking_value AS __discrete_booking_value_p99
-                    , bookings_source_src_28000.booking_value AS __approximate_continuous_booking_value_p99
-                    , bookings_source_src_28000.booking_value AS __approximate_discrete_booking_value_p99
-                    , 1 AS __bookings_join_to_time_spine
-                    , 1 AS __bookings_fill_nulls_with_0_without_time_spine
-                    , 1 AS __bookings_fill_nulls_with_0
-                    , 1 AS __instant_bookings_with_measure_filter
-                    , 1 AS __bookings_join_to_time_spine_with_tiered_filters
-                    , bookings_source_src_28000.guest_id AS __bookers_fill_nulls_with_0_join_to_timespine
-                    , bookings_source_src_28000.booking_value AS __booking_payments
-                    , bookings_source_src_28000.is_instant
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                    , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                    , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                    , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                    , bookings_source_src_28000.is_instant AS booking__is_instant
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                    , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                    , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                    , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                    , bookings_source_src_28000.listing_id AS listing
-                    , bookings_source_src_28000.guest_id AS guest
-                    , bookings_source_src_28000.host_id AS host
-                    , bookings_source_src_28000.listing_id AS booking__listing
-                    , bookings_source_src_28000.guest_id AS booking__guest
-                    , bookings_source_src_28000.host_id AS booking__host
-                  FROM ***************************.fct_bookings bookings_source_src_28000
-                ) subq_0
-              ) subq_1
-            ) subq_2
-            WHERE metric_time__day = '2020-01-01'
-          ) subq_3
-        ) subq_4
+                  1 AS __bookings
+                  , bookings_source_src_28000.booking_value AS __average_booking_value
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS __instant_bookings
+                  , bookings_source_src_28000.booking_value AS __booking_value
+                  , bookings_source_src_28000.booking_value AS __max_booking_value
+                  , bookings_source_src_28000.booking_value AS __min_booking_value
+                  , bookings_source_src_28000.booking_value AS __instant_booking_value
+                  , bookings_source_src_28000.booking_value AS __average_instant_booking_value
+                  , bookings_source_src_28000.booking_value AS __booking_value_for_non_null_listing_id
+                  , bookings_source_src_28000.guest_id AS __bookers
+                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS __referred_bookings
+                  , bookings_source_src_28000.booking_value AS __median_booking_value
+                  , bookings_source_src_28000.booking_value AS __booking_value_p99
+                  , bookings_source_src_28000.booking_value AS __discrete_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS __approximate_continuous_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS __approximate_discrete_booking_value_p99
+                  , 1 AS __bookings_join_to_time_spine
+                  , 1 AS __bookings_fill_nulls_with_0_without_time_spine
+                  , 1 AS __bookings_fill_nulls_with_0
+                  , 1 AS __instant_bookings_with_measure_filter
+                  , 1 AS __bookings_join_to_time_spine_with_tiered_filters
+                  , bookings_source_src_28000.guest_id AS __bookers_fill_nulls_with_0_join_to_timespine
+                  , bookings_source_src_28000.booking_value AS __booking_payments
+                  , bookings_source_src_28000.is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                  , bookings_source_src_28000.is_instant AS booking__is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                  , bookings_source_src_28000.listing_id AS listing
+                  , bookings_source_src_28000.guest_id AS guest
+                  , bookings_source_src_28000.host_id AS host
+                  , bookings_source_src_28000.listing_id AS booking__listing
+                  , bookings_source_src_28000.guest_id AS booking__guest
+                  , bookings_source_src_28000.host_id AS booking__host
+                FROM ***************************.fct_bookings bookings_source_src_28000
+              ) subq_0
+            ) subq_1
+          ) subq_2
+        ) subq_3
         GROUP BY
-          subq_4.metric_time__month
-      ) subq_5
+          subq_3.metric_time__month
+      ) subq_4
       ON
-        DATE_TRUNC('month', subq_10.metric_time__month) = subq_5.metric_time__month
-    ) subq_11
-  ) subq_12
-) subq_13
+        DATE_TRUNC('month', subq_9.metric_time__month) = subq_4.metric_time__month
+    ) subq_10
+  ) subq_11
+) subq_12

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
@@ -13,8 +13,8 @@ FROM (
   -- Join to Time Spine Dataset
   -- Compute Metrics via Expressions
   SELECT
-    subq_24.metric_time__month AS metric_time__month
-    , subq_19.__bookings AS bookings_start_of_month
+    subq_22.metric_time__month AS metric_time__month
+    , subq_17.__bookings AS bookings_start_of_month
   FROM (
     -- Constrain Output with WHERE
     -- Select: ['metric_time__month']
@@ -28,32 +28,29 @@ FROM (
         ds AS metric_time__day
         , DATE_TRUNC('month', ds) AS metric_time__month
       FROM ***************************.mf_time_spine time_spine_src_28006
-    ) subq_22
+    ) subq_20
     WHERE metric_time__day = '2020-01-01'
     GROUP BY
       metric_time__month
-  ) subq_24
+  ) subq_22
   INNER JOIN (
-    -- Constrain Output with WHERE
-    -- Select: ['__bookings', 'metric_time__month']
     -- Aggregate Inputs for Simple Metrics
     SELECT
       metric_time__month
-      , SUM(bookings) AS __bookings
+      , SUM(__bookings) AS __bookings
     FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
-      -- Select: ['__bookings', 'metric_time__month', 'metric_time__day']
+      -- Select: ['__bookings', 'metric_time__month']
+      -- Select: ['__bookings', 'metric_time__month']
       SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , DATE_TRUNC('month', ds) AS metric_time__month
-        , 1 AS bookings
+        DATE_TRUNC('month', ds) AS metric_time__month
+        , 1 AS __bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
     ) subq_16
-    WHERE metric_time__day = '2020-01-01'
     GROUP BY
       metric_time__month
-  ) subq_19
+  ) subq_17
   ON
-    DATE_TRUNC('month', subq_24.metric_time__month) = subq_19.metric_time__month
-) subq_26
+    DATE_TRUNC('month', subq_22.metric_time__month) = subq_17.metric_time__month
+) subq_24

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_offset_window_metric_filter_and_query_have_different_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_offset_window_metric_filter_and_query_have_different_granularities__plan0.sql
@@ -35,129 +35,127 @@ FROM (
             subq_8.metric_time__month
             , subq_8.__booking_value
           FROM (
-            -- Constrain Output with WHERE
+            -- Select: ['__booking_value', 'metric_time__month']
             SELECT
-              subq_7.booking_value AS __booking_value
-              , subq_7.metric_time__day
-              , subq_7.metric_time__month
+              subq_7.metric_time__month
+              , subq_7.__booking_value
             FROM (
-              -- Select: ['__booking_value', 'metric_time__month', 'metric_time__day']
+              -- Join to Time Spine Dataset
               SELECT
-                subq_6.metric_time__day
-                , subq_6.metric_time__month
-                , subq_6.__booking_value AS booking_value
+                subq_6.metric_time__day AS metric_time__day
+                , subq_6.metric_time__month AS metric_time__month
+                , subq_1.ds__day AS ds__day
+                , subq_1.ds__week AS ds__week
+                , subq_1.ds__month AS ds__month
+                , subq_1.ds__quarter AS ds__quarter
+                , subq_1.ds__year AS ds__year
+                , subq_1.ds__extract_year AS ds__extract_year
+                , subq_1.ds__extract_quarter AS ds__extract_quarter
+                , subq_1.ds__extract_month AS ds__extract_month
+                , subq_1.ds__extract_day AS ds__extract_day
+                , subq_1.ds__extract_dow AS ds__extract_dow
+                , subq_1.ds__extract_doy AS ds__extract_doy
+                , subq_1.ds_partitioned__day AS ds_partitioned__day
+                , subq_1.ds_partitioned__week AS ds_partitioned__week
+                , subq_1.ds_partitioned__month AS ds_partitioned__month
+                , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
+                , subq_1.ds_partitioned__year AS ds_partitioned__year
+                , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
+                , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+                , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
+                , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
+                , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+                , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+                , subq_1.paid_at__day AS paid_at__day
+                , subq_1.paid_at__week AS paid_at__week
+                , subq_1.paid_at__month AS paid_at__month
+                , subq_1.paid_at__quarter AS paid_at__quarter
+                , subq_1.paid_at__year AS paid_at__year
+                , subq_1.paid_at__extract_year AS paid_at__extract_year
+                , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
+                , subq_1.paid_at__extract_month AS paid_at__extract_month
+                , subq_1.paid_at__extract_day AS paid_at__extract_day
+                , subq_1.paid_at__extract_dow AS paid_at__extract_dow
+                , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+                , subq_1.booking__ds__day AS booking__ds__day
+                , subq_1.booking__ds__week AS booking__ds__week
+                , subq_1.booking__ds__month AS booking__ds__month
+                , subq_1.booking__ds__quarter AS booking__ds__quarter
+                , subq_1.booking__ds__year AS booking__ds__year
+                , subq_1.booking__ds__extract_year AS booking__ds__extract_year
+                , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
+                , subq_1.booking__ds__extract_month AS booking__ds__extract_month
+                , subq_1.booking__ds__extract_day AS booking__ds__extract_day
+                , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
+                , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
+                , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
+                , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
+                , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
+                , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+                , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
+                , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+                , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+                , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+                , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+                , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+                , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+                , subq_1.booking__paid_at__day AS booking__paid_at__day
+                , subq_1.booking__paid_at__week AS booking__paid_at__week
+                , subq_1.booking__paid_at__month AS booking__paid_at__month
+                , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
+                , subq_1.booking__paid_at__year AS booking__paid_at__year
+                , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
+                , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+                , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
+                , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
+                , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+                , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                , subq_1.metric_time__week AS metric_time__week
+                , subq_1.metric_time__quarter AS metric_time__quarter
+                , subq_1.metric_time__year AS metric_time__year
+                , subq_1.metric_time__extract_year AS metric_time__extract_year
+                , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+                , subq_1.metric_time__extract_month AS metric_time__extract_month
+                , subq_1.metric_time__extract_day AS metric_time__extract_day
+                , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+                , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+                , subq_1.listing AS listing
+                , subq_1.guest AS guest
+                , subq_1.host AS host
+                , subq_1.booking__listing AS booking__listing
+                , subq_1.booking__guest AS booking__guest
+                , subq_1.booking__host AS booking__host
+                , subq_1.is_instant AS is_instant
+                , subq_1.booking__is_instant AS booking__is_instant
+                , subq_1.__bookings AS __bookings
+                , subq_1.__average_booking_value AS __average_booking_value
+                , subq_1.__instant_bookings AS __instant_bookings
+                , subq_1.__booking_value AS __booking_value
+                , subq_1.__max_booking_value AS __max_booking_value
+                , subq_1.__min_booking_value AS __min_booking_value
+                , subq_1.__instant_booking_value AS __instant_booking_value
+                , subq_1.__average_instant_booking_value AS __average_instant_booking_value
+                , subq_1.__booking_value_for_non_null_listing_id AS __booking_value_for_non_null_listing_id
+                , subq_1.__bookers AS __bookers
+                , subq_1.__referred_bookings AS __referred_bookings
+                , subq_1.__median_booking_value AS __median_booking_value
+                , subq_1.__booking_value_p99 AS __booking_value_p99
+                , subq_1.__discrete_booking_value_p99 AS __discrete_booking_value_p99
+                , subq_1.__approximate_continuous_booking_value_p99 AS __approximate_continuous_booking_value_p99
+                , subq_1.__approximate_discrete_booking_value_p99 AS __approximate_discrete_booking_value_p99
+                , subq_1.__bookings_join_to_time_spine AS __bookings_join_to_time_spine
+                , subq_1.__bookings_fill_nulls_with_0_without_time_spine AS __bookings_fill_nulls_with_0_without_time_spine
+                , subq_1.__bookings_fill_nulls_with_0 AS __bookings_fill_nulls_with_0
+                , subq_1.__instant_bookings_with_measure_filter AS __instant_bookings_with_measure_filter
+                , subq_1.__bookings_join_to_time_spine_with_tiered_filters AS __bookings_join_to_time_spine_with_tiered_filters
+                , subq_1.__bookers_fill_nulls_with_0_join_to_timespine AS __bookers_fill_nulls_with_0_join_to_timespine
               FROM (
-                -- Join to Time Spine Dataset
+                -- Select: ['metric_time__day', 'metric_time__month']
                 SELECT
-                  subq_5.metric_time__day AS metric_time__day
-                  , subq_5.metric_time__month AS metric_time__month
-                  , subq_1.ds__day AS ds__day
-                  , subq_1.ds__week AS ds__week
-                  , subq_1.ds__month AS ds__month
-                  , subq_1.ds__quarter AS ds__quarter
-                  , subq_1.ds__year AS ds__year
-                  , subq_1.ds__extract_year AS ds__extract_year
-                  , subq_1.ds__extract_quarter AS ds__extract_quarter
-                  , subq_1.ds__extract_month AS ds__extract_month
-                  , subq_1.ds__extract_day AS ds__extract_day
-                  , subq_1.ds__extract_dow AS ds__extract_dow
-                  , subq_1.ds__extract_doy AS ds__extract_doy
-                  , subq_1.ds_partitioned__day AS ds_partitioned__day
-                  , subq_1.ds_partitioned__week AS ds_partitioned__week
-                  , subq_1.ds_partitioned__month AS ds_partitioned__month
-                  , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
-                  , subq_1.ds_partitioned__year AS ds_partitioned__year
-                  , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
-                  , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
-                  , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
-                  , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
-                  , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
-                  , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
-                  , subq_1.paid_at__day AS paid_at__day
-                  , subq_1.paid_at__week AS paid_at__week
-                  , subq_1.paid_at__month AS paid_at__month
-                  , subq_1.paid_at__quarter AS paid_at__quarter
-                  , subq_1.paid_at__year AS paid_at__year
-                  , subq_1.paid_at__extract_year AS paid_at__extract_year
-                  , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
-                  , subq_1.paid_at__extract_month AS paid_at__extract_month
-                  , subq_1.paid_at__extract_day AS paid_at__extract_day
-                  , subq_1.paid_at__extract_dow AS paid_at__extract_dow
-                  , subq_1.paid_at__extract_doy AS paid_at__extract_doy
-                  , subq_1.booking__ds__day AS booking__ds__day
-                  , subq_1.booking__ds__week AS booking__ds__week
-                  , subq_1.booking__ds__month AS booking__ds__month
-                  , subq_1.booking__ds__quarter AS booking__ds__quarter
-                  , subq_1.booking__ds__year AS booking__ds__year
-                  , subq_1.booking__ds__extract_year AS booking__ds__extract_year
-                  , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
-                  , subq_1.booking__ds__extract_month AS booking__ds__extract_month
-                  , subq_1.booking__ds__extract_day AS booking__ds__extract_day
-                  , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
-                  , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
-                  , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
-                  , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
-                  , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
-                  , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
-                  , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
-                  , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
-                  , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
-                  , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
-                  , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
-                  , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
-                  , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
-                  , subq_1.booking__paid_at__day AS booking__paid_at__day
-                  , subq_1.booking__paid_at__week AS booking__paid_at__week
-                  , subq_1.booking__paid_at__month AS booking__paid_at__month
-                  , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
-                  , subq_1.booking__paid_at__year AS booking__paid_at__year
-                  , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
-                  , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
-                  , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
-                  , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
-                  , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
-                  , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
-                  , subq_1.metric_time__week AS metric_time__week
-                  , subq_1.metric_time__quarter AS metric_time__quarter
-                  , subq_1.metric_time__year AS metric_time__year
-                  , subq_1.metric_time__extract_year AS metric_time__extract_year
-                  , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
-                  , subq_1.metric_time__extract_month AS metric_time__extract_month
-                  , subq_1.metric_time__extract_day AS metric_time__extract_day
-                  , subq_1.metric_time__extract_dow AS metric_time__extract_dow
-                  , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-                  , subq_1.listing AS listing
-                  , subq_1.guest AS guest
-                  , subq_1.host AS host
-                  , subq_1.booking__listing AS booking__listing
-                  , subq_1.booking__guest AS booking__guest
-                  , subq_1.booking__host AS booking__host
-                  , subq_1.is_instant AS is_instant
-                  , subq_1.booking__is_instant AS booking__is_instant
-                  , subq_1.__bookings AS __bookings
-                  , subq_1.__average_booking_value AS __average_booking_value
-                  , subq_1.__instant_bookings AS __instant_bookings
-                  , subq_1.__booking_value AS __booking_value
-                  , subq_1.__max_booking_value AS __max_booking_value
-                  , subq_1.__min_booking_value AS __min_booking_value
-                  , subq_1.__instant_booking_value AS __instant_booking_value
-                  , subq_1.__average_instant_booking_value AS __average_instant_booking_value
-                  , subq_1.__booking_value_for_non_null_listing_id AS __booking_value_for_non_null_listing_id
-                  , subq_1.__bookers AS __bookers
-                  , subq_1.__referred_bookings AS __referred_bookings
-                  , subq_1.__median_booking_value AS __median_booking_value
-                  , subq_1.__booking_value_p99 AS __booking_value_p99
-                  , subq_1.__discrete_booking_value_p99 AS __discrete_booking_value_p99
-                  , subq_1.__approximate_continuous_booking_value_p99 AS __approximate_continuous_booking_value_p99
-                  , subq_1.__approximate_discrete_booking_value_p99 AS __approximate_discrete_booking_value_p99
-                  , subq_1.__bookings_join_to_time_spine AS __bookings_join_to_time_spine
-                  , subq_1.__bookings_fill_nulls_with_0_without_time_spine AS __bookings_fill_nulls_with_0_without_time_spine
-                  , subq_1.__bookings_fill_nulls_with_0 AS __bookings_fill_nulls_with_0
-                  , subq_1.__instant_bookings_with_measure_filter AS __instant_bookings_with_measure_filter
-                  , subq_1.__bookings_join_to_time_spine_with_tiered_filters AS __bookings_join_to_time_spine_with_tiered_filters
-                  , subq_1.__bookers_fill_nulls_with_0_join_to_timespine AS __bookers_fill_nulls_with_0_join_to_timespine
+                  subq_5.metric_time__day
+                  , subq_5.metric_time__month
                 FROM (
-                  -- Select: ['metric_time__day', 'metric_time__month']
+                  -- Constrain Output with WHERE
                   SELECT
                     subq_4.metric_time__day
                     , subq_4.metric_time__month
@@ -200,225 +198,225 @@ FROM (
                       ) subq_2
                     ) subq_3
                   ) subq_4
+                  WHERE metric_time__day = '2020-01-01'
                 ) subq_5
-                INNER JOIN (
-                  -- Metric Time Dimension 'ds'
-                  SELECT
-                    subq_0.ds__day
-                    , subq_0.ds__week
-                    , subq_0.ds__month
-                    , subq_0.ds__quarter
-                    , subq_0.ds__year
-                    , subq_0.ds__extract_year
-                    , subq_0.ds__extract_quarter
-                    , subq_0.ds__extract_month
-                    , subq_0.ds__extract_day
-                    , subq_0.ds__extract_dow
-                    , subq_0.ds__extract_doy
-                    , subq_0.ds_partitioned__day
-                    , subq_0.ds_partitioned__week
-                    , subq_0.ds_partitioned__month
-                    , subq_0.ds_partitioned__quarter
-                    , subq_0.ds_partitioned__year
-                    , subq_0.ds_partitioned__extract_year
-                    , subq_0.ds_partitioned__extract_quarter
-                    , subq_0.ds_partitioned__extract_month
-                    , subq_0.ds_partitioned__extract_day
-                    , subq_0.ds_partitioned__extract_dow
-                    , subq_0.ds_partitioned__extract_doy
-                    , subq_0.paid_at__day
-                    , subq_0.paid_at__week
-                    , subq_0.paid_at__month
-                    , subq_0.paid_at__quarter
-                    , subq_0.paid_at__year
-                    , subq_0.paid_at__extract_year
-                    , subq_0.paid_at__extract_quarter
-                    , subq_0.paid_at__extract_month
-                    , subq_0.paid_at__extract_day
-                    , subq_0.paid_at__extract_dow
-                    , subq_0.paid_at__extract_doy
-                    , subq_0.booking__ds__day
-                    , subq_0.booking__ds__week
-                    , subq_0.booking__ds__month
-                    , subq_0.booking__ds__quarter
-                    , subq_0.booking__ds__year
-                    , subq_0.booking__ds__extract_year
-                    , subq_0.booking__ds__extract_quarter
-                    , subq_0.booking__ds__extract_month
-                    , subq_0.booking__ds__extract_day
-                    , subq_0.booking__ds__extract_dow
-                    , subq_0.booking__ds__extract_doy
-                    , subq_0.booking__ds_partitioned__day
-                    , subq_0.booking__ds_partitioned__week
-                    , subq_0.booking__ds_partitioned__month
-                    , subq_0.booking__ds_partitioned__quarter
-                    , subq_0.booking__ds_partitioned__year
-                    , subq_0.booking__ds_partitioned__extract_year
-                    , subq_0.booking__ds_partitioned__extract_quarter
-                    , subq_0.booking__ds_partitioned__extract_month
-                    , subq_0.booking__ds_partitioned__extract_day
-                    , subq_0.booking__ds_partitioned__extract_dow
-                    , subq_0.booking__ds_partitioned__extract_doy
-                    , subq_0.booking__paid_at__day
-                    , subq_0.booking__paid_at__week
-                    , subq_0.booking__paid_at__month
-                    , subq_0.booking__paid_at__quarter
-                    , subq_0.booking__paid_at__year
-                    , subq_0.booking__paid_at__extract_year
-                    , subq_0.booking__paid_at__extract_quarter
-                    , subq_0.booking__paid_at__extract_month
-                    , subq_0.booking__paid_at__extract_day
-                    , subq_0.booking__paid_at__extract_dow
-                    , subq_0.booking__paid_at__extract_doy
-                    , subq_0.ds__day AS metric_time__day
-                    , subq_0.ds__week AS metric_time__week
-                    , subq_0.ds__month AS metric_time__month
-                    , subq_0.ds__quarter AS metric_time__quarter
-                    , subq_0.ds__year AS metric_time__year
-                    , subq_0.ds__extract_year AS metric_time__extract_year
-                    , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                    , subq_0.ds__extract_month AS metric_time__extract_month
-                    , subq_0.ds__extract_day AS metric_time__extract_day
-                    , subq_0.ds__extract_dow AS metric_time__extract_dow
-                    , subq_0.ds__extract_doy AS metric_time__extract_doy
-                    , subq_0.listing
-                    , subq_0.guest
-                    , subq_0.host
-                    , subq_0.booking__listing
-                    , subq_0.booking__guest
-                    , subq_0.booking__host
-                    , subq_0.is_instant
-                    , subq_0.booking__is_instant
-                    , subq_0.__bookings
-                    , subq_0.__average_booking_value
-                    , subq_0.__instant_bookings
-                    , subq_0.__booking_value
-                    , subq_0.__max_booking_value
-                    , subq_0.__min_booking_value
-                    , subq_0.__instant_booking_value
-                    , subq_0.__average_instant_booking_value
-                    , subq_0.__booking_value_for_non_null_listing_id
-                    , subq_0.__bookers
-                    , subq_0.__referred_bookings
-                    , subq_0.__median_booking_value
-                    , subq_0.__booking_value_p99
-                    , subq_0.__discrete_booking_value_p99
-                    , subq_0.__approximate_continuous_booking_value_p99
-                    , subq_0.__approximate_discrete_booking_value_p99
-                    , subq_0.__bookings_join_to_time_spine
-                    , subq_0.__bookings_fill_nulls_with_0_without_time_spine
-                    , subq_0.__bookings_fill_nulls_with_0
-                    , subq_0.__instant_bookings_with_measure_filter
-                    , subq_0.__bookings_join_to_time_spine_with_tiered_filters
-                    , subq_0.__bookers_fill_nulls_with_0_join_to_timespine
-                  FROM (
-                    -- Read Elements From Semantic Model 'bookings_source'
-                    SELECT
-                      1 AS __bookings
-                      , bookings_source_src_28000.booking_value AS __average_booking_value
-                      , CASE WHEN is_instant THEN 1 ELSE 0 END AS __instant_bookings
-                      , bookings_source_src_28000.booking_value AS __booking_value
-                      , bookings_source_src_28000.booking_value AS __max_booking_value
-                      , bookings_source_src_28000.booking_value AS __min_booking_value
-                      , bookings_source_src_28000.booking_value AS __instant_booking_value
-                      , bookings_source_src_28000.booking_value AS __average_instant_booking_value
-                      , bookings_source_src_28000.booking_value AS __booking_value_for_non_null_listing_id
-                      , bookings_source_src_28000.guest_id AS __bookers
-                      , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS __referred_bookings
-                      , bookings_source_src_28000.booking_value AS __median_booking_value
-                      , bookings_source_src_28000.booking_value AS __booking_value_p99
-                      , bookings_source_src_28000.booking_value AS __discrete_booking_value_p99
-                      , bookings_source_src_28000.booking_value AS __approximate_continuous_booking_value_p99
-                      , bookings_source_src_28000.booking_value AS __approximate_discrete_booking_value_p99
-                      , 1 AS __bookings_join_to_time_spine
-                      , 1 AS __bookings_fill_nulls_with_0_without_time_spine
-                      , 1 AS __bookings_fill_nulls_with_0
-                      , 1 AS __instant_bookings_with_measure_filter
-                      , 1 AS __bookings_join_to_time_spine_with_tiered_filters
-                      , bookings_source_src_28000.guest_id AS __bookers_fill_nulls_with_0_join_to_timespine
-                      , bookings_source_src_28000.booking_value AS __booking_payments
-                      , bookings_source_src_28000.is_instant
-                      , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                      , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                      , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                      , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                      , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                      , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                      , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                      , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                      , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                      , bookings_source_src_28000.is_instant AS booking__is_instant
-                      , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                      , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                      , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                      , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                      , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                      , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                      , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                      , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                      , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                      , bookings_source_src_28000.listing_id AS listing
-                      , bookings_source_src_28000.guest_id AS guest
-                      , bookings_source_src_28000.host_id AS host
-                      , bookings_source_src_28000.listing_id AS booking__listing
-                      , bookings_source_src_28000.guest_id AS booking__guest
-                      , bookings_source_src_28000.host_id AS booking__host
-                    FROM ***************************.fct_bookings bookings_source_src_28000
-                  ) subq_0
-                ) subq_1
-                ON
-                  subq_5.metric_time__day - MAKE_INTERVAL(weeks => 1) = subq_1.metric_time__day
               ) subq_6
+              INNER JOIN (
+                -- Metric Time Dimension 'ds'
+                SELECT
+                  subq_0.ds__day
+                  , subq_0.ds__week
+                  , subq_0.ds__month
+                  , subq_0.ds__quarter
+                  , subq_0.ds__year
+                  , subq_0.ds__extract_year
+                  , subq_0.ds__extract_quarter
+                  , subq_0.ds__extract_month
+                  , subq_0.ds__extract_day
+                  , subq_0.ds__extract_dow
+                  , subq_0.ds__extract_doy
+                  , subq_0.ds_partitioned__day
+                  , subq_0.ds_partitioned__week
+                  , subq_0.ds_partitioned__month
+                  , subq_0.ds_partitioned__quarter
+                  , subq_0.ds_partitioned__year
+                  , subq_0.ds_partitioned__extract_year
+                  , subq_0.ds_partitioned__extract_quarter
+                  , subq_0.ds_partitioned__extract_month
+                  , subq_0.ds_partitioned__extract_day
+                  , subq_0.ds_partitioned__extract_dow
+                  , subq_0.ds_partitioned__extract_doy
+                  , subq_0.paid_at__day
+                  , subq_0.paid_at__week
+                  , subq_0.paid_at__month
+                  , subq_0.paid_at__quarter
+                  , subq_0.paid_at__year
+                  , subq_0.paid_at__extract_year
+                  , subq_0.paid_at__extract_quarter
+                  , subq_0.paid_at__extract_month
+                  , subq_0.paid_at__extract_day
+                  , subq_0.paid_at__extract_dow
+                  , subq_0.paid_at__extract_doy
+                  , subq_0.booking__ds__day
+                  , subq_0.booking__ds__week
+                  , subq_0.booking__ds__month
+                  , subq_0.booking__ds__quarter
+                  , subq_0.booking__ds__year
+                  , subq_0.booking__ds__extract_year
+                  , subq_0.booking__ds__extract_quarter
+                  , subq_0.booking__ds__extract_month
+                  , subq_0.booking__ds__extract_day
+                  , subq_0.booking__ds__extract_dow
+                  , subq_0.booking__ds__extract_doy
+                  , subq_0.booking__ds_partitioned__day
+                  , subq_0.booking__ds_partitioned__week
+                  , subq_0.booking__ds_partitioned__month
+                  , subq_0.booking__ds_partitioned__quarter
+                  , subq_0.booking__ds_partitioned__year
+                  , subq_0.booking__ds_partitioned__extract_year
+                  , subq_0.booking__ds_partitioned__extract_quarter
+                  , subq_0.booking__ds_partitioned__extract_month
+                  , subq_0.booking__ds_partitioned__extract_day
+                  , subq_0.booking__ds_partitioned__extract_dow
+                  , subq_0.booking__ds_partitioned__extract_doy
+                  , subq_0.booking__paid_at__day
+                  , subq_0.booking__paid_at__week
+                  , subq_0.booking__paid_at__month
+                  , subq_0.booking__paid_at__quarter
+                  , subq_0.booking__paid_at__year
+                  , subq_0.booking__paid_at__extract_year
+                  , subq_0.booking__paid_at__extract_quarter
+                  , subq_0.booking__paid_at__extract_month
+                  , subq_0.booking__paid_at__extract_day
+                  , subq_0.booking__paid_at__extract_dow
+                  , subq_0.booking__paid_at__extract_doy
+                  , subq_0.ds__day AS metric_time__day
+                  , subq_0.ds__week AS metric_time__week
+                  , subq_0.ds__month AS metric_time__month
+                  , subq_0.ds__quarter AS metric_time__quarter
+                  , subq_0.ds__year AS metric_time__year
+                  , subq_0.ds__extract_year AS metric_time__extract_year
+                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_0.ds__extract_month AS metric_time__extract_month
+                  , subq_0.ds__extract_day AS metric_time__extract_day
+                  , subq_0.ds__extract_dow AS metric_time__extract_dow
+                  , subq_0.ds__extract_doy AS metric_time__extract_doy
+                  , subq_0.listing
+                  , subq_0.guest
+                  , subq_0.host
+                  , subq_0.booking__listing
+                  , subq_0.booking__guest
+                  , subq_0.booking__host
+                  , subq_0.is_instant
+                  , subq_0.booking__is_instant
+                  , subq_0.__bookings
+                  , subq_0.__average_booking_value
+                  , subq_0.__instant_bookings
+                  , subq_0.__booking_value
+                  , subq_0.__max_booking_value
+                  , subq_0.__min_booking_value
+                  , subq_0.__instant_booking_value
+                  , subq_0.__average_instant_booking_value
+                  , subq_0.__booking_value_for_non_null_listing_id
+                  , subq_0.__bookers
+                  , subq_0.__referred_bookings
+                  , subq_0.__median_booking_value
+                  , subq_0.__booking_value_p99
+                  , subq_0.__discrete_booking_value_p99
+                  , subq_0.__approximate_continuous_booking_value_p99
+                  , subq_0.__approximate_discrete_booking_value_p99
+                  , subq_0.__bookings_join_to_time_spine
+                  , subq_0.__bookings_fill_nulls_with_0_without_time_spine
+                  , subq_0.__bookings_fill_nulls_with_0
+                  , subq_0.__instant_bookings_with_measure_filter
+                  , subq_0.__bookings_join_to_time_spine_with_tiered_filters
+                  , subq_0.__bookers_fill_nulls_with_0_join_to_timespine
+                FROM (
+                  -- Read Elements From Semantic Model 'bookings_source'
+                  SELECT
+                    1 AS __bookings
+                    , bookings_source_src_28000.booking_value AS __average_booking_value
+                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS __instant_bookings
+                    , bookings_source_src_28000.booking_value AS __booking_value
+                    , bookings_source_src_28000.booking_value AS __max_booking_value
+                    , bookings_source_src_28000.booking_value AS __min_booking_value
+                    , bookings_source_src_28000.booking_value AS __instant_booking_value
+                    , bookings_source_src_28000.booking_value AS __average_instant_booking_value
+                    , bookings_source_src_28000.booking_value AS __booking_value_for_non_null_listing_id
+                    , bookings_source_src_28000.guest_id AS __bookers
+                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS __referred_bookings
+                    , bookings_source_src_28000.booking_value AS __median_booking_value
+                    , bookings_source_src_28000.booking_value AS __booking_value_p99
+                    , bookings_source_src_28000.booking_value AS __discrete_booking_value_p99
+                    , bookings_source_src_28000.booking_value AS __approximate_continuous_booking_value_p99
+                    , bookings_source_src_28000.booking_value AS __approximate_discrete_booking_value_p99
+                    , 1 AS __bookings_join_to_time_spine
+                    , 1 AS __bookings_fill_nulls_with_0_without_time_spine
+                    , 1 AS __bookings_fill_nulls_with_0
+                    , 1 AS __instant_bookings_with_measure_filter
+                    , 1 AS __bookings_join_to_time_spine_with_tiered_filters
+                    , bookings_source_src_28000.guest_id AS __bookers_fill_nulls_with_0_join_to_timespine
+                    , bookings_source_src_28000.booking_value AS __booking_payments
+                    , bookings_source_src_28000.is_instant
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                    , bookings_source_src_28000.is_instant AS booking__is_instant
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                    , bookings_source_src_28000.listing_id AS listing
+                    , bookings_source_src_28000.guest_id AS guest
+                    , bookings_source_src_28000.host_id AS host
+                    , bookings_source_src_28000.listing_id AS booking__listing
+                    , bookings_source_src_28000.guest_id AS booking__guest
+                    , bookings_source_src_28000.host_id AS booking__host
+                  FROM ***************************.fct_bookings bookings_source_src_28000
+                ) subq_0
+              ) subq_1
+              ON
+                subq_6.metric_time__day - MAKE_INTERVAL(weeks => 1) = subq_1.metric_time__day
             ) subq_7
-            WHERE metric_time__day = '2020-01-01'
           ) subq_8
         ) subq_9
         GROUP BY

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_offset_window_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Postgres/test_offset_window_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
@@ -27,29 +27,37 @@ FROM (
     , MAX(subq_31.booking_value) AS booking_value
     , MAX(subq_37.bookers) AS bookers
   FROM (
-    -- Constrain Output with WHERE
+    -- Join to Time Spine Dataset
+    -- Select: ['__booking_value', 'metric_time__month']
     -- Select: ['__booking_value', 'metric_time__month']
     -- Aggregate Inputs for Simple Metrics
     -- Compute Metrics via Expressions
     SELECT
-      metric_time__month
-      , SUM(booking_value) AS booking_value
+      subq_26.metric_time__month AS metric_time__month
+      , SUM(sma_28009_cte.__booking_value) AS booking_value
     FROM (
-      -- Join to Time Spine Dataset
-      -- Select: ['__booking_value', 'metric_time__month', 'metric_time__day']
+      -- Constrain Output with WHERE
+      -- Select: ['metric_time__day', 'metric_time__month']
       SELECT
-        time_spine_src_28006.ds AS metric_time__day
-        , DATE_TRUNC('month', time_spine_src_28006.ds) AS metric_time__month
-        , sma_28009_cte.__booking_value AS booking_value
-      FROM ***************************.mf_time_spine time_spine_src_28006
-      INNER JOIN
-        sma_28009_cte
-      ON
-        time_spine_src_28006.ds - MAKE_INTERVAL(weeks => 1) = sma_28009_cte.metric_time__day
-    ) subq_27
-    WHERE metric_time__day = '2020-01-01'
+        metric_time__day
+        , metric_time__month
+      FROM (
+        -- Read From Time Spine 'mf_time_spine'
+        -- Change Column Aliases
+        -- Select: ['metric_time__day', 'metric_time__month']
+        SELECT
+          ds AS metric_time__day
+          , DATE_TRUNC('month', ds) AS metric_time__month
+        FROM ***************************.mf_time_spine time_spine_src_28006
+      ) subq_24
+      WHERE metric_time__day = '2020-01-01'
+    ) subq_26
+    INNER JOIN
+      sma_28009_cte
+    ON
+      subq_26.metric_time__day - MAKE_INTERVAL(weeks => 1) = sma_28009_cte.metric_time__day
     GROUP BY
-      metric_time__month
+      subq_26.metric_time__month
   ) subq_31
   FULL OUTER JOIN (
     -- Constrain Output with WHERE

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
@@ -4,19 +4,19 @@ sql_engine: Redshift
 ---
 -- Write to DataTable
 SELECT
-  subq_20.metric_time__day
-  , subq_20.bookings_growth_2_weeks
+  subq_19.metric_time__day
+  , subq_19.bookings_growth_2_weeks
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_19.metric_time__day
+    subq_18.metric_time__day
     , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
   FROM (
     -- Combine Aggregated Outputs
     SELECT
-      COALESCE(subq_6.metric_time__day, subq_18.metric_time__day) AS metric_time__day
+      COALESCE(subq_6.metric_time__day, subq_17.metric_time__day) AS metric_time__day
       , MAX(subq_6.bookings) AS bookings
-      , MAX(subq_18.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+      , MAX(subq_17.bookings_2_weeks_ago) AS bookings_2_weeks_ago
     FROM (
       -- Compute Metrics via Expressions
       SELECT
@@ -266,40 +266,40 @@ FROM (
     FULL OUTER JOIN (
       -- Compute Metrics via Expressions
       SELECT
-        subq_17.metric_time__day
-        , subq_17.__bookings AS bookings_2_weeks_ago
+        subq_16.metric_time__day
+        , subq_16.__bookings AS bookings_2_weeks_ago
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_16.metric_time__day AS metric_time__day
-          , subq_11.__bookings AS __bookings
+          subq_15.metric_time__day AS metric_time__day
+          , subq_10.__bookings AS __bookings
         FROM (
           -- Select: ['metric_time__day']
           SELECT
-            subq_15.metric_time__day
+            subq_14.metric_time__day
           FROM (
             -- Constrain Output with WHERE
             SELECT
-              subq_14.metric_time__day
+              subq_13.metric_time__day
             FROM (
               -- Select: ['metric_time__day']
               SELECT
-                subq_13.metric_time__day
+                subq_12.metric_time__day
               FROM (
                 -- Change Column Aliases
                 SELECT
-                  subq_12.ds__day AS metric_time__day
-                  , subq_12.ds__week
-                  , subq_12.ds__month
-                  , subq_12.ds__quarter
-                  , subq_12.ds__year
-                  , subq_12.ds__extract_year
-                  , subq_12.ds__extract_quarter
-                  , subq_12.ds__extract_month
-                  , subq_12.ds__extract_day
-                  , subq_12.ds__extract_dow
-                  , subq_12.ds__extract_doy
-                  , subq_12.ds__alien_day
+                  subq_11.ds__day AS metric_time__day
+                  , subq_11.ds__week
+                  , subq_11.ds__month
+                  , subq_11.ds__quarter
+                  , subq_11.ds__year
+                  , subq_11.ds__extract_year
+                  , subq_11.ds__extract_quarter
+                  , subq_11.ds__extract_month
+                  , subq_11.ds__extract_day
+                  , subq_11.ds__extract_dow
+                  , subq_11.ds__extract_doy
+                  , subq_11.ds__alien_day
                 FROM (
                   -- Read From Time Spine 'mf_time_spine'
                   SELECT
@@ -316,259 +316,252 @@ FROM (
                     , EXTRACT(doy FROM time_spine_src_28006.ds) AS ds__extract_doy
                     , time_spine_src_28006.alien_day AS ds__alien_day
                   FROM ***************************.mf_time_spine time_spine_src_28006
-                ) subq_12
-              ) subq_13
-            ) subq_14
+                ) subq_11
+              ) subq_12
+            ) subq_13
             WHERE metric_time__day = '2020-01-01' or metric_time__day = '2020-01-14'
-          ) subq_15
-        ) subq_16
+          ) subq_14
+        ) subq_15
         INNER JOIN (
           -- Aggregate Inputs for Simple Metrics
           SELECT
-            subq_10.metric_time__day
-            , SUM(subq_10.__bookings) AS __bookings
+            subq_9.metric_time__day
+            , SUM(subq_9.__bookings) AS __bookings
           FROM (
             -- Select: ['__bookings', 'metric_time__day']
             SELECT
-              subq_9.metric_time__day
-              , subq_9.__bookings
+              subq_8.metric_time__day
+              , subq_8.__bookings
             FROM (
-              -- Constrain Output with WHERE
+              -- Select: ['__bookings', 'metric_time__day']
               SELECT
-                subq_8.bookings AS __bookings
-                , subq_8.metric_time__day
+                subq_7.metric_time__day
+                , subq_7.__bookings
               FROM (
-                -- Select: ['__bookings', 'metric_time__day']
+                -- Metric Time Dimension 'ds'
                 SELECT
-                  subq_7.metric_time__day
-                  , subq_7.__bookings AS bookings
+                  subq_0.ds__day
+                  , subq_0.ds__week
+                  , subq_0.ds__month
+                  , subq_0.ds__quarter
+                  , subq_0.ds__year
+                  , subq_0.ds__extract_year
+                  , subq_0.ds__extract_quarter
+                  , subq_0.ds__extract_month
+                  , subq_0.ds__extract_day
+                  , subq_0.ds__extract_dow
+                  , subq_0.ds__extract_doy
+                  , subq_0.ds_partitioned__day
+                  , subq_0.ds_partitioned__week
+                  , subq_0.ds_partitioned__month
+                  , subq_0.ds_partitioned__quarter
+                  , subq_0.ds_partitioned__year
+                  , subq_0.ds_partitioned__extract_year
+                  , subq_0.ds_partitioned__extract_quarter
+                  , subq_0.ds_partitioned__extract_month
+                  , subq_0.ds_partitioned__extract_day
+                  , subq_0.ds_partitioned__extract_dow
+                  , subq_0.ds_partitioned__extract_doy
+                  , subq_0.paid_at__day
+                  , subq_0.paid_at__week
+                  , subq_0.paid_at__month
+                  , subq_0.paid_at__quarter
+                  , subq_0.paid_at__year
+                  , subq_0.paid_at__extract_year
+                  , subq_0.paid_at__extract_quarter
+                  , subq_0.paid_at__extract_month
+                  , subq_0.paid_at__extract_day
+                  , subq_0.paid_at__extract_dow
+                  , subq_0.paid_at__extract_doy
+                  , subq_0.booking__ds__day
+                  , subq_0.booking__ds__week
+                  , subq_0.booking__ds__month
+                  , subq_0.booking__ds__quarter
+                  , subq_0.booking__ds__year
+                  , subq_0.booking__ds__extract_year
+                  , subq_0.booking__ds__extract_quarter
+                  , subq_0.booking__ds__extract_month
+                  , subq_0.booking__ds__extract_day
+                  , subq_0.booking__ds__extract_dow
+                  , subq_0.booking__ds__extract_doy
+                  , subq_0.booking__ds_partitioned__day
+                  , subq_0.booking__ds_partitioned__week
+                  , subq_0.booking__ds_partitioned__month
+                  , subq_0.booking__ds_partitioned__quarter
+                  , subq_0.booking__ds_partitioned__year
+                  , subq_0.booking__ds_partitioned__extract_year
+                  , subq_0.booking__ds_partitioned__extract_quarter
+                  , subq_0.booking__ds_partitioned__extract_month
+                  , subq_0.booking__ds_partitioned__extract_day
+                  , subq_0.booking__ds_partitioned__extract_dow
+                  , subq_0.booking__ds_partitioned__extract_doy
+                  , subq_0.booking__paid_at__day
+                  , subq_0.booking__paid_at__week
+                  , subq_0.booking__paid_at__month
+                  , subq_0.booking__paid_at__quarter
+                  , subq_0.booking__paid_at__year
+                  , subq_0.booking__paid_at__extract_year
+                  , subq_0.booking__paid_at__extract_quarter
+                  , subq_0.booking__paid_at__extract_month
+                  , subq_0.booking__paid_at__extract_day
+                  , subq_0.booking__paid_at__extract_dow
+                  , subq_0.booking__paid_at__extract_doy
+                  , subq_0.ds__day AS metric_time__day
+                  , subq_0.ds__week AS metric_time__week
+                  , subq_0.ds__month AS metric_time__month
+                  , subq_0.ds__quarter AS metric_time__quarter
+                  , subq_0.ds__year AS metric_time__year
+                  , subq_0.ds__extract_year AS metric_time__extract_year
+                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_0.ds__extract_month AS metric_time__extract_month
+                  , subq_0.ds__extract_day AS metric_time__extract_day
+                  , subq_0.ds__extract_dow AS metric_time__extract_dow
+                  , subq_0.ds__extract_doy AS metric_time__extract_doy
+                  , subq_0.listing
+                  , subq_0.guest
+                  , subq_0.host
+                  , subq_0.booking__listing
+                  , subq_0.booking__guest
+                  , subq_0.booking__host
+                  , subq_0.is_instant
+                  , subq_0.booking__is_instant
+                  , subq_0.__bookings
+                  , subq_0.__average_booking_value
+                  , subq_0.__instant_bookings
+                  , subq_0.__booking_value
+                  , subq_0.__max_booking_value
+                  , subq_0.__min_booking_value
+                  , subq_0.__instant_booking_value
+                  , subq_0.__average_instant_booking_value
+                  , subq_0.__booking_value_for_non_null_listing_id
+                  , subq_0.__bookers
+                  , subq_0.__referred_bookings
+                  , subq_0.__median_booking_value
+                  , subq_0.__booking_value_p99
+                  , subq_0.__discrete_booking_value_p99
+                  , subq_0.__approximate_continuous_booking_value_p99
+                  , subq_0.__approximate_discrete_booking_value_p99
+                  , subq_0.__bookings_join_to_time_spine
+                  , subq_0.__bookings_fill_nulls_with_0_without_time_spine
+                  , subq_0.__bookings_fill_nulls_with_0
+                  , subq_0.__instant_bookings_with_measure_filter
+                  , subq_0.__bookings_join_to_time_spine_with_tiered_filters
+                  , subq_0.__bookers_fill_nulls_with_0_join_to_timespine
                 FROM (
-                  -- Metric Time Dimension 'ds'
+                  -- Read Elements From Semantic Model 'bookings_source'
                   SELECT
-                    subq_0.ds__day
-                    , subq_0.ds__week
-                    , subq_0.ds__month
-                    , subq_0.ds__quarter
-                    , subq_0.ds__year
-                    , subq_0.ds__extract_year
-                    , subq_0.ds__extract_quarter
-                    , subq_0.ds__extract_month
-                    , subq_0.ds__extract_day
-                    , subq_0.ds__extract_dow
-                    , subq_0.ds__extract_doy
-                    , subq_0.ds_partitioned__day
-                    , subq_0.ds_partitioned__week
-                    , subq_0.ds_partitioned__month
-                    , subq_0.ds_partitioned__quarter
-                    , subq_0.ds_partitioned__year
-                    , subq_0.ds_partitioned__extract_year
-                    , subq_0.ds_partitioned__extract_quarter
-                    , subq_0.ds_partitioned__extract_month
-                    , subq_0.ds_partitioned__extract_day
-                    , subq_0.ds_partitioned__extract_dow
-                    , subq_0.ds_partitioned__extract_doy
-                    , subq_0.paid_at__day
-                    , subq_0.paid_at__week
-                    , subq_0.paid_at__month
-                    , subq_0.paid_at__quarter
-                    , subq_0.paid_at__year
-                    , subq_0.paid_at__extract_year
-                    , subq_0.paid_at__extract_quarter
-                    , subq_0.paid_at__extract_month
-                    , subq_0.paid_at__extract_day
-                    , subq_0.paid_at__extract_dow
-                    , subq_0.paid_at__extract_doy
-                    , subq_0.booking__ds__day
-                    , subq_0.booking__ds__week
-                    , subq_0.booking__ds__month
-                    , subq_0.booking__ds__quarter
-                    , subq_0.booking__ds__year
-                    , subq_0.booking__ds__extract_year
-                    , subq_0.booking__ds__extract_quarter
-                    , subq_0.booking__ds__extract_month
-                    , subq_0.booking__ds__extract_day
-                    , subq_0.booking__ds__extract_dow
-                    , subq_0.booking__ds__extract_doy
-                    , subq_0.booking__ds_partitioned__day
-                    , subq_0.booking__ds_partitioned__week
-                    , subq_0.booking__ds_partitioned__month
-                    , subq_0.booking__ds_partitioned__quarter
-                    , subq_0.booking__ds_partitioned__year
-                    , subq_0.booking__ds_partitioned__extract_year
-                    , subq_0.booking__ds_partitioned__extract_quarter
-                    , subq_0.booking__ds_partitioned__extract_month
-                    , subq_0.booking__ds_partitioned__extract_day
-                    , subq_0.booking__ds_partitioned__extract_dow
-                    , subq_0.booking__ds_partitioned__extract_doy
-                    , subq_0.booking__paid_at__day
-                    , subq_0.booking__paid_at__week
-                    , subq_0.booking__paid_at__month
-                    , subq_0.booking__paid_at__quarter
-                    , subq_0.booking__paid_at__year
-                    , subq_0.booking__paid_at__extract_year
-                    , subq_0.booking__paid_at__extract_quarter
-                    , subq_0.booking__paid_at__extract_month
-                    , subq_0.booking__paid_at__extract_day
-                    , subq_0.booking__paid_at__extract_dow
-                    , subq_0.booking__paid_at__extract_doy
-                    , subq_0.ds__day AS metric_time__day
-                    , subq_0.ds__week AS metric_time__week
-                    , subq_0.ds__month AS metric_time__month
-                    , subq_0.ds__quarter AS metric_time__quarter
-                    , subq_0.ds__year AS metric_time__year
-                    , subq_0.ds__extract_year AS metric_time__extract_year
-                    , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                    , subq_0.ds__extract_month AS metric_time__extract_month
-                    , subq_0.ds__extract_day AS metric_time__extract_day
-                    , subq_0.ds__extract_dow AS metric_time__extract_dow
-                    , subq_0.ds__extract_doy AS metric_time__extract_doy
-                    , subq_0.listing
-                    , subq_0.guest
-                    , subq_0.host
-                    , subq_0.booking__listing
-                    , subq_0.booking__guest
-                    , subq_0.booking__host
-                    , subq_0.is_instant
-                    , subq_0.booking__is_instant
-                    , subq_0.__bookings
-                    , subq_0.__average_booking_value
-                    , subq_0.__instant_bookings
-                    , subq_0.__booking_value
-                    , subq_0.__max_booking_value
-                    , subq_0.__min_booking_value
-                    , subq_0.__instant_booking_value
-                    , subq_0.__average_instant_booking_value
-                    , subq_0.__booking_value_for_non_null_listing_id
-                    , subq_0.__bookers
-                    , subq_0.__referred_bookings
-                    , subq_0.__median_booking_value
-                    , subq_0.__booking_value_p99
-                    , subq_0.__discrete_booking_value_p99
-                    , subq_0.__approximate_continuous_booking_value_p99
-                    , subq_0.__approximate_discrete_booking_value_p99
-                    , subq_0.__bookings_join_to_time_spine
-                    , subq_0.__bookings_fill_nulls_with_0_without_time_spine
-                    , subq_0.__bookings_fill_nulls_with_0
-                    , subq_0.__instant_bookings_with_measure_filter
-                    , subq_0.__bookings_join_to_time_spine_with_tiered_filters
-                    , subq_0.__bookers_fill_nulls_with_0_join_to_timespine
-                  FROM (
-                    -- Read Elements From Semantic Model 'bookings_source'
-                    SELECT
-                      1 AS __bookings
-                      , bookings_source_src_28000.booking_value AS __average_booking_value
-                      , CASE WHEN is_instant THEN 1 ELSE 0 END AS __instant_bookings
-                      , bookings_source_src_28000.booking_value AS __booking_value
-                      , bookings_source_src_28000.booking_value AS __max_booking_value
-                      , bookings_source_src_28000.booking_value AS __min_booking_value
-                      , bookings_source_src_28000.booking_value AS __instant_booking_value
-                      , bookings_source_src_28000.booking_value AS __average_instant_booking_value
-                      , bookings_source_src_28000.booking_value AS __booking_value_for_non_null_listing_id
-                      , bookings_source_src_28000.guest_id AS __bookers
-                      , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS __referred_bookings
-                      , bookings_source_src_28000.booking_value AS __median_booking_value
-                      , bookings_source_src_28000.booking_value AS __booking_value_p99
-                      , bookings_source_src_28000.booking_value AS __discrete_booking_value_p99
-                      , bookings_source_src_28000.booking_value AS __approximate_continuous_booking_value_p99
-                      , bookings_source_src_28000.booking_value AS __approximate_discrete_booking_value_p99
-                      , 1 AS __bookings_join_to_time_spine
-                      , 1 AS __bookings_fill_nulls_with_0_without_time_spine
-                      , 1 AS __bookings_fill_nulls_with_0
-                      , 1 AS __instant_bookings_with_measure_filter
-                      , 1 AS __bookings_join_to_time_spine_with_tiered_filters
-                      , bookings_source_src_28000.guest_id AS __bookers_fill_nulls_with_0_join_to_timespine
-                      , bookings_source_src_28000.booking_value AS __booking_payments
-                      , bookings_source_src_28000.is_instant
-                      , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                      , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                      , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS ds__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                      , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                      , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                      , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS ds_partitioned__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                      , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                      , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                      , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS paid_at__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                      , bookings_source_src_28000.is_instant AS booking__is_instant
-                      , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                      , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                      , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS booking__ds__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                      , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                      , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                      , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS booking__ds_partitioned__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                      , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                      , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                      , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS booking__paid_at__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                      , bookings_source_src_28000.listing_id AS listing
-                      , bookings_source_src_28000.guest_id AS guest
-                      , bookings_source_src_28000.host_id AS host
-                      , bookings_source_src_28000.listing_id AS booking__listing
-                      , bookings_source_src_28000.guest_id AS booking__guest
-                      , bookings_source_src_28000.host_id AS booking__host
-                    FROM ***************************.fct_bookings bookings_source_src_28000
-                  ) subq_0
-                ) subq_7
-              ) subq_8
-              WHERE metric_time__day = '2020-01-01' or metric_time__day = '2020-01-14'
-            ) subq_9
-          ) subq_10
+                    1 AS __bookings
+                    , bookings_source_src_28000.booking_value AS __average_booking_value
+                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS __instant_bookings
+                    , bookings_source_src_28000.booking_value AS __booking_value
+                    , bookings_source_src_28000.booking_value AS __max_booking_value
+                    , bookings_source_src_28000.booking_value AS __min_booking_value
+                    , bookings_source_src_28000.booking_value AS __instant_booking_value
+                    , bookings_source_src_28000.booking_value AS __average_instant_booking_value
+                    , bookings_source_src_28000.booking_value AS __booking_value_for_non_null_listing_id
+                    , bookings_source_src_28000.guest_id AS __bookers
+                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS __referred_bookings
+                    , bookings_source_src_28000.booking_value AS __median_booking_value
+                    , bookings_source_src_28000.booking_value AS __booking_value_p99
+                    , bookings_source_src_28000.booking_value AS __discrete_booking_value_p99
+                    , bookings_source_src_28000.booking_value AS __approximate_continuous_booking_value_p99
+                    , bookings_source_src_28000.booking_value AS __approximate_discrete_booking_value_p99
+                    , 1 AS __bookings_join_to_time_spine
+                    , 1 AS __bookings_fill_nulls_with_0_without_time_spine
+                    , 1 AS __bookings_fill_nulls_with_0
+                    , 1 AS __instant_bookings_with_measure_filter
+                    , 1 AS __bookings_join_to_time_spine_with_tiered_filters
+                    , bookings_source_src_28000.guest_id AS __bookers_fill_nulls_with_0_join_to_timespine
+                    , bookings_source_src_28000.booking_value AS __booking_payments
+                    , bookings_source_src_28000.is_instant
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                    , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                    , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                    , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                    , bookings_source_src_28000.is_instant AS booking__is_instant
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                    , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS booking__ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                    , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS booking__ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                    , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS booking__paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                    , bookings_source_src_28000.listing_id AS listing
+                    , bookings_source_src_28000.guest_id AS guest
+                    , bookings_source_src_28000.host_id AS host
+                    , bookings_source_src_28000.listing_id AS booking__listing
+                    , bookings_source_src_28000.guest_id AS booking__guest
+                    , bookings_source_src_28000.host_id AS booking__host
+                  FROM ***************************.fct_bookings bookings_source_src_28000
+                ) subq_0
+              ) subq_7
+            ) subq_8
+          ) subq_9
           GROUP BY
-            subq_10.metric_time__day
-        ) subq_11
+            subq_9.metric_time__day
+        ) subq_10
         ON
-          DATEADD(day, -14, subq_16.metric_time__day) = subq_11.metric_time__day
-      ) subq_17
-    ) subq_18
+          DATEADD(day, -14, subq_15.metric_time__day) = subq_10.metric_time__day
+      ) subq_16
+    ) subq_17
     ON
-      subq_6.metric_time__day = subq_18.metric_time__day
+      subq_6.metric_time__day = subq_17.metric_time__day
     GROUP BY
-      COALESCE(subq_6.metric_time__day, subq_18.metric_time__day)
-  ) subq_19
-) subq_20
+      COALESCE(subq_6.metric_time__day, subq_17.metric_time__day)
+  ) subq_18
+) subq_19

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_derived_metric_with_offset_window_and_time_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_derived_metric_with_offset_window_and_time_filter__plan0_optimized.sql
@@ -19,9 +19,9 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_27.metric_time__day, subq_39.metric_time__day) AS metric_time__day
-    , MAX(subq_27.bookings) AS bookings
-    , MAX(subq_39.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+    COALESCE(subq_26.metric_time__day, subq_37.metric_time__day) AS metric_time__day
+    , MAX(subq_26.bookings) AS bookings
+    , MAX(subq_37.bookings_2_weeks_ago) AS bookings_2_weeks_ago
   FROM (
     -- Constrain Output with WHERE
     -- Select: ['__bookings', 'metric_time__day']
@@ -37,17 +37,17 @@ FROM (
         metric_time__day
         , __bookings AS bookings
       FROM sma_28009_cte
-    ) subq_23
+    ) subq_22
     WHERE metric_time__day = '2020-01-01' or metric_time__day = '2020-01-14'
     GROUP BY
       metric_time__day
-  ) subq_27
+  ) subq_26
   FULL OUTER JOIN (
     -- Join to Time Spine Dataset
     -- Compute Metrics via Expressions
     SELECT
-      subq_37.metric_time__day AS metric_time__day
-      , subq_32.__bookings AS bookings_2_weeks_ago
+      subq_35.metric_time__day AS metric_time__day
+      , subq_30.__bookings AS bookings_2_weeks_ago
     FROM (
       -- Constrain Output with WHERE
       -- Select: ['metric_time__day']
@@ -60,33 +60,26 @@ FROM (
         SELECT
           ds AS metric_time__day
         FROM ***************************.mf_time_spine time_spine_src_28006
-      ) subq_35
+      ) subq_33
       WHERE metric_time__day = '2020-01-01' or metric_time__day = '2020-01-14'
-    ) subq_37
+    ) subq_35
     INNER JOIN (
-      -- Constrain Output with WHERE
+      -- Read From CTE For node_id=sma_28009
+      -- Select: ['__bookings', 'metric_time__day']
       -- Select: ['__bookings', 'metric_time__day']
       -- Aggregate Inputs for Simple Metrics
       SELECT
         metric_time__day
-        , SUM(bookings) AS __bookings
-      FROM (
-        -- Read From CTE For node_id=sma_28009
-        -- Select: ['__bookings', 'metric_time__day']
-        SELECT
-          metric_time__day
-          , __bookings AS bookings
-        FROM sma_28009_cte
-      ) subq_29
-      WHERE metric_time__day = '2020-01-01' or metric_time__day = '2020-01-14'
+        , SUM(__bookings) AS __bookings
+      FROM sma_28009_cte
       GROUP BY
         metric_time__day
-    ) subq_32
+    ) subq_30
     ON
-      DATEADD(day, -14, subq_37.metric_time__day) = subq_32.metric_time__day
-  ) subq_39
+      DATEADD(day, -14, subq_35.metric_time__day) = subq_30.metric_time__day
+  ) subq_37
   ON
-    subq_27.metric_time__day = subq_39.metric_time__day
+    subq_26.metric_time__day = subq_37.metric_time__day
   GROUP BY
-    COALESCE(subq_27.metric_time__day, subq_39.metric_time__day)
-) subq_40
+    COALESCE(subq_26.metric_time__day, subq_37.metric_time__day)
+) subq_38

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0.sql
@@ -6,52 +6,52 @@ sql_engine: Redshift
 ---
 -- Write to DataTable
 SELECT
-  subq_13.metric_time__month
-  , subq_13.bookings_at_start_of_month
+  subq_12.metric_time__month
+  , subq_12.bookings_at_start_of_month
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_12.metric_time__month
+    subq_11.metric_time__month
     , bookings_start_of_month AS bookings_at_start_of_month
   FROM (
     -- Compute Metrics via Expressions
     SELECT
-      subq_11.metric_time__month
-      , subq_11.__bookings AS bookings_start_of_month
+      subq_10.metric_time__month
+      , subq_10.__bookings AS bookings_start_of_month
     FROM (
       -- Join to Time Spine Dataset
       SELECT
-        subq_10.metric_time__month AS metric_time__month
-        , subq_5.__bookings AS __bookings
+        subq_9.metric_time__month AS metric_time__month
+        , subq_4.__bookings AS __bookings
       FROM (
         -- Select: ['metric_time__month']
         SELECT
-          subq_9.metric_time__month
+          subq_8.metric_time__month
         FROM (
           -- Constrain Output with WHERE
           SELECT
-            subq_8.metric_time__day
-            , subq_8.metric_time__month
+            subq_7.metric_time__day
+            , subq_7.metric_time__month
           FROM (
             -- Select: ['metric_time__month', 'metric_time__day']
             SELECT
-              subq_7.metric_time__day
-              , subq_7.metric_time__month
+              subq_6.metric_time__day
+              , subq_6.metric_time__month
             FROM (
               -- Change Column Aliases
               SELECT
-                subq_6.ds__day AS metric_time__day
-                , subq_6.ds__week
-                , subq_6.ds__month AS metric_time__month
-                , subq_6.ds__quarter
-                , subq_6.ds__year
-                , subq_6.ds__extract_year
-                , subq_6.ds__extract_quarter
-                , subq_6.ds__extract_month
-                , subq_6.ds__extract_day
-                , subq_6.ds__extract_dow
-                , subq_6.ds__extract_doy
-                , subq_6.ds__alien_day
+                subq_5.ds__day AS metric_time__day
+                , subq_5.ds__week
+                , subq_5.ds__month AS metric_time__month
+                , subq_5.ds__quarter
+                , subq_5.ds__year
+                , subq_5.ds__extract_year
+                , subq_5.ds__extract_quarter
+                , subq_5.ds__extract_month
+                , subq_5.ds__extract_day
+                , subq_5.ds__extract_dow
+                , subq_5.ds__extract_doy
+                , subq_5.ds__alien_day
               FROM (
                 -- Read From Time Spine 'mf_time_spine'
                 SELECT
@@ -68,258 +68,249 @@ FROM (
                   , EXTRACT(doy FROM time_spine_src_28006.ds) AS ds__extract_doy
                   , time_spine_src_28006.alien_day AS ds__alien_day
                 FROM ***************************.mf_time_spine time_spine_src_28006
-              ) subq_6
-            ) subq_7
-          ) subq_8
+              ) subq_5
+            ) subq_6
+          ) subq_7
           WHERE metric_time__day = '2020-01-01'
-        ) subq_9
+        ) subq_8
         GROUP BY
-          subq_9.metric_time__month
-      ) subq_10
+          subq_8.metric_time__month
+      ) subq_9
       INNER JOIN (
         -- Aggregate Inputs for Simple Metrics
         SELECT
-          subq_4.metric_time__month
-          , SUM(subq_4.__bookings) AS __bookings
+          subq_3.metric_time__month
+          , SUM(subq_3.__bookings) AS __bookings
         FROM (
           -- Select: ['__bookings', 'metric_time__month']
           SELECT
-            subq_3.metric_time__month
-            , subq_3.__bookings
+            subq_2.metric_time__month
+            , subq_2.__bookings
           FROM (
-            -- Constrain Output with WHERE
+            -- Select: ['__bookings', 'metric_time__month']
             SELECT
-              subq_2.bookings AS __bookings
-              , subq_2.metric_time__day
-              , subq_2.metric_time__month
+              subq_1.metric_time__month
+              , subq_1.__bookings
             FROM (
-              -- Select: ['__bookings', 'metric_time__month', 'metric_time__day']
+              -- Metric Time Dimension 'ds'
               SELECT
-                subq_1.metric_time__day
-                , subq_1.metric_time__month
-                , subq_1.__bookings AS bookings
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.__bookings
+                , subq_0.__average_booking_value
+                , subq_0.__instant_bookings
+                , subq_0.__booking_value
+                , subq_0.__max_booking_value
+                , subq_0.__min_booking_value
+                , subq_0.__instant_booking_value
+                , subq_0.__average_instant_booking_value
+                , subq_0.__booking_value_for_non_null_listing_id
+                , subq_0.__bookers
+                , subq_0.__referred_bookings
+                , subq_0.__median_booking_value
+                , subq_0.__booking_value_p99
+                , subq_0.__discrete_booking_value_p99
+                , subq_0.__approximate_continuous_booking_value_p99
+                , subq_0.__approximate_discrete_booking_value_p99
+                , subq_0.__bookings_join_to_time_spine
+                , subq_0.__bookings_fill_nulls_with_0_without_time_spine
+                , subq_0.__bookings_fill_nulls_with_0
+                , subq_0.__instant_bookings_with_measure_filter
+                , subq_0.__bookings_join_to_time_spine_with_tiered_filters
+                , subq_0.__bookers_fill_nulls_with_0_join_to_timespine
               FROM (
-                -- Metric Time Dimension 'ds'
+                -- Read Elements From Semantic Model 'bookings_source'
                 SELECT
-                  subq_0.ds__day
-                  , subq_0.ds__week
-                  , subq_0.ds__month
-                  , subq_0.ds__quarter
-                  , subq_0.ds__year
-                  , subq_0.ds__extract_year
-                  , subq_0.ds__extract_quarter
-                  , subq_0.ds__extract_month
-                  , subq_0.ds__extract_day
-                  , subq_0.ds__extract_dow
-                  , subq_0.ds__extract_doy
-                  , subq_0.ds_partitioned__day
-                  , subq_0.ds_partitioned__week
-                  , subq_0.ds_partitioned__month
-                  , subq_0.ds_partitioned__quarter
-                  , subq_0.ds_partitioned__year
-                  , subq_0.ds_partitioned__extract_year
-                  , subq_0.ds_partitioned__extract_quarter
-                  , subq_0.ds_partitioned__extract_month
-                  , subq_0.ds_partitioned__extract_day
-                  , subq_0.ds_partitioned__extract_dow
-                  , subq_0.ds_partitioned__extract_doy
-                  , subq_0.paid_at__day
-                  , subq_0.paid_at__week
-                  , subq_0.paid_at__month
-                  , subq_0.paid_at__quarter
-                  , subq_0.paid_at__year
-                  , subq_0.paid_at__extract_year
-                  , subq_0.paid_at__extract_quarter
-                  , subq_0.paid_at__extract_month
-                  , subq_0.paid_at__extract_day
-                  , subq_0.paid_at__extract_dow
-                  , subq_0.paid_at__extract_doy
-                  , subq_0.booking__ds__day
-                  , subq_0.booking__ds__week
-                  , subq_0.booking__ds__month
-                  , subq_0.booking__ds__quarter
-                  , subq_0.booking__ds__year
-                  , subq_0.booking__ds__extract_year
-                  , subq_0.booking__ds__extract_quarter
-                  , subq_0.booking__ds__extract_month
-                  , subq_0.booking__ds__extract_day
-                  , subq_0.booking__ds__extract_dow
-                  , subq_0.booking__ds__extract_doy
-                  , subq_0.booking__ds_partitioned__day
-                  , subq_0.booking__ds_partitioned__week
-                  , subq_0.booking__ds_partitioned__month
-                  , subq_0.booking__ds_partitioned__quarter
-                  , subq_0.booking__ds_partitioned__year
-                  , subq_0.booking__ds_partitioned__extract_year
-                  , subq_0.booking__ds_partitioned__extract_quarter
-                  , subq_0.booking__ds_partitioned__extract_month
-                  , subq_0.booking__ds_partitioned__extract_day
-                  , subq_0.booking__ds_partitioned__extract_dow
-                  , subq_0.booking__ds_partitioned__extract_doy
-                  , subq_0.booking__paid_at__day
-                  , subq_0.booking__paid_at__week
-                  , subq_0.booking__paid_at__month
-                  , subq_0.booking__paid_at__quarter
-                  , subq_0.booking__paid_at__year
-                  , subq_0.booking__paid_at__extract_year
-                  , subq_0.booking__paid_at__extract_quarter
-                  , subq_0.booking__paid_at__extract_month
-                  , subq_0.booking__paid_at__extract_day
-                  , subq_0.booking__paid_at__extract_dow
-                  , subq_0.booking__paid_at__extract_doy
-                  , subq_0.ds__day AS metric_time__day
-                  , subq_0.ds__week AS metric_time__week
-                  , subq_0.ds__month AS metric_time__month
-                  , subq_0.ds__quarter AS metric_time__quarter
-                  , subq_0.ds__year AS metric_time__year
-                  , subq_0.ds__extract_year AS metric_time__extract_year
-                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_0.ds__extract_month AS metric_time__extract_month
-                  , subq_0.ds__extract_day AS metric_time__extract_day
-                  , subq_0.ds__extract_dow AS metric_time__extract_dow
-                  , subq_0.ds__extract_doy AS metric_time__extract_doy
-                  , subq_0.listing
-                  , subq_0.guest
-                  , subq_0.host
-                  , subq_0.booking__listing
-                  , subq_0.booking__guest
-                  , subq_0.booking__host
-                  , subq_0.is_instant
-                  , subq_0.booking__is_instant
-                  , subq_0.__bookings
-                  , subq_0.__average_booking_value
-                  , subq_0.__instant_bookings
-                  , subq_0.__booking_value
-                  , subq_0.__max_booking_value
-                  , subq_0.__min_booking_value
-                  , subq_0.__instant_booking_value
-                  , subq_0.__average_instant_booking_value
-                  , subq_0.__booking_value_for_non_null_listing_id
-                  , subq_0.__bookers
-                  , subq_0.__referred_bookings
-                  , subq_0.__median_booking_value
-                  , subq_0.__booking_value_p99
-                  , subq_0.__discrete_booking_value_p99
-                  , subq_0.__approximate_continuous_booking_value_p99
-                  , subq_0.__approximate_discrete_booking_value_p99
-                  , subq_0.__bookings_join_to_time_spine
-                  , subq_0.__bookings_fill_nulls_with_0_without_time_spine
-                  , subq_0.__bookings_fill_nulls_with_0
-                  , subq_0.__instant_bookings_with_measure_filter
-                  , subq_0.__bookings_join_to_time_spine_with_tiered_filters
-                  , subq_0.__bookers_fill_nulls_with_0_join_to_timespine
-                FROM (
-                  -- Read Elements From Semantic Model 'bookings_source'
-                  SELECT
-                    1 AS __bookings
-                    , bookings_source_src_28000.booking_value AS __average_booking_value
-                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS __instant_bookings
-                    , bookings_source_src_28000.booking_value AS __booking_value
-                    , bookings_source_src_28000.booking_value AS __max_booking_value
-                    , bookings_source_src_28000.booking_value AS __min_booking_value
-                    , bookings_source_src_28000.booking_value AS __instant_booking_value
-                    , bookings_source_src_28000.booking_value AS __average_instant_booking_value
-                    , bookings_source_src_28000.booking_value AS __booking_value_for_non_null_listing_id
-                    , bookings_source_src_28000.guest_id AS __bookers
-                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS __referred_bookings
-                    , bookings_source_src_28000.booking_value AS __median_booking_value
-                    , bookings_source_src_28000.booking_value AS __booking_value_p99
-                    , bookings_source_src_28000.booking_value AS __discrete_booking_value_p99
-                    , bookings_source_src_28000.booking_value AS __approximate_continuous_booking_value_p99
-                    , bookings_source_src_28000.booking_value AS __approximate_discrete_booking_value_p99
-                    , 1 AS __bookings_join_to_time_spine
-                    , 1 AS __bookings_fill_nulls_with_0_without_time_spine
-                    , 1 AS __bookings_fill_nulls_with_0
-                    , 1 AS __instant_bookings_with_measure_filter
-                    , 1 AS __bookings_join_to_time_spine_with_tiered_filters
-                    , bookings_source_src_28000.guest_id AS __bookers_fill_nulls_with_0_join_to_timespine
-                    , bookings_source_src_28000.booking_value AS __booking_payments
-                    , bookings_source_src_28000.is_instant
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                    , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS ds__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                    , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS ds_partitioned__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                    , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS paid_at__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                    , bookings_source_src_28000.is_instant AS booking__is_instant
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                    , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS booking__ds__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                    , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS booking__ds_partitioned__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                    , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS booking__paid_at__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                    , bookings_source_src_28000.listing_id AS listing
-                    , bookings_source_src_28000.guest_id AS guest
-                    , bookings_source_src_28000.host_id AS host
-                    , bookings_source_src_28000.listing_id AS booking__listing
-                    , bookings_source_src_28000.guest_id AS booking__guest
-                    , bookings_source_src_28000.host_id AS booking__host
-                  FROM ***************************.fct_bookings bookings_source_src_28000
-                ) subq_0
-              ) subq_1
-            ) subq_2
-            WHERE metric_time__day = '2020-01-01'
-          ) subq_3
-        ) subq_4
+                  1 AS __bookings
+                  , bookings_source_src_28000.booking_value AS __average_booking_value
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS __instant_bookings
+                  , bookings_source_src_28000.booking_value AS __booking_value
+                  , bookings_source_src_28000.booking_value AS __max_booking_value
+                  , bookings_source_src_28000.booking_value AS __min_booking_value
+                  , bookings_source_src_28000.booking_value AS __instant_booking_value
+                  , bookings_source_src_28000.booking_value AS __average_instant_booking_value
+                  , bookings_source_src_28000.booking_value AS __booking_value_for_non_null_listing_id
+                  , bookings_source_src_28000.guest_id AS __bookers
+                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS __referred_bookings
+                  , bookings_source_src_28000.booking_value AS __median_booking_value
+                  , bookings_source_src_28000.booking_value AS __booking_value_p99
+                  , bookings_source_src_28000.booking_value AS __discrete_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS __approximate_continuous_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS __approximate_discrete_booking_value_p99
+                  , 1 AS __bookings_join_to_time_spine
+                  , 1 AS __bookings_fill_nulls_with_0_without_time_spine
+                  , 1 AS __bookings_fill_nulls_with_0
+                  , 1 AS __instant_bookings_with_measure_filter
+                  , 1 AS __bookings_join_to_time_spine_with_tiered_filters
+                  , bookings_source_src_28000.guest_id AS __bookers_fill_nulls_with_0_join_to_timespine
+                  , bookings_source_src_28000.booking_value AS __booking_payments
+                  , bookings_source_src_28000.is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                  , bookings_source_src_28000.is_instant AS booking__is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS booking__ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS booking__ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS booking__paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                  , bookings_source_src_28000.listing_id AS listing
+                  , bookings_source_src_28000.guest_id AS guest
+                  , bookings_source_src_28000.host_id AS host
+                  , bookings_source_src_28000.listing_id AS booking__listing
+                  , bookings_source_src_28000.guest_id AS booking__guest
+                  , bookings_source_src_28000.host_id AS booking__host
+                FROM ***************************.fct_bookings bookings_source_src_28000
+              ) subq_0
+            ) subq_1
+          ) subq_2
+        ) subq_3
         GROUP BY
-          subq_4.metric_time__month
-      ) subq_5
+          subq_3.metric_time__month
+      ) subq_4
       ON
-        DATE_TRUNC('month', subq_10.metric_time__month) = subq_5.metric_time__month
-    ) subq_11
-  ) subq_12
-) subq_13
+        DATE_TRUNC('month', subq_9.metric_time__month) = subq_4.metric_time__month
+    ) subq_10
+  ) subq_11
+) subq_12

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
@@ -13,8 +13,8 @@ FROM (
   -- Join to Time Spine Dataset
   -- Compute Metrics via Expressions
   SELECT
-    subq_24.metric_time__month AS metric_time__month
-    , subq_19.__bookings AS bookings_start_of_month
+    subq_22.metric_time__month AS metric_time__month
+    , subq_17.__bookings AS bookings_start_of_month
   FROM (
     -- Constrain Output with WHERE
     -- Select: ['metric_time__month']
@@ -28,32 +28,29 @@ FROM (
         ds AS metric_time__day
         , DATE_TRUNC('month', ds) AS metric_time__month
       FROM ***************************.mf_time_spine time_spine_src_28006
-    ) subq_22
+    ) subq_20
     WHERE metric_time__day = '2020-01-01'
     GROUP BY
       metric_time__month
-  ) subq_24
+  ) subq_22
   INNER JOIN (
-    -- Constrain Output with WHERE
-    -- Select: ['__bookings', 'metric_time__month']
     -- Aggregate Inputs for Simple Metrics
     SELECT
       metric_time__month
-      , SUM(bookings) AS __bookings
+      , SUM(__bookings) AS __bookings
     FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
-      -- Select: ['__bookings', 'metric_time__month', 'metric_time__day']
+      -- Select: ['__bookings', 'metric_time__month']
+      -- Select: ['__bookings', 'metric_time__month']
       SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , DATE_TRUNC('month', ds) AS metric_time__month
-        , 1 AS bookings
+        DATE_TRUNC('month', ds) AS metric_time__month
+        , 1 AS __bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
     ) subq_16
-    WHERE metric_time__day = '2020-01-01'
     GROUP BY
       metric_time__month
-  ) subq_19
+  ) subq_17
   ON
-    DATE_TRUNC('month', subq_24.metric_time__month) = subq_19.metric_time__month
-) subq_26
+    DATE_TRUNC('month', subq_22.metric_time__month) = subq_17.metric_time__month
+) subq_24

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_offset_window_metric_filter_and_query_have_different_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_offset_window_metric_filter_and_query_have_different_granularities__plan0.sql
@@ -35,129 +35,127 @@ FROM (
             subq_8.metric_time__month
             , subq_8.__booking_value
           FROM (
-            -- Constrain Output with WHERE
+            -- Select: ['__booking_value', 'metric_time__month']
             SELECT
-              subq_7.booking_value AS __booking_value
-              , subq_7.metric_time__day
-              , subq_7.metric_time__month
+              subq_7.metric_time__month
+              , subq_7.__booking_value
             FROM (
-              -- Select: ['__booking_value', 'metric_time__month', 'metric_time__day']
+              -- Join to Time Spine Dataset
               SELECT
-                subq_6.metric_time__day
-                , subq_6.metric_time__month
-                , subq_6.__booking_value AS booking_value
+                subq_6.metric_time__day AS metric_time__day
+                , subq_6.metric_time__month AS metric_time__month
+                , subq_1.ds__day AS ds__day
+                , subq_1.ds__week AS ds__week
+                , subq_1.ds__month AS ds__month
+                , subq_1.ds__quarter AS ds__quarter
+                , subq_1.ds__year AS ds__year
+                , subq_1.ds__extract_year AS ds__extract_year
+                , subq_1.ds__extract_quarter AS ds__extract_quarter
+                , subq_1.ds__extract_month AS ds__extract_month
+                , subq_1.ds__extract_day AS ds__extract_day
+                , subq_1.ds__extract_dow AS ds__extract_dow
+                , subq_1.ds__extract_doy AS ds__extract_doy
+                , subq_1.ds_partitioned__day AS ds_partitioned__day
+                , subq_1.ds_partitioned__week AS ds_partitioned__week
+                , subq_1.ds_partitioned__month AS ds_partitioned__month
+                , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
+                , subq_1.ds_partitioned__year AS ds_partitioned__year
+                , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
+                , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+                , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
+                , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
+                , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+                , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+                , subq_1.paid_at__day AS paid_at__day
+                , subq_1.paid_at__week AS paid_at__week
+                , subq_1.paid_at__month AS paid_at__month
+                , subq_1.paid_at__quarter AS paid_at__quarter
+                , subq_1.paid_at__year AS paid_at__year
+                , subq_1.paid_at__extract_year AS paid_at__extract_year
+                , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
+                , subq_1.paid_at__extract_month AS paid_at__extract_month
+                , subq_1.paid_at__extract_day AS paid_at__extract_day
+                , subq_1.paid_at__extract_dow AS paid_at__extract_dow
+                , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+                , subq_1.booking__ds__day AS booking__ds__day
+                , subq_1.booking__ds__week AS booking__ds__week
+                , subq_1.booking__ds__month AS booking__ds__month
+                , subq_1.booking__ds__quarter AS booking__ds__quarter
+                , subq_1.booking__ds__year AS booking__ds__year
+                , subq_1.booking__ds__extract_year AS booking__ds__extract_year
+                , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
+                , subq_1.booking__ds__extract_month AS booking__ds__extract_month
+                , subq_1.booking__ds__extract_day AS booking__ds__extract_day
+                , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
+                , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
+                , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
+                , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
+                , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
+                , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+                , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
+                , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+                , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+                , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+                , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+                , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+                , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+                , subq_1.booking__paid_at__day AS booking__paid_at__day
+                , subq_1.booking__paid_at__week AS booking__paid_at__week
+                , subq_1.booking__paid_at__month AS booking__paid_at__month
+                , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
+                , subq_1.booking__paid_at__year AS booking__paid_at__year
+                , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
+                , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+                , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
+                , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
+                , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+                , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                , subq_1.metric_time__week AS metric_time__week
+                , subq_1.metric_time__quarter AS metric_time__quarter
+                , subq_1.metric_time__year AS metric_time__year
+                , subq_1.metric_time__extract_year AS metric_time__extract_year
+                , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+                , subq_1.metric_time__extract_month AS metric_time__extract_month
+                , subq_1.metric_time__extract_day AS metric_time__extract_day
+                , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+                , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+                , subq_1.listing AS listing
+                , subq_1.guest AS guest
+                , subq_1.host AS host
+                , subq_1.booking__listing AS booking__listing
+                , subq_1.booking__guest AS booking__guest
+                , subq_1.booking__host AS booking__host
+                , subq_1.is_instant AS is_instant
+                , subq_1.booking__is_instant AS booking__is_instant
+                , subq_1.__bookings AS __bookings
+                , subq_1.__average_booking_value AS __average_booking_value
+                , subq_1.__instant_bookings AS __instant_bookings
+                , subq_1.__booking_value AS __booking_value
+                , subq_1.__max_booking_value AS __max_booking_value
+                , subq_1.__min_booking_value AS __min_booking_value
+                , subq_1.__instant_booking_value AS __instant_booking_value
+                , subq_1.__average_instant_booking_value AS __average_instant_booking_value
+                , subq_1.__booking_value_for_non_null_listing_id AS __booking_value_for_non_null_listing_id
+                , subq_1.__bookers AS __bookers
+                , subq_1.__referred_bookings AS __referred_bookings
+                , subq_1.__median_booking_value AS __median_booking_value
+                , subq_1.__booking_value_p99 AS __booking_value_p99
+                , subq_1.__discrete_booking_value_p99 AS __discrete_booking_value_p99
+                , subq_1.__approximate_continuous_booking_value_p99 AS __approximate_continuous_booking_value_p99
+                , subq_1.__approximate_discrete_booking_value_p99 AS __approximate_discrete_booking_value_p99
+                , subq_1.__bookings_join_to_time_spine AS __bookings_join_to_time_spine
+                , subq_1.__bookings_fill_nulls_with_0_without_time_spine AS __bookings_fill_nulls_with_0_without_time_spine
+                , subq_1.__bookings_fill_nulls_with_0 AS __bookings_fill_nulls_with_0
+                , subq_1.__instant_bookings_with_measure_filter AS __instant_bookings_with_measure_filter
+                , subq_1.__bookings_join_to_time_spine_with_tiered_filters AS __bookings_join_to_time_spine_with_tiered_filters
+                , subq_1.__bookers_fill_nulls_with_0_join_to_timespine AS __bookers_fill_nulls_with_0_join_to_timespine
               FROM (
-                -- Join to Time Spine Dataset
+                -- Select: ['metric_time__day', 'metric_time__month']
                 SELECT
-                  subq_5.metric_time__day AS metric_time__day
-                  , subq_5.metric_time__month AS metric_time__month
-                  , subq_1.ds__day AS ds__day
-                  , subq_1.ds__week AS ds__week
-                  , subq_1.ds__month AS ds__month
-                  , subq_1.ds__quarter AS ds__quarter
-                  , subq_1.ds__year AS ds__year
-                  , subq_1.ds__extract_year AS ds__extract_year
-                  , subq_1.ds__extract_quarter AS ds__extract_quarter
-                  , subq_1.ds__extract_month AS ds__extract_month
-                  , subq_1.ds__extract_day AS ds__extract_day
-                  , subq_1.ds__extract_dow AS ds__extract_dow
-                  , subq_1.ds__extract_doy AS ds__extract_doy
-                  , subq_1.ds_partitioned__day AS ds_partitioned__day
-                  , subq_1.ds_partitioned__week AS ds_partitioned__week
-                  , subq_1.ds_partitioned__month AS ds_partitioned__month
-                  , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
-                  , subq_1.ds_partitioned__year AS ds_partitioned__year
-                  , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
-                  , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
-                  , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
-                  , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
-                  , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
-                  , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
-                  , subq_1.paid_at__day AS paid_at__day
-                  , subq_1.paid_at__week AS paid_at__week
-                  , subq_1.paid_at__month AS paid_at__month
-                  , subq_1.paid_at__quarter AS paid_at__quarter
-                  , subq_1.paid_at__year AS paid_at__year
-                  , subq_1.paid_at__extract_year AS paid_at__extract_year
-                  , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
-                  , subq_1.paid_at__extract_month AS paid_at__extract_month
-                  , subq_1.paid_at__extract_day AS paid_at__extract_day
-                  , subq_1.paid_at__extract_dow AS paid_at__extract_dow
-                  , subq_1.paid_at__extract_doy AS paid_at__extract_doy
-                  , subq_1.booking__ds__day AS booking__ds__day
-                  , subq_1.booking__ds__week AS booking__ds__week
-                  , subq_1.booking__ds__month AS booking__ds__month
-                  , subq_1.booking__ds__quarter AS booking__ds__quarter
-                  , subq_1.booking__ds__year AS booking__ds__year
-                  , subq_1.booking__ds__extract_year AS booking__ds__extract_year
-                  , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
-                  , subq_1.booking__ds__extract_month AS booking__ds__extract_month
-                  , subq_1.booking__ds__extract_day AS booking__ds__extract_day
-                  , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
-                  , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
-                  , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
-                  , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
-                  , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
-                  , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
-                  , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
-                  , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
-                  , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
-                  , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
-                  , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
-                  , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
-                  , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
-                  , subq_1.booking__paid_at__day AS booking__paid_at__day
-                  , subq_1.booking__paid_at__week AS booking__paid_at__week
-                  , subq_1.booking__paid_at__month AS booking__paid_at__month
-                  , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
-                  , subq_1.booking__paid_at__year AS booking__paid_at__year
-                  , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
-                  , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
-                  , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
-                  , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
-                  , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
-                  , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
-                  , subq_1.metric_time__week AS metric_time__week
-                  , subq_1.metric_time__quarter AS metric_time__quarter
-                  , subq_1.metric_time__year AS metric_time__year
-                  , subq_1.metric_time__extract_year AS metric_time__extract_year
-                  , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
-                  , subq_1.metric_time__extract_month AS metric_time__extract_month
-                  , subq_1.metric_time__extract_day AS metric_time__extract_day
-                  , subq_1.metric_time__extract_dow AS metric_time__extract_dow
-                  , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-                  , subq_1.listing AS listing
-                  , subq_1.guest AS guest
-                  , subq_1.host AS host
-                  , subq_1.booking__listing AS booking__listing
-                  , subq_1.booking__guest AS booking__guest
-                  , subq_1.booking__host AS booking__host
-                  , subq_1.is_instant AS is_instant
-                  , subq_1.booking__is_instant AS booking__is_instant
-                  , subq_1.__bookings AS __bookings
-                  , subq_1.__average_booking_value AS __average_booking_value
-                  , subq_1.__instant_bookings AS __instant_bookings
-                  , subq_1.__booking_value AS __booking_value
-                  , subq_1.__max_booking_value AS __max_booking_value
-                  , subq_1.__min_booking_value AS __min_booking_value
-                  , subq_1.__instant_booking_value AS __instant_booking_value
-                  , subq_1.__average_instant_booking_value AS __average_instant_booking_value
-                  , subq_1.__booking_value_for_non_null_listing_id AS __booking_value_for_non_null_listing_id
-                  , subq_1.__bookers AS __bookers
-                  , subq_1.__referred_bookings AS __referred_bookings
-                  , subq_1.__median_booking_value AS __median_booking_value
-                  , subq_1.__booking_value_p99 AS __booking_value_p99
-                  , subq_1.__discrete_booking_value_p99 AS __discrete_booking_value_p99
-                  , subq_1.__approximate_continuous_booking_value_p99 AS __approximate_continuous_booking_value_p99
-                  , subq_1.__approximate_discrete_booking_value_p99 AS __approximate_discrete_booking_value_p99
-                  , subq_1.__bookings_join_to_time_spine AS __bookings_join_to_time_spine
-                  , subq_1.__bookings_fill_nulls_with_0_without_time_spine AS __bookings_fill_nulls_with_0_without_time_spine
-                  , subq_1.__bookings_fill_nulls_with_0 AS __bookings_fill_nulls_with_0
-                  , subq_1.__instant_bookings_with_measure_filter AS __instant_bookings_with_measure_filter
-                  , subq_1.__bookings_join_to_time_spine_with_tiered_filters AS __bookings_join_to_time_spine_with_tiered_filters
-                  , subq_1.__bookers_fill_nulls_with_0_join_to_timespine AS __bookers_fill_nulls_with_0_join_to_timespine
+                  subq_5.metric_time__day
+                  , subq_5.metric_time__month
                 FROM (
-                  -- Select: ['metric_time__day', 'metric_time__month']
+                  -- Constrain Output with WHERE
                   SELECT
                     subq_4.metric_time__day
                     , subq_4.metric_time__month
@@ -200,225 +198,225 @@ FROM (
                       ) subq_2
                     ) subq_3
                   ) subq_4
+                  WHERE metric_time__day = '2020-01-01'
                 ) subq_5
-                INNER JOIN (
-                  -- Metric Time Dimension 'ds'
-                  SELECT
-                    subq_0.ds__day
-                    , subq_0.ds__week
-                    , subq_0.ds__month
-                    , subq_0.ds__quarter
-                    , subq_0.ds__year
-                    , subq_0.ds__extract_year
-                    , subq_0.ds__extract_quarter
-                    , subq_0.ds__extract_month
-                    , subq_0.ds__extract_day
-                    , subq_0.ds__extract_dow
-                    , subq_0.ds__extract_doy
-                    , subq_0.ds_partitioned__day
-                    , subq_0.ds_partitioned__week
-                    , subq_0.ds_partitioned__month
-                    , subq_0.ds_partitioned__quarter
-                    , subq_0.ds_partitioned__year
-                    , subq_0.ds_partitioned__extract_year
-                    , subq_0.ds_partitioned__extract_quarter
-                    , subq_0.ds_partitioned__extract_month
-                    , subq_0.ds_partitioned__extract_day
-                    , subq_0.ds_partitioned__extract_dow
-                    , subq_0.ds_partitioned__extract_doy
-                    , subq_0.paid_at__day
-                    , subq_0.paid_at__week
-                    , subq_0.paid_at__month
-                    , subq_0.paid_at__quarter
-                    , subq_0.paid_at__year
-                    , subq_0.paid_at__extract_year
-                    , subq_0.paid_at__extract_quarter
-                    , subq_0.paid_at__extract_month
-                    , subq_0.paid_at__extract_day
-                    , subq_0.paid_at__extract_dow
-                    , subq_0.paid_at__extract_doy
-                    , subq_0.booking__ds__day
-                    , subq_0.booking__ds__week
-                    , subq_0.booking__ds__month
-                    , subq_0.booking__ds__quarter
-                    , subq_0.booking__ds__year
-                    , subq_0.booking__ds__extract_year
-                    , subq_0.booking__ds__extract_quarter
-                    , subq_0.booking__ds__extract_month
-                    , subq_0.booking__ds__extract_day
-                    , subq_0.booking__ds__extract_dow
-                    , subq_0.booking__ds__extract_doy
-                    , subq_0.booking__ds_partitioned__day
-                    , subq_0.booking__ds_partitioned__week
-                    , subq_0.booking__ds_partitioned__month
-                    , subq_0.booking__ds_partitioned__quarter
-                    , subq_0.booking__ds_partitioned__year
-                    , subq_0.booking__ds_partitioned__extract_year
-                    , subq_0.booking__ds_partitioned__extract_quarter
-                    , subq_0.booking__ds_partitioned__extract_month
-                    , subq_0.booking__ds_partitioned__extract_day
-                    , subq_0.booking__ds_partitioned__extract_dow
-                    , subq_0.booking__ds_partitioned__extract_doy
-                    , subq_0.booking__paid_at__day
-                    , subq_0.booking__paid_at__week
-                    , subq_0.booking__paid_at__month
-                    , subq_0.booking__paid_at__quarter
-                    , subq_0.booking__paid_at__year
-                    , subq_0.booking__paid_at__extract_year
-                    , subq_0.booking__paid_at__extract_quarter
-                    , subq_0.booking__paid_at__extract_month
-                    , subq_0.booking__paid_at__extract_day
-                    , subq_0.booking__paid_at__extract_dow
-                    , subq_0.booking__paid_at__extract_doy
-                    , subq_0.ds__day AS metric_time__day
-                    , subq_0.ds__week AS metric_time__week
-                    , subq_0.ds__month AS metric_time__month
-                    , subq_0.ds__quarter AS metric_time__quarter
-                    , subq_0.ds__year AS metric_time__year
-                    , subq_0.ds__extract_year AS metric_time__extract_year
-                    , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                    , subq_0.ds__extract_month AS metric_time__extract_month
-                    , subq_0.ds__extract_day AS metric_time__extract_day
-                    , subq_0.ds__extract_dow AS metric_time__extract_dow
-                    , subq_0.ds__extract_doy AS metric_time__extract_doy
-                    , subq_0.listing
-                    , subq_0.guest
-                    , subq_0.host
-                    , subq_0.booking__listing
-                    , subq_0.booking__guest
-                    , subq_0.booking__host
-                    , subq_0.is_instant
-                    , subq_0.booking__is_instant
-                    , subq_0.__bookings
-                    , subq_0.__average_booking_value
-                    , subq_0.__instant_bookings
-                    , subq_0.__booking_value
-                    , subq_0.__max_booking_value
-                    , subq_0.__min_booking_value
-                    , subq_0.__instant_booking_value
-                    , subq_0.__average_instant_booking_value
-                    , subq_0.__booking_value_for_non_null_listing_id
-                    , subq_0.__bookers
-                    , subq_0.__referred_bookings
-                    , subq_0.__median_booking_value
-                    , subq_0.__booking_value_p99
-                    , subq_0.__discrete_booking_value_p99
-                    , subq_0.__approximate_continuous_booking_value_p99
-                    , subq_0.__approximate_discrete_booking_value_p99
-                    , subq_0.__bookings_join_to_time_spine
-                    , subq_0.__bookings_fill_nulls_with_0_without_time_spine
-                    , subq_0.__bookings_fill_nulls_with_0
-                    , subq_0.__instant_bookings_with_measure_filter
-                    , subq_0.__bookings_join_to_time_spine_with_tiered_filters
-                    , subq_0.__bookers_fill_nulls_with_0_join_to_timespine
-                  FROM (
-                    -- Read Elements From Semantic Model 'bookings_source'
-                    SELECT
-                      1 AS __bookings
-                      , bookings_source_src_28000.booking_value AS __average_booking_value
-                      , CASE WHEN is_instant THEN 1 ELSE 0 END AS __instant_bookings
-                      , bookings_source_src_28000.booking_value AS __booking_value
-                      , bookings_source_src_28000.booking_value AS __max_booking_value
-                      , bookings_source_src_28000.booking_value AS __min_booking_value
-                      , bookings_source_src_28000.booking_value AS __instant_booking_value
-                      , bookings_source_src_28000.booking_value AS __average_instant_booking_value
-                      , bookings_source_src_28000.booking_value AS __booking_value_for_non_null_listing_id
-                      , bookings_source_src_28000.guest_id AS __bookers
-                      , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS __referred_bookings
-                      , bookings_source_src_28000.booking_value AS __median_booking_value
-                      , bookings_source_src_28000.booking_value AS __booking_value_p99
-                      , bookings_source_src_28000.booking_value AS __discrete_booking_value_p99
-                      , bookings_source_src_28000.booking_value AS __approximate_continuous_booking_value_p99
-                      , bookings_source_src_28000.booking_value AS __approximate_discrete_booking_value_p99
-                      , 1 AS __bookings_join_to_time_spine
-                      , 1 AS __bookings_fill_nulls_with_0_without_time_spine
-                      , 1 AS __bookings_fill_nulls_with_0
-                      , 1 AS __instant_bookings_with_measure_filter
-                      , 1 AS __bookings_join_to_time_spine_with_tiered_filters
-                      , bookings_source_src_28000.guest_id AS __bookers_fill_nulls_with_0_join_to_timespine
-                      , bookings_source_src_28000.booking_value AS __booking_payments
-                      , bookings_source_src_28000.is_instant
-                      , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                      , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                      , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS ds__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                      , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                      , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                      , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS ds_partitioned__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                      , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                      , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                      , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS paid_at__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                      , bookings_source_src_28000.is_instant AS booking__is_instant
-                      , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                      , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                      , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS booking__ds__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                      , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                      , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                      , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS booking__ds_partitioned__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                      , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                      , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                      , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS booking__paid_at__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                      , bookings_source_src_28000.listing_id AS listing
-                      , bookings_source_src_28000.guest_id AS guest
-                      , bookings_source_src_28000.host_id AS host
-                      , bookings_source_src_28000.listing_id AS booking__listing
-                      , bookings_source_src_28000.guest_id AS booking__guest
-                      , bookings_source_src_28000.host_id AS booking__host
-                    FROM ***************************.fct_bookings bookings_source_src_28000
-                  ) subq_0
-                ) subq_1
-                ON
-                  DATEADD(week, -1, subq_5.metric_time__day) = subq_1.metric_time__day
               ) subq_6
+              INNER JOIN (
+                -- Metric Time Dimension 'ds'
+                SELECT
+                  subq_0.ds__day
+                  , subq_0.ds__week
+                  , subq_0.ds__month
+                  , subq_0.ds__quarter
+                  , subq_0.ds__year
+                  , subq_0.ds__extract_year
+                  , subq_0.ds__extract_quarter
+                  , subq_0.ds__extract_month
+                  , subq_0.ds__extract_day
+                  , subq_0.ds__extract_dow
+                  , subq_0.ds__extract_doy
+                  , subq_0.ds_partitioned__day
+                  , subq_0.ds_partitioned__week
+                  , subq_0.ds_partitioned__month
+                  , subq_0.ds_partitioned__quarter
+                  , subq_0.ds_partitioned__year
+                  , subq_0.ds_partitioned__extract_year
+                  , subq_0.ds_partitioned__extract_quarter
+                  , subq_0.ds_partitioned__extract_month
+                  , subq_0.ds_partitioned__extract_day
+                  , subq_0.ds_partitioned__extract_dow
+                  , subq_0.ds_partitioned__extract_doy
+                  , subq_0.paid_at__day
+                  , subq_0.paid_at__week
+                  , subq_0.paid_at__month
+                  , subq_0.paid_at__quarter
+                  , subq_0.paid_at__year
+                  , subq_0.paid_at__extract_year
+                  , subq_0.paid_at__extract_quarter
+                  , subq_0.paid_at__extract_month
+                  , subq_0.paid_at__extract_day
+                  , subq_0.paid_at__extract_dow
+                  , subq_0.paid_at__extract_doy
+                  , subq_0.booking__ds__day
+                  , subq_0.booking__ds__week
+                  , subq_0.booking__ds__month
+                  , subq_0.booking__ds__quarter
+                  , subq_0.booking__ds__year
+                  , subq_0.booking__ds__extract_year
+                  , subq_0.booking__ds__extract_quarter
+                  , subq_0.booking__ds__extract_month
+                  , subq_0.booking__ds__extract_day
+                  , subq_0.booking__ds__extract_dow
+                  , subq_0.booking__ds__extract_doy
+                  , subq_0.booking__ds_partitioned__day
+                  , subq_0.booking__ds_partitioned__week
+                  , subq_0.booking__ds_partitioned__month
+                  , subq_0.booking__ds_partitioned__quarter
+                  , subq_0.booking__ds_partitioned__year
+                  , subq_0.booking__ds_partitioned__extract_year
+                  , subq_0.booking__ds_partitioned__extract_quarter
+                  , subq_0.booking__ds_partitioned__extract_month
+                  , subq_0.booking__ds_partitioned__extract_day
+                  , subq_0.booking__ds_partitioned__extract_dow
+                  , subq_0.booking__ds_partitioned__extract_doy
+                  , subq_0.booking__paid_at__day
+                  , subq_0.booking__paid_at__week
+                  , subq_0.booking__paid_at__month
+                  , subq_0.booking__paid_at__quarter
+                  , subq_0.booking__paid_at__year
+                  , subq_0.booking__paid_at__extract_year
+                  , subq_0.booking__paid_at__extract_quarter
+                  , subq_0.booking__paid_at__extract_month
+                  , subq_0.booking__paid_at__extract_day
+                  , subq_0.booking__paid_at__extract_dow
+                  , subq_0.booking__paid_at__extract_doy
+                  , subq_0.ds__day AS metric_time__day
+                  , subq_0.ds__week AS metric_time__week
+                  , subq_0.ds__month AS metric_time__month
+                  , subq_0.ds__quarter AS metric_time__quarter
+                  , subq_0.ds__year AS metric_time__year
+                  , subq_0.ds__extract_year AS metric_time__extract_year
+                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_0.ds__extract_month AS metric_time__extract_month
+                  , subq_0.ds__extract_day AS metric_time__extract_day
+                  , subq_0.ds__extract_dow AS metric_time__extract_dow
+                  , subq_0.ds__extract_doy AS metric_time__extract_doy
+                  , subq_0.listing
+                  , subq_0.guest
+                  , subq_0.host
+                  , subq_0.booking__listing
+                  , subq_0.booking__guest
+                  , subq_0.booking__host
+                  , subq_0.is_instant
+                  , subq_0.booking__is_instant
+                  , subq_0.__bookings
+                  , subq_0.__average_booking_value
+                  , subq_0.__instant_bookings
+                  , subq_0.__booking_value
+                  , subq_0.__max_booking_value
+                  , subq_0.__min_booking_value
+                  , subq_0.__instant_booking_value
+                  , subq_0.__average_instant_booking_value
+                  , subq_0.__booking_value_for_non_null_listing_id
+                  , subq_0.__bookers
+                  , subq_0.__referred_bookings
+                  , subq_0.__median_booking_value
+                  , subq_0.__booking_value_p99
+                  , subq_0.__discrete_booking_value_p99
+                  , subq_0.__approximate_continuous_booking_value_p99
+                  , subq_0.__approximate_discrete_booking_value_p99
+                  , subq_0.__bookings_join_to_time_spine
+                  , subq_0.__bookings_fill_nulls_with_0_without_time_spine
+                  , subq_0.__bookings_fill_nulls_with_0
+                  , subq_0.__instant_bookings_with_measure_filter
+                  , subq_0.__bookings_join_to_time_spine_with_tiered_filters
+                  , subq_0.__bookers_fill_nulls_with_0_join_to_timespine
+                FROM (
+                  -- Read Elements From Semantic Model 'bookings_source'
+                  SELECT
+                    1 AS __bookings
+                    , bookings_source_src_28000.booking_value AS __average_booking_value
+                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS __instant_bookings
+                    , bookings_source_src_28000.booking_value AS __booking_value
+                    , bookings_source_src_28000.booking_value AS __max_booking_value
+                    , bookings_source_src_28000.booking_value AS __min_booking_value
+                    , bookings_source_src_28000.booking_value AS __instant_booking_value
+                    , bookings_source_src_28000.booking_value AS __average_instant_booking_value
+                    , bookings_source_src_28000.booking_value AS __booking_value_for_non_null_listing_id
+                    , bookings_source_src_28000.guest_id AS __bookers
+                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS __referred_bookings
+                    , bookings_source_src_28000.booking_value AS __median_booking_value
+                    , bookings_source_src_28000.booking_value AS __booking_value_p99
+                    , bookings_source_src_28000.booking_value AS __discrete_booking_value_p99
+                    , bookings_source_src_28000.booking_value AS __approximate_continuous_booking_value_p99
+                    , bookings_source_src_28000.booking_value AS __approximate_discrete_booking_value_p99
+                    , 1 AS __bookings_join_to_time_spine
+                    , 1 AS __bookings_fill_nulls_with_0_without_time_spine
+                    , 1 AS __bookings_fill_nulls_with_0
+                    , 1 AS __instant_bookings_with_measure_filter
+                    , 1 AS __bookings_join_to_time_spine_with_tiered_filters
+                    , bookings_source_src_28000.guest_id AS __bookers_fill_nulls_with_0_join_to_timespine
+                    , bookings_source_src_28000.booking_value AS __booking_payments
+                    , bookings_source_src_28000.is_instant
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                    , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                    , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                    , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                    , bookings_source_src_28000.is_instant AS booking__is_instant
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                    , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS booking__ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                    , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS booking__ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                    , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS booking__paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                    , bookings_source_src_28000.listing_id AS listing
+                    , bookings_source_src_28000.guest_id AS guest
+                    , bookings_source_src_28000.host_id AS host
+                    , bookings_source_src_28000.listing_id AS booking__listing
+                    , bookings_source_src_28000.guest_id AS booking__guest
+                    , bookings_source_src_28000.host_id AS booking__host
+                  FROM ***************************.fct_bookings bookings_source_src_28000
+                ) subq_0
+              ) subq_1
+              ON
+                DATEADD(week, -1, subq_6.metric_time__day) = subq_1.metric_time__day
             ) subq_7
-            WHERE metric_time__day = '2020-01-01'
           ) subq_8
         ) subq_9
         GROUP BY

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_offset_window_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Redshift/test_offset_window_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
@@ -27,29 +27,37 @@ FROM (
     , MAX(subq_31.booking_value) AS booking_value
     , MAX(subq_37.bookers) AS bookers
   FROM (
-    -- Constrain Output with WHERE
+    -- Join to Time Spine Dataset
+    -- Select: ['__booking_value', 'metric_time__month']
     -- Select: ['__booking_value', 'metric_time__month']
     -- Aggregate Inputs for Simple Metrics
     -- Compute Metrics via Expressions
     SELECT
-      metric_time__month
-      , SUM(booking_value) AS booking_value
+      subq_26.metric_time__month AS metric_time__month
+      , SUM(sma_28009_cte.__booking_value) AS booking_value
     FROM (
-      -- Join to Time Spine Dataset
-      -- Select: ['__booking_value', 'metric_time__month', 'metric_time__day']
+      -- Constrain Output with WHERE
+      -- Select: ['metric_time__day', 'metric_time__month']
       SELECT
-        time_spine_src_28006.ds AS metric_time__day
-        , DATE_TRUNC('month', time_spine_src_28006.ds) AS metric_time__month
-        , sma_28009_cte.__booking_value AS booking_value
-      FROM ***************************.mf_time_spine time_spine_src_28006
-      INNER JOIN
-        sma_28009_cte
-      ON
-        DATEADD(week, -1, time_spine_src_28006.ds) = sma_28009_cte.metric_time__day
-    ) subq_27
-    WHERE metric_time__day = '2020-01-01'
+        metric_time__day
+        , metric_time__month
+      FROM (
+        -- Read From Time Spine 'mf_time_spine'
+        -- Change Column Aliases
+        -- Select: ['metric_time__day', 'metric_time__month']
+        SELECT
+          ds AS metric_time__day
+          , DATE_TRUNC('month', ds) AS metric_time__month
+        FROM ***************************.mf_time_spine time_spine_src_28006
+      ) subq_24
+      WHERE metric_time__day = '2020-01-01'
+    ) subq_26
+    INNER JOIN
+      sma_28009_cte
+    ON
+      DATEADD(week, -1, subq_26.metric_time__day) = sma_28009_cte.metric_time__day
     GROUP BY
-      metric_time__month
+      subq_26.metric_time__month
   ) subq_31
   FULL OUTER JOIN (
     -- Constrain Output with WHERE

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
@@ -4,19 +4,19 @@ sql_engine: Snowflake
 ---
 -- Write to DataTable
 SELECT
-  subq_20.metric_time__day
-  , subq_20.bookings_growth_2_weeks
+  subq_19.metric_time__day
+  , subq_19.bookings_growth_2_weeks
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_19.metric_time__day
+    subq_18.metric_time__day
     , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
   FROM (
     -- Combine Aggregated Outputs
     SELECT
-      COALESCE(subq_6.metric_time__day, subq_18.metric_time__day) AS metric_time__day
+      COALESCE(subq_6.metric_time__day, subq_17.metric_time__day) AS metric_time__day
       , MAX(subq_6.bookings) AS bookings
-      , MAX(subq_18.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+      , MAX(subq_17.bookings_2_weeks_ago) AS bookings_2_weeks_ago
     FROM (
       -- Compute Metrics via Expressions
       SELECT
@@ -266,40 +266,40 @@ FROM (
     FULL OUTER JOIN (
       -- Compute Metrics via Expressions
       SELECT
-        subq_17.metric_time__day
-        , subq_17.__bookings AS bookings_2_weeks_ago
+        subq_16.metric_time__day
+        , subq_16.__bookings AS bookings_2_weeks_ago
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_16.metric_time__day AS metric_time__day
-          , subq_11.__bookings AS __bookings
+          subq_15.metric_time__day AS metric_time__day
+          , subq_10.__bookings AS __bookings
         FROM (
           -- Select: ['metric_time__day']
           SELECT
-            subq_15.metric_time__day
+            subq_14.metric_time__day
           FROM (
             -- Constrain Output with WHERE
             SELECT
-              subq_14.metric_time__day
+              subq_13.metric_time__day
             FROM (
               -- Select: ['metric_time__day']
               SELECT
-                subq_13.metric_time__day
+                subq_12.metric_time__day
               FROM (
                 -- Change Column Aliases
                 SELECT
-                  subq_12.ds__day AS metric_time__day
-                  , subq_12.ds__week
-                  , subq_12.ds__month
-                  , subq_12.ds__quarter
-                  , subq_12.ds__year
-                  , subq_12.ds__extract_year
-                  , subq_12.ds__extract_quarter
-                  , subq_12.ds__extract_month
-                  , subq_12.ds__extract_day
-                  , subq_12.ds__extract_dow
-                  , subq_12.ds__extract_doy
-                  , subq_12.ds__alien_day
+                  subq_11.ds__day AS metric_time__day
+                  , subq_11.ds__week
+                  , subq_11.ds__month
+                  , subq_11.ds__quarter
+                  , subq_11.ds__year
+                  , subq_11.ds__extract_year
+                  , subq_11.ds__extract_quarter
+                  , subq_11.ds__extract_month
+                  , subq_11.ds__extract_day
+                  , subq_11.ds__extract_dow
+                  , subq_11.ds__extract_doy
+                  , subq_11.ds__alien_day
                 FROM (
                   -- Read From Time Spine 'mf_time_spine'
                   SELECT
@@ -316,259 +316,252 @@ FROM (
                     , EXTRACT(doy FROM time_spine_src_28006.ds) AS ds__extract_doy
                     , time_spine_src_28006.alien_day AS ds__alien_day
                   FROM ***************************.mf_time_spine time_spine_src_28006
-                ) subq_12
-              ) subq_13
-            ) subq_14
+                ) subq_11
+              ) subq_12
+            ) subq_13
             WHERE metric_time__day = '2020-01-01' or metric_time__day = '2020-01-14'
-          ) subq_15
-        ) subq_16
+          ) subq_14
+        ) subq_15
         INNER JOIN (
           -- Aggregate Inputs for Simple Metrics
           SELECT
-            subq_10.metric_time__day
-            , SUM(subq_10.__bookings) AS __bookings
+            subq_9.metric_time__day
+            , SUM(subq_9.__bookings) AS __bookings
           FROM (
             -- Select: ['__bookings', 'metric_time__day']
             SELECT
-              subq_9.metric_time__day
-              , subq_9.__bookings
+              subq_8.metric_time__day
+              , subq_8.__bookings
             FROM (
-              -- Constrain Output with WHERE
+              -- Select: ['__bookings', 'metric_time__day']
               SELECT
-                subq_8.bookings AS __bookings
-                , subq_8.metric_time__day
+                subq_7.metric_time__day
+                , subq_7.__bookings
               FROM (
-                -- Select: ['__bookings', 'metric_time__day']
+                -- Metric Time Dimension 'ds'
                 SELECT
-                  subq_7.metric_time__day
-                  , subq_7.__bookings AS bookings
+                  subq_0.ds__day
+                  , subq_0.ds__week
+                  , subq_0.ds__month
+                  , subq_0.ds__quarter
+                  , subq_0.ds__year
+                  , subq_0.ds__extract_year
+                  , subq_0.ds__extract_quarter
+                  , subq_0.ds__extract_month
+                  , subq_0.ds__extract_day
+                  , subq_0.ds__extract_dow
+                  , subq_0.ds__extract_doy
+                  , subq_0.ds_partitioned__day
+                  , subq_0.ds_partitioned__week
+                  , subq_0.ds_partitioned__month
+                  , subq_0.ds_partitioned__quarter
+                  , subq_0.ds_partitioned__year
+                  , subq_0.ds_partitioned__extract_year
+                  , subq_0.ds_partitioned__extract_quarter
+                  , subq_0.ds_partitioned__extract_month
+                  , subq_0.ds_partitioned__extract_day
+                  , subq_0.ds_partitioned__extract_dow
+                  , subq_0.ds_partitioned__extract_doy
+                  , subq_0.paid_at__day
+                  , subq_0.paid_at__week
+                  , subq_0.paid_at__month
+                  , subq_0.paid_at__quarter
+                  , subq_0.paid_at__year
+                  , subq_0.paid_at__extract_year
+                  , subq_0.paid_at__extract_quarter
+                  , subq_0.paid_at__extract_month
+                  , subq_0.paid_at__extract_day
+                  , subq_0.paid_at__extract_dow
+                  , subq_0.paid_at__extract_doy
+                  , subq_0.booking__ds__day
+                  , subq_0.booking__ds__week
+                  , subq_0.booking__ds__month
+                  , subq_0.booking__ds__quarter
+                  , subq_0.booking__ds__year
+                  , subq_0.booking__ds__extract_year
+                  , subq_0.booking__ds__extract_quarter
+                  , subq_0.booking__ds__extract_month
+                  , subq_0.booking__ds__extract_day
+                  , subq_0.booking__ds__extract_dow
+                  , subq_0.booking__ds__extract_doy
+                  , subq_0.booking__ds_partitioned__day
+                  , subq_0.booking__ds_partitioned__week
+                  , subq_0.booking__ds_partitioned__month
+                  , subq_0.booking__ds_partitioned__quarter
+                  , subq_0.booking__ds_partitioned__year
+                  , subq_0.booking__ds_partitioned__extract_year
+                  , subq_0.booking__ds_partitioned__extract_quarter
+                  , subq_0.booking__ds_partitioned__extract_month
+                  , subq_0.booking__ds_partitioned__extract_day
+                  , subq_0.booking__ds_partitioned__extract_dow
+                  , subq_0.booking__ds_partitioned__extract_doy
+                  , subq_0.booking__paid_at__day
+                  , subq_0.booking__paid_at__week
+                  , subq_0.booking__paid_at__month
+                  , subq_0.booking__paid_at__quarter
+                  , subq_0.booking__paid_at__year
+                  , subq_0.booking__paid_at__extract_year
+                  , subq_0.booking__paid_at__extract_quarter
+                  , subq_0.booking__paid_at__extract_month
+                  , subq_0.booking__paid_at__extract_day
+                  , subq_0.booking__paid_at__extract_dow
+                  , subq_0.booking__paid_at__extract_doy
+                  , subq_0.ds__day AS metric_time__day
+                  , subq_0.ds__week AS metric_time__week
+                  , subq_0.ds__month AS metric_time__month
+                  , subq_0.ds__quarter AS metric_time__quarter
+                  , subq_0.ds__year AS metric_time__year
+                  , subq_0.ds__extract_year AS metric_time__extract_year
+                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_0.ds__extract_month AS metric_time__extract_month
+                  , subq_0.ds__extract_day AS metric_time__extract_day
+                  , subq_0.ds__extract_dow AS metric_time__extract_dow
+                  , subq_0.ds__extract_doy AS metric_time__extract_doy
+                  , subq_0.listing
+                  , subq_0.guest
+                  , subq_0.host
+                  , subq_0.booking__listing
+                  , subq_0.booking__guest
+                  , subq_0.booking__host
+                  , subq_0.is_instant
+                  , subq_0.booking__is_instant
+                  , subq_0.__bookings
+                  , subq_0.__average_booking_value
+                  , subq_0.__instant_bookings
+                  , subq_0.__booking_value
+                  , subq_0.__max_booking_value
+                  , subq_0.__min_booking_value
+                  , subq_0.__instant_booking_value
+                  , subq_0.__average_instant_booking_value
+                  , subq_0.__booking_value_for_non_null_listing_id
+                  , subq_0.__bookers
+                  , subq_0.__referred_bookings
+                  , subq_0.__median_booking_value
+                  , subq_0.__booking_value_p99
+                  , subq_0.__discrete_booking_value_p99
+                  , subq_0.__approximate_continuous_booking_value_p99
+                  , subq_0.__approximate_discrete_booking_value_p99
+                  , subq_0.__bookings_join_to_time_spine
+                  , subq_0.__bookings_fill_nulls_with_0_without_time_spine
+                  , subq_0.__bookings_fill_nulls_with_0
+                  , subq_0.__instant_bookings_with_measure_filter
+                  , subq_0.__bookings_join_to_time_spine_with_tiered_filters
+                  , subq_0.__bookers_fill_nulls_with_0_join_to_timespine
                 FROM (
-                  -- Metric Time Dimension 'ds'
+                  -- Read Elements From Semantic Model 'bookings_source'
                   SELECT
-                    subq_0.ds__day
-                    , subq_0.ds__week
-                    , subq_0.ds__month
-                    , subq_0.ds__quarter
-                    , subq_0.ds__year
-                    , subq_0.ds__extract_year
-                    , subq_0.ds__extract_quarter
-                    , subq_0.ds__extract_month
-                    , subq_0.ds__extract_day
-                    , subq_0.ds__extract_dow
-                    , subq_0.ds__extract_doy
-                    , subq_0.ds_partitioned__day
-                    , subq_0.ds_partitioned__week
-                    , subq_0.ds_partitioned__month
-                    , subq_0.ds_partitioned__quarter
-                    , subq_0.ds_partitioned__year
-                    , subq_0.ds_partitioned__extract_year
-                    , subq_0.ds_partitioned__extract_quarter
-                    , subq_0.ds_partitioned__extract_month
-                    , subq_0.ds_partitioned__extract_day
-                    , subq_0.ds_partitioned__extract_dow
-                    , subq_0.ds_partitioned__extract_doy
-                    , subq_0.paid_at__day
-                    , subq_0.paid_at__week
-                    , subq_0.paid_at__month
-                    , subq_0.paid_at__quarter
-                    , subq_0.paid_at__year
-                    , subq_0.paid_at__extract_year
-                    , subq_0.paid_at__extract_quarter
-                    , subq_0.paid_at__extract_month
-                    , subq_0.paid_at__extract_day
-                    , subq_0.paid_at__extract_dow
-                    , subq_0.paid_at__extract_doy
-                    , subq_0.booking__ds__day
-                    , subq_0.booking__ds__week
-                    , subq_0.booking__ds__month
-                    , subq_0.booking__ds__quarter
-                    , subq_0.booking__ds__year
-                    , subq_0.booking__ds__extract_year
-                    , subq_0.booking__ds__extract_quarter
-                    , subq_0.booking__ds__extract_month
-                    , subq_0.booking__ds__extract_day
-                    , subq_0.booking__ds__extract_dow
-                    , subq_0.booking__ds__extract_doy
-                    , subq_0.booking__ds_partitioned__day
-                    , subq_0.booking__ds_partitioned__week
-                    , subq_0.booking__ds_partitioned__month
-                    , subq_0.booking__ds_partitioned__quarter
-                    , subq_0.booking__ds_partitioned__year
-                    , subq_0.booking__ds_partitioned__extract_year
-                    , subq_0.booking__ds_partitioned__extract_quarter
-                    , subq_0.booking__ds_partitioned__extract_month
-                    , subq_0.booking__ds_partitioned__extract_day
-                    , subq_0.booking__ds_partitioned__extract_dow
-                    , subq_0.booking__ds_partitioned__extract_doy
-                    , subq_0.booking__paid_at__day
-                    , subq_0.booking__paid_at__week
-                    , subq_0.booking__paid_at__month
-                    , subq_0.booking__paid_at__quarter
-                    , subq_0.booking__paid_at__year
-                    , subq_0.booking__paid_at__extract_year
-                    , subq_0.booking__paid_at__extract_quarter
-                    , subq_0.booking__paid_at__extract_month
-                    , subq_0.booking__paid_at__extract_day
-                    , subq_0.booking__paid_at__extract_dow
-                    , subq_0.booking__paid_at__extract_doy
-                    , subq_0.ds__day AS metric_time__day
-                    , subq_0.ds__week AS metric_time__week
-                    , subq_0.ds__month AS metric_time__month
-                    , subq_0.ds__quarter AS metric_time__quarter
-                    , subq_0.ds__year AS metric_time__year
-                    , subq_0.ds__extract_year AS metric_time__extract_year
-                    , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                    , subq_0.ds__extract_month AS metric_time__extract_month
-                    , subq_0.ds__extract_day AS metric_time__extract_day
-                    , subq_0.ds__extract_dow AS metric_time__extract_dow
-                    , subq_0.ds__extract_doy AS metric_time__extract_doy
-                    , subq_0.listing
-                    , subq_0.guest
-                    , subq_0.host
-                    , subq_0.booking__listing
-                    , subq_0.booking__guest
-                    , subq_0.booking__host
-                    , subq_0.is_instant
-                    , subq_0.booking__is_instant
-                    , subq_0.__bookings
-                    , subq_0.__average_booking_value
-                    , subq_0.__instant_bookings
-                    , subq_0.__booking_value
-                    , subq_0.__max_booking_value
-                    , subq_0.__min_booking_value
-                    , subq_0.__instant_booking_value
-                    , subq_0.__average_instant_booking_value
-                    , subq_0.__booking_value_for_non_null_listing_id
-                    , subq_0.__bookers
-                    , subq_0.__referred_bookings
-                    , subq_0.__median_booking_value
-                    , subq_0.__booking_value_p99
-                    , subq_0.__discrete_booking_value_p99
-                    , subq_0.__approximate_continuous_booking_value_p99
-                    , subq_0.__approximate_discrete_booking_value_p99
-                    , subq_0.__bookings_join_to_time_spine
-                    , subq_0.__bookings_fill_nulls_with_0_without_time_spine
-                    , subq_0.__bookings_fill_nulls_with_0
-                    , subq_0.__instant_bookings_with_measure_filter
-                    , subq_0.__bookings_join_to_time_spine_with_tiered_filters
-                    , subq_0.__bookers_fill_nulls_with_0_join_to_timespine
-                  FROM (
-                    -- Read Elements From Semantic Model 'bookings_source'
-                    SELECT
-                      1 AS __bookings
-                      , bookings_source_src_28000.booking_value AS __average_booking_value
-                      , CASE WHEN is_instant THEN 1 ELSE 0 END AS __instant_bookings
-                      , bookings_source_src_28000.booking_value AS __booking_value
-                      , bookings_source_src_28000.booking_value AS __max_booking_value
-                      , bookings_source_src_28000.booking_value AS __min_booking_value
-                      , bookings_source_src_28000.booking_value AS __instant_booking_value
-                      , bookings_source_src_28000.booking_value AS __average_instant_booking_value
-                      , bookings_source_src_28000.booking_value AS __booking_value_for_non_null_listing_id
-                      , bookings_source_src_28000.guest_id AS __bookers
-                      , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS __referred_bookings
-                      , bookings_source_src_28000.booking_value AS __median_booking_value
-                      , bookings_source_src_28000.booking_value AS __booking_value_p99
-                      , bookings_source_src_28000.booking_value AS __discrete_booking_value_p99
-                      , bookings_source_src_28000.booking_value AS __approximate_continuous_booking_value_p99
-                      , bookings_source_src_28000.booking_value AS __approximate_discrete_booking_value_p99
-                      , 1 AS __bookings_join_to_time_spine
-                      , 1 AS __bookings_fill_nulls_with_0_without_time_spine
-                      , 1 AS __bookings_fill_nulls_with_0
-                      , 1 AS __instant_bookings_with_measure_filter
-                      , 1 AS __bookings_join_to_time_spine_with_tiered_filters
-                      , bookings_source_src_28000.guest_id AS __bookers_fill_nulls_with_0_join_to_timespine
-                      , bookings_source_src_28000.booking_value AS __booking_payments
-                      , bookings_source_src_28000.is_instant
-                      , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                      , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                      , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS ds__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                      , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                      , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                      , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                      , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                      , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                      , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                      , bookings_source_src_28000.is_instant AS booking__is_instant
-                      , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                      , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                      , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                      , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                      , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                      , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                      , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                      , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                      , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                      , bookings_source_src_28000.listing_id AS listing
-                      , bookings_source_src_28000.guest_id AS guest
-                      , bookings_source_src_28000.host_id AS host
-                      , bookings_source_src_28000.listing_id AS booking__listing
-                      , bookings_source_src_28000.guest_id AS booking__guest
-                      , bookings_source_src_28000.host_id AS booking__host
-                    FROM ***************************.fct_bookings bookings_source_src_28000
-                  ) subq_0
-                ) subq_7
-              ) subq_8
-              WHERE metric_time__day = '2020-01-01' or metric_time__day = '2020-01-14'
-            ) subq_9
-          ) subq_10
+                    1 AS __bookings
+                    , bookings_source_src_28000.booking_value AS __average_booking_value
+                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS __instant_bookings
+                    , bookings_source_src_28000.booking_value AS __booking_value
+                    , bookings_source_src_28000.booking_value AS __max_booking_value
+                    , bookings_source_src_28000.booking_value AS __min_booking_value
+                    , bookings_source_src_28000.booking_value AS __instant_booking_value
+                    , bookings_source_src_28000.booking_value AS __average_instant_booking_value
+                    , bookings_source_src_28000.booking_value AS __booking_value_for_non_null_listing_id
+                    , bookings_source_src_28000.guest_id AS __bookers
+                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS __referred_bookings
+                    , bookings_source_src_28000.booking_value AS __median_booking_value
+                    , bookings_source_src_28000.booking_value AS __booking_value_p99
+                    , bookings_source_src_28000.booking_value AS __discrete_booking_value_p99
+                    , bookings_source_src_28000.booking_value AS __approximate_continuous_booking_value_p99
+                    , bookings_source_src_28000.booking_value AS __approximate_discrete_booking_value_p99
+                    , 1 AS __bookings_join_to_time_spine
+                    , 1 AS __bookings_fill_nulls_with_0_without_time_spine
+                    , 1 AS __bookings_fill_nulls_with_0
+                    , 1 AS __instant_bookings_with_measure_filter
+                    , 1 AS __bookings_join_to_time_spine_with_tiered_filters
+                    , bookings_source_src_28000.guest_id AS __bookers_fill_nulls_with_0_join_to_timespine
+                    , bookings_source_src_28000.booking_value AS __booking_payments
+                    , bookings_source_src_28000.is_instant
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                    , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                    , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                    , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                    , bookings_source_src_28000.is_instant AS booking__is_instant
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                    , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                    , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                    , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                    , bookings_source_src_28000.listing_id AS listing
+                    , bookings_source_src_28000.guest_id AS guest
+                    , bookings_source_src_28000.host_id AS host
+                    , bookings_source_src_28000.listing_id AS booking__listing
+                    , bookings_source_src_28000.guest_id AS booking__guest
+                    , bookings_source_src_28000.host_id AS booking__host
+                  FROM ***************************.fct_bookings bookings_source_src_28000
+                ) subq_0
+              ) subq_7
+            ) subq_8
+          ) subq_9
           GROUP BY
-            subq_10.metric_time__day
-        ) subq_11
+            subq_9.metric_time__day
+        ) subq_10
         ON
-          DATEADD(day, -14, subq_16.metric_time__day) = subq_11.metric_time__day
-      ) subq_17
-    ) subq_18
+          DATEADD(day, -14, subq_15.metric_time__day) = subq_10.metric_time__day
+      ) subq_16
+    ) subq_17
     ON
-      subq_6.metric_time__day = subq_18.metric_time__day
+      subq_6.metric_time__day = subq_17.metric_time__day
     GROUP BY
-      COALESCE(subq_6.metric_time__day, subq_18.metric_time__day)
-  ) subq_19
-) subq_20
+      COALESCE(subq_6.metric_time__day, subq_17.metric_time__day)
+  ) subq_18
+) subq_19

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_derived_metric_with_offset_window_and_time_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_derived_metric_with_offset_window_and_time_filter__plan0_optimized.sql
@@ -19,9 +19,9 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_27.metric_time__day, subq_39.metric_time__day) AS metric_time__day
-    , MAX(subq_27.bookings) AS bookings
-    , MAX(subq_39.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+    COALESCE(subq_26.metric_time__day, subq_37.metric_time__day) AS metric_time__day
+    , MAX(subq_26.bookings) AS bookings
+    , MAX(subq_37.bookings_2_weeks_ago) AS bookings_2_weeks_ago
   FROM (
     -- Constrain Output with WHERE
     -- Select: ['__bookings', 'metric_time__day']
@@ -37,17 +37,17 @@ FROM (
         metric_time__day
         , __bookings AS bookings
       FROM sma_28009_cte
-    ) subq_23
+    ) subq_22
     WHERE metric_time__day = '2020-01-01' or metric_time__day = '2020-01-14'
     GROUP BY
       metric_time__day
-  ) subq_27
+  ) subq_26
   FULL OUTER JOIN (
     -- Join to Time Spine Dataset
     -- Compute Metrics via Expressions
     SELECT
-      subq_37.metric_time__day AS metric_time__day
-      , subq_32.__bookings AS bookings_2_weeks_ago
+      subq_35.metric_time__day AS metric_time__day
+      , subq_30.__bookings AS bookings_2_weeks_ago
     FROM (
       -- Constrain Output with WHERE
       -- Select: ['metric_time__day']
@@ -60,33 +60,26 @@ FROM (
         SELECT
           ds AS metric_time__day
         FROM ***************************.mf_time_spine time_spine_src_28006
-      ) subq_35
+      ) subq_33
       WHERE metric_time__day = '2020-01-01' or metric_time__day = '2020-01-14'
-    ) subq_37
+    ) subq_35
     INNER JOIN (
-      -- Constrain Output with WHERE
+      -- Read From CTE For node_id=sma_28009
+      -- Select: ['__bookings', 'metric_time__day']
       -- Select: ['__bookings', 'metric_time__day']
       -- Aggregate Inputs for Simple Metrics
       SELECT
         metric_time__day
-        , SUM(bookings) AS __bookings
-      FROM (
-        -- Read From CTE For node_id=sma_28009
-        -- Select: ['__bookings', 'metric_time__day']
-        SELECT
-          metric_time__day
-          , __bookings AS bookings
-        FROM sma_28009_cte
-      ) subq_29
-      WHERE metric_time__day = '2020-01-01' or metric_time__day = '2020-01-14'
+        , SUM(__bookings) AS __bookings
+      FROM sma_28009_cte
       GROUP BY
         metric_time__day
-    ) subq_32
+    ) subq_30
     ON
-      DATEADD(day, -14, subq_37.metric_time__day) = subq_32.metric_time__day
-  ) subq_39
+      DATEADD(day, -14, subq_35.metric_time__day) = subq_30.metric_time__day
+  ) subq_37
   ON
-    subq_27.metric_time__day = subq_39.metric_time__day
+    subq_26.metric_time__day = subq_37.metric_time__day
   GROUP BY
-    COALESCE(subq_27.metric_time__day, subq_39.metric_time__day)
-) subq_40
+    COALESCE(subq_26.metric_time__day, subq_37.metric_time__day)
+) subq_38

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0.sql
@@ -6,52 +6,52 @@ sql_engine: Snowflake
 ---
 -- Write to DataTable
 SELECT
-  subq_13.metric_time__month
-  , subq_13.bookings_at_start_of_month
+  subq_12.metric_time__month
+  , subq_12.bookings_at_start_of_month
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_12.metric_time__month
+    subq_11.metric_time__month
     , bookings_start_of_month AS bookings_at_start_of_month
   FROM (
     -- Compute Metrics via Expressions
     SELECT
-      subq_11.metric_time__month
-      , subq_11.__bookings AS bookings_start_of_month
+      subq_10.metric_time__month
+      , subq_10.__bookings AS bookings_start_of_month
     FROM (
       -- Join to Time Spine Dataset
       SELECT
-        subq_10.metric_time__month AS metric_time__month
-        , subq_5.__bookings AS __bookings
+        subq_9.metric_time__month AS metric_time__month
+        , subq_4.__bookings AS __bookings
       FROM (
         -- Select: ['metric_time__month']
         SELECT
-          subq_9.metric_time__month
+          subq_8.metric_time__month
         FROM (
           -- Constrain Output with WHERE
           SELECT
-            subq_8.metric_time__day
-            , subq_8.metric_time__month
+            subq_7.metric_time__day
+            , subq_7.metric_time__month
           FROM (
             -- Select: ['metric_time__month', 'metric_time__day']
             SELECT
-              subq_7.metric_time__day
-              , subq_7.metric_time__month
+              subq_6.metric_time__day
+              , subq_6.metric_time__month
             FROM (
               -- Change Column Aliases
               SELECT
-                subq_6.ds__day AS metric_time__day
-                , subq_6.ds__week
-                , subq_6.ds__month AS metric_time__month
-                , subq_6.ds__quarter
-                , subq_6.ds__year
-                , subq_6.ds__extract_year
-                , subq_6.ds__extract_quarter
-                , subq_6.ds__extract_month
-                , subq_6.ds__extract_day
-                , subq_6.ds__extract_dow
-                , subq_6.ds__extract_doy
-                , subq_6.ds__alien_day
+                subq_5.ds__day AS metric_time__day
+                , subq_5.ds__week
+                , subq_5.ds__month AS metric_time__month
+                , subq_5.ds__quarter
+                , subq_5.ds__year
+                , subq_5.ds__extract_year
+                , subq_5.ds__extract_quarter
+                , subq_5.ds__extract_month
+                , subq_5.ds__extract_day
+                , subq_5.ds__extract_dow
+                , subq_5.ds__extract_doy
+                , subq_5.ds__alien_day
               FROM (
                 -- Read From Time Spine 'mf_time_spine'
                 SELECT
@@ -68,258 +68,249 @@ FROM (
                   , EXTRACT(doy FROM time_spine_src_28006.ds) AS ds__extract_doy
                   , time_spine_src_28006.alien_day AS ds__alien_day
                 FROM ***************************.mf_time_spine time_spine_src_28006
-              ) subq_6
-            ) subq_7
-          ) subq_8
+              ) subq_5
+            ) subq_6
+          ) subq_7
           WHERE metric_time__day = '2020-01-01'
-        ) subq_9
+        ) subq_8
         GROUP BY
-          subq_9.metric_time__month
-      ) subq_10
+          subq_8.metric_time__month
+      ) subq_9
       INNER JOIN (
         -- Aggregate Inputs for Simple Metrics
         SELECT
-          subq_4.metric_time__month
-          , SUM(subq_4.__bookings) AS __bookings
+          subq_3.metric_time__month
+          , SUM(subq_3.__bookings) AS __bookings
         FROM (
           -- Select: ['__bookings', 'metric_time__month']
           SELECT
-            subq_3.metric_time__month
-            , subq_3.__bookings
+            subq_2.metric_time__month
+            , subq_2.__bookings
           FROM (
-            -- Constrain Output with WHERE
+            -- Select: ['__bookings', 'metric_time__month']
             SELECT
-              subq_2.bookings AS __bookings
-              , subq_2.metric_time__day
-              , subq_2.metric_time__month
+              subq_1.metric_time__month
+              , subq_1.__bookings
             FROM (
-              -- Select: ['__bookings', 'metric_time__month', 'metric_time__day']
+              -- Metric Time Dimension 'ds'
               SELECT
-                subq_1.metric_time__day
-                , subq_1.metric_time__month
-                , subq_1.__bookings AS bookings
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.__bookings
+                , subq_0.__average_booking_value
+                , subq_0.__instant_bookings
+                , subq_0.__booking_value
+                , subq_0.__max_booking_value
+                , subq_0.__min_booking_value
+                , subq_0.__instant_booking_value
+                , subq_0.__average_instant_booking_value
+                , subq_0.__booking_value_for_non_null_listing_id
+                , subq_0.__bookers
+                , subq_0.__referred_bookings
+                , subq_0.__median_booking_value
+                , subq_0.__booking_value_p99
+                , subq_0.__discrete_booking_value_p99
+                , subq_0.__approximate_continuous_booking_value_p99
+                , subq_0.__approximate_discrete_booking_value_p99
+                , subq_0.__bookings_join_to_time_spine
+                , subq_0.__bookings_fill_nulls_with_0_without_time_spine
+                , subq_0.__bookings_fill_nulls_with_0
+                , subq_0.__instant_bookings_with_measure_filter
+                , subq_0.__bookings_join_to_time_spine_with_tiered_filters
+                , subq_0.__bookers_fill_nulls_with_0_join_to_timespine
               FROM (
-                -- Metric Time Dimension 'ds'
+                -- Read Elements From Semantic Model 'bookings_source'
                 SELECT
-                  subq_0.ds__day
-                  , subq_0.ds__week
-                  , subq_0.ds__month
-                  , subq_0.ds__quarter
-                  , subq_0.ds__year
-                  , subq_0.ds__extract_year
-                  , subq_0.ds__extract_quarter
-                  , subq_0.ds__extract_month
-                  , subq_0.ds__extract_day
-                  , subq_0.ds__extract_dow
-                  , subq_0.ds__extract_doy
-                  , subq_0.ds_partitioned__day
-                  , subq_0.ds_partitioned__week
-                  , subq_0.ds_partitioned__month
-                  , subq_0.ds_partitioned__quarter
-                  , subq_0.ds_partitioned__year
-                  , subq_0.ds_partitioned__extract_year
-                  , subq_0.ds_partitioned__extract_quarter
-                  , subq_0.ds_partitioned__extract_month
-                  , subq_0.ds_partitioned__extract_day
-                  , subq_0.ds_partitioned__extract_dow
-                  , subq_0.ds_partitioned__extract_doy
-                  , subq_0.paid_at__day
-                  , subq_0.paid_at__week
-                  , subq_0.paid_at__month
-                  , subq_0.paid_at__quarter
-                  , subq_0.paid_at__year
-                  , subq_0.paid_at__extract_year
-                  , subq_0.paid_at__extract_quarter
-                  , subq_0.paid_at__extract_month
-                  , subq_0.paid_at__extract_day
-                  , subq_0.paid_at__extract_dow
-                  , subq_0.paid_at__extract_doy
-                  , subq_0.booking__ds__day
-                  , subq_0.booking__ds__week
-                  , subq_0.booking__ds__month
-                  , subq_0.booking__ds__quarter
-                  , subq_0.booking__ds__year
-                  , subq_0.booking__ds__extract_year
-                  , subq_0.booking__ds__extract_quarter
-                  , subq_0.booking__ds__extract_month
-                  , subq_0.booking__ds__extract_day
-                  , subq_0.booking__ds__extract_dow
-                  , subq_0.booking__ds__extract_doy
-                  , subq_0.booking__ds_partitioned__day
-                  , subq_0.booking__ds_partitioned__week
-                  , subq_0.booking__ds_partitioned__month
-                  , subq_0.booking__ds_partitioned__quarter
-                  , subq_0.booking__ds_partitioned__year
-                  , subq_0.booking__ds_partitioned__extract_year
-                  , subq_0.booking__ds_partitioned__extract_quarter
-                  , subq_0.booking__ds_partitioned__extract_month
-                  , subq_0.booking__ds_partitioned__extract_day
-                  , subq_0.booking__ds_partitioned__extract_dow
-                  , subq_0.booking__ds_partitioned__extract_doy
-                  , subq_0.booking__paid_at__day
-                  , subq_0.booking__paid_at__week
-                  , subq_0.booking__paid_at__month
-                  , subq_0.booking__paid_at__quarter
-                  , subq_0.booking__paid_at__year
-                  , subq_0.booking__paid_at__extract_year
-                  , subq_0.booking__paid_at__extract_quarter
-                  , subq_0.booking__paid_at__extract_month
-                  , subq_0.booking__paid_at__extract_day
-                  , subq_0.booking__paid_at__extract_dow
-                  , subq_0.booking__paid_at__extract_doy
-                  , subq_0.ds__day AS metric_time__day
-                  , subq_0.ds__week AS metric_time__week
-                  , subq_0.ds__month AS metric_time__month
-                  , subq_0.ds__quarter AS metric_time__quarter
-                  , subq_0.ds__year AS metric_time__year
-                  , subq_0.ds__extract_year AS metric_time__extract_year
-                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_0.ds__extract_month AS metric_time__extract_month
-                  , subq_0.ds__extract_day AS metric_time__extract_day
-                  , subq_0.ds__extract_dow AS metric_time__extract_dow
-                  , subq_0.ds__extract_doy AS metric_time__extract_doy
-                  , subq_0.listing
-                  , subq_0.guest
-                  , subq_0.host
-                  , subq_0.booking__listing
-                  , subq_0.booking__guest
-                  , subq_0.booking__host
-                  , subq_0.is_instant
-                  , subq_0.booking__is_instant
-                  , subq_0.__bookings
-                  , subq_0.__average_booking_value
-                  , subq_0.__instant_bookings
-                  , subq_0.__booking_value
-                  , subq_0.__max_booking_value
-                  , subq_0.__min_booking_value
-                  , subq_0.__instant_booking_value
-                  , subq_0.__average_instant_booking_value
-                  , subq_0.__booking_value_for_non_null_listing_id
-                  , subq_0.__bookers
-                  , subq_0.__referred_bookings
-                  , subq_0.__median_booking_value
-                  , subq_0.__booking_value_p99
-                  , subq_0.__discrete_booking_value_p99
-                  , subq_0.__approximate_continuous_booking_value_p99
-                  , subq_0.__approximate_discrete_booking_value_p99
-                  , subq_0.__bookings_join_to_time_spine
-                  , subq_0.__bookings_fill_nulls_with_0_without_time_spine
-                  , subq_0.__bookings_fill_nulls_with_0
-                  , subq_0.__instant_bookings_with_measure_filter
-                  , subq_0.__bookings_join_to_time_spine_with_tiered_filters
-                  , subq_0.__bookers_fill_nulls_with_0_join_to_timespine
-                FROM (
-                  -- Read Elements From Semantic Model 'bookings_source'
-                  SELECT
-                    1 AS __bookings
-                    , bookings_source_src_28000.booking_value AS __average_booking_value
-                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS __instant_bookings
-                    , bookings_source_src_28000.booking_value AS __booking_value
-                    , bookings_source_src_28000.booking_value AS __max_booking_value
-                    , bookings_source_src_28000.booking_value AS __min_booking_value
-                    , bookings_source_src_28000.booking_value AS __instant_booking_value
-                    , bookings_source_src_28000.booking_value AS __average_instant_booking_value
-                    , bookings_source_src_28000.booking_value AS __booking_value_for_non_null_listing_id
-                    , bookings_source_src_28000.guest_id AS __bookers
-                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS __referred_bookings
-                    , bookings_source_src_28000.booking_value AS __median_booking_value
-                    , bookings_source_src_28000.booking_value AS __booking_value_p99
-                    , bookings_source_src_28000.booking_value AS __discrete_booking_value_p99
-                    , bookings_source_src_28000.booking_value AS __approximate_continuous_booking_value_p99
-                    , bookings_source_src_28000.booking_value AS __approximate_discrete_booking_value_p99
-                    , 1 AS __bookings_join_to_time_spine
-                    , 1 AS __bookings_fill_nulls_with_0_without_time_spine
-                    , 1 AS __bookings_fill_nulls_with_0
-                    , 1 AS __instant_bookings_with_measure_filter
-                    , 1 AS __bookings_join_to_time_spine_with_tiered_filters
-                    , bookings_source_src_28000.guest_id AS __bookers_fill_nulls_with_0_join_to_timespine
-                    , bookings_source_src_28000.booking_value AS __booking_payments
-                    , bookings_source_src_28000.is_instant
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                    , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS ds__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                    , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                    , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                    , bookings_source_src_28000.is_instant AS booking__is_instant
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                    , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                    , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                    , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                    , bookings_source_src_28000.listing_id AS listing
-                    , bookings_source_src_28000.guest_id AS guest
-                    , bookings_source_src_28000.host_id AS host
-                    , bookings_source_src_28000.listing_id AS booking__listing
-                    , bookings_source_src_28000.guest_id AS booking__guest
-                    , bookings_source_src_28000.host_id AS booking__host
-                  FROM ***************************.fct_bookings bookings_source_src_28000
-                ) subq_0
-              ) subq_1
-            ) subq_2
-            WHERE metric_time__day = '2020-01-01'
-          ) subq_3
-        ) subq_4
+                  1 AS __bookings
+                  , bookings_source_src_28000.booking_value AS __average_booking_value
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS __instant_bookings
+                  , bookings_source_src_28000.booking_value AS __booking_value
+                  , bookings_source_src_28000.booking_value AS __max_booking_value
+                  , bookings_source_src_28000.booking_value AS __min_booking_value
+                  , bookings_source_src_28000.booking_value AS __instant_booking_value
+                  , bookings_source_src_28000.booking_value AS __average_instant_booking_value
+                  , bookings_source_src_28000.booking_value AS __booking_value_for_non_null_listing_id
+                  , bookings_source_src_28000.guest_id AS __bookers
+                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS __referred_bookings
+                  , bookings_source_src_28000.booking_value AS __median_booking_value
+                  , bookings_source_src_28000.booking_value AS __booking_value_p99
+                  , bookings_source_src_28000.booking_value AS __discrete_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS __approximate_continuous_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS __approximate_discrete_booking_value_p99
+                  , 1 AS __bookings_join_to_time_spine
+                  , 1 AS __bookings_fill_nulls_with_0_without_time_spine
+                  , 1 AS __bookings_fill_nulls_with_0
+                  , 1 AS __instant_bookings_with_measure_filter
+                  , 1 AS __bookings_join_to_time_spine_with_tiered_filters
+                  , bookings_source_src_28000.guest_id AS __bookers_fill_nulls_with_0_join_to_timespine
+                  , bookings_source_src_28000.booking_value AS __booking_payments
+                  , bookings_source_src_28000.is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                  , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                  , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                  , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                  , bookings_source_src_28000.is_instant AS booking__is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                  , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                  , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                  , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                  , bookings_source_src_28000.listing_id AS listing
+                  , bookings_source_src_28000.guest_id AS guest
+                  , bookings_source_src_28000.host_id AS host
+                  , bookings_source_src_28000.listing_id AS booking__listing
+                  , bookings_source_src_28000.guest_id AS booking__guest
+                  , bookings_source_src_28000.host_id AS booking__host
+                FROM ***************************.fct_bookings bookings_source_src_28000
+              ) subq_0
+            ) subq_1
+          ) subq_2
+        ) subq_3
         GROUP BY
-          subq_4.metric_time__month
-      ) subq_5
+          subq_3.metric_time__month
+      ) subq_4
       ON
-        DATE_TRUNC('month', subq_10.metric_time__month) = subq_5.metric_time__month
-    ) subq_11
-  ) subq_12
-) subq_13
+        DATE_TRUNC('month', subq_9.metric_time__month) = subq_4.metric_time__month
+    ) subq_10
+  ) subq_11
+) subq_12

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
@@ -13,8 +13,8 @@ FROM (
   -- Join to Time Spine Dataset
   -- Compute Metrics via Expressions
   SELECT
-    subq_24.metric_time__month AS metric_time__month
-    , subq_19.__bookings AS bookings_start_of_month
+    subq_22.metric_time__month AS metric_time__month
+    , subq_17.__bookings AS bookings_start_of_month
   FROM (
     -- Constrain Output with WHERE
     -- Select: ['metric_time__month']
@@ -28,32 +28,29 @@ FROM (
         ds AS metric_time__day
         , DATE_TRUNC('month', ds) AS metric_time__month
       FROM ***************************.mf_time_spine time_spine_src_28006
-    ) subq_22
+    ) subq_20
     WHERE metric_time__day = '2020-01-01'
     GROUP BY
       metric_time__month
-  ) subq_24
+  ) subq_22
   INNER JOIN (
-    -- Constrain Output with WHERE
-    -- Select: ['__bookings', 'metric_time__month']
     -- Aggregate Inputs for Simple Metrics
     SELECT
       metric_time__month
-      , SUM(bookings) AS __bookings
+      , SUM(__bookings) AS __bookings
     FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
-      -- Select: ['__bookings', 'metric_time__month', 'metric_time__day']
+      -- Select: ['__bookings', 'metric_time__month']
+      -- Select: ['__bookings', 'metric_time__month']
       SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , DATE_TRUNC('month', ds) AS metric_time__month
-        , 1 AS bookings
+        DATE_TRUNC('month', ds) AS metric_time__month
+        , 1 AS __bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
     ) subq_16
-    WHERE metric_time__day = '2020-01-01'
     GROUP BY
       metric_time__month
-  ) subq_19
+  ) subq_17
   ON
-    DATE_TRUNC('month', subq_24.metric_time__month) = subq_19.metric_time__month
-) subq_26
+    DATE_TRUNC('month', subq_22.metric_time__month) = subq_17.metric_time__month
+) subq_24

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_offset_window_metric_filter_and_query_have_different_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_offset_window_metric_filter_and_query_have_different_granularities__plan0.sql
@@ -35,129 +35,127 @@ FROM (
             subq_8.metric_time__month
             , subq_8.__booking_value
           FROM (
-            -- Constrain Output with WHERE
+            -- Select: ['__booking_value', 'metric_time__month']
             SELECT
-              subq_7.booking_value AS __booking_value
-              , subq_7.metric_time__day
-              , subq_7.metric_time__month
+              subq_7.metric_time__month
+              , subq_7.__booking_value
             FROM (
-              -- Select: ['__booking_value', 'metric_time__month', 'metric_time__day']
+              -- Join to Time Spine Dataset
               SELECT
-                subq_6.metric_time__day
-                , subq_6.metric_time__month
-                , subq_6.__booking_value AS booking_value
+                subq_6.metric_time__day AS metric_time__day
+                , subq_6.metric_time__month AS metric_time__month
+                , subq_1.ds__day AS ds__day
+                , subq_1.ds__week AS ds__week
+                , subq_1.ds__month AS ds__month
+                , subq_1.ds__quarter AS ds__quarter
+                , subq_1.ds__year AS ds__year
+                , subq_1.ds__extract_year AS ds__extract_year
+                , subq_1.ds__extract_quarter AS ds__extract_quarter
+                , subq_1.ds__extract_month AS ds__extract_month
+                , subq_1.ds__extract_day AS ds__extract_day
+                , subq_1.ds__extract_dow AS ds__extract_dow
+                , subq_1.ds__extract_doy AS ds__extract_doy
+                , subq_1.ds_partitioned__day AS ds_partitioned__day
+                , subq_1.ds_partitioned__week AS ds_partitioned__week
+                , subq_1.ds_partitioned__month AS ds_partitioned__month
+                , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
+                , subq_1.ds_partitioned__year AS ds_partitioned__year
+                , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
+                , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+                , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
+                , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
+                , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+                , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+                , subq_1.paid_at__day AS paid_at__day
+                , subq_1.paid_at__week AS paid_at__week
+                , subq_1.paid_at__month AS paid_at__month
+                , subq_1.paid_at__quarter AS paid_at__quarter
+                , subq_1.paid_at__year AS paid_at__year
+                , subq_1.paid_at__extract_year AS paid_at__extract_year
+                , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
+                , subq_1.paid_at__extract_month AS paid_at__extract_month
+                , subq_1.paid_at__extract_day AS paid_at__extract_day
+                , subq_1.paid_at__extract_dow AS paid_at__extract_dow
+                , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+                , subq_1.booking__ds__day AS booking__ds__day
+                , subq_1.booking__ds__week AS booking__ds__week
+                , subq_1.booking__ds__month AS booking__ds__month
+                , subq_1.booking__ds__quarter AS booking__ds__quarter
+                , subq_1.booking__ds__year AS booking__ds__year
+                , subq_1.booking__ds__extract_year AS booking__ds__extract_year
+                , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
+                , subq_1.booking__ds__extract_month AS booking__ds__extract_month
+                , subq_1.booking__ds__extract_day AS booking__ds__extract_day
+                , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
+                , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
+                , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
+                , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
+                , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
+                , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+                , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
+                , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+                , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+                , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+                , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+                , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+                , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+                , subq_1.booking__paid_at__day AS booking__paid_at__day
+                , subq_1.booking__paid_at__week AS booking__paid_at__week
+                , subq_1.booking__paid_at__month AS booking__paid_at__month
+                , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
+                , subq_1.booking__paid_at__year AS booking__paid_at__year
+                , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
+                , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+                , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
+                , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
+                , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+                , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                , subq_1.metric_time__week AS metric_time__week
+                , subq_1.metric_time__quarter AS metric_time__quarter
+                , subq_1.metric_time__year AS metric_time__year
+                , subq_1.metric_time__extract_year AS metric_time__extract_year
+                , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+                , subq_1.metric_time__extract_month AS metric_time__extract_month
+                , subq_1.metric_time__extract_day AS metric_time__extract_day
+                , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+                , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+                , subq_1.listing AS listing
+                , subq_1.guest AS guest
+                , subq_1.host AS host
+                , subq_1.booking__listing AS booking__listing
+                , subq_1.booking__guest AS booking__guest
+                , subq_1.booking__host AS booking__host
+                , subq_1.is_instant AS is_instant
+                , subq_1.booking__is_instant AS booking__is_instant
+                , subq_1.__bookings AS __bookings
+                , subq_1.__average_booking_value AS __average_booking_value
+                , subq_1.__instant_bookings AS __instant_bookings
+                , subq_1.__booking_value AS __booking_value
+                , subq_1.__max_booking_value AS __max_booking_value
+                , subq_1.__min_booking_value AS __min_booking_value
+                , subq_1.__instant_booking_value AS __instant_booking_value
+                , subq_1.__average_instant_booking_value AS __average_instant_booking_value
+                , subq_1.__booking_value_for_non_null_listing_id AS __booking_value_for_non_null_listing_id
+                , subq_1.__bookers AS __bookers
+                , subq_1.__referred_bookings AS __referred_bookings
+                , subq_1.__median_booking_value AS __median_booking_value
+                , subq_1.__booking_value_p99 AS __booking_value_p99
+                , subq_1.__discrete_booking_value_p99 AS __discrete_booking_value_p99
+                , subq_1.__approximate_continuous_booking_value_p99 AS __approximate_continuous_booking_value_p99
+                , subq_1.__approximate_discrete_booking_value_p99 AS __approximate_discrete_booking_value_p99
+                , subq_1.__bookings_join_to_time_spine AS __bookings_join_to_time_spine
+                , subq_1.__bookings_fill_nulls_with_0_without_time_spine AS __bookings_fill_nulls_with_0_without_time_spine
+                , subq_1.__bookings_fill_nulls_with_0 AS __bookings_fill_nulls_with_0
+                , subq_1.__instant_bookings_with_measure_filter AS __instant_bookings_with_measure_filter
+                , subq_1.__bookings_join_to_time_spine_with_tiered_filters AS __bookings_join_to_time_spine_with_tiered_filters
+                , subq_1.__bookers_fill_nulls_with_0_join_to_timespine AS __bookers_fill_nulls_with_0_join_to_timespine
               FROM (
-                -- Join to Time Spine Dataset
+                -- Select: ['metric_time__day', 'metric_time__month']
                 SELECT
-                  subq_5.metric_time__day AS metric_time__day
-                  , subq_5.metric_time__month AS metric_time__month
-                  , subq_1.ds__day AS ds__day
-                  , subq_1.ds__week AS ds__week
-                  , subq_1.ds__month AS ds__month
-                  , subq_1.ds__quarter AS ds__quarter
-                  , subq_1.ds__year AS ds__year
-                  , subq_1.ds__extract_year AS ds__extract_year
-                  , subq_1.ds__extract_quarter AS ds__extract_quarter
-                  , subq_1.ds__extract_month AS ds__extract_month
-                  , subq_1.ds__extract_day AS ds__extract_day
-                  , subq_1.ds__extract_dow AS ds__extract_dow
-                  , subq_1.ds__extract_doy AS ds__extract_doy
-                  , subq_1.ds_partitioned__day AS ds_partitioned__day
-                  , subq_1.ds_partitioned__week AS ds_partitioned__week
-                  , subq_1.ds_partitioned__month AS ds_partitioned__month
-                  , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
-                  , subq_1.ds_partitioned__year AS ds_partitioned__year
-                  , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
-                  , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
-                  , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
-                  , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
-                  , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
-                  , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
-                  , subq_1.paid_at__day AS paid_at__day
-                  , subq_1.paid_at__week AS paid_at__week
-                  , subq_1.paid_at__month AS paid_at__month
-                  , subq_1.paid_at__quarter AS paid_at__quarter
-                  , subq_1.paid_at__year AS paid_at__year
-                  , subq_1.paid_at__extract_year AS paid_at__extract_year
-                  , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
-                  , subq_1.paid_at__extract_month AS paid_at__extract_month
-                  , subq_1.paid_at__extract_day AS paid_at__extract_day
-                  , subq_1.paid_at__extract_dow AS paid_at__extract_dow
-                  , subq_1.paid_at__extract_doy AS paid_at__extract_doy
-                  , subq_1.booking__ds__day AS booking__ds__day
-                  , subq_1.booking__ds__week AS booking__ds__week
-                  , subq_1.booking__ds__month AS booking__ds__month
-                  , subq_1.booking__ds__quarter AS booking__ds__quarter
-                  , subq_1.booking__ds__year AS booking__ds__year
-                  , subq_1.booking__ds__extract_year AS booking__ds__extract_year
-                  , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
-                  , subq_1.booking__ds__extract_month AS booking__ds__extract_month
-                  , subq_1.booking__ds__extract_day AS booking__ds__extract_day
-                  , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
-                  , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
-                  , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
-                  , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
-                  , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
-                  , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
-                  , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
-                  , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
-                  , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
-                  , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
-                  , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
-                  , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
-                  , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
-                  , subq_1.booking__paid_at__day AS booking__paid_at__day
-                  , subq_1.booking__paid_at__week AS booking__paid_at__week
-                  , subq_1.booking__paid_at__month AS booking__paid_at__month
-                  , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
-                  , subq_1.booking__paid_at__year AS booking__paid_at__year
-                  , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
-                  , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
-                  , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
-                  , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
-                  , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
-                  , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
-                  , subq_1.metric_time__week AS metric_time__week
-                  , subq_1.metric_time__quarter AS metric_time__quarter
-                  , subq_1.metric_time__year AS metric_time__year
-                  , subq_1.metric_time__extract_year AS metric_time__extract_year
-                  , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
-                  , subq_1.metric_time__extract_month AS metric_time__extract_month
-                  , subq_1.metric_time__extract_day AS metric_time__extract_day
-                  , subq_1.metric_time__extract_dow AS metric_time__extract_dow
-                  , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-                  , subq_1.listing AS listing
-                  , subq_1.guest AS guest
-                  , subq_1.host AS host
-                  , subq_1.booking__listing AS booking__listing
-                  , subq_1.booking__guest AS booking__guest
-                  , subq_1.booking__host AS booking__host
-                  , subq_1.is_instant AS is_instant
-                  , subq_1.booking__is_instant AS booking__is_instant
-                  , subq_1.__bookings AS __bookings
-                  , subq_1.__average_booking_value AS __average_booking_value
-                  , subq_1.__instant_bookings AS __instant_bookings
-                  , subq_1.__booking_value AS __booking_value
-                  , subq_1.__max_booking_value AS __max_booking_value
-                  , subq_1.__min_booking_value AS __min_booking_value
-                  , subq_1.__instant_booking_value AS __instant_booking_value
-                  , subq_1.__average_instant_booking_value AS __average_instant_booking_value
-                  , subq_1.__booking_value_for_non_null_listing_id AS __booking_value_for_non_null_listing_id
-                  , subq_1.__bookers AS __bookers
-                  , subq_1.__referred_bookings AS __referred_bookings
-                  , subq_1.__median_booking_value AS __median_booking_value
-                  , subq_1.__booking_value_p99 AS __booking_value_p99
-                  , subq_1.__discrete_booking_value_p99 AS __discrete_booking_value_p99
-                  , subq_1.__approximate_continuous_booking_value_p99 AS __approximate_continuous_booking_value_p99
-                  , subq_1.__approximate_discrete_booking_value_p99 AS __approximate_discrete_booking_value_p99
-                  , subq_1.__bookings_join_to_time_spine AS __bookings_join_to_time_spine
-                  , subq_1.__bookings_fill_nulls_with_0_without_time_spine AS __bookings_fill_nulls_with_0_without_time_spine
-                  , subq_1.__bookings_fill_nulls_with_0 AS __bookings_fill_nulls_with_0
-                  , subq_1.__instant_bookings_with_measure_filter AS __instant_bookings_with_measure_filter
-                  , subq_1.__bookings_join_to_time_spine_with_tiered_filters AS __bookings_join_to_time_spine_with_tiered_filters
-                  , subq_1.__bookers_fill_nulls_with_0_join_to_timespine AS __bookers_fill_nulls_with_0_join_to_timespine
+                  subq_5.metric_time__day
+                  , subq_5.metric_time__month
                 FROM (
-                  -- Select: ['metric_time__day', 'metric_time__month']
+                  -- Constrain Output with WHERE
                   SELECT
                     subq_4.metric_time__day
                     , subq_4.metric_time__month
@@ -200,225 +198,225 @@ FROM (
                       ) subq_2
                     ) subq_3
                   ) subq_4
+                  WHERE metric_time__day = '2020-01-01'
                 ) subq_5
-                INNER JOIN (
-                  -- Metric Time Dimension 'ds'
-                  SELECT
-                    subq_0.ds__day
-                    , subq_0.ds__week
-                    , subq_0.ds__month
-                    , subq_0.ds__quarter
-                    , subq_0.ds__year
-                    , subq_0.ds__extract_year
-                    , subq_0.ds__extract_quarter
-                    , subq_0.ds__extract_month
-                    , subq_0.ds__extract_day
-                    , subq_0.ds__extract_dow
-                    , subq_0.ds__extract_doy
-                    , subq_0.ds_partitioned__day
-                    , subq_0.ds_partitioned__week
-                    , subq_0.ds_partitioned__month
-                    , subq_0.ds_partitioned__quarter
-                    , subq_0.ds_partitioned__year
-                    , subq_0.ds_partitioned__extract_year
-                    , subq_0.ds_partitioned__extract_quarter
-                    , subq_0.ds_partitioned__extract_month
-                    , subq_0.ds_partitioned__extract_day
-                    , subq_0.ds_partitioned__extract_dow
-                    , subq_0.ds_partitioned__extract_doy
-                    , subq_0.paid_at__day
-                    , subq_0.paid_at__week
-                    , subq_0.paid_at__month
-                    , subq_0.paid_at__quarter
-                    , subq_0.paid_at__year
-                    , subq_0.paid_at__extract_year
-                    , subq_0.paid_at__extract_quarter
-                    , subq_0.paid_at__extract_month
-                    , subq_0.paid_at__extract_day
-                    , subq_0.paid_at__extract_dow
-                    , subq_0.paid_at__extract_doy
-                    , subq_0.booking__ds__day
-                    , subq_0.booking__ds__week
-                    , subq_0.booking__ds__month
-                    , subq_0.booking__ds__quarter
-                    , subq_0.booking__ds__year
-                    , subq_0.booking__ds__extract_year
-                    , subq_0.booking__ds__extract_quarter
-                    , subq_0.booking__ds__extract_month
-                    , subq_0.booking__ds__extract_day
-                    , subq_0.booking__ds__extract_dow
-                    , subq_0.booking__ds__extract_doy
-                    , subq_0.booking__ds_partitioned__day
-                    , subq_0.booking__ds_partitioned__week
-                    , subq_0.booking__ds_partitioned__month
-                    , subq_0.booking__ds_partitioned__quarter
-                    , subq_0.booking__ds_partitioned__year
-                    , subq_0.booking__ds_partitioned__extract_year
-                    , subq_0.booking__ds_partitioned__extract_quarter
-                    , subq_0.booking__ds_partitioned__extract_month
-                    , subq_0.booking__ds_partitioned__extract_day
-                    , subq_0.booking__ds_partitioned__extract_dow
-                    , subq_0.booking__ds_partitioned__extract_doy
-                    , subq_0.booking__paid_at__day
-                    , subq_0.booking__paid_at__week
-                    , subq_0.booking__paid_at__month
-                    , subq_0.booking__paid_at__quarter
-                    , subq_0.booking__paid_at__year
-                    , subq_0.booking__paid_at__extract_year
-                    , subq_0.booking__paid_at__extract_quarter
-                    , subq_0.booking__paid_at__extract_month
-                    , subq_0.booking__paid_at__extract_day
-                    , subq_0.booking__paid_at__extract_dow
-                    , subq_0.booking__paid_at__extract_doy
-                    , subq_0.ds__day AS metric_time__day
-                    , subq_0.ds__week AS metric_time__week
-                    , subq_0.ds__month AS metric_time__month
-                    , subq_0.ds__quarter AS metric_time__quarter
-                    , subq_0.ds__year AS metric_time__year
-                    , subq_0.ds__extract_year AS metric_time__extract_year
-                    , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                    , subq_0.ds__extract_month AS metric_time__extract_month
-                    , subq_0.ds__extract_day AS metric_time__extract_day
-                    , subq_0.ds__extract_dow AS metric_time__extract_dow
-                    , subq_0.ds__extract_doy AS metric_time__extract_doy
-                    , subq_0.listing
-                    , subq_0.guest
-                    , subq_0.host
-                    , subq_0.booking__listing
-                    , subq_0.booking__guest
-                    , subq_0.booking__host
-                    , subq_0.is_instant
-                    , subq_0.booking__is_instant
-                    , subq_0.__bookings
-                    , subq_0.__average_booking_value
-                    , subq_0.__instant_bookings
-                    , subq_0.__booking_value
-                    , subq_0.__max_booking_value
-                    , subq_0.__min_booking_value
-                    , subq_0.__instant_booking_value
-                    , subq_0.__average_instant_booking_value
-                    , subq_0.__booking_value_for_non_null_listing_id
-                    , subq_0.__bookers
-                    , subq_0.__referred_bookings
-                    , subq_0.__median_booking_value
-                    , subq_0.__booking_value_p99
-                    , subq_0.__discrete_booking_value_p99
-                    , subq_0.__approximate_continuous_booking_value_p99
-                    , subq_0.__approximate_discrete_booking_value_p99
-                    , subq_0.__bookings_join_to_time_spine
-                    , subq_0.__bookings_fill_nulls_with_0_without_time_spine
-                    , subq_0.__bookings_fill_nulls_with_0
-                    , subq_0.__instant_bookings_with_measure_filter
-                    , subq_0.__bookings_join_to_time_spine_with_tiered_filters
-                    , subq_0.__bookers_fill_nulls_with_0_join_to_timespine
-                  FROM (
-                    -- Read Elements From Semantic Model 'bookings_source'
-                    SELECT
-                      1 AS __bookings
-                      , bookings_source_src_28000.booking_value AS __average_booking_value
-                      , CASE WHEN is_instant THEN 1 ELSE 0 END AS __instant_bookings
-                      , bookings_source_src_28000.booking_value AS __booking_value
-                      , bookings_source_src_28000.booking_value AS __max_booking_value
-                      , bookings_source_src_28000.booking_value AS __min_booking_value
-                      , bookings_source_src_28000.booking_value AS __instant_booking_value
-                      , bookings_source_src_28000.booking_value AS __average_instant_booking_value
-                      , bookings_source_src_28000.booking_value AS __booking_value_for_non_null_listing_id
-                      , bookings_source_src_28000.guest_id AS __bookers
-                      , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS __referred_bookings
-                      , bookings_source_src_28000.booking_value AS __median_booking_value
-                      , bookings_source_src_28000.booking_value AS __booking_value_p99
-                      , bookings_source_src_28000.booking_value AS __discrete_booking_value_p99
-                      , bookings_source_src_28000.booking_value AS __approximate_continuous_booking_value_p99
-                      , bookings_source_src_28000.booking_value AS __approximate_discrete_booking_value_p99
-                      , 1 AS __bookings_join_to_time_spine
-                      , 1 AS __bookings_fill_nulls_with_0_without_time_spine
-                      , 1 AS __bookings_fill_nulls_with_0
-                      , 1 AS __instant_bookings_with_measure_filter
-                      , 1 AS __bookings_join_to_time_spine_with_tiered_filters
-                      , bookings_source_src_28000.guest_id AS __bookers_fill_nulls_with_0_join_to_timespine
-                      , bookings_source_src_28000.booking_value AS __booking_payments
-                      , bookings_source_src_28000.is_instant
-                      , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                      , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                      , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS ds__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                      , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                      , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                      , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                      , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                      , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                      , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                      , bookings_source_src_28000.is_instant AS booking__is_instant
-                      , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                      , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                      , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                      , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                      , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                      , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                      , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                      , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                      , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                      , bookings_source_src_28000.listing_id AS listing
-                      , bookings_source_src_28000.guest_id AS guest
-                      , bookings_source_src_28000.host_id AS host
-                      , bookings_source_src_28000.listing_id AS booking__listing
-                      , bookings_source_src_28000.guest_id AS booking__guest
-                      , bookings_source_src_28000.host_id AS booking__host
-                    FROM ***************************.fct_bookings bookings_source_src_28000
-                  ) subq_0
-                ) subq_1
-                ON
-                  DATEADD(week, -1, subq_5.metric_time__day) = subq_1.metric_time__day
               ) subq_6
+              INNER JOIN (
+                -- Metric Time Dimension 'ds'
+                SELECT
+                  subq_0.ds__day
+                  , subq_0.ds__week
+                  , subq_0.ds__month
+                  , subq_0.ds__quarter
+                  , subq_0.ds__year
+                  , subq_0.ds__extract_year
+                  , subq_0.ds__extract_quarter
+                  , subq_0.ds__extract_month
+                  , subq_0.ds__extract_day
+                  , subq_0.ds__extract_dow
+                  , subq_0.ds__extract_doy
+                  , subq_0.ds_partitioned__day
+                  , subq_0.ds_partitioned__week
+                  , subq_0.ds_partitioned__month
+                  , subq_0.ds_partitioned__quarter
+                  , subq_0.ds_partitioned__year
+                  , subq_0.ds_partitioned__extract_year
+                  , subq_0.ds_partitioned__extract_quarter
+                  , subq_0.ds_partitioned__extract_month
+                  , subq_0.ds_partitioned__extract_day
+                  , subq_0.ds_partitioned__extract_dow
+                  , subq_0.ds_partitioned__extract_doy
+                  , subq_0.paid_at__day
+                  , subq_0.paid_at__week
+                  , subq_0.paid_at__month
+                  , subq_0.paid_at__quarter
+                  , subq_0.paid_at__year
+                  , subq_0.paid_at__extract_year
+                  , subq_0.paid_at__extract_quarter
+                  , subq_0.paid_at__extract_month
+                  , subq_0.paid_at__extract_day
+                  , subq_0.paid_at__extract_dow
+                  , subq_0.paid_at__extract_doy
+                  , subq_0.booking__ds__day
+                  , subq_0.booking__ds__week
+                  , subq_0.booking__ds__month
+                  , subq_0.booking__ds__quarter
+                  , subq_0.booking__ds__year
+                  , subq_0.booking__ds__extract_year
+                  , subq_0.booking__ds__extract_quarter
+                  , subq_0.booking__ds__extract_month
+                  , subq_0.booking__ds__extract_day
+                  , subq_0.booking__ds__extract_dow
+                  , subq_0.booking__ds__extract_doy
+                  , subq_0.booking__ds_partitioned__day
+                  , subq_0.booking__ds_partitioned__week
+                  , subq_0.booking__ds_partitioned__month
+                  , subq_0.booking__ds_partitioned__quarter
+                  , subq_0.booking__ds_partitioned__year
+                  , subq_0.booking__ds_partitioned__extract_year
+                  , subq_0.booking__ds_partitioned__extract_quarter
+                  , subq_0.booking__ds_partitioned__extract_month
+                  , subq_0.booking__ds_partitioned__extract_day
+                  , subq_0.booking__ds_partitioned__extract_dow
+                  , subq_0.booking__ds_partitioned__extract_doy
+                  , subq_0.booking__paid_at__day
+                  , subq_0.booking__paid_at__week
+                  , subq_0.booking__paid_at__month
+                  , subq_0.booking__paid_at__quarter
+                  , subq_0.booking__paid_at__year
+                  , subq_0.booking__paid_at__extract_year
+                  , subq_0.booking__paid_at__extract_quarter
+                  , subq_0.booking__paid_at__extract_month
+                  , subq_0.booking__paid_at__extract_day
+                  , subq_0.booking__paid_at__extract_dow
+                  , subq_0.booking__paid_at__extract_doy
+                  , subq_0.ds__day AS metric_time__day
+                  , subq_0.ds__week AS metric_time__week
+                  , subq_0.ds__month AS metric_time__month
+                  , subq_0.ds__quarter AS metric_time__quarter
+                  , subq_0.ds__year AS metric_time__year
+                  , subq_0.ds__extract_year AS metric_time__extract_year
+                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_0.ds__extract_month AS metric_time__extract_month
+                  , subq_0.ds__extract_day AS metric_time__extract_day
+                  , subq_0.ds__extract_dow AS metric_time__extract_dow
+                  , subq_0.ds__extract_doy AS metric_time__extract_doy
+                  , subq_0.listing
+                  , subq_0.guest
+                  , subq_0.host
+                  , subq_0.booking__listing
+                  , subq_0.booking__guest
+                  , subq_0.booking__host
+                  , subq_0.is_instant
+                  , subq_0.booking__is_instant
+                  , subq_0.__bookings
+                  , subq_0.__average_booking_value
+                  , subq_0.__instant_bookings
+                  , subq_0.__booking_value
+                  , subq_0.__max_booking_value
+                  , subq_0.__min_booking_value
+                  , subq_0.__instant_booking_value
+                  , subq_0.__average_instant_booking_value
+                  , subq_0.__booking_value_for_non_null_listing_id
+                  , subq_0.__bookers
+                  , subq_0.__referred_bookings
+                  , subq_0.__median_booking_value
+                  , subq_0.__booking_value_p99
+                  , subq_0.__discrete_booking_value_p99
+                  , subq_0.__approximate_continuous_booking_value_p99
+                  , subq_0.__approximate_discrete_booking_value_p99
+                  , subq_0.__bookings_join_to_time_spine
+                  , subq_0.__bookings_fill_nulls_with_0_without_time_spine
+                  , subq_0.__bookings_fill_nulls_with_0
+                  , subq_0.__instant_bookings_with_measure_filter
+                  , subq_0.__bookings_join_to_time_spine_with_tiered_filters
+                  , subq_0.__bookers_fill_nulls_with_0_join_to_timespine
+                FROM (
+                  -- Read Elements From Semantic Model 'bookings_source'
+                  SELECT
+                    1 AS __bookings
+                    , bookings_source_src_28000.booking_value AS __average_booking_value
+                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS __instant_bookings
+                    , bookings_source_src_28000.booking_value AS __booking_value
+                    , bookings_source_src_28000.booking_value AS __max_booking_value
+                    , bookings_source_src_28000.booking_value AS __min_booking_value
+                    , bookings_source_src_28000.booking_value AS __instant_booking_value
+                    , bookings_source_src_28000.booking_value AS __average_instant_booking_value
+                    , bookings_source_src_28000.booking_value AS __booking_value_for_non_null_listing_id
+                    , bookings_source_src_28000.guest_id AS __bookers
+                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS __referred_bookings
+                    , bookings_source_src_28000.booking_value AS __median_booking_value
+                    , bookings_source_src_28000.booking_value AS __booking_value_p99
+                    , bookings_source_src_28000.booking_value AS __discrete_booking_value_p99
+                    , bookings_source_src_28000.booking_value AS __approximate_continuous_booking_value_p99
+                    , bookings_source_src_28000.booking_value AS __approximate_discrete_booking_value_p99
+                    , 1 AS __bookings_join_to_time_spine
+                    , 1 AS __bookings_fill_nulls_with_0_without_time_spine
+                    , 1 AS __bookings_fill_nulls_with_0
+                    , 1 AS __instant_bookings_with_measure_filter
+                    , 1 AS __bookings_join_to_time_spine_with_tiered_filters
+                    , bookings_source_src_28000.guest_id AS __bookers_fill_nulls_with_0_join_to_timespine
+                    , bookings_source_src_28000.booking_value AS __booking_payments
+                    , bookings_source_src_28000.is_instant
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                    , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                    , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                    , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                    , bookings_source_src_28000.is_instant AS booking__is_instant
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                    , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                    , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                    , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                    , bookings_source_src_28000.listing_id AS listing
+                    , bookings_source_src_28000.guest_id AS guest
+                    , bookings_source_src_28000.host_id AS host
+                    , bookings_source_src_28000.listing_id AS booking__listing
+                    , bookings_source_src_28000.guest_id AS booking__guest
+                    , bookings_source_src_28000.host_id AS booking__host
+                  FROM ***************************.fct_bookings bookings_source_src_28000
+                ) subq_0
+              ) subq_1
+              ON
+                DATEADD(week, -1, subq_6.metric_time__day) = subq_1.metric_time__day
             ) subq_7
-            WHERE metric_time__day = '2020-01-01'
           ) subq_8
         ) subq_9
         GROUP BY

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_offset_window_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Snowflake/test_offset_window_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
@@ -27,29 +27,37 @@ FROM (
     , MAX(subq_31.booking_value) AS booking_value
     , MAX(subq_37.bookers) AS bookers
   FROM (
-    -- Constrain Output with WHERE
+    -- Join to Time Spine Dataset
+    -- Select: ['__booking_value', 'metric_time__month']
     -- Select: ['__booking_value', 'metric_time__month']
     -- Aggregate Inputs for Simple Metrics
     -- Compute Metrics via Expressions
     SELECT
-      metric_time__month
-      , SUM(booking_value) AS booking_value
+      subq_26.metric_time__month AS metric_time__month
+      , SUM(sma_28009_cte.__booking_value) AS booking_value
     FROM (
-      -- Join to Time Spine Dataset
-      -- Select: ['__booking_value', 'metric_time__month', 'metric_time__day']
+      -- Constrain Output with WHERE
+      -- Select: ['metric_time__day', 'metric_time__month']
       SELECT
-        time_spine_src_28006.ds AS metric_time__day
-        , DATE_TRUNC('month', time_spine_src_28006.ds) AS metric_time__month
-        , sma_28009_cte.__booking_value AS booking_value
-      FROM ***************************.mf_time_spine time_spine_src_28006
-      INNER JOIN
-        sma_28009_cte
-      ON
-        DATEADD(week, -1, time_spine_src_28006.ds) = sma_28009_cte.metric_time__day
-    ) subq_27
-    WHERE metric_time__day = '2020-01-01'
+        metric_time__day
+        , metric_time__month
+      FROM (
+        -- Read From Time Spine 'mf_time_spine'
+        -- Change Column Aliases
+        -- Select: ['metric_time__day', 'metric_time__month']
+        SELECT
+          ds AS metric_time__day
+          , DATE_TRUNC('month', ds) AS metric_time__month
+        FROM ***************************.mf_time_spine time_spine_src_28006
+      ) subq_24
+      WHERE metric_time__day = '2020-01-01'
+    ) subq_26
+    INNER JOIN
+      sma_28009_cte
+    ON
+      DATEADD(week, -1, subq_26.metric_time__day) = sma_28009_cte.metric_time__day
     GROUP BY
-      metric_time__month
+      subq_26.metric_time__month
   ) subq_31
   FULL OUTER JOIN (
     -- Constrain Output with WHERE

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
@@ -4,19 +4,19 @@ sql_engine: Trino
 ---
 -- Write to DataTable
 SELECT
-  subq_20.metric_time__day
-  , subq_20.bookings_growth_2_weeks
+  subq_19.metric_time__day
+  , subq_19.bookings_growth_2_weeks
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_19.metric_time__day
+    subq_18.metric_time__day
     , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
   FROM (
     -- Combine Aggregated Outputs
     SELECT
-      COALESCE(subq_6.metric_time__day, subq_18.metric_time__day) AS metric_time__day
+      COALESCE(subq_6.metric_time__day, subq_17.metric_time__day) AS metric_time__day
       , MAX(subq_6.bookings) AS bookings
-      , MAX(subq_18.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+      , MAX(subq_17.bookings_2_weeks_ago) AS bookings_2_weeks_ago
     FROM (
       -- Compute Metrics via Expressions
       SELECT
@@ -266,40 +266,40 @@ FROM (
     FULL OUTER JOIN (
       -- Compute Metrics via Expressions
       SELECT
-        subq_17.metric_time__day
-        , subq_17.__bookings AS bookings_2_weeks_ago
+        subq_16.metric_time__day
+        , subq_16.__bookings AS bookings_2_weeks_ago
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_16.metric_time__day AS metric_time__day
-          , subq_11.__bookings AS __bookings
+          subq_15.metric_time__day AS metric_time__day
+          , subq_10.__bookings AS __bookings
         FROM (
           -- Select: ['metric_time__day']
           SELECT
-            subq_15.metric_time__day
+            subq_14.metric_time__day
           FROM (
             -- Constrain Output with WHERE
             SELECT
-              subq_14.metric_time__day
+              subq_13.metric_time__day
             FROM (
               -- Select: ['metric_time__day']
               SELECT
-                subq_13.metric_time__day
+                subq_12.metric_time__day
               FROM (
                 -- Change Column Aliases
                 SELECT
-                  subq_12.ds__day AS metric_time__day
-                  , subq_12.ds__week
-                  , subq_12.ds__month
-                  , subq_12.ds__quarter
-                  , subq_12.ds__year
-                  , subq_12.ds__extract_year
-                  , subq_12.ds__extract_quarter
-                  , subq_12.ds__extract_month
-                  , subq_12.ds__extract_day
-                  , subq_12.ds__extract_dow
-                  , subq_12.ds__extract_doy
-                  , subq_12.ds__alien_day
+                  subq_11.ds__day AS metric_time__day
+                  , subq_11.ds__week
+                  , subq_11.ds__month
+                  , subq_11.ds__quarter
+                  , subq_11.ds__year
+                  , subq_11.ds__extract_year
+                  , subq_11.ds__extract_quarter
+                  , subq_11.ds__extract_month
+                  , subq_11.ds__extract_day
+                  , subq_11.ds__extract_dow
+                  , subq_11.ds__extract_doy
+                  , subq_11.ds__alien_day
                 FROM (
                   -- Read From Time Spine 'mf_time_spine'
                   SELECT
@@ -316,259 +316,252 @@ FROM (
                     , EXTRACT(doy FROM time_spine_src_28006.ds) AS ds__extract_doy
                     , time_spine_src_28006.alien_day AS ds__alien_day
                   FROM ***************************.mf_time_spine time_spine_src_28006
-                ) subq_12
-              ) subq_13
-            ) subq_14
+                ) subq_11
+              ) subq_12
+            ) subq_13
             WHERE metric_time__day = '2020-01-01' or metric_time__day = '2020-01-14'
-          ) subq_15
-        ) subq_16
+          ) subq_14
+        ) subq_15
         INNER JOIN (
           -- Aggregate Inputs for Simple Metrics
           SELECT
-            subq_10.metric_time__day
-            , SUM(subq_10.__bookings) AS __bookings
+            subq_9.metric_time__day
+            , SUM(subq_9.__bookings) AS __bookings
           FROM (
             -- Select: ['__bookings', 'metric_time__day']
             SELECT
-              subq_9.metric_time__day
-              , subq_9.__bookings
+              subq_8.metric_time__day
+              , subq_8.__bookings
             FROM (
-              -- Constrain Output with WHERE
+              -- Select: ['__bookings', 'metric_time__day']
               SELECT
-                subq_8.bookings AS __bookings
-                , subq_8.metric_time__day
+                subq_7.metric_time__day
+                , subq_7.__bookings
               FROM (
-                -- Select: ['__bookings', 'metric_time__day']
+                -- Metric Time Dimension 'ds'
                 SELECT
-                  subq_7.metric_time__day
-                  , subq_7.__bookings AS bookings
+                  subq_0.ds__day
+                  , subq_0.ds__week
+                  , subq_0.ds__month
+                  , subq_0.ds__quarter
+                  , subq_0.ds__year
+                  , subq_0.ds__extract_year
+                  , subq_0.ds__extract_quarter
+                  , subq_0.ds__extract_month
+                  , subq_0.ds__extract_day
+                  , subq_0.ds__extract_dow
+                  , subq_0.ds__extract_doy
+                  , subq_0.ds_partitioned__day
+                  , subq_0.ds_partitioned__week
+                  , subq_0.ds_partitioned__month
+                  , subq_0.ds_partitioned__quarter
+                  , subq_0.ds_partitioned__year
+                  , subq_0.ds_partitioned__extract_year
+                  , subq_0.ds_partitioned__extract_quarter
+                  , subq_0.ds_partitioned__extract_month
+                  , subq_0.ds_partitioned__extract_day
+                  , subq_0.ds_partitioned__extract_dow
+                  , subq_0.ds_partitioned__extract_doy
+                  , subq_0.paid_at__day
+                  , subq_0.paid_at__week
+                  , subq_0.paid_at__month
+                  , subq_0.paid_at__quarter
+                  , subq_0.paid_at__year
+                  , subq_0.paid_at__extract_year
+                  , subq_0.paid_at__extract_quarter
+                  , subq_0.paid_at__extract_month
+                  , subq_0.paid_at__extract_day
+                  , subq_0.paid_at__extract_dow
+                  , subq_0.paid_at__extract_doy
+                  , subq_0.booking__ds__day
+                  , subq_0.booking__ds__week
+                  , subq_0.booking__ds__month
+                  , subq_0.booking__ds__quarter
+                  , subq_0.booking__ds__year
+                  , subq_0.booking__ds__extract_year
+                  , subq_0.booking__ds__extract_quarter
+                  , subq_0.booking__ds__extract_month
+                  , subq_0.booking__ds__extract_day
+                  , subq_0.booking__ds__extract_dow
+                  , subq_0.booking__ds__extract_doy
+                  , subq_0.booking__ds_partitioned__day
+                  , subq_0.booking__ds_partitioned__week
+                  , subq_0.booking__ds_partitioned__month
+                  , subq_0.booking__ds_partitioned__quarter
+                  , subq_0.booking__ds_partitioned__year
+                  , subq_0.booking__ds_partitioned__extract_year
+                  , subq_0.booking__ds_partitioned__extract_quarter
+                  , subq_0.booking__ds_partitioned__extract_month
+                  , subq_0.booking__ds_partitioned__extract_day
+                  , subq_0.booking__ds_partitioned__extract_dow
+                  , subq_0.booking__ds_partitioned__extract_doy
+                  , subq_0.booking__paid_at__day
+                  , subq_0.booking__paid_at__week
+                  , subq_0.booking__paid_at__month
+                  , subq_0.booking__paid_at__quarter
+                  , subq_0.booking__paid_at__year
+                  , subq_0.booking__paid_at__extract_year
+                  , subq_0.booking__paid_at__extract_quarter
+                  , subq_0.booking__paid_at__extract_month
+                  , subq_0.booking__paid_at__extract_day
+                  , subq_0.booking__paid_at__extract_dow
+                  , subq_0.booking__paid_at__extract_doy
+                  , subq_0.ds__day AS metric_time__day
+                  , subq_0.ds__week AS metric_time__week
+                  , subq_0.ds__month AS metric_time__month
+                  , subq_0.ds__quarter AS metric_time__quarter
+                  , subq_0.ds__year AS metric_time__year
+                  , subq_0.ds__extract_year AS metric_time__extract_year
+                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_0.ds__extract_month AS metric_time__extract_month
+                  , subq_0.ds__extract_day AS metric_time__extract_day
+                  , subq_0.ds__extract_dow AS metric_time__extract_dow
+                  , subq_0.ds__extract_doy AS metric_time__extract_doy
+                  , subq_0.listing
+                  , subq_0.guest
+                  , subq_0.host
+                  , subq_0.booking__listing
+                  , subq_0.booking__guest
+                  , subq_0.booking__host
+                  , subq_0.is_instant
+                  , subq_0.booking__is_instant
+                  , subq_0.__bookings
+                  , subq_0.__average_booking_value
+                  , subq_0.__instant_bookings
+                  , subq_0.__booking_value
+                  , subq_0.__max_booking_value
+                  , subq_0.__min_booking_value
+                  , subq_0.__instant_booking_value
+                  , subq_0.__average_instant_booking_value
+                  , subq_0.__booking_value_for_non_null_listing_id
+                  , subq_0.__bookers
+                  , subq_0.__referred_bookings
+                  , subq_0.__median_booking_value
+                  , subq_0.__booking_value_p99
+                  , subq_0.__discrete_booking_value_p99
+                  , subq_0.__approximate_continuous_booking_value_p99
+                  , subq_0.__approximate_discrete_booking_value_p99
+                  , subq_0.__bookings_join_to_time_spine
+                  , subq_0.__bookings_fill_nulls_with_0_without_time_spine
+                  , subq_0.__bookings_fill_nulls_with_0
+                  , subq_0.__instant_bookings_with_measure_filter
+                  , subq_0.__bookings_join_to_time_spine_with_tiered_filters
+                  , subq_0.__bookers_fill_nulls_with_0_join_to_timespine
                 FROM (
-                  -- Metric Time Dimension 'ds'
+                  -- Read Elements From Semantic Model 'bookings_source'
                   SELECT
-                    subq_0.ds__day
-                    , subq_0.ds__week
-                    , subq_0.ds__month
-                    , subq_0.ds__quarter
-                    , subq_0.ds__year
-                    , subq_0.ds__extract_year
-                    , subq_0.ds__extract_quarter
-                    , subq_0.ds__extract_month
-                    , subq_0.ds__extract_day
-                    , subq_0.ds__extract_dow
-                    , subq_0.ds__extract_doy
-                    , subq_0.ds_partitioned__day
-                    , subq_0.ds_partitioned__week
-                    , subq_0.ds_partitioned__month
-                    , subq_0.ds_partitioned__quarter
-                    , subq_0.ds_partitioned__year
-                    , subq_0.ds_partitioned__extract_year
-                    , subq_0.ds_partitioned__extract_quarter
-                    , subq_0.ds_partitioned__extract_month
-                    , subq_0.ds_partitioned__extract_day
-                    , subq_0.ds_partitioned__extract_dow
-                    , subq_0.ds_partitioned__extract_doy
-                    , subq_0.paid_at__day
-                    , subq_0.paid_at__week
-                    , subq_0.paid_at__month
-                    , subq_0.paid_at__quarter
-                    , subq_0.paid_at__year
-                    , subq_0.paid_at__extract_year
-                    , subq_0.paid_at__extract_quarter
-                    , subq_0.paid_at__extract_month
-                    , subq_0.paid_at__extract_day
-                    , subq_0.paid_at__extract_dow
-                    , subq_0.paid_at__extract_doy
-                    , subq_0.booking__ds__day
-                    , subq_0.booking__ds__week
-                    , subq_0.booking__ds__month
-                    , subq_0.booking__ds__quarter
-                    , subq_0.booking__ds__year
-                    , subq_0.booking__ds__extract_year
-                    , subq_0.booking__ds__extract_quarter
-                    , subq_0.booking__ds__extract_month
-                    , subq_0.booking__ds__extract_day
-                    , subq_0.booking__ds__extract_dow
-                    , subq_0.booking__ds__extract_doy
-                    , subq_0.booking__ds_partitioned__day
-                    , subq_0.booking__ds_partitioned__week
-                    , subq_0.booking__ds_partitioned__month
-                    , subq_0.booking__ds_partitioned__quarter
-                    , subq_0.booking__ds_partitioned__year
-                    , subq_0.booking__ds_partitioned__extract_year
-                    , subq_0.booking__ds_partitioned__extract_quarter
-                    , subq_0.booking__ds_partitioned__extract_month
-                    , subq_0.booking__ds_partitioned__extract_day
-                    , subq_0.booking__ds_partitioned__extract_dow
-                    , subq_0.booking__ds_partitioned__extract_doy
-                    , subq_0.booking__paid_at__day
-                    , subq_0.booking__paid_at__week
-                    , subq_0.booking__paid_at__month
-                    , subq_0.booking__paid_at__quarter
-                    , subq_0.booking__paid_at__year
-                    , subq_0.booking__paid_at__extract_year
-                    , subq_0.booking__paid_at__extract_quarter
-                    , subq_0.booking__paid_at__extract_month
-                    , subq_0.booking__paid_at__extract_day
-                    , subq_0.booking__paid_at__extract_dow
-                    , subq_0.booking__paid_at__extract_doy
-                    , subq_0.ds__day AS metric_time__day
-                    , subq_0.ds__week AS metric_time__week
-                    , subq_0.ds__month AS metric_time__month
-                    , subq_0.ds__quarter AS metric_time__quarter
-                    , subq_0.ds__year AS metric_time__year
-                    , subq_0.ds__extract_year AS metric_time__extract_year
-                    , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                    , subq_0.ds__extract_month AS metric_time__extract_month
-                    , subq_0.ds__extract_day AS metric_time__extract_day
-                    , subq_0.ds__extract_dow AS metric_time__extract_dow
-                    , subq_0.ds__extract_doy AS metric_time__extract_doy
-                    , subq_0.listing
-                    , subq_0.guest
-                    , subq_0.host
-                    , subq_0.booking__listing
-                    , subq_0.booking__guest
-                    , subq_0.booking__host
-                    , subq_0.is_instant
-                    , subq_0.booking__is_instant
-                    , subq_0.__bookings
-                    , subq_0.__average_booking_value
-                    , subq_0.__instant_bookings
-                    , subq_0.__booking_value
-                    , subq_0.__max_booking_value
-                    , subq_0.__min_booking_value
-                    , subq_0.__instant_booking_value
-                    , subq_0.__average_instant_booking_value
-                    , subq_0.__booking_value_for_non_null_listing_id
-                    , subq_0.__bookers
-                    , subq_0.__referred_bookings
-                    , subq_0.__median_booking_value
-                    , subq_0.__booking_value_p99
-                    , subq_0.__discrete_booking_value_p99
-                    , subq_0.__approximate_continuous_booking_value_p99
-                    , subq_0.__approximate_discrete_booking_value_p99
-                    , subq_0.__bookings_join_to_time_spine
-                    , subq_0.__bookings_fill_nulls_with_0_without_time_spine
-                    , subq_0.__bookings_fill_nulls_with_0
-                    , subq_0.__instant_bookings_with_measure_filter
-                    , subq_0.__bookings_join_to_time_spine_with_tiered_filters
-                    , subq_0.__bookers_fill_nulls_with_0_join_to_timespine
-                  FROM (
-                    -- Read Elements From Semantic Model 'bookings_source'
-                    SELECT
-                      1 AS __bookings
-                      , bookings_source_src_28000.booking_value AS __average_booking_value
-                      , CASE WHEN is_instant THEN 1 ELSE 0 END AS __instant_bookings
-                      , bookings_source_src_28000.booking_value AS __booking_value
-                      , bookings_source_src_28000.booking_value AS __max_booking_value
-                      , bookings_source_src_28000.booking_value AS __min_booking_value
-                      , bookings_source_src_28000.booking_value AS __instant_booking_value
-                      , bookings_source_src_28000.booking_value AS __average_instant_booking_value
-                      , bookings_source_src_28000.booking_value AS __booking_value_for_non_null_listing_id
-                      , bookings_source_src_28000.guest_id AS __bookers
-                      , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS __referred_bookings
-                      , bookings_source_src_28000.booking_value AS __median_booking_value
-                      , bookings_source_src_28000.booking_value AS __booking_value_p99
-                      , bookings_source_src_28000.booking_value AS __discrete_booking_value_p99
-                      , bookings_source_src_28000.booking_value AS __approximate_continuous_booking_value_p99
-                      , bookings_source_src_28000.booking_value AS __approximate_discrete_booking_value_p99
-                      , 1 AS __bookings_join_to_time_spine
-                      , 1 AS __bookings_fill_nulls_with_0_without_time_spine
-                      , 1 AS __bookings_fill_nulls_with_0
-                      , 1 AS __instant_bookings_with_measure_filter
-                      , 1 AS __bookings_join_to_time_spine_with_tiered_filters
-                      , bookings_source_src_28000.guest_id AS __bookers_fill_nulls_with_0_join_to_timespine
-                      , bookings_source_src_28000.booking_value AS __booking_payments
-                      , bookings_source_src_28000.is_instant
-                      , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                      , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                      , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS ds__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                      , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                      , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                      , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                      , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                      , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                      , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                      , bookings_source_src_28000.is_instant AS booking__is_instant
-                      , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                      , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                      , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                      , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                      , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                      , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                      , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                      , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                      , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                      , bookings_source_src_28000.listing_id AS listing
-                      , bookings_source_src_28000.guest_id AS guest
-                      , bookings_source_src_28000.host_id AS host
-                      , bookings_source_src_28000.listing_id AS booking__listing
-                      , bookings_source_src_28000.guest_id AS booking__guest
-                      , bookings_source_src_28000.host_id AS booking__host
-                    FROM ***************************.fct_bookings bookings_source_src_28000
-                  ) subq_0
-                ) subq_7
-              ) subq_8
-              WHERE metric_time__day = '2020-01-01' or metric_time__day = '2020-01-14'
-            ) subq_9
-          ) subq_10
+                    1 AS __bookings
+                    , bookings_source_src_28000.booking_value AS __average_booking_value
+                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS __instant_bookings
+                    , bookings_source_src_28000.booking_value AS __booking_value
+                    , bookings_source_src_28000.booking_value AS __max_booking_value
+                    , bookings_source_src_28000.booking_value AS __min_booking_value
+                    , bookings_source_src_28000.booking_value AS __instant_booking_value
+                    , bookings_source_src_28000.booking_value AS __average_instant_booking_value
+                    , bookings_source_src_28000.booking_value AS __booking_value_for_non_null_listing_id
+                    , bookings_source_src_28000.guest_id AS __bookers
+                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS __referred_bookings
+                    , bookings_source_src_28000.booking_value AS __median_booking_value
+                    , bookings_source_src_28000.booking_value AS __booking_value_p99
+                    , bookings_source_src_28000.booking_value AS __discrete_booking_value_p99
+                    , bookings_source_src_28000.booking_value AS __approximate_continuous_booking_value_p99
+                    , bookings_source_src_28000.booking_value AS __approximate_discrete_booking_value_p99
+                    , 1 AS __bookings_join_to_time_spine
+                    , 1 AS __bookings_fill_nulls_with_0_without_time_spine
+                    , 1 AS __bookings_fill_nulls_with_0
+                    , 1 AS __instant_bookings_with_measure_filter
+                    , 1 AS __bookings_join_to_time_spine_with_tiered_filters
+                    , bookings_source_src_28000.guest_id AS __bookers_fill_nulls_with_0_join_to_timespine
+                    , bookings_source_src_28000.booking_value AS __booking_payments
+                    , bookings_source_src_28000.is_instant
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                    , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                    , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                    , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                    , bookings_source_src_28000.is_instant AS booking__is_instant
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                    , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                    , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                    , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                    , bookings_source_src_28000.listing_id AS listing
+                    , bookings_source_src_28000.guest_id AS guest
+                    , bookings_source_src_28000.host_id AS host
+                    , bookings_source_src_28000.listing_id AS booking__listing
+                    , bookings_source_src_28000.guest_id AS booking__guest
+                    , bookings_source_src_28000.host_id AS booking__host
+                  FROM ***************************.fct_bookings bookings_source_src_28000
+                ) subq_0
+              ) subq_7
+            ) subq_8
+          ) subq_9
           GROUP BY
-            subq_10.metric_time__day
-        ) subq_11
+            subq_9.metric_time__day
+        ) subq_10
         ON
-          DATE_ADD('day', -14, subq_16.metric_time__day) = subq_11.metric_time__day
-      ) subq_17
-    ) subq_18
+          DATE_ADD('day', -14, subq_15.metric_time__day) = subq_10.metric_time__day
+      ) subq_16
+    ) subq_17
     ON
-      subq_6.metric_time__day = subq_18.metric_time__day
+      subq_6.metric_time__day = subq_17.metric_time__day
     GROUP BY
-      COALESCE(subq_6.metric_time__day, subq_18.metric_time__day)
-  ) subq_19
-) subq_20
+      COALESCE(subq_6.metric_time__day, subq_17.metric_time__day)
+  ) subq_18
+) subq_19

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_derived_metric_with_offset_window_and_time_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_derived_metric_with_offset_window_and_time_filter__plan0_optimized.sql
@@ -19,9 +19,9 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_27.metric_time__day, subq_39.metric_time__day) AS metric_time__day
-    , MAX(subq_27.bookings) AS bookings
-    , MAX(subq_39.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+    COALESCE(subq_26.metric_time__day, subq_37.metric_time__day) AS metric_time__day
+    , MAX(subq_26.bookings) AS bookings
+    , MAX(subq_37.bookings_2_weeks_ago) AS bookings_2_weeks_ago
   FROM (
     -- Constrain Output with WHERE
     -- Select: ['__bookings', 'metric_time__day']
@@ -37,17 +37,17 @@ FROM (
         metric_time__day
         , __bookings AS bookings
       FROM sma_28009_cte
-    ) subq_23
+    ) subq_22
     WHERE metric_time__day = '2020-01-01' or metric_time__day = '2020-01-14'
     GROUP BY
       metric_time__day
-  ) subq_27
+  ) subq_26
   FULL OUTER JOIN (
     -- Join to Time Spine Dataset
     -- Compute Metrics via Expressions
     SELECT
-      subq_37.metric_time__day AS metric_time__day
-      , subq_32.__bookings AS bookings_2_weeks_ago
+      subq_35.metric_time__day AS metric_time__day
+      , subq_30.__bookings AS bookings_2_weeks_ago
     FROM (
       -- Constrain Output with WHERE
       -- Select: ['metric_time__day']
@@ -60,33 +60,26 @@ FROM (
         SELECT
           ds AS metric_time__day
         FROM ***************************.mf_time_spine time_spine_src_28006
-      ) subq_35
+      ) subq_33
       WHERE metric_time__day = '2020-01-01' or metric_time__day = '2020-01-14'
-    ) subq_37
+    ) subq_35
     INNER JOIN (
-      -- Constrain Output with WHERE
+      -- Read From CTE For node_id=sma_28009
+      -- Select: ['__bookings', 'metric_time__day']
       -- Select: ['__bookings', 'metric_time__day']
       -- Aggregate Inputs for Simple Metrics
       SELECT
         metric_time__day
-        , SUM(bookings) AS __bookings
-      FROM (
-        -- Read From CTE For node_id=sma_28009
-        -- Select: ['__bookings', 'metric_time__day']
-        SELECT
-          metric_time__day
-          , __bookings AS bookings
-        FROM sma_28009_cte
-      ) subq_29
-      WHERE metric_time__day = '2020-01-01' or metric_time__day = '2020-01-14'
+        , SUM(__bookings) AS __bookings
+      FROM sma_28009_cte
       GROUP BY
         metric_time__day
-    ) subq_32
+    ) subq_30
     ON
-      DATE_ADD('day', -14, subq_37.metric_time__day) = subq_32.metric_time__day
-  ) subq_39
+      DATE_ADD('day', -14, subq_35.metric_time__day) = subq_30.metric_time__day
+  ) subq_37
   ON
-    subq_27.metric_time__day = subq_39.metric_time__day
+    subq_26.metric_time__day = subq_37.metric_time__day
   GROUP BY
-    COALESCE(subq_27.metric_time__day, subq_39.metric_time__day)
-) subq_40
+    COALESCE(subq_26.metric_time__day, subq_37.metric_time__day)
+) subq_38

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0.sql
@@ -6,52 +6,52 @@ sql_engine: Trino
 ---
 -- Write to DataTable
 SELECT
-  subq_13.metric_time__month
-  , subq_13.bookings_at_start_of_month
+  subq_12.metric_time__month
+  , subq_12.bookings_at_start_of_month
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_12.metric_time__month
+    subq_11.metric_time__month
     , bookings_start_of_month AS bookings_at_start_of_month
   FROM (
     -- Compute Metrics via Expressions
     SELECT
-      subq_11.metric_time__month
-      , subq_11.__bookings AS bookings_start_of_month
+      subq_10.metric_time__month
+      , subq_10.__bookings AS bookings_start_of_month
     FROM (
       -- Join to Time Spine Dataset
       SELECT
-        subq_10.metric_time__month AS metric_time__month
-        , subq_5.__bookings AS __bookings
+        subq_9.metric_time__month AS metric_time__month
+        , subq_4.__bookings AS __bookings
       FROM (
         -- Select: ['metric_time__month']
         SELECT
-          subq_9.metric_time__month
+          subq_8.metric_time__month
         FROM (
           -- Constrain Output with WHERE
           SELECT
-            subq_8.metric_time__day
-            , subq_8.metric_time__month
+            subq_7.metric_time__day
+            , subq_7.metric_time__month
           FROM (
             -- Select: ['metric_time__month', 'metric_time__day']
             SELECT
-              subq_7.metric_time__day
-              , subq_7.metric_time__month
+              subq_6.metric_time__day
+              , subq_6.metric_time__month
             FROM (
               -- Change Column Aliases
               SELECT
-                subq_6.ds__day AS metric_time__day
-                , subq_6.ds__week
-                , subq_6.ds__month AS metric_time__month
-                , subq_6.ds__quarter
-                , subq_6.ds__year
-                , subq_6.ds__extract_year
-                , subq_6.ds__extract_quarter
-                , subq_6.ds__extract_month
-                , subq_6.ds__extract_day
-                , subq_6.ds__extract_dow
-                , subq_6.ds__extract_doy
-                , subq_6.ds__alien_day
+                subq_5.ds__day AS metric_time__day
+                , subq_5.ds__week
+                , subq_5.ds__month AS metric_time__month
+                , subq_5.ds__quarter
+                , subq_5.ds__year
+                , subq_5.ds__extract_year
+                , subq_5.ds__extract_quarter
+                , subq_5.ds__extract_month
+                , subq_5.ds__extract_day
+                , subq_5.ds__extract_dow
+                , subq_5.ds__extract_doy
+                , subq_5.ds__alien_day
               FROM (
                 -- Read From Time Spine 'mf_time_spine'
                 SELECT
@@ -68,258 +68,249 @@ FROM (
                   , EXTRACT(doy FROM time_spine_src_28006.ds) AS ds__extract_doy
                   , time_spine_src_28006.alien_day AS ds__alien_day
                 FROM ***************************.mf_time_spine time_spine_src_28006
-              ) subq_6
-            ) subq_7
-          ) subq_8
+              ) subq_5
+            ) subq_6
+          ) subq_7
           WHERE metric_time__day = '2020-01-01'
-        ) subq_9
+        ) subq_8
         GROUP BY
-          subq_9.metric_time__month
-      ) subq_10
+          subq_8.metric_time__month
+      ) subq_9
       INNER JOIN (
         -- Aggregate Inputs for Simple Metrics
         SELECT
-          subq_4.metric_time__month
-          , SUM(subq_4.__bookings) AS __bookings
+          subq_3.metric_time__month
+          , SUM(subq_3.__bookings) AS __bookings
         FROM (
           -- Select: ['__bookings', 'metric_time__month']
           SELECT
-            subq_3.metric_time__month
-            , subq_3.__bookings
+            subq_2.metric_time__month
+            , subq_2.__bookings
           FROM (
-            -- Constrain Output with WHERE
+            -- Select: ['__bookings', 'metric_time__month']
             SELECT
-              subq_2.bookings AS __bookings
-              , subq_2.metric_time__day
-              , subq_2.metric_time__month
+              subq_1.metric_time__month
+              , subq_1.__bookings
             FROM (
-              -- Select: ['__bookings', 'metric_time__month', 'metric_time__day']
+              -- Metric Time Dimension 'ds'
               SELECT
-                subq_1.metric_time__day
-                , subq_1.metric_time__month
-                , subq_1.__bookings AS bookings
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.__bookings
+                , subq_0.__average_booking_value
+                , subq_0.__instant_bookings
+                , subq_0.__booking_value
+                , subq_0.__max_booking_value
+                , subq_0.__min_booking_value
+                , subq_0.__instant_booking_value
+                , subq_0.__average_instant_booking_value
+                , subq_0.__booking_value_for_non_null_listing_id
+                , subq_0.__bookers
+                , subq_0.__referred_bookings
+                , subq_0.__median_booking_value
+                , subq_0.__booking_value_p99
+                , subq_0.__discrete_booking_value_p99
+                , subq_0.__approximate_continuous_booking_value_p99
+                , subq_0.__approximate_discrete_booking_value_p99
+                , subq_0.__bookings_join_to_time_spine
+                , subq_0.__bookings_fill_nulls_with_0_without_time_spine
+                , subq_0.__bookings_fill_nulls_with_0
+                , subq_0.__instant_bookings_with_measure_filter
+                , subq_0.__bookings_join_to_time_spine_with_tiered_filters
+                , subq_0.__bookers_fill_nulls_with_0_join_to_timespine
               FROM (
-                -- Metric Time Dimension 'ds'
+                -- Read Elements From Semantic Model 'bookings_source'
                 SELECT
-                  subq_0.ds__day
-                  , subq_0.ds__week
-                  , subq_0.ds__month
-                  , subq_0.ds__quarter
-                  , subq_0.ds__year
-                  , subq_0.ds__extract_year
-                  , subq_0.ds__extract_quarter
-                  , subq_0.ds__extract_month
-                  , subq_0.ds__extract_day
-                  , subq_0.ds__extract_dow
-                  , subq_0.ds__extract_doy
-                  , subq_0.ds_partitioned__day
-                  , subq_0.ds_partitioned__week
-                  , subq_0.ds_partitioned__month
-                  , subq_0.ds_partitioned__quarter
-                  , subq_0.ds_partitioned__year
-                  , subq_0.ds_partitioned__extract_year
-                  , subq_0.ds_partitioned__extract_quarter
-                  , subq_0.ds_partitioned__extract_month
-                  , subq_0.ds_partitioned__extract_day
-                  , subq_0.ds_partitioned__extract_dow
-                  , subq_0.ds_partitioned__extract_doy
-                  , subq_0.paid_at__day
-                  , subq_0.paid_at__week
-                  , subq_0.paid_at__month
-                  , subq_0.paid_at__quarter
-                  , subq_0.paid_at__year
-                  , subq_0.paid_at__extract_year
-                  , subq_0.paid_at__extract_quarter
-                  , subq_0.paid_at__extract_month
-                  , subq_0.paid_at__extract_day
-                  , subq_0.paid_at__extract_dow
-                  , subq_0.paid_at__extract_doy
-                  , subq_0.booking__ds__day
-                  , subq_0.booking__ds__week
-                  , subq_0.booking__ds__month
-                  , subq_0.booking__ds__quarter
-                  , subq_0.booking__ds__year
-                  , subq_0.booking__ds__extract_year
-                  , subq_0.booking__ds__extract_quarter
-                  , subq_0.booking__ds__extract_month
-                  , subq_0.booking__ds__extract_day
-                  , subq_0.booking__ds__extract_dow
-                  , subq_0.booking__ds__extract_doy
-                  , subq_0.booking__ds_partitioned__day
-                  , subq_0.booking__ds_partitioned__week
-                  , subq_0.booking__ds_partitioned__month
-                  , subq_0.booking__ds_partitioned__quarter
-                  , subq_0.booking__ds_partitioned__year
-                  , subq_0.booking__ds_partitioned__extract_year
-                  , subq_0.booking__ds_partitioned__extract_quarter
-                  , subq_0.booking__ds_partitioned__extract_month
-                  , subq_0.booking__ds_partitioned__extract_day
-                  , subq_0.booking__ds_partitioned__extract_dow
-                  , subq_0.booking__ds_partitioned__extract_doy
-                  , subq_0.booking__paid_at__day
-                  , subq_0.booking__paid_at__week
-                  , subq_0.booking__paid_at__month
-                  , subq_0.booking__paid_at__quarter
-                  , subq_0.booking__paid_at__year
-                  , subq_0.booking__paid_at__extract_year
-                  , subq_0.booking__paid_at__extract_quarter
-                  , subq_0.booking__paid_at__extract_month
-                  , subq_0.booking__paid_at__extract_day
-                  , subq_0.booking__paid_at__extract_dow
-                  , subq_0.booking__paid_at__extract_doy
-                  , subq_0.ds__day AS metric_time__day
-                  , subq_0.ds__week AS metric_time__week
-                  , subq_0.ds__month AS metric_time__month
-                  , subq_0.ds__quarter AS metric_time__quarter
-                  , subq_0.ds__year AS metric_time__year
-                  , subq_0.ds__extract_year AS metric_time__extract_year
-                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_0.ds__extract_month AS metric_time__extract_month
-                  , subq_0.ds__extract_day AS metric_time__extract_day
-                  , subq_0.ds__extract_dow AS metric_time__extract_dow
-                  , subq_0.ds__extract_doy AS metric_time__extract_doy
-                  , subq_0.listing
-                  , subq_0.guest
-                  , subq_0.host
-                  , subq_0.booking__listing
-                  , subq_0.booking__guest
-                  , subq_0.booking__host
-                  , subq_0.is_instant
-                  , subq_0.booking__is_instant
-                  , subq_0.__bookings
-                  , subq_0.__average_booking_value
-                  , subq_0.__instant_bookings
-                  , subq_0.__booking_value
-                  , subq_0.__max_booking_value
-                  , subq_0.__min_booking_value
-                  , subq_0.__instant_booking_value
-                  , subq_0.__average_instant_booking_value
-                  , subq_0.__booking_value_for_non_null_listing_id
-                  , subq_0.__bookers
-                  , subq_0.__referred_bookings
-                  , subq_0.__median_booking_value
-                  , subq_0.__booking_value_p99
-                  , subq_0.__discrete_booking_value_p99
-                  , subq_0.__approximate_continuous_booking_value_p99
-                  , subq_0.__approximate_discrete_booking_value_p99
-                  , subq_0.__bookings_join_to_time_spine
-                  , subq_0.__bookings_fill_nulls_with_0_without_time_spine
-                  , subq_0.__bookings_fill_nulls_with_0
-                  , subq_0.__instant_bookings_with_measure_filter
-                  , subq_0.__bookings_join_to_time_spine_with_tiered_filters
-                  , subq_0.__bookers_fill_nulls_with_0_join_to_timespine
-                FROM (
-                  -- Read Elements From Semantic Model 'bookings_source'
-                  SELECT
-                    1 AS __bookings
-                    , bookings_source_src_28000.booking_value AS __average_booking_value
-                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS __instant_bookings
-                    , bookings_source_src_28000.booking_value AS __booking_value
-                    , bookings_source_src_28000.booking_value AS __max_booking_value
-                    , bookings_source_src_28000.booking_value AS __min_booking_value
-                    , bookings_source_src_28000.booking_value AS __instant_booking_value
-                    , bookings_source_src_28000.booking_value AS __average_instant_booking_value
-                    , bookings_source_src_28000.booking_value AS __booking_value_for_non_null_listing_id
-                    , bookings_source_src_28000.guest_id AS __bookers
-                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS __referred_bookings
-                    , bookings_source_src_28000.booking_value AS __median_booking_value
-                    , bookings_source_src_28000.booking_value AS __booking_value_p99
-                    , bookings_source_src_28000.booking_value AS __discrete_booking_value_p99
-                    , bookings_source_src_28000.booking_value AS __approximate_continuous_booking_value_p99
-                    , bookings_source_src_28000.booking_value AS __approximate_discrete_booking_value_p99
-                    , 1 AS __bookings_join_to_time_spine
-                    , 1 AS __bookings_fill_nulls_with_0_without_time_spine
-                    , 1 AS __bookings_fill_nulls_with_0
-                    , 1 AS __instant_bookings_with_measure_filter
-                    , 1 AS __bookings_join_to_time_spine_with_tiered_filters
-                    , bookings_source_src_28000.guest_id AS __bookers_fill_nulls_with_0_join_to_timespine
-                    , bookings_source_src_28000.booking_value AS __booking_payments
-                    , bookings_source_src_28000.is_instant
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                    , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS ds__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                    , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                    , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                    , bookings_source_src_28000.is_instant AS booking__is_instant
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                    , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                    , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                    , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                    , bookings_source_src_28000.listing_id AS listing
-                    , bookings_source_src_28000.guest_id AS guest
-                    , bookings_source_src_28000.host_id AS host
-                    , bookings_source_src_28000.listing_id AS booking__listing
-                    , bookings_source_src_28000.guest_id AS booking__guest
-                    , bookings_source_src_28000.host_id AS booking__host
-                  FROM ***************************.fct_bookings bookings_source_src_28000
-                ) subq_0
-              ) subq_1
-            ) subq_2
-            WHERE metric_time__day = '2020-01-01'
-          ) subq_3
-        ) subq_4
+                  1 AS __bookings
+                  , bookings_source_src_28000.booking_value AS __average_booking_value
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS __instant_bookings
+                  , bookings_source_src_28000.booking_value AS __booking_value
+                  , bookings_source_src_28000.booking_value AS __max_booking_value
+                  , bookings_source_src_28000.booking_value AS __min_booking_value
+                  , bookings_source_src_28000.booking_value AS __instant_booking_value
+                  , bookings_source_src_28000.booking_value AS __average_instant_booking_value
+                  , bookings_source_src_28000.booking_value AS __booking_value_for_non_null_listing_id
+                  , bookings_source_src_28000.guest_id AS __bookers
+                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS __referred_bookings
+                  , bookings_source_src_28000.booking_value AS __median_booking_value
+                  , bookings_source_src_28000.booking_value AS __booking_value_p99
+                  , bookings_source_src_28000.booking_value AS __discrete_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS __approximate_continuous_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS __approximate_discrete_booking_value_p99
+                  , 1 AS __bookings_join_to_time_spine
+                  , 1 AS __bookings_fill_nulls_with_0_without_time_spine
+                  , 1 AS __bookings_fill_nulls_with_0
+                  , 1 AS __instant_bookings_with_measure_filter
+                  , 1 AS __bookings_join_to_time_spine_with_tiered_filters
+                  , bookings_source_src_28000.guest_id AS __bookers_fill_nulls_with_0_join_to_timespine
+                  , bookings_source_src_28000.booking_value AS __booking_payments
+                  , bookings_source_src_28000.is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                  , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                  , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                  , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                  , bookings_source_src_28000.is_instant AS booking__is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                  , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                  , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                  , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                  , bookings_source_src_28000.listing_id AS listing
+                  , bookings_source_src_28000.guest_id AS guest
+                  , bookings_source_src_28000.host_id AS host
+                  , bookings_source_src_28000.listing_id AS booking__listing
+                  , bookings_source_src_28000.guest_id AS booking__guest
+                  , bookings_source_src_28000.host_id AS booking__host
+                FROM ***************************.fct_bookings bookings_source_src_28000
+              ) subq_0
+            ) subq_1
+          ) subq_2
+        ) subq_3
         GROUP BY
-          subq_4.metric_time__month
-      ) subq_5
+          subq_3.metric_time__month
+      ) subq_4
       ON
-        DATE_TRUNC('month', subq_10.metric_time__month) = subq_5.metric_time__month
-    ) subq_11
-  ) subq_12
-) subq_13
+        DATE_TRUNC('month', subq_9.metric_time__month) = subq_4.metric_time__month
+    ) subq_10
+  ) subq_11
+) subq_12

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_offset_to_grain_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
@@ -13,8 +13,8 @@ FROM (
   -- Join to Time Spine Dataset
   -- Compute Metrics via Expressions
   SELECT
-    subq_24.metric_time__month AS metric_time__month
-    , subq_19.__bookings AS bookings_start_of_month
+    subq_22.metric_time__month AS metric_time__month
+    , subq_17.__bookings AS bookings_start_of_month
   FROM (
     -- Constrain Output with WHERE
     -- Select: ['metric_time__month']
@@ -28,32 +28,29 @@ FROM (
         ds AS metric_time__day
         , DATE_TRUNC('month', ds) AS metric_time__month
       FROM ***************************.mf_time_spine time_spine_src_28006
-    ) subq_22
+    ) subq_20
     WHERE metric_time__day = '2020-01-01'
     GROUP BY
       metric_time__month
-  ) subq_24
+  ) subq_22
   INNER JOIN (
-    -- Constrain Output with WHERE
-    -- Select: ['__bookings', 'metric_time__month']
     -- Aggregate Inputs for Simple Metrics
     SELECT
       metric_time__month
-      , SUM(bookings) AS __bookings
+      , SUM(__bookings) AS __bookings
     FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
-      -- Select: ['__bookings', 'metric_time__month', 'metric_time__day']
+      -- Select: ['__bookings', 'metric_time__month']
+      -- Select: ['__bookings', 'metric_time__month']
       SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , DATE_TRUNC('month', ds) AS metric_time__month
-        , 1 AS bookings
+        DATE_TRUNC('month', ds) AS metric_time__month
+        , 1 AS __bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
     ) subq_16
-    WHERE metric_time__day = '2020-01-01'
     GROUP BY
       metric_time__month
-  ) subq_19
+  ) subq_17
   ON
-    DATE_TRUNC('month', subq_24.metric_time__month) = subq_19.metric_time__month
-) subq_26
+    DATE_TRUNC('month', subq_22.metric_time__month) = subq_17.metric_time__month
+) subq_24

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_offset_window_metric_filter_and_query_have_different_granularities__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_offset_window_metric_filter_and_query_have_different_granularities__plan0.sql
@@ -35,129 +35,127 @@ FROM (
             subq_8.metric_time__month
             , subq_8.__booking_value
           FROM (
-            -- Constrain Output with WHERE
+            -- Select: ['__booking_value', 'metric_time__month']
             SELECT
-              subq_7.booking_value AS __booking_value
-              , subq_7.metric_time__day
-              , subq_7.metric_time__month
+              subq_7.metric_time__month
+              , subq_7.__booking_value
             FROM (
-              -- Select: ['__booking_value', 'metric_time__month', 'metric_time__day']
+              -- Join to Time Spine Dataset
               SELECT
-                subq_6.metric_time__day
-                , subq_6.metric_time__month
-                , subq_6.__booking_value AS booking_value
+                subq_6.metric_time__day AS metric_time__day
+                , subq_6.metric_time__month AS metric_time__month
+                , subq_1.ds__day AS ds__day
+                , subq_1.ds__week AS ds__week
+                , subq_1.ds__month AS ds__month
+                , subq_1.ds__quarter AS ds__quarter
+                , subq_1.ds__year AS ds__year
+                , subq_1.ds__extract_year AS ds__extract_year
+                , subq_1.ds__extract_quarter AS ds__extract_quarter
+                , subq_1.ds__extract_month AS ds__extract_month
+                , subq_1.ds__extract_day AS ds__extract_day
+                , subq_1.ds__extract_dow AS ds__extract_dow
+                , subq_1.ds__extract_doy AS ds__extract_doy
+                , subq_1.ds_partitioned__day AS ds_partitioned__day
+                , subq_1.ds_partitioned__week AS ds_partitioned__week
+                , subq_1.ds_partitioned__month AS ds_partitioned__month
+                , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
+                , subq_1.ds_partitioned__year AS ds_partitioned__year
+                , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
+                , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+                , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
+                , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
+                , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+                , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+                , subq_1.paid_at__day AS paid_at__day
+                , subq_1.paid_at__week AS paid_at__week
+                , subq_1.paid_at__month AS paid_at__month
+                , subq_1.paid_at__quarter AS paid_at__quarter
+                , subq_1.paid_at__year AS paid_at__year
+                , subq_1.paid_at__extract_year AS paid_at__extract_year
+                , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
+                , subq_1.paid_at__extract_month AS paid_at__extract_month
+                , subq_1.paid_at__extract_day AS paid_at__extract_day
+                , subq_1.paid_at__extract_dow AS paid_at__extract_dow
+                , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+                , subq_1.booking__ds__day AS booking__ds__day
+                , subq_1.booking__ds__week AS booking__ds__week
+                , subq_1.booking__ds__month AS booking__ds__month
+                , subq_1.booking__ds__quarter AS booking__ds__quarter
+                , subq_1.booking__ds__year AS booking__ds__year
+                , subq_1.booking__ds__extract_year AS booking__ds__extract_year
+                , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
+                , subq_1.booking__ds__extract_month AS booking__ds__extract_month
+                , subq_1.booking__ds__extract_day AS booking__ds__extract_day
+                , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
+                , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
+                , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
+                , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
+                , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
+                , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+                , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
+                , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+                , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+                , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+                , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+                , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+                , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+                , subq_1.booking__paid_at__day AS booking__paid_at__day
+                , subq_1.booking__paid_at__week AS booking__paid_at__week
+                , subq_1.booking__paid_at__month AS booking__paid_at__month
+                , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
+                , subq_1.booking__paid_at__year AS booking__paid_at__year
+                , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
+                , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+                , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
+                , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
+                , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+                , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                , subq_1.metric_time__week AS metric_time__week
+                , subq_1.metric_time__quarter AS metric_time__quarter
+                , subq_1.metric_time__year AS metric_time__year
+                , subq_1.metric_time__extract_year AS metric_time__extract_year
+                , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+                , subq_1.metric_time__extract_month AS metric_time__extract_month
+                , subq_1.metric_time__extract_day AS metric_time__extract_day
+                , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+                , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+                , subq_1.listing AS listing
+                , subq_1.guest AS guest
+                , subq_1.host AS host
+                , subq_1.booking__listing AS booking__listing
+                , subq_1.booking__guest AS booking__guest
+                , subq_1.booking__host AS booking__host
+                , subq_1.is_instant AS is_instant
+                , subq_1.booking__is_instant AS booking__is_instant
+                , subq_1.__bookings AS __bookings
+                , subq_1.__average_booking_value AS __average_booking_value
+                , subq_1.__instant_bookings AS __instant_bookings
+                , subq_1.__booking_value AS __booking_value
+                , subq_1.__max_booking_value AS __max_booking_value
+                , subq_1.__min_booking_value AS __min_booking_value
+                , subq_1.__instant_booking_value AS __instant_booking_value
+                , subq_1.__average_instant_booking_value AS __average_instant_booking_value
+                , subq_1.__booking_value_for_non_null_listing_id AS __booking_value_for_non_null_listing_id
+                , subq_1.__bookers AS __bookers
+                , subq_1.__referred_bookings AS __referred_bookings
+                , subq_1.__median_booking_value AS __median_booking_value
+                , subq_1.__booking_value_p99 AS __booking_value_p99
+                , subq_1.__discrete_booking_value_p99 AS __discrete_booking_value_p99
+                , subq_1.__approximate_continuous_booking_value_p99 AS __approximate_continuous_booking_value_p99
+                , subq_1.__approximate_discrete_booking_value_p99 AS __approximate_discrete_booking_value_p99
+                , subq_1.__bookings_join_to_time_spine AS __bookings_join_to_time_spine
+                , subq_1.__bookings_fill_nulls_with_0_without_time_spine AS __bookings_fill_nulls_with_0_without_time_spine
+                , subq_1.__bookings_fill_nulls_with_0 AS __bookings_fill_nulls_with_0
+                , subq_1.__instant_bookings_with_measure_filter AS __instant_bookings_with_measure_filter
+                , subq_1.__bookings_join_to_time_spine_with_tiered_filters AS __bookings_join_to_time_spine_with_tiered_filters
+                , subq_1.__bookers_fill_nulls_with_0_join_to_timespine AS __bookers_fill_nulls_with_0_join_to_timespine
               FROM (
-                -- Join to Time Spine Dataset
+                -- Select: ['metric_time__day', 'metric_time__month']
                 SELECT
-                  subq_5.metric_time__day AS metric_time__day
-                  , subq_5.metric_time__month AS metric_time__month
-                  , subq_1.ds__day AS ds__day
-                  , subq_1.ds__week AS ds__week
-                  , subq_1.ds__month AS ds__month
-                  , subq_1.ds__quarter AS ds__quarter
-                  , subq_1.ds__year AS ds__year
-                  , subq_1.ds__extract_year AS ds__extract_year
-                  , subq_1.ds__extract_quarter AS ds__extract_quarter
-                  , subq_1.ds__extract_month AS ds__extract_month
-                  , subq_1.ds__extract_day AS ds__extract_day
-                  , subq_1.ds__extract_dow AS ds__extract_dow
-                  , subq_1.ds__extract_doy AS ds__extract_doy
-                  , subq_1.ds_partitioned__day AS ds_partitioned__day
-                  , subq_1.ds_partitioned__week AS ds_partitioned__week
-                  , subq_1.ds_partitioned__month AS ds_partitioned__month
-                  , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
-                  , subq_1.ds_partitioned__year AS ds_partitioned__year
-                  , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
-                  , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
-                  , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
-                  , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
-                  , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
-                  , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
-                  , subq_1.paid_at__day AS paid_at__day
-                  , subq_1.paid_at__week AS paid_at__week
-                  , subq_1.paid_at__month AS paid_at__month
-                  , subq_1.paid_at__quarter AS paid_at__quarter
-                  , subq_1.paid_at__year AS paid_at__year
-                  , subq_1.paid_at__extract_year AS paid_at__extract_year
-                  , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
-                  , subq_1.paid_at__extract_month AS paid_at__extract_month
-                  , subq_1.paid_at__extract_day AS paid_at__extract_day
-                  , subq_1.paid_at__extract_dow AS paid_at__extract_dow
-                  , subq_1.paid_at__extract_doy AS paid_at__extract_doy
-                  , subq_1.booking__ds__day AS booking__ds__day
-                  , subq_1.booking__ds__week AS booking__ds__week
-                  , subq_1.booking__ds__month AS booking__ds__month
-                  , subq_1.booking__ds__quarter AS booking__ds__quarter
-                  , subq_1.booking__ds__year AS booking__ds__year
-                  , subq_1.booking__ds__extract_year AS booking__ds__extract_year
-                  , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
-                  , subq_1.booking__ds__extract_month AS booking__ds__extract_month
-                  , subq_1.booking__ds__extract_day AS booking__ds__extract_day
-                  , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
-                  , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
-                  , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
-                  , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
-                  , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
-                  , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
-                  , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
-                  , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
-                  , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
-                  , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
-                  , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
-                  , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
-                  , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
-                  , subq_1.booking__paid_at__day AS booking__paid_at__day
-                  , subq_1.booking__paid_at__week AS booking__paid_at__week
-                  , subq_1.booking__paid_at__month AS booking__paid_at__month
-                  , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
-                  , subq_1.booking__paid_at__year AS booking__paid_at__year
-                  , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
-                  , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
-                  , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
-                  , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
-                  , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
-                  , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
-                  , subq_1.metric_time__week AS metric_time__week
-                  , subq_1.metric_time__quarter AS metric_time__quarter
-                  , subq_1.metric_time__year AS metric_time__year
-                  , subq_1.metric_time__extract_year AS metric_time__extract_year
-                  , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
-                  , subq_1.metric_time__extract_month AS metric_time__extract_month
-                  , subq_1.metric_time__extract_day AS metric_time__extract_day
-                  , subq_1.metric_time__extract_dow AS metric_time__extract_dow
-                  , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-                  , subq_1.listing AS listing
-                  , subq_1.guest AS guest
-                  , subq_1.host AS host
-                  , subq_1.booking__listing AS booking__listing
-                  , subq_1.booking__guest AS booking__guest
-                  , subq_1.booking__host AS booking__host
-                  , subq_1.is_instant AS is_instant
-                  , subq_1.booking__is_instant AS booking__is_instant
-                  , subq_1.__bookings AS __bookings
-                  , subq_1.__average_booking_value AS __average_booking_value
-                  , subq_1.__instant_bookings AS __instant_bookings
-                  , subq_1.__booking_value AS __booking_value
-                  , subq_1.__max_booking_value AS __max_booking_value
-                  , subq_1.__min_booking_value AS __min_booking_value
-                  , subq_1.__instant_booking_value AS __instant_booking_value
-                  , subq_1.__average_instant_booking_value AS __average_instant_booking_value
-                  , subq_1.__booking_value_for_non_null_listing_id AS __booking_value_for_non_null_listing_id
-                  , subq_1.__bookers AS __bookers
-                  , subq_1.__referred_bookings AS __referred_bookings
-                  , subq_1.__median_booking_value AS __median_booking_value
-                  , subq_1.__booking_value_p99 AS __booking_value_p99
-                  , subq_1.__discrete_booking_value_p99 AS __discrete_booking_value_p99
-                  , subq_1.__approximate_continuous_booking_value_p99 AS __approximate_continuous_booking_value_p99
-                  , subq_1.__approximate_discrete_booking_value_p99 AS __approximate_discrete_booking_value_p99
-                  , subq_1.__bookings_join_to_time_spine AS __bookings_join_to_time_spine
-                  , subq_1.__bookings_fill_nulls_with_0_without_time_spine AS __bookings_fill_nulls_with_0_without_time_spine
-                  , subq_1.__bookings_fill_nulls_with_0 AS __bookings_fill_nulls_with_0
-                  , subq_1.__instant_bookings_with_measure_filter AS __instant_bookings_with_measure_filter
-                  , subq_1.__bookings_join_to_time_spine_with_tiered_filters AS __bookings_join_to_time_spine_with_tiered_filters
-                  , subq_1.__bookers_fill_nulls_with_0_join_to_timespine AS __bookers_fill_nulls_with_0_join_to_timespine
+                  subq_5.metric_time__day
+                  , subq_5.metric_time__month
                 FROM (
-                  -- Select: ['metric_time__day', 'metric_time__month']
+                  -- Constrain Output with WHERE
                   SELECT
                     subq_4.metric_time__day
                     , subq_4.metric_time__month
@@ -200,225 +198,225 @@ FROM (
                       ) subq_2
                     ) subq_3
                   ) subq_4
+                  WHERE metric_time__day = '2020-01-01'
                 ) subq_5
-                INNER JOIN (
-                  -- Metric Time Dimension 'ds'
-                  SELECT
-                    subq_0.ds__day
-                    , subq_0.ds__week
-                    , subq_0.ds__month
-                    , subq_0.ds__quarter
-                    , subq_0.ds__year
-                    , subq_0.ds__extract_year
-                    , subq_0.ds__extract_quarter
-                    , subq_0.ds__extract_month
-                    , subq_0.ds__extract_day
-                    , subq_0.ds__extract_dow
-                    , subq_0.ds__extract_doy
-                    , subq_0.ds_partitioned__day
-                    , subq_0.ds_partitioned__week
-                    , subq_0.ds_partitioned__month
-                    , subq_0.ds_partitioned__quarter
-                    , subq_0.ds_partitioned__year
-                    , subq_0.ds_partitioned__extract_year
-                    , subq_0.ds_partitioned__extract_quarter
-                    , subq_0.ds_partitioned__extract_month
-                    , subq_0.ds_partitioned__extract_day
-                    , subq_0.ds_partitioned__extract_dow
-                    , subq_0.ds_partitioned__extract_doy
-                    , subq_0.paid_at__day
-                    , subq_0.paid_at__week
-                    , subq_0.paid_at__month
-                    , subq_0.paid_at__quarter
-                    , subq_0.paid_at__year
-                    , subq_0.paid_at__extract_year
-                    , subq_0.paid_at__extract_quarter
-                    , subq_0.paid_at__extract_month
-                    , subq_0.paid_at__extract_day
-                    , subq_0.paid_at__extract_dow
-                    , subq_0.paid_at__extract_doy
-                    , subq_0.booking__ds__day
-                    , subq_0.booking__ds__week
-                    , subq_0.booking__ds__month
-                    , subq_0.booking__ds__quarter
-                    , subq_0.booking__ds__year
-                    , subq_0.booking__ds__extract_year
-                    , subq_0.booking__ds__extract_quarter
-                    , subq_0.booking__ds__extract_month
-                    , subq_0.booking__ds__extract_day
-                    , subq_0.booking__ds__extract_dow
-                    , subq_0.booking__ds__extract_doy
-                    , subq_0.booking__ds_partitioned__day
-                    , subq_0.booking__ds_partitioned__week
-                    , subq_0.booking__ds_partitioned__month
-                    , subq_0.booking__ds_partitioned__quarter
-                    , subq_0.booking__ds_partitioned__year
-                    , subq_0.booking__ds_partitioned__extract_year
-                    , subq_0.booking__ds_partitioned__extract_quarter
-                    , subq_0.booking__ds_partitioned__extract_month
-                    , subq_0.booking__ds_partitioned__extract_day
-                    , subq_0.booking__ds_partitioned__extract_dow
-                    , subq_0.booking__ds_partitioned__extract_doy
-                    , subq_0.booking__paid_at__day
-                    , subq_0.booking__paid_at__week
-                    , subq_0.booking__paid_at__month
-                    , subq_0.booking__paid_at__quarter
-                    , subq_0.booking__paid_at__year
-                    , subq_0.booking__paid_at__extract_year
-                    , subq_0.booking__paid_at__extract_quarter
-                    , subq_0.booking__paid_at__extract_month
-                    , subq_0.booking__paid_at__extract_day
-                    , subq_0.booking__paid_at__extract_dow
-                    , subq_0.booking__paid_at__extract_doy
-                    , subq_0.ds__day AS metric_time__day
-                    , subq_0.ds__week AS metric_time__week
-                    , subq_0.ds__month AS metric_time__month
-                    , subq_0.ds__quarter AS metric_time__quarter
-                    , subq_0.ds__year AS metric_time__year
-                    , subq_0.ds__extract_year AS metric_time__extract_year
-                    , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                    , subq_0.ds__extract_month AS metric_time__extract_month
-                    , subq_0.ds__extract_day AS metric_time__extract_day
-                    , subq_0.ds__extract_dow AS metric_time__extract_dow
-                    , subq_0.ds__extract_doy AS metric_time__extract_doy
-                    , subq_0.listing
-                    , subq_0.guest
-                    , subq_0.host
-                    , subq_0.booking__listing
-                    , subq_0.booking__guest
-                    , subq_0.booking__host
-                    , subq_0.is_instant
-                    , subq_0.booking__is_instant
-                    , subq_0.__bookings
-                    , subq_0.__average_booking_value
-                    , subq_0.__instant_bookings
-                    , subq_0.__booking_value
-                    , subq_0.__max_booking_value
-                    , subq_0.__min_booking_value
-                    , subq_0.__instant_booking_value
-                    , subq_0.__average_instant_booking_value
-                    , subq_0.__booking_value_for_non_null_listing_id
-                    , subq_0.__bookers
-                    , subq_0.__referred_bookings
-                    , subq_0.__median_booking_value
-                    , subq_0.__booking_value_p99
-                    , subq_0.__discrete_booking_value_p99
-                    , subq_0.__approximate_continuous_booking_value_p99
-                    , subq_0.__approximate_discrete_booking_value_p99
-                    , subq_0.__bookings_join_to_time_spine
-                    , subq_0.__bookings_fill_nulls_with_0_without_time_spine
-                    , subq_0.__bookings_fill_nulls_with_0
-                    , subq_0.__instant_bookings_with_measure_filter
-                    , subq_0.__bookings_join_to_time_spine_with_tiered_filters
-                    , subq_0.__bookers_fill_nulls_with_0_join_to_timespine
-                  FROM (
-                    -- Read Elements From Semantic Model 'bookings_source'
-                    SELECT
-                      1 AS __bookings
-                      , bookings_source_src_28000.booking_value AS __average_booking_value
-                      , CASE WHEN is_instant THEN 1 ELSE 0 END AS __instant_bookings
-                      , bookings_source_src_28000.booking_value AS __booking_value
-                      , bookings_source_src_28000.booking_value AS __max_booking_value
-                      , bookings_source_src_28000.booking_value AS __min_booking_value
-                      , bookings_source_src_28000.booking_value AS __instant_booking_value
-                      , bookings_source_src_28000.booking_value AS __average_instant_booking_value
-                      , bookings_source_src_28000.booking_value AS __booking_value_for_non_null_listing_id
-                      , bookings_source_src_28000.guest_id AS __bookers
-                      , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS __referred_bookings
-                      , bookings_source_src_28000.booking_value AS __median_booking_value
-                      , bookings_source_src_28000.booking_value AS __booking_value_p99
-                      , bookings_source_src_28000.booking_value AS __discrete_booking_value_p99
-                      , bookings_source_src_28000.booking_value AS __approximate_continuous_booking_value_p99
-                      , bookings_source_src_28000.booking_value AS __approximate_discrete_booking_value_p99
-                      , 1 AS __bookings_join_to_time_spine
-                      , 1 AS __bookings_fill_nulls_with_0_without_time_spine
-                      , 1 AS __bookings_fill_nulls_with_0
-                      , 1 AS __instant_bookings_with_measure_filter
-                      , 1 AS __bookings_join_to_time_spine_with_tiered_filters
-                      , bookings_source_src_28000.guest_id AS __bookers_fill_nulls_with_0_join_to_timespine
-                      , bookings_source_src_28000.booking_value AS __booking_payments
-                      , bookings_source_src_28000.is_instant
-                      , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                      , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                      , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS ds__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                      , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                      , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                      , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                      , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                      , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                      , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                      , bookings_source_src_28000.is_instant AS booking__is_instant
-                      , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                      , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                      , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                      , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                      , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                      , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                      , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                      , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                      , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                      , bookings_source_src_28000.listing_id AS listing
-                      , bookings_source_src_28000.guest_id AS guest
-                      , bookings_source_src_28000.host_id AS host
-                      , bookings_source_src_28000.listing_id AS booking__listing
-                      , bookings_source_src_28000.guest_id AS booking__guest
-                      , bookings_source_src_28000.host_id AS booking__host
-                    FROM ***************************.fct_bookings bookings_source_src_28000
-                  ) subq_0
-                ) subq_1
-                ON
-                  DATE_ADD('week', -1, subq_5.metric_time__day) = subq_1.metric_time__day
               ) subq_6
+              INNER JOIN (
+                -- Metric Time Dimension 'ds'
+                SELECT
+                  subq_0.ds__day
+                  , subq_0.ds__week
+                  , subq_0.ds__month
+                  , subq_0.ds__quarter
+                  , subq_0.ds__year
+                  , subq_0.ds__extract_year
+                  , subq_0.ds__extract_quarter
+                  , subq_0.ds__extract_month
+                  , subq_0.ds__extract_day
+                  , subq_0.ds__extract_dow
+                  , subq_0.ds__extract_doy
+                  , subq_0.ds_partitioned__day
+                  , subq_0.ds_partitioned__week
+                  , subq_0.ds_partitioned__month
+                  , subq_0.ds_partitioned__quarter
+                  , subq_0.ds_partitioned__year
+                  , subq_0.ds_partitioned__extract_year
+                  , subq_0.ds_partitioned__extract_quarter
+                  , subq_0.ds_partitioned__extract_month
+                  , subq_0.ds_partitioned__extract_day
+                  , subq_0.ds_partitioned__extract_dow
+                  , subq_0.ds_partitioned__extract_doy
+                  , subq_0.paid_at__day
+                  , subq_0.paid_at__week
+                  , subq_0.paid_at__month
+                  , subq_0.paid_at__quarter
+                  , subq_0.paid_at__year
+                  , subq_0.paid_at__extract_year
+                  , subq_0.paid_at__extract_quarter
+                  , subq_0.paid_at__extract_month
+                  , subq_0.paid_at__extract_day
+                  , subq_0.paid_at__extract_dow
+                  , subq_0.paid_at__extract_doy
+                  , subq_0.booking__ds__day
+                  , subq_0.booking__ds__week
+                  , subq_0.booking__ds__month
+                  , subq_0.booking__ds__quarter
+                  , subq_0.booking__ds__year
+                  , subq_0.booking__ds__extract_year
+                  , subq_0.booking__ds__extract_quarter
+                  , subq_0.booking__ds__extract_month
+                  , subq_0.booking__ds__extract_day
+                  , subq_0.booking__ds__extract_dow
+                  , subq_0.booking__ds__extract_doy
+                  , subq_0.booking__ds_partitioned__day
+                  , subq_0.booking__ds_partitioned__week
+                  , subq_0.booking__ds_partitioned__month
+                  , subq_0.booking__ds_partitioned__quarter
+                  , subq_0.booking__ds_partitioned__year
+                  , subq_0.booking__ds_partitioned__extract_year
+                  , subq_0.booking__ds_partitioned__extract_quarter
+                  , subq_0.booking__ds_partitioned__extract_month
+                  , subq_0.booking__ds_partitioned__extract_day
+                  , subq_0.booking__ds_partitioned__extract_dow
+                  , subq_0.booking__ds_partitioned__extract_doy
+                  , subq_0.booking__paid_at__day
+                  , subq_0.booking__paid_at__week
+                  , subq_0.booking__paid_at__month
+                  , subq_0.booking__paid_at__quarter
+                  , subq_0.booking__paid_at__year
+                  , subq_0.booking__paid_at__extract_year
+                  , subq_0.booking__paid_at__extract_quarter
+                  , subq_0.booking__paid_at__extract_month
+                  , subq_0.booking__paid_at__extract_day
+                  , subq_0.booking__paid_at__extract_dow
+                  , subq_0.booking__paid_at__extract_doy
+                  , subq_0.ds__day AS metric_time__day
+                  , subq_0.ds__week AS metric_time__week
+                  , subq_0.ds__month AS metric_time__month
+                  , subq_0.ds__quarter AS metric_time__quarter
+                  , subq_0.ds__year AS metric_time__year
+                  , subq_0.ds__extract_year AS metric_time__extract_year
+                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_0.ds__extract_month AS metric_time__extract_month
+                  , subq_0.ds__extract_day AS metric_time__extract_day
+                  , subq_0.ds__extract_dow AS metric_time__extract_dow
+                  , subq_0.ds__extract_doy AS metric_time__extract_doy
+                  , subq_0.listing
+                  , subq_0.guest
+                  , subq_0.host
+                  , subq_0.booking__listing
+                  , subq_0.booking__guest
+                  , subq_0.booking__host
+                  , subq_0.is_instant
+                  , subq_0.booking__is_instant
+                  , subq_0.__bookings
+                  , subq_0.__average_booking_value
+                  , subq_0.__instant_bookings
+                  , subq_0.__booking_value
+                  , subq_0.__max_booking_value
+                  , subq_0.__min_booking_value
+                  , subq_0.__instant_booking_value
+                  , subq_0.__average_instant_booking_value
+                  , subq_0.__booking_value_for_non_null_listing_id
+                  , subq_0.__bookers
+                  , subq_0.__referred_bookings
+                  , subq_0.__median_booking_value
+                  , subq_0.__booking_value_p99
+                  , subq_0.__discrete_booking_value_p99
+                  , subq_0.__approximate_continuous_booking_value_p99
+                  , subq_0.__approximate_discrete_booking_value_p99
+                  , subq_0.__bookings_join_to_time_spine
+                  , subq_0.__bookings_fill_nulls_with_0_without_time_spine
+                  , subq_0.__bookings_fill_nulls_with_0
+                  , subq_0.__instant_bookings_with_measure_filter
+                  , subq_0.__bookings_join_to_time_spine_with_tiered_filters
+                  , subq_0.__bookers_fill_nulls_with_0_join_to_timespine
+                FROM (
+                  -- Read Elements From Semantic Model 'bookings_source'
+                  SELECT
+                    1 AS __bookings
+                    , bookings_source_src_28000.booking_value AS __average_booking_value
+                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS __instant_bookings
+                    , bookings_source_src_28000.booking_value AS __booking_value
+                    , bookings_source_src_28000.booking_value AS __max_booking_value
+                    , bookings_source_src_28000.booking_value AS __min_booking_value
+                    , bookings_source_src_28000.booking_value AS __instant_booking_value
+                    , bookings_source_src_28000.booking_value AS __average_instant_booking_value
+                    , bookings_source_src_28000.booking_value AS __booking_value_for_non_null_listing_id
+                    , bookings_source_src_28000.guest_id AS __bookers
+                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS __referred_bookings
+                    , bookings_source_src_28000.booking_value AS __median_booking_value
+                    , bookings_source_src_28000.booking_value AS __booking_value_p99
+                    , bookings_source_src_28000.booking_value AS __discrete_booking_value_p99
+                    , bookings_source_src_28000.booking_value AS __approximate_continuous_booking_value_p99
+                    , bookings_source_src_28000.booking_value AS __approximate_discrete_booking_value_p99
+                    , 1 AS __bookings_join_to_time_spine
+                    , 1 AS __bookings_fill_nulls_with_0_without_time_spine
+                    , 1 AS __bookings_fill_nulls_with_0
+                    , 1 AS __instant_bookings_with_measure_filter
+                    , 1 AS __bookings_join_to_time_spine_with_tiered_filters
+                    , bookings_source_src_28000.guest_id AS __bookers_fill_nulls_with_0_join_to_timespine
+                    , bookings_source_src_28000.booking_value AS __booking_payments
+                    , bookings_source_src_28000.is_instant
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                    , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                    , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                    , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                    , bookings_source_src_28000.is_instant AS booking__is_instant
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                    , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                    , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                    , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                    , bookings_source_src_28000.listing_id AS listing
+                    , bookings_source_src_28000.guest_id AS guest
+                    , bookings_source_src_28000.host_id AS host
+                    , bookings_source_src_28000.listing_id AS booking__listing
+                    , bookings_source_src_28000.guest_id AS booking__guest
+                    , bookings_source_src_28000.host_id AS booking__host
+                  FROM ***************************.fct_bookings bookings_source_src_28000
+                ) subq_0
+              ) subq_1
+              ON
+                DATE_ADD('week', -1, subq_6.metric_time__day) = subq_1.metric_time__day
             ) subq_7
-            WHERE metric_time__day = '2020-01-01'
           ) subq_8
         ) subq_9
         GROUP BY

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_offset_window_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlPlan/Trino/test_offset_window_metric_filter_and_query_have_different_granularities__plan0_optimized.sql
@@ -27,29 +27,37 @@ FROM (
     , MAX(subq_31.booking_value) AS booking_value
     , MAX(subq_37.bookers) AS bookers
   FROM (
-    -- Constrain Output with WHERE
+    -- Join to Time Spine Dataset
+    -- Select: ['__booking_value', 'metric_time__month']
     -- Select: ['__booking_value', 'metric_time__month']
     -- Aggregate Inputs for Simple Metrics
     -- Compute Metrics via Expressions
     SELECT
-      metric_time__month
-      , SUM(booking_value) AS booking_value
+      subq_26.metric_time__month AS metric_time__month
+      , SUM(sma_28009_cte.__booking_value) AS booking_value
     FROM (
-      -- Join to Time Spine Dataset
-      -- Select: ['__booking_value', 'metric_time__month', 'metric_time__day']
+      -- Constrain Output with WHERE
+      -- Select: ['metric_time__day', 'metric_time__month']
       SELECT
-        time_spine_src_28006.ds AS metric_time__day
-        , DATE_TRUNC('month', time_spine_src_28006.ds) AS metric_time__month
-        , sma_28009_cte.__booking_value AS booking_value
-      FROM ***************************.mf_time_spine time_spine_src_28006
-      INNER JOIN
-        sma_28009_cte
-      ON
-        DATE_ADD('week', -1, time_spine_src_28006.ds) = sma_28009_cte.metric_time__day
-    ) subq_27
-    WHERE metric_time__day = '2020-01-01'
+        metric_time__day
+        , metric_time__month
+      FROM (
+        -- Read From Time Spine 'mf_time_spine'
+        -- Change Column Aliases
+        -- Select: ['metric_time__day', 'metric_time__month']
+        SELECT
+          ds AS metric_time__day
+          , DATE_TRUNC('month', ds) AS metric_time__month
+        FROM ***************************.mf_time_spine time_spine_src_28006
+      ) subq_24
+      WHERE metric_time__day = '2020-01-01'
+    ) subq_26
+    INNER JOIN
+      sma_28009_cte
+    ON
+      DATE_ADD('week', -1, subq_26.metric_time__day) = sma_28009_cte.metric_time__day
     GROUP BY
-      metric_time__month
+      subq_26.metric_time__month
   ) subq_31
   FULL OUTER JOIN (
     -- Constrain Output with WHERE

--- a/tests_metricflow/snapshots/test_dfs_planner.py/str/test_cases_with_dfs_planner__07__time_offset_metric_with_metric_time_filter__result.txt
+++ b/tests_metricflow/snapshots/test_dfs_planner.py/str/test_cases_with_dfs_planner__07__time_offset_metric_with_metric_time_filter__result.txt
@@ -124,8 +124,8 @@ Query for a time offset metric with a `metric_time` filter
       , 2 * bookings AS bookings_offset_once
     FROM (
       SELECT
-        subq_10.metric_time__day AS metric_time__day
-        , subq_5.__bookings AS bookings
+        subq_9.metric_time__day AS metric_time__day
+        , subq_4.__bookings AS bookings
       FROM (
         SELECT
           metric_time__day
@@ -133,23 +133,22 @@ Query for a time offset metric with a `metric_time` filter
           SELECT
             ds AS metric_time__day
           FROM ***************************.mf_time_spine time_spine_src_28006
-        ) subq_8
+        ) subq_7
         WHERE metric_time__day = '2020-01-01' 
-      ) subq_10
+      ) subq_9
       INNER JOIN (
         SELECT
           metric_time__day
-          , SUM(bookings) AS __bookings
+          , SUM(__bookings) AS __bookings
         FROM (
           SELECT
             DATE_TRUNC('day', ds) AS metric_time__day
-            , 1 AS bookings
+            , 1 AS __bookings
           FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_2
-        WHERE metric_time__day = '2020-01-01' 
+        ) subq_3
         GROUP BY
           metric_time__day
-      ) subq_5
+      ) subq_4
       ON
-        subq_10.metric_time__day - INTERVAL 5 day = subq_5.metric_time__day
-    ) subq_12
+        subq_9.metric_time__day - INTERVAL 5 day = subq_4.metric_time__day
+    ) subq_11

--- a/tests_metricflow/snapshots/test_offset_metrics_with_filters.py/SqlPlan/DuckDB/test_offset_cumulative_metric_with_metric_time_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_offset_metrics_with_filters.py/SqlPlan/DuckDB/test_offset_cumulative_metric_with_metric_time_filter__plan0.sql
@@ -10,55 +10,55 @@ expectation_description:
 ---
 -- Write to DataTable
 SELECT
-  subq_17.metric_time__day
-  , subq_17.trailing_7_days_bookings_offset_1_week
+  subq_16.metric_time__day
+  , subq_16.trailing_7_days_bookings_offset_1_week
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_16.metric_time__day
+    subq_15.metric_time__day
     , trailing_7_days_bookings_1_week_ago AS trailing_7_days_bookings_offset_1_week
   FROM (
     -- Compute Metrics via Expressions
     SELECT
-      subq_15.metric_time__day
-      , subq_15.bookings AS trailing_7_days_bookings_1_week_ago
+      subq_14.metric_time__day
+      , subq_14.bookings AS trailing_7_days_bookings_1_week_ago
     FROM (
       -- Compute Metrics via Expressions
       SELECT
-        subq_14.metric_time__day
-        , subq_14.__bookings AS bookings
+        subq_13.metric_time__day
+        , subq_13.__bookings AS bookings
       FROM (
         -- Join to Time Spine Dataset
         SELECT
-          subq_13.metric_time__day AS metric_time__day
-          , subq_8.__bookings AS __bookings
+          subq_12.metric_time__day AS metric_time__day
+          , subq_7.__bookings AS __bookings
         FROM (
           -- Select: ['metric_time__day']
           SELECT
-            subq_12.metric_time__day
+            subq_11.metric_time__day
           FROM (
             -- Constrain Output with WHERE
             SELECT
-              subq_11.metric_time__day
+              subq_10.metric_time__day
             FROM (
               -- Select: ['metric_time__day']
               SELECT
-                subq_10.metric_time__day
+                subq_9.metric_time__day
               FROM (
                 -- Change Column Aliases
                 SELECT
-                  subq_9.ds__day AS metric_time__day
-                  , subq_9.ds__week
-                  , subq_9.ds__month
-                  , subq_9.ds__quarter
-                  , subq_9.ds__year
-                  , subq_9.ds__extract_year
-                  , subq_9.ds__extract_quarter
-                  , subq_9.ds__extract_month
-                  , subq_9.ds__extract_day
-                  , subq_9.ds__extract_dow
-                  , subq_9.ds__extract_doy
-                  , subq_9.ds__alien_day
+                  subq_8.ds__day AS metric_time__day
+                  , subq_8.ds__week
+                  , subq_8.ds__month
+                  , subq_8.ds__quarter
+                  , subq_8.ds__year
+                  , subq_8.ds__extract_year
+                  , subq_8.ds__extract_quarter
+                  , subq_8.ds__extract_month
+                  , subq_8.ds__extract_day
+                  , subq_8.ds__extract_dow
+                  , subq_8.ds__extract_doy
+                  , subq_8.ds__alien_day
                 FROM (
                   -- Read From Time Spine 'mf_time_spine'
                   SELECT
@@ -75,378 +75,371 @@ FROM (
                     , EXTRACT(doy FROM time_spine_src_28006.ds) AS ds__extract_doy
                     , time_spine_src_28006.alien_day AS ds__alien_day
                   FROM ***************************.mf_time_spine time_spine_src_28006
-                ) subq_9
-              ) subq_10
-            ) subq_11
+                ) subq_8
+              ) subq_9
+            ) subq_10
             WHERE metric_time__day = '2020-01-01'
-          ) subq_12
-        ) subq_13
+          ) subq_11
+        ) subq_12
         INNER JOIN (
           -- Aggregate Inputs for Simple Metrics
           SELECT
-            subq_7.metric_time__day
-            , SUM(subq_7.__bookings) AS __bookings
+            subq_6.metric_time__day
+            , SUM(subq_6.__bookings) AS __bookings
           FROM (
             -- Select: ['__bookings', 'metric_time__day']
             SELECT
-              subq_6.metric_time__day
-              , subq_6.__bookings
+              subq_5.metric_time__day
+              , subq_5.__bookings
             FROM (
-              -- Constrain Output with WHERE
+              -- Select: ['__bookings', 'metric_time__day']
               SELECT
-                subq_5.bookings AS __bookings
-                , subq_5.metric_time__day
+                subq_4.metric_time__day
+                , subq_4.__bookings
               FROM (
-                -- Select: ['__bookings', 'metric_time__day']
+                -- Join Self Over Time Range
                 SELECT
-                  subq_4.metric_time__day
-                  , subq_4.__bookings AS bookings
+                  subq_2.metric_time__day AS metric_time__day
+                  , subq_1.ds__day AS ds__day
+                  , subq_1.ds__week AS ds__week
+                  , subq_1.ds__month AS ds__month
+                  , subq_1.ds__quarter AS ds__quarter
+                  , subq_1.ds__year AS ds__year
+                  , subq_1.ds__extract_year AS ds__extract_year
+                  , subq_1.ds__extract_quarter AS ds__extract_quarter
+                  , subq_1.ds__extract_month AS ds__extract_month
+                  , subq_1.ds__extract_day AS ds__extract_day
+                  , subq_1.ds__extract_dow AS ds__extract_dow
+                  , subq_1.ds__extract_doy AS ds__extract_doy
+                  , subq_1.ds_partitioned__day AS ds_partitioned__day
+                  , subq_1.ds_partitioned__week AS ds_partitioned__week
+                  , subq_1.ds_partitioned__month AS ds_partitioned__month
+                  , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
+                  , subq_1.ds_partitioned__year AS ds_partitioned__year
+                  , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
+                  , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+                  , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
+                  , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
+                  , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+                  , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+                  , subq_1.paid_at__day AS paid_at__day
+                  , subq_1.paid_at__week AS paid_at__week
+                  , subq_1.paid_at__month AS paid_at__month
+                  , subq_1.paid_at__quarter AS paid_at__quarter
+                  , subq_1.paid_at__year AS paid_at__year
+                  , subq_1.paid_at__extract_year AS paid_at__extract_year
+                  , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
+                  , subq_1.paid_at__extract_month AS paid_at__extract_month
+                  , subq_1.paid_at__extract_day AS paid_at__extract_day
+                  , subq_1.paid_at__extract_dow AS paid_at__extract_dow
+                  , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+                  , subq_1.booking__ds__day AS booking__ds__day
+                  , subq_1.booking__ds__week AS booking__ds__week
+                  , subq_1.booking__ds__month AS booking__ds__month
+                  , subq_1.booking__ds__quarter AS booking__ds__quarter
+                  , subq_1.booking__ds__year AS booking__ds__year
+                  , subq_1.booking__ds__extract_year AS booking__ds__extract_year
+                  , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
+                  , subq_1.booking__ds__extract_month AS booking__ds__extract_month
+                  , subq_1.booking__ds__extract_day AS booking__ds__extract_day
+                  , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
+                  , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
+                  , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
+                  , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
+                  , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
+                  , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+                  , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
+                  , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+                  , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+                  , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+                  , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+                  , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+                  , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+                  , subq_1.booking__paid_at__day AS booking__paid_at__day
+                  , subq_1.booking__paid_at__week AS booking__paid_at__week
+                  , subq_1.booking__paid_at__month AS booking__paid_at__month
+                  , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
+                  , subq_1.booking__paid_at__year AS booking__paid_at__year
+                  , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
+                  , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+                  , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
+                  , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
+                  , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+                  , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                  , subq_1.metric_time__week AS metric_time__week
+                  , subq_1.metric_time__month AS metric_time__month
+                  , subq_1.metric_time__quarter AS metric_time__quarter
+                  , subq_1.metric_time__year AS metric_time__year
+                  , subq_1.metric_time__extract_year AS metric_time__extract_year
+                  , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+                  , subq_1.metric_time__extract_month AS metric_time__extract_month
+                  , subq_1.metric_time__extract_day AS metric_time__extract_day
+                  , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+                  , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+                  , subq_1.listing AS listing
+                  , subq_1.guest AS guest
+                  , subq_1.host AS host
+                  , subq_1.booking__listing AS booking__listing
+                  , subq_1.booking__guest AS booking__guest
+                  , subq_1.booking__host AS booking__host
+                  , subq_1.is_instant AS is_instant
+                  , subq_1.booking__is_instant AS booking__is_instant
+                  , subq_1.__bookings AS __bookings
+                  , subq_1.__average_booking_value AS __average_booking_value
+                  , subq_1.__instant_bookings AS __instant_bookings
+                  , subq_1.__booking_value AS __booking_value
+                  , subq_1.__max_booking_value AS __max_booking_value
+                  , subq_1.__min_booking_value AS __min_booking_value
+                  , subq_1.__instant_booking_value AS __instant_booking_value
+                  , subq_1.__average_instant_booking_value AS __average_instant_booking_value
+                  , subq_1.__booking_value_for_non_null_listing_id AS __booking_value_for_non_null_listing_id
+                  , subq_1.__bookers AS __bookers
+                  , subq_1.__referred_bookings AS __referred_bookings
+                  , subq_1.__median_booking_value AS __median_booking_value
+                  , subq_1.__booking_value_p99 AS __booking_value_p99
+                  , subq_1.__discrete_booking_value_p99 AS __discrete_booking_value_p99
+                  , subq_1.__approximate_continuous_booking_value_p99 AS __approximate_continuous_booking_value_p99
+                  , subq_1.__approximate_discrete_booking_value_p99 AS __approximate_discrete_booking_value_p99
+                  , subq_1.__bookings_join_to_time_spine AS __bookings_join_to_time_spine
+                  , subq_1.__bookings_fill_nulls_with_0_without_time_spine AS __bookings_fill_nulls_with_0_without_time_spine
+                  , subq_1.__bookings_fill_nulls_with_0 AS __bookings_fill_nulls_with_0
+                  , subq_1.__instant_bookings_with_measure_filter AS __instant_bookings_with_measure_filter
+                  , subq_1.__bookings_join_to_time_spine_with_tiered_filters AS __bookings_join_to_time_spine_with_tiered_filters
+                  , subq_1.__bookers_fill_nulls_with_0_join_to_timespine AS __bookers_fill_nulls_with_0_join_to_timespine
                 FROM (
-                  -- Join Self Over Time Range
+                  -- Read From Time Spine 'mf_time_spine'
                   SELECT
-                    subq_2.metric_time__day AS metric_time__day
-                    , subq_1.ds__day AS ds__day
-                    , subq_1.ds__week AS ds__week
-                    , subq_1.ds__month AS ds__month
-                    , subq_1.ds__quarter AS ds__quarter
-                    , subq_1.ds__year AS ds__year
-                    , subq_1.ds__extract_year AS ds__extract_year
-                    , subq_1.ds__extract_quarter AS ds__extract_quarter
-                    , subq_1.ds__extract_month AS ds__extract_month
-                    , subq_1.ds__extract_day AS ds__extract_day
-                    , subq_1.ds__extract_dow AS ds__extract_dow
-                    , subq_1.ds__extract_doy AS ds__extract_doy
-                    , subq_1.ds_partitioned__day AS ds_partitioned__day
-                    , subq_1.ds_partitioned__week AS ds_partitioned__week
-                    , subq_1.ds_partitioned__month AS ds_partitioned__month
-                    , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
-                    , subq_1.ds_partitioned__year AS ds_partitioned__year
-                    , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
-                    , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
-                    , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
-                    , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
-                    , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
-                    , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
-                    , subq_1.paid_at__day AS paid_at__day
-                    , subq_1.paid_at__week AS paid_at__week
-                    , subq_1.paid_at__month AS paid_at__month
-                    , subq_1.paid_at__quarter AS paid_at__quarter
-                    , subq_1.paid_at__year AS paid_at__year
-                    , subq_1.paid_at__extract_year AS paid_at__extract_year
-                    , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
-                    , subq_1.paid_at__extract_month AS paid_at__extract_month
-                    , subq_1.paid_at__extract_day AS paid_at__extract_day
-                    , subq_1.paid_at__extract_dow AS paid_at__extract_dow
-                    , subq_1.paid_at__extract_doy AS paid_at__extract_doy
-                    , subq_1.booking__ds__day AS booking__ds__day
-                    , subq_1.booking__ds__week AS booking__ds__week
-                    , subq_1.booking__ds__month AS booking__ds__month
-                    , subq_1.booking__ds__quarter AS booking__ds__quarter
-                    , subq_1.booking__ds__year AS booking__ds__year
-                    , subq_1.booking__ds__extract_year AS booking__ds__extract_year
-                    , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
-                    , subq_1.booking__ds__extract_month AS booking__ds__extract_month
-                    , subq_1.booking__ds__extract_day AS booking__ds__extract_day
-                    , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
-                    , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
-                    , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
-                    , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
-                    , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
-                    , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
-                    , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
-                    , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
-                    , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
-                    , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
-                    , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
-                    , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
-                    , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
-                    , subq_1.booking__paid_at__day AS booking__paid_at__day
-                    , subq_1.booking__paid_at__week AS booking__paid_at__week
-                    , subq_1.booking__paid_at__month AS booking__paid_at__month
-                    , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
-                    , subq_1.booking__paid_at__year AS booking__paid_at__year
-                    , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
-                    , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
-                    , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
-                    , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
-                    , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
-                    , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
-                    , subq_1.metric_time__week AS metric_time__week
-                    , subq_1.metric_time__month AS metric_time__month
-                    , subq_1.metric_time__quarter AS metric_time__quarter
-                    , subq_1.metric_time__year AS metric_time__year
-                    , subq_1.metric_time__extract_year AS metric_time__extract_year
-                    , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
-                    , subq_1.metric_time__extract_month AS metric_time__extract_month
-                    , subq_1.metric_time__extract_day AS metric_time__extract_day
-                    , subq_1.metric_time__extract_dow AS metric_time__extract_dow
-                    , subq_1.metric_time__extract_doy AS metric_time__extract_doy
-                    , subq_1.listing AS listing
-                    , subq_1.guest AS guest
-                    , subq_1.host AS host
-                    , subq_1.booking__listing AS booking__listing
-                    , subq_1.booking__guest AS booking__guest
-                    , subq_1.booking__host AS booking__host
-                    , subq_1.is_instant AS is_instant
-                    , subq_1.booking__is_instant AS booking__is_instant
-                    , subq_1.__bookings AS __bookings
-                    , subq_1.__average_booking_value AS __average_booking_value
-                    , subq_1.__instant_bookings AS __instant_bookings
-                    , subq_1.__booking_value AS __booking_value
-                    , subq_1.__max_booking_value AS __max_booking_value
-                    , subq_1.__min_booking_value AS __min_booking_value
-                    , subq_1.__instant_booking_value AS __instant_booking_value
-                    , subq_1.__average_instant_booking_value AS __average_instant_booking_value
-                    , subq_1.__booking_value_for_non_null_listing_id AS __booking_value_for_non_null_listing_id
-                    , subq_1.__bookers AS __bookers
-                    , subq_1.__referred_bookings AS __referred_bookings
-                    , subq_1.__median_booking_value AS __median_booking_value
-                    , subq_1.__booking_value_p99 AS __booking_value_p99
-                    , subq_1.__discrete_booking_value_p99 AS __discrete_booking_value_p99
-                    , subq_1.__approximate_continuous_booking_value_p99 AS __approximate_continuous_booking_value_p99
-                    , subq_1.__approximate_discrete_booking_value_p99 AS __approximate_discrete_booking_value_p99
-                    , subq_1.__bookings_join_to_time_spine AS __bookings_join_to_time_spine
-                    , subq_1.__bookings_fill_nulls_with_0_without_time_spine AS __bookings_fill_nulls_with_0_without_time_spine
-                    , subq_1.__bookings_fill_nulls_with_0 AS __bookings_fill_nulls_with_0
-                    , subq_1.__instant_bookings_with_measure_filter AS __instant_bookings_with_measure_filter
-                    , subq_1.__bookings_join_to_time_spine_with_tiered_filters AS __bookings_join_to_time_spine_with_tiered_filters
-                    , subq_1.__bookers_fill_nulls_with_0_join_to_timespine AS __bookers_fill_nulls_with_0_join_to_timespine
+                    subq_3.ds AS metric_time__day
+                  FROM ***************************.mf_time_spine subq_3
+                ) subq_2
+                INNER JOIN (
+                  -- Metric Time Dimension 'ds'
+                  SELECT
+                    subq_0.ds__day
+                    , subq_0.ds__week
+                    , subq_0.ds__month
+                    , subq_0.ds__quarter
+                    , subq_0.ds__year
+                    , subq_0.ds__extract_year
+                    , subq_0.ds__extract_quarter
+                    , subq_0.ds__extract_month
+                    , subq_0.ds__extract_day
+                    , subq_0.ds__extract_dow
+                    , subq_0.ds__extract_doy
+                    , subq_0.ds_partitioned__day
+                    , subq_0.ds_partitioned__week
+                    , subq_0.ds_partitioned__month
+                    , subq_0.ds_partitioned__quarter
+                    , subq_0.ds_partitioned__year
+                    , subq_0.ds_partitioned__extract_year
+                    , subq_0.ds_partitioned__extract_quarter
+                    , subq_0.ds_partitioned__extract_month
+                    , subq_0.ds_partitioned__extract_day
+                    , subq_0.ds_partitioned__extract_dow
+                    , subq_0.ds_partitioned__extract_doy
+                    , subq_0.paid_at__day
+                    , subq_0.paid_at__week
+                    , subq_0.paid_at__month
+                    , subq_0.paid_at__quarter
+                    , subq_0.paid_at__year
+                    , subq_0.paid_at__extract_year
+                    , subq_0.paid_at__extract_quarter
+                    , subq_0.paid_at__extract_month
+                    , subq_0.paid_at__extract_day
+                    , subq_0.paid_at__extract_dow
+                    , subq_0.paid_at__extract_doy
+                    , subq_0.booking__ds__day
+                    , subq_0.booking__ds__week
+                    , subq_0.booking__ds__month
+                    , subq_0.booking__ds__quarter
+                    , subq_0.booking__ds__year
+                    , subq_0.booking__ds__extract_year
+                    , subq_0.booking__ds__extract_quarter
+                    , subq_0.booking__ds__extract_month
+                    , subq_0.booking__ds__extract_day
+                    , subq_0.booking__ds__extract_dow
+                    , subq_0.booking__ds__extract_doy
+                    , subq_0.booking__ds_partitioned__day
+                    , subq_0.booking__ds_partitioned__week
+                    , subq_0.booking__ds_partitioned__month
+                    , subq_0.booking__ds_partitioned__quarter
+                    , subq_0.booking__ds_partitioned__year
+                    , subq_0.booking__ds_partitioned__extract_year
+                    , subq_0.booking__ds_partitioned__extract_quarter
+                    , subq_0.booking__ds_partitioned__extract_month
+                    , subq_0.booking__ds_partitioned__extract_day
+                    , subq_0.booking__ds_partitioned__extract_dow
+                    , subq_0.booking__ds_partitioned__extract_doy
+                    , subq_0.booking__paid_at__day
+                    , subq_0.booking__paid_at__week
+                    , subq_0.booking__paid_at__month
+                    , subq_0.booking__paid_at__quarter
+                    , subq_0.booking__paid_at__year
+                    , subq_0.booking__paid_at__extract_year
+                    , subq_0.booking__paid_at__extract_quarter
+                    , subq_0.booking__paid_at__extract_month
+                    , subq_0.booking__paid_at__extract_day
+                    , subq_0.booking__paid_at__extract_dow
+                    , subq_0.booking__paid_at__extract_doy
+                    , subq_0.ds__day AS metric_time__day
+                    , subq_0.ds__week AS metric_time__week
+                    , subq_0.ds__month AS metric_time__month
+                    , subq_0.ds__quarter AS metric_time__quarter
+                    , subq_0.ds__year AS metric_time__year
+                    , subq_0.ds__extract_year AS metric_time__extract_year
+                    , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                    , subq_0.ds__extract_month AS metric_time__extract_month
+                    , subq_0.ds__extract_day AS metric_time__extract_day
+                    , subq_0.ds__extract_dow AS metric_time__extract_dow
+                    , subq_0.ds__extract_doy AS metric_time__extract_doy
+                    , subq_0.listing
+                    , subq_0.guest
+                    , subq_0.host
+                    , subq_0.booking__listing
+                    , subq_0.booking__guest
+                    , subq_0.booking__host
+                    , subq_0.is_instant
+                    , subq_0.booking__is_instant
+                    , subq_0.__bookings
+                    , subq_0.__average_booking_value
+                    , subq_0.__instant_bookings
+                    , subq_0.__booking_value
+                    , subq_0.__max_booking_value
+                    , subq_0.__min_booking_value
+                    , subq_0.__instant_booking_value
+                    , subq_0.__average_instant_booking_value
+                    , subq_0.__booking_value_for_non_null_listing_id
+                    , subq_0.__bookers
+                    , subq_0.__referred_bookings
+                    , subq_0.__median_booking_value
+                    , subq_0.__booking_value_p99
+                    , subq_0.__discrete_booking_value_p99
+                    , subq_0.__approximate_continuous_booking_value_p99
+                    , subq_0.__approximate_discrete_booking_value_p99
+                    , subq_0.__bookings_join_to_time_spine
+                    , subq_0.__bookings_fill_nulls_with_0_without_time_spine
+                    , subq_0.__bookings_fill_nulls_with_0
+                    , subq_0.__instant_bookings_with_measure_filter
+                    , subq_0.__bookings_join_to_time_spine_with_tiered_filters
+                    , subq_0.__bookers_fill_nulls_with_0_join_to_timespine
                   FROM (
-                    -- Read From Time Spine 'mf_time_spine'
+                    -- Read Elements From Semantic Model 'bookings_source'
                     SELECT
-                      subq_3.ds AS metric_time__day
-                    FROM ***************************.mf_time_spine subq_3
-                  ) subq_2
-                  INNER JOIN (
-                    -- Metric Time Dimension 'ds'
-                    SELECT
-                      subq_0.ds__day
-                      , subq_0.ds__week
-                      , subq_0.ds__month
-                      , subq_0.ds__quarter
-                      , subq_0.ds__year
-                      , subq_0.ds__extract_year
-                      , subq_0.ds__extract_quarter
-                      , subq_0.ds__extract_month
-                      , subq_0.ds__extract_day
-                      , subq_0.ds__extract_dow
-                      , subq_0.ds__extract_doy
-                      , subq_0.ds_partitioned__day
-                      , subq_0.ds_partitioned__week
-                      , subq_0.ds_partitioned__month
-                      , subq_0.ds_partitioned__quarter
-                      , subq_0.ds_partitioned__year
-                      , subq_0.ds_partitioned__extract_year
-                      , subq_0.ds_partitioned__extract_quarter
-                      , subq_0.ds_partitioned__extract_month
-                      , subq_0.ds_partitioned__extract_day
-                      , subq_0.ds_partitioned__extract_dow
-                      , subq_0.ds_partitioned__extract_doy
-                      , subq_0.paid_at__day
-                      , subq_0.paid_at__week
-                      , subq_0.paid_at__month
-                      , subq_0.paid_at__quarter
-                      , subq_0.paid_at__year
-                      , subq_0.paid_at__extract_year
-                      , subq_0.paid_at__extract_quarter
-                      , subq_0.paid_at__extract_month
-                      , subq_0.paid_at__extract_day
-                      , subq_0.paid_at__extract_dow
-                      , subq_0.paid_at__extract_doy
-                      , subq_0.booking__ds__day
-                      , subq_0.booking__ds__week
-                      , subq_0.booking__ds__month
-                      , subq_0.booking__ds__quarter
-                      , subq_0.booking__ds__year
-                      , subq_0.booking__ds__extract_year
-                      , subq_0.booking__ds__extract_quarter
-                      , subq_0.booking__ds__extract_month
-                      , subq_0.booking__ds__extract_day
-                      , subq_0.booking__ds__extract_dow
-                      , subq_0.booking__ds__extract_doy
-                      , subq_0.booking__ds_partitioned__day
-                      , subq_0.booking__ds_partitioned__week
-                      , subq_0.booking__ds_partitioned__month
-                      , subq_0.booking__ds_partitioned__quarter
-                      , subq_0.booking__ds_partitioned__year
-                      , subq_0.booking__ds_partitioned__extract_year
-                      , subq_0.booking__ds_partitioned__extract_quarter
-                      , subq_0.booking__ds_partitioned__extract_month
-                      , subq_0.booking__ds_partitioned__extract_day
-                      , subq_0.booking__ds_partitioned__extract_dow
-                      , subq_0.booking__ds_partitioned__extract_doy
-                      , subq_0.booking__paid_at__day
-                      , subq_0.booking__paid_at__week
-                      , subq_0.booking__paid_at__month
-                      , subq_0.booking__paid_at__quarter
-                      , subq_0.booking__paid_at__year
-                      , subq_0.booking__paid_at__extract_year
-                      , subq_0.booking__paid_at__extract_quarter
-                      , subq_0.booking__paid_at__extract_month
-                      , subq_0.booking__paid_at__extract_day
-                      , subq_0.booking__paid_at__extract_dow
-                      , subq_0.booking__paid_at__extract_doy
-                      , subq_0.ds__day AS metric_time__day
-                      , subq_0.ds__week AS metric_time__week
-                      , subq_0.ds__month AS metric_time__month
-                      , subq_0.ds__quarter AS metric_time__quarter
-                      , subq_0.ds__year AS metric_time__year
-                      , subq_0.ds__extract_year AS metric_time__extract_year
-                      , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                      , subq_0.ds__extract_month AS metric_time__extract_month
-                      , subq_0.ds__extract_day AS metric_time__extract_day
-                      , subq_0.ds__extract_dow AS metric_time__extract_dow
-                      , subq_0.ds__extract_doy AS metric_time__extract_doy
-                      , subq_0.listing
-                      , subq_0.guest
-                      , subq_0.host
-                      , subq_0.booking__listing
-                      , subq_0.booking__guest
-                      , subq_0.booking__host
-                      , subq_0.is_instant
-                      , subq_0.booking__is_instant
-                      , subq_0.__bookings
-                      , subq_0.__average_booking_value
-                      , subq_0.__instant_bookings
-                      , subq_0.__booking_value
-                      , subq_0.__max_booking_value
-                      , subq_0.__min_booking_value
-                      , subq_0.__instant_booking_value
-                      , subq_0.__average_instant_booking_value
-                      , subq_0.__booking_value_for_non_null_listing_id
-                      , subq_0.__bookers
-                      , subq_0.__referred_bookings
-                      , subq_0.__median_booking_value
-                      , subq_0.__booking_value_p99
-                      , subq_0.__discrete_booking_value_p99
-                      , subq_0.__approximate_continuous_booking_value_p99
-                      , subq_0.__approximate_discrete_booking_value_p99
-                      , subq_0.__bookings_join_to_time_spine
-                      , subq_0.__bookings_fill_nulls_with_0_without_time_spine
-                      , subq_0.__bookings_fill_nulls_with_0
-                      , subq_0.__instant_bookings_with_measure_filter
-                      , subq_0.__bookings_join_to_time_spine_with_tiered_filters
-                      , subq_0.__bookers_fill_nulls_with_0_join_to_timespine
-                    FROM (
-                      -- Read Elements From Semantic Model 'bookings_source'
-                      SELECT
-                        1 AS __bookings
-                        , bookings_source_src_28000.booking_value AS __average_booking_value
-                        , CASE WHEN is_instant THEN 1 ELSE 0 END AS __instant_bookings
-                        , bookings_source_src_28000.booking_value AS __booking_value
-                        , bookings_source_src_28000.booking_value AS __max_booking_value
-                        , bookings_source_src_28000.booking_value AS __min_booking_value
-                        , bookings_source_src_28000.booking_value AS __instant_booking_value
-                        , bookings_source_src_28000.booking_value AS __average_instant_booking_value
-                        , bookings_source_src_28000.booking_value AS __booking_value_for_non_null_listing_id
-                        , bookings_source_src_28000.guest_id AS __bookers
-                        , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS __referred_bookings
-                        , bookings_source_src_28000.booking_value AS __median_booking_value
-                        , bookings_source_src_28000.booking_value AS __booking_value_p99
-                        , bookings_source_src_28000.booking_value AS __discrete_booking_value_p99
-                        , bookings_source_src_28000.booking_value AS __approximate_continuous_booking_value_p99
-                        , bookings_source_src_28000.booking_value AS __approximate_discrete_booking_value_p99
-                        , 1 AS __bookings_join_to_time_spine
-                        , 1 AS __bookings_fill_nulls_with_0_without_time_spine
-                        , 1 AS __bookings_fill_nulls_with_0
-                        , 1 AS __instant_bookings_with_measure_filter
-                        , 1 AS __bookings_join_to_time_spine_with_tiered_filters
-                        , bookings_source_src_28000.guest_id AS __bookers_fill_nulls_with_0_join_to_timespine
-                        , bookings_source_src_28000.booking_value AS __booking_payments
-                        , bookings_source_src_28000.is_instant
-                        , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                        , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                        , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                        , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                        , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                        , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                        , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                        , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                        , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
-                        , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                        , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                        , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                        , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                        , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                        , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                        , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                        , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                        , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                        , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
-                        , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                        , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                        , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                        , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                        , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                        , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                        , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                        , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                        , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                        , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                        , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
-                        , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                        , bookings_source_src_28000.is_instant AS booking__is_instant
-                        , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                        , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                        , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                        , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                        , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                        , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                        , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                        , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                        , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
-                        , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                        , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                        , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                        , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                        , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                        , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                        , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                        , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                        , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                        , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
-                        , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                        , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                        , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                        , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                        , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                        , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                        , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                        , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                        , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                        , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                        , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
-                        , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                        , bookings_source_src_28000.listing_id AS listing
-                        , bookings_source_src_28000.guest_id AS guest
-                        , bookings_source_src_28000.host_id AS host
-                        , bookings_source_src_28000.listing_id AS booking__listing
-                        , bookings_source_src_28000.guest_id AS booking__guest
-                        , bookings_source_src_28000.host_id AS booking__host
-                      FROM ***************************.fct_bookings bookings_source_src_28000
-                    ) subq_0
-                  ) subq_1
-                  ON
-                    (
-                      subq_1.metric_time__day <= subq_2.metric_time__day
-                    ) AND (
-                      subq_1.metric_time__day > subq_2.metric_time__day - INTERVAL 7 day
-                    )
-                ) subq_4
-              ) subq_5
-              WHERE metric_time__day = '2020-01-01'
-            ) subq_6
-          ) subq_7
+                      1 AS __bookings
+                      , bookings_source_src_28000.booking_value AS __average_booking_value
+                      , CASE WHEN is_instant THEN 1 ELSE 0 END AS __instant_bookings
+                      , bookings_source_src_28000.booking_value AS __booking_value
+                      , bookings_source_src_28000.booking_value AS __max_booking_value
+                      , bookings_source_src_28000.booking_value AS __min_booking_value
+                      , bookings_source_src_28000.booking_value AS __instant_booking_value
+                      , bookings_source_src_28000.booking_value AS __average_instant_booking_value
+                      , bookings_source_src_28000.booking_value AS __booking_value_for_non_null_listing_id
+                      , bookings_source_src_28000.guest_id AS __bookers
+                      , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS __referred_bookings
+                      , bookings_source_src_28000.booking_value AS __median_booking_value
+                      , bookings_source_src_28000.booking_value AS __booking_value_p99
+                      , bookings_source_src_28000.booking_value AS __discrete_booking_value_p99
+                      , bookings_source_src_28000.booking_value AS __approximate_continuous_booking_value_p99
+                      , bookings_source_src_28000.booking_value AS __approximate_discrete_booking_value_p99
+                      , 1 AS __bookings_join_to_time_spine
+                      , 1 AS __bookings_fill_nulls_with_0_without_time_spine
+                      , 1 AS __bookings_fill_nulls_with_0
+                      , 1 AS __instant_bookings_with_measure_filter
+                      , 1 AS __bookings_join_to_time_spine_with_tiered_filters
+                      , bookings_source_src_28000.guest_id AS __bookers_fill_nulls_with_0_join_to_timespine
+                      , bookings_source_src_28000.booking_value AS __booking_payments
+                      , bookings_source_src_28000.is_instant
+                      , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                      , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                      , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                      , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                      , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                      , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                      , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                      , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                      , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                      , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                      , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                      , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                      , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                      , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                      , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                      , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                      , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                      , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                      , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                      , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                      , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                      , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                      , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                      , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                      , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                      , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                      , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                      , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                      , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                      , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                      , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                      , bookings_source_src_28000.is_instant AS booking__is_instant
+                      , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                      , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                      , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                      , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                      , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                      , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                      , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                      , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                      , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                      , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                      , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                      , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                      , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                      , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                      , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                      , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                      , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                      , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                      , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                      , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                      , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                      , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                      , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                      , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                      , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                      , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                      , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                      , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                      , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                      , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                      , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                      , bookings_source_src_28000.listing_id AS listing
+                      , bookings_source_src_28000.guest_id AS guest
+                      , bookings_source_src_28000.host_id AS host
+                      , bookings_source_src_28000.listing_id AS booking__listing
+                      , bookings_source_src_28000.guest_id AS booking__guest
+                      , bookings_source_src_28000.host_id AS booking__host
+                    FROM ***************************.fct_bookings bookings_source_src_28000
+                  ) subq_0
+                ) subq_1
+                ON
+                  (
+                    subq_1.metric_time__day <= subq_2.metric_time__day
+                  ) AND (
+                    subq_1.metric_time__day > subq_2.metric_time__day - INTERVAL 7 day
+                  )
+              ) subq_4
+            ) subq_5
+          ) subq_6
           GROUP BY
-            subq_7.metric_time__day
-        ) subq_8
+            subq_6.metric_time__day
+        ) subq_7
         ON
-          subq_13.metric_time__day - INTERVAL 1 week = subq_8.metric_time__day
-      ) subq_14
-    ) subq_15
-  ) subq_16
-) subq_17
+          subq_12.metric_time__day - INTERVAL 1 week = subq_7.metric_time__day
+      ) subq_13
+    ) subq_14
+  ) subq_15
+) subq_16

--- a/tests_metricflow/snapshots/test_offset_metrics_with_filters.py/SqlPlan/DuckDB/test_offset_cumulative_metric_with_metric_time_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_offset_metrics_with_filters.py/SqlPlan/DuckDB/test_offset_cumulative_metric_with_metric_time_filter__plan0_optimized.sql
@@ -18,8 +18,8 @@ FROM (
   -- Compute Metrics via Expressions
   -- Compute Metrics via Expressions
   SELECT
-    subq_31.metric_time__day AS metric_time__day
-    , subq_26.__bookings AS trailing_7_days_bookings_1_week_ago
+    subq_29.metric_time__day AS metric_time__day
+    , subq_24.__bookings AS trailing_7_days_bookings_1_week_ago
   FROM (
     -- Constrain Output with WHERE
     -- Select: ['metric_time__day']
@@ -32,42 +32,35 @@ FROM (
       SELECT
         ds AS metric_time__day
       FROM ***************************.mf_time_spine time_spine_src_28006
-    ) subq_29
+    ) subq_27
     WHERE metric_time__day = '2020-01-01'
-  ) subq_31
+  ) subq_29
   INNER JOIN (
-    -- Constrain Output with WHERE
+    -- Join Self Over Time Range
+    -- Select: ['__bookings', 'metric_time__day']
     -- Select: ['__bookings', 'metric_time__day']
     -- Aggregate Inputs for Simple Metrics
     SELECT
-      metric_time__day
-      , SUM(bookings) AS __bookings
-    FROM (
-      -- Join Self Over Time Range
-      -- Select: ['__bookings', 'metric_time__day']
+      subq_20.ds AS metric_time__day
+      , SUM(subq_18.__bookings) AS __bookings
+    FROM ***************************.mf_time_spine subq_20
+    INNER JOIN (
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
       SELECT
-        subq_21.ds AS metric_time__day
-        , subq_19.__bookings AS bookings
-      FROM ***************************.mf_time_spine subq_21
-      INNER JOIN (
-        -- Read Elements From Semantic Model 'bookings_source'
-        -- Metric Time Dimension 'ds'
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , 1 AS __bookings
-        FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_19
-      ON
-        (
-          subq_19.metric_time__day <= subq_21.ds
-        ) AND (
-          subq_19.metric_time__day > subq_21.ds - INTERVAL 7 day
-        )
-    ) subq_23
-    WHERE metric_time__day = '2020-01-01'
+        DATE_TRUNC('day', ds) AS metric_time__day
+        , 1 AS __bookings
+      FROM ***************************.fct_bookings bookings_source_src_28000
+    ) subq_18
+    ON
+      (
+        subq_18.metric_time__day <= subq_20.ds
+      ) AND (
+        subq_18.metric_time__day > subq_20.ds - INTERVAL 7 day
+      )
     GROUP BY
-      metric_time__day
-  ) subq_26
+      subq_20.ds
+  ) subq_24
   ON
-    subq_31.metric_time__day - INTERVAL 1 week = subq_26.metric_time__day
-) subq_34
+    subq_29.metric_time__day - INTERVAL 1 week = subq_24.metric_time__day
+) subq_32

--- a/tests_metricflow/snapshots/test_offset_metrics_with_filters.py/SqlPlan/DuckDB/test_offset_metric_with_metric_time_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_offset_metrics_with_filters.py/SqlPlan/DuckDB/test_offset_metric_with_metric_time_filter__plan0.sql
@@ -8,50 +8,50 @@ expectation_description:
 ---
 -- Write to DataTable
 SELECT
-  subq_13.metric_time__day
-  , subq_13.bookings_offset_once
+  subq_12.metric_time__day
+  , subq_12.bookings_offset_once
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_12.metric_time__day
+    subq_11.metric_time__day
     , 2 * bookings AS bookings_offset_once
   FROM (
     -- Compute Metrics via Expressions
     SELECT
-      subq_11.metric_time__day
-      , subq_11.__bookings AS bookings
+      subq_10.metric_time__day
+      , subq_10.__bookings AS bookings
     FROM (
       -- Join to Time Spine Dataset
       SELECT
-        subq_10.metric_time__day AS metric_time__day
-        , subq_5.__bookings AS __bookings
+        subq_9.metric_time__day AS metric_time__day
+        , subq_4.__bookings AS __bookings
       FROM (
         -- Select: ['metric_time__day']
         SELECT
-          subq_9.metric_time__day
+          subq_8.metric_time__day
         FROM (
           -- Constrain Output with WHERE
           SELECT
-            subq_8.metric_time__day
+            subq_7.metric_time__day
           FROM (
             -- Select: ['metric_time__day']
             SELECT
-              subq_7.metric_time__day
+              subq_6.metric_time__day
             FROM (
               -- Change Column Aliases
               SELECT
-                subq_6.ds__day AS metric_time__day
-                , subq_6.ds__week
-                , subq_6.ds__month
-                , subq_6.ds__quarter
-                , subq_6.ds__year
-                , subq_6.ds__extract_year
-                , subq_6.ds__extract_quarter
-                , subq_6.ds__extract_month
-                , subq_6.ds__extract_day
-                , subq_6.ds__extract_dow
-                , subq_6.ds__extract_doy
-                , subq_6.ds__alien_day
+                subq_5.ds__day AS metric_time__day
+                , subq_5.ds__week
+                , subq_5.ds__month
+                , subq_5.ds__quarter
+                , subq_5.ds__year
+                , subq_5.ds__extract_year
+                , subq_5.ds__extract_quarter
+                , subq_5.ds__extract_month
+                , subq_5.ds__extract_day
+                , subq_5.ds__extract_dow
+                , subq_5.ds__extract_doy
+                , subq_5.ds__alien_day
               FROM (
                 -- Read From Time Spine 'mf_time_spine'
                 SELECT
@@ -68,254 +68,247 @@ FROM (
                   , EXTRACT(doy FROM time_spine_src_28006.ds) AS ds__extract_doy
                   , time_spine_src_28006.alien_day AS ds__alien_day
                 FROM ***************************.mf_time_spine time_spine_src_28006
-              ) subq_6
-            ) subq_7
-          ) subq_8
+              ) subq_5
+            ) subq_6
+          ) subq_7
           WHERE metric_time__day = '2020-01-01' 
-        ) subq_9
-      ) subq_10
+        ) subq_8
+      ) subq_9
       INNER JOIN (
         -- Aggregate Inputs for Simple Metrics
         SELECT
-          subq_4.metric_time__day
-          , SUM(subq_4.__bookings) AS __bookings
+          subq_3.metric_time__day
+          , SUM(subq_3.__bookings) AS __bookings
         FROM (
           -- Select: ['__bookings', 'metric_time__day']
           SELECT
-            subq_3.metric_time__day
-            , subq_3.__bookings
+            subq_2.metric_time__day
+            , subq_2.__bookings
           FROM (
-            -- Constrain Output with WHERE
+            -- Select: ['__bookings', 'metric_time__day']
             SELECT
-              subq_2.bookings AS __bookings
-              , subq_2.metric_time__day
+              subq_1.metric_time__day
+              , subq_1.__bookings
             FROM (
-              -- Select: ['__bookings', 'metric_time__day']
+              -- Metric Time Dimension 'ds'
               SELECT
-                subq_1.metric_time__day
-                , subq_1.__bookings AS bookings
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.__bookings
+                , subq_0.__average_booking_value
+                , subq_0.__instant_bookings
+                , subq_0.__booking_value
+                , subq_0.__max_booking_value
+                , subq_0.__min_booking_value
+                , subq_0.__instant_booking_value
+                , subq_0.__average_instant_booking_value
+                , subq_0.__booking_value_for_non_null_listing_id
+                , subq_0.__bookers
+                , subq_0.__referred_bookings
+                , subq_0.__median_booking_value
+                , subq_0.__booking_value_p99
+                , subq_0.__discrete_booking_value_p99
+                , subq_0.__approximate_continuous_booking_value_p99
+                , subq_0.__approximate_discrete_booking_value_p99
+                , subq_0.__bookings_join_to_time_spine
+                , subq_0.__bookings_fill_nulls_with_0_without_time_spine
+                , subq_0.__bookings_fill_nulls_with_0
+                , subq_0.__instant_bookings_with_measure_filter
+                , subq_0.__bookings_join_to_time_spine_with_tiered_filters
+                , subq_0.__bookers_fill_nulls_with_0_join_to_timespine
               FROM (
-                -- Metric Time Dimension 'ds'
+                -- Read Elements From Semantic Model 'bookings_source'
                 SELECT
-                  subq_0.ds__day
-                  , subq_0.ds__week
-                  , subq_0.ds__month
-                  , subq_0.ds__quarter
-                  , subq_0.ds__year
-                  , subq_0.ds__extract_year
-                  , subq_0.ds__extract_quarter
-                  , subq_0.ds__extract_month
-                  , subq_0.ds__extract_day
-                  , subq_0.ds__extract_dow
-                  , subq_0.ds__extract_doy
-                  , subq_0.ds_partitioned__day
-                  , subq_0.ds_partitioned__week
-                  , subq_0.ds_partitioned__month
-                  , subq_0.ds_partitioned__quarter
-                  , subq_0.ds_partitioned__year
-                  , subq_0.ds_partitioned__extract_year
-                  , subq_0.ds_partitioned__extract_quarter
-                  , subq_0.ds_partitioned__extract_month
-                  , subq_0.ds_partitioned__extract_day
-                  , subq_0.ds_partitioned__extract_dow
-                  , subq_0.ds_partitioned__extract_doy
-                  , subq_0.paid_at__day
-                  , subq_0.paid_at__week
-                  , subq_0.paid_at__month
-                  , subq_0.paid_at__quarter
-                  , subq_0.paid_at__year
-                  , subq_0.paid_at__extract_year
-                  , subq_0.paid_at__extract_quarter
-                  , subq_0.paid_at__extract_month
-                  , subq_0.paid_at__extract_day
-                  , subq_0.paid_at__extract_dow
-                  , subq_0.paid_at__extract_doy
-                  , subq_0.booking__ds__day
-                  , subq_0.booking__ds__week
-                  , subq_0.booking__ds__month
-                  , subq_0.booking__ds__quarter
-                  , subq_0.booking__ds__year
-                  , subq_0.booking__ds__extract_year
-                  , subq_0.booking__ds__extract_quarter
-                  , subq_0.booking__ds__extract_month
-                  , subq_0.booking__ds__extract_day
-                  , subq_0.booking__ds__extract_dow
-                  , subq_0.booking__ds__extract_doy
-                  , subq_0.booking__ds_partitioned__day
-                  , subq_0.booking__ds_partitioned__week
-                  , subq_0.booking__ds_partitioned__month
-                  , subq_0.booking__ds_partitioned__quarter
-                  , subq_0.booking__ds_partitioned__year
-                  , subq_0.booking__ds_partitioned__extract_year
-                  , subq_0.booking__ds_partitioned__extract_quarter
-                  , subq_0.booking__ds_partitioned__extract_month
-                  , subq_0.booking__ds_partitioned__extract_day
-                  , subq_0.booking__ds_partitioned__extract_dow
-                  , subq_0.booking__ds_partitioned__extract_doy
-                  , subq_0.booking__paid_at__day
-                  , subq_0.booking__paid_at__week
-                  , subq_0.booking__paid_at__month
-                  , subq_0.booking__paid_at__quarter
-                  , subq_0.booking__paid_at__year
-                  , subq_0.booking__paid_at__extract_year
-                  , subq_0.booking__paid_at__extract_quarter
-                  , subq_0.booking__paid_at__extract_month
-                  , subq_0.booking__paid_at__extract_day
-                  , subq_0.booking__paid_at__extract_dow
-                  , subq_0.booking__paid_at__extract_doy
-                  , subq_0.ds__day AS metric_time__day
-                  , subq_0.ds__week AS metric_time__week
-                  , subq_0.ds__month AS metric_time__month
-                  , subq_0.ds__quarter AS metric_time__quarter
-                  , subq_0.ds__year AS metric_time__year
-                  , subq_0.ds__extract_year AS metric_time__extract_year
-                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_0.ds__extract_month AS metric_time__extract_month
-                  , subq_0.ds__extract_day AS metric_time__extract_day
-                  , subq_0.ds__extract_dow AS metric_time__extract_dow
-                  , subq_0.ds__extract_doy AS metric_time__extract_doy
-                  , subq_0.listing
-                  , subq_0.guest
-                  , subq_0.host
-                  , subq_0.booking__listing
-                  , subq_0.booking__guest
-                  , subq_0.booking__host
-                  , subq_0.is_instant
-                  , subq_0.booking__is_instant
-                  , subq_0.__bookings
-                  , subq_0.__average_booking_value
-                  , subq_0.__instant_bookings
-                  , subq_0.__booking_value
-                  , subq_0.__max_booking_value
-                  , subq_0.__min_booking_value
-                  , subq_0.__instant_booking_value
-                  , subq_0.__average_instant_booking_value
-                  , subq_0.__booking_value_for_non_null_listing_id
-                  , subq_0.__bookers
-                  , subq_0.__referred_bookings
-                  , subq_0.__median_booking_value
-                  , subq_0.__booking_value_p99
-                  , subq_0.__discrete_booking_value_p99
-                  , subq_0.__approximate_continuous_booking_value_p99
-                  , subq_0.__approximate_discrete_booking_value_p99
-                  , subq_0.__bookings_join_to_time_spine
-                  , subq_0.__bookings_fill_nulls_with_0_without_time_spine
-                  , subq_0.__bookings_fill_nulls_with_0
-                  , subq_0.__instant_bookings_with_measure_filter
-                  , subq_0.__bookings_join_to_time_spine_with_tiered_filters
-                  , subq_0.__bookers_fill_nulls_with_0_join_to_timespine
-                FROM (
-                  -- Read Elements From Semantic Model 'bookings_source'
-                  SELECT
-                    1 AS __bookings
-                    , bookings_source_src_28000.booking_value AS __average_booking_value
-                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS __instant_bookings
-                    , bookings_source_src_28000.booking_value AS __booking_value
-                    , bookings_source_src_28000.booking_value AS __max_booking_value
-                    , bookings_source_src_28000.booking_value AS __min_booking_value
-                    , bookings_source_src_28000.booking_value AS __instant_booking_value
-                    , bookings_source_src_28000.booking_value AS __average_instant_booking_value
-                    , bookings_source_src_28000.booking_value AS __booking_value_for_non_null_listing_id
-                    , bookings_source_src_28000.guest_id AS __bookers
-                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS __referred_bookings
-                    , bookings_source_src_28000.booking_value AS __median_booking_value
-                    , bookings_source_src_28000.booking_value AS __booking_value_p99
-                    , bookings_source_src_28000.booking_value AS __discrete_booking_value_p99
-                    , bookings_source_src_28000.booking_value AS __approximate_continuous_booking_value_p99
-                    , bookings_source_src_28000.booking_value AS __approximate_discrete_booking_value_p99
-                    , 1 AS __bookings_join_to_time_spine
-                    , 1 AS __bookings_fill_nulls_with_0_without_time_spine
-                    , 1 AS __bookings_fill_nulls_with_0
-                    , 1 AS __instant_bookings_with_measure_filter
-                    , 1 AS __bookings_join_to_time_spine_with_tiered_filters
-                    , bookings_source_src_28000.guest_id AS __bookers_fill_nulls_with_0_join_to_timespine
-                    , bookings_source_src_28000.booking_value AS __booking_payments
-                    , bookings_source_src_28000.is_instant
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                    , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                    , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                    , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                    , bookings_source_src_28000.is_instant AS booking__is_instant
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                    , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                    , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                    , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                    , bookings_source_src_28000.listing_id AS listing
-                    , bookings_source_src_28000.guest_id AS guest
-                    , bookings_source_src_28000.host_id AS host
-                    , bookings_source_src_28000.listing_id AS booking__listing
-                    , bookings_source_src_28000.guest_id AS booking__guest
-                    , bookings_source_src_28000.host_id AS booking__host
-                  FROM ***************************.fct_bookings bookings_source_src_28000
-                ) subq_0
-              ) subq_1
-            ) subq_2
-            WHERE metric_time__day = '2020-01-01' 
-          ) subq_3
-        ) subq_4
+                  1 AS __bookings
+                  , bookings_source_src_28000.booking_value AS __average_booking_value
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS __instant_bookings
+                  , bookings_source_src_28000.booking_value AS __booking_value
+                  , bookings_source_src_28000.booking_value AS __max_booking_value
+                  , bookings_source_src_28000.booking_value AS __min_booking_value
+                  , bookings_source_src_28000.booking_value AS __instant_booking_value
+                  , bookings_source_src_28000.booking_value AS __average_instant_booking_value
+                  , bookings_source_src_28000.booking_value AS __booking_value_for_non_null_listing_id
+                  , bookings_source_src_28000.guest_id AS __bookers
+                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS __referred_bookings
+                  , bookings_source_src_28000.booking_value AS __median_booking_value
+                  , bookings_source_src_28000.booking_value AS __booking_value_p99
+                  , bookings_source_src_28000.booking_value AS __discrete_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS __approximate_continuous_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS __approximate_discrete_booking_value_p99
+                  , 1 AS __bookings_join_to_time_spine
+                  , 1 AS __bookings_fill_nulls_with_0_without_time_spine
+                  , 1 AS __bookings_fill_nulls_with_0
+                  , 1 AS __instant_bookings_with_measure_filter
+                  , 1 AS __bookings_join_to_time_spine_with_tiered_filters
+                  , bookings_source_src_28000.guest_id AS __bookers_fill_nulls_with_0_join_to_timespine
+                  , bookings_source_src_28000.booking_value AS __booking_payments
+                  , bookings_source_src_28000.is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                  , bookings_source_src_28000.is_instant AS booking__is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                  , bookings_source_src_28000.listing_id AS listing
+                  , bookings_source_src_28000.guest_id AS guest
+                  , bookings_source_src_28000.host_id AS host
+                  , bookings_source_src_28000.listing_id AS booking__listing
+                  , bookings_source_src_28000.guest_id AS booking__guest
+                  , bookings_source_src_28000.host_id AS booking__host
+                FROM ***************************.fct_bookings bookings_source_src_28000
+              ) subq_0
+            ) subq_1
+          ) subq_2
+        ) subq_3
         GROUP BY
-          subq_4.metric_time__day
-      ) subq_5
+          subq_3.metric_time__day
+      ) subq_4
       ON
-        subq_10.metric_time__day - INTERVAL 5 day = subq_5.metric_time__day
-    ) subq_11
-  ) subq_12
-) subq_13
+        subq_9.metric_time__day - INTERVAL 5 day = subq_4.metric_time__day
+    ) subq_10
+  ) subq_11
+) subq_12

--- a/tests_metricflow/snapshots/test_offset_metrics_with_filters.py/SqlPlan/DuckDB/test_offset_metric_with_metric_time_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_offset_metrics_with_filters.py/SqlPlan/DuckDB/test_offset_metric_with_metric_time_filter__plan0_optimized.sql
@@ -15,8 +15,8 @@ FROM (
   -- Join to Time Spine Dataset
   -- Compute Metrics via Expressions
   SELECT
-    subq_24.metric_time__day AS metric_time__day
-    , subq_19.__bookings AS bookings
+    subq_22.metric_time__day AS metric_time__day
+    , subq_17.__bookings AS bookings
   FROM (
     -- Constrain Output with WHERE
     -- Select: ['metric_time__day']
@@ -29,29 +29,27 @@ FROM (
       SELECT
         ds AS metric_time__day
       FROM ***************************.mf_time_spine time_spine_src_28006
-    ) subq_22
+    ) subq_20
     WHERE metric_time__day = '2020-01-01' 
-  ) subq_24
+  ) subq_22
   INNER JOIN (
-    -- Constrain Output with WHERE
-    -- Select: ['__bookings', 'metric_time__day']
     -- Aggregate Inputs for Simple Metrics
     SELECT
       metric_time__day
-      , SUM(bookings) AS __bookings
+      , SUM(__bookings) AS __bookings
     FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
       -- Select: ['__bookings', 'metric_time__day']
+      -- Select: ['__bookings', 'metric_time__day']
       SELECT
         DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS bookings
+        , 1 AS __bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
     ) subq_16
-    WHERE metric_time__day = '2020-01-01' 
     GROUP BY
       metric_time__day
-  ) subq_19
+  ) subq_17
   ON
-    subq_24.metric_time__day - INTERVAL 5 day = subq_19.metric_time__day
-) subq_26
+    subq_22.metric_time__day - INTERVAL 5 day = subq_17.metric_time__day
+) subq_24

--- a/tests_metricflow/snapshots/test_offset_metrics_with_filters.py/SqlPlan/DuckDB/test_offset_metric_with_separate_metric_time_and_dimension_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_offset_metrics_with_filters.py/SqlPlan/DuckDB/test_offset_metric_with_separate_metric_time_and_dimension_filters__plan0.sql
@@ -1,0 +1,583 @@
+test_name: test_offset_metric_with_separate_metric_time_and_dimension_filters
+test_filename: test_offset_metrics_with_filters.py
+docstring:
+  Test querying a time-offset metric with separate filters that allow for different filter placement.
+sql_engine: DuckDB
+expectation_description:
+  The metric_time portion of the filter (`{{ TimeDimension('metric_time', 'day')
+  }} = '2020-01-01'`) should be applied on the time spine / output side of the
+  offset join, ideally by pushing it to the time spine before the join, while the
+  dimension portion (`{{ Dimension('listing__country_latest') }} == 'us'`) should
+  stay on the pre-offset metric input.
+---
+-- Write to DataTable
+SELECT
+  subq_17.metric_time__day
+  , subq_17.bookings_offset_once
+FROM (
+  -- Compute Metrics via Expressions
+  SELECT
+    subq_16.metric_time__day
+    , 2 * bookings AS bookings_offset_once
+  FROM (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_15.metric_time__day
+      , subq_15.__bookings AS bookings
+    FROM (
+      -- Join to Time Spine Dataset
+      SELECT
+        subq_14.metric_time__day AS metric_time__day
+        , subq_9.__bookings AS __bookings
+      FROM (
+        -- Select: ['metric_time__day']
+        SELECT
+          subq_13.metric_time__day
+        FROM (
+          -- Constrain Output with WHERE
+          SELECT
+            subq_12.metric_time__day
+          FROM (
+            -- Select: ['metric_time__day']
+            SELECT
+              subq_11.metric_time__day
+            FROM (
+              -- Change Column Aliases
+              SELECT
+                subq_10.ds__day AS metric_time__day
+                , subq_10.ds__week
+                , subq_10.ds__month
+                , subq_10.ds__quarter
+                , subq_10.ds__year
+                , subq_10.ds__extract_year
+                , subq_10.ds__extract_quarter
+                , subq_10.ds__extract_month
+                , subq_10.ds__extract_day
+                , subq_10.ds__extract_dow
+                , subq_10.ds__extract_doy
+                , subq_10.ds__alien_day
+              FROM (
+                -- Read From Time Spine 'mf_time_spine'
+                SELECT
+                  time_spine_src_28006.ds AS ds__day
+                  , DATE_TRUNC('week', time_spine_src_28006.ds) AS ds__week
+                  , DATE_TRUNC('month', time_spine_src_28006.ds) AS ds__month
+                  , DATE_TRUNC('quarter', time_spine_src_28006.ds) AS ds__quarter
+                  , DATE_TRUNC('year', time_spine_src_28006.ds) AS ds__year
+                  , EXTRACT(year FROM time_spine_src_28006.ds) AS ds__extract_year
+                  , EXTRACT(quarter FROM time_spine_src_28006.ds) AS ds__extract_quarter
+                  , EXTRACT(month FROM time_spine_src_28006.ds) AS ds__extract_month
+                  , EXTRACT(day FROM time_spine_src_28006.ds) AS ds__extract_day
+                  , EXTRACT(isodow FROM time_spine_src_28006.ds) AS ds__extract_dow
+                  , EXTRACT(doy FROM time_spine_src_28006.ds) AS ds__extract_doy
+                  , time_spine_src_28006.alien_day AS ds__alien_day
+                FROM ***************************.mf_time_spine time_spine_src_28006
+              ) subq_10
+            ) subq_11
+          ) subq_12
+          WHERE metric_time__day = '2020-01-01'
+        ) subq_13
+      ) subq_14
+      INNER JOIN (
+        -- Aggregate Inputs for Simple Metrics
+        SELECT
+          subq_8.metric_time__day
+          , SUM(subq_8.__bookings) AS __bookings
+        FROM (
+          -- Select: ['__bookings', 'metric_time__day']
+          SELECT
+            subq_7.metric_time__day
+            , subq_7.__bookings
+          FROM (
+            -- Constrain Output with WHERE
+            SELECT
+              subq_6.bookings AS __bookings
+              , subq_6.listing__country_latest
+              , subq_6.metric_time__day
+            FROM (
+              -- Select: ['__bookings', 'listing__country_latest', 'metric_time__day']
+              SELECT
+                subq_5.metric_time__day
+                , subq_5.listing__country_latest
+                , subq_5.__bookings AS bookings
+              FROM (
+                -- Join Standard Outputs
+                SELECT
+                  subq_4.country_latest AS listing__country_latest
+                  , subq_1.ds__day AS ds__day
+                  , subq_1.ds__week AS ds__week
+                  , subq_1.ds__month AS ds__month
+                  , subq_1.ds__quarter AS ds__quarter
+                  , subq_1.ds__year AS ds__year
+                  , subq_1.ds__extract_year AS ds__extract_year
+                  , subq_1.ds__extract_quarter AS ds__extract_quarter
+                  , subq_1.ds__extract_month AS ds__extract_month
+                  , subq_1.ds__extract_day AS ds__extract_day
+                  , subq_1.ds__extract_dow AS ds__extract_dow
+                  , subq_1.ds__extract_doy AS ds__extract_doy
+                  , subq_1.ds_partitioned__day AS ds_partitioned__day
+                  , subq_1.ds_partitioned__week AS ds_partitioned__week
+                  , subq_1.ds_partitioned__month AS ds_partitioned__month
+                  , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
+                  , subq_1.ds_partitioned__year AS ds_partitioned__year
+                  , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
+                  , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+                  , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
+                  , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
+                  , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+                  , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+                  , subq_1.paid_at__day AS paid_at__day
+                  , subq_1.paid_at__week AS paid_at__week
+                  , subq_1.paid_at__month AS paid_at__month
+                  , subq_1.paid_at__quarter AS paid_at__quarter
+                  , subq_1.paid_at__year AS paid_at__year
+                  , subq_1.paid_at__extract_year AS paid_at__extract_year
+                  , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
+                  , subq_1.paid_at__extract_month AS paid_at__extract_month
+                  , subq_1.paid_at__extract_day AS paid_at__extract_day
+                  , subq_1.paid_at__extract_dow AS paid_at__extract_dow
+                  , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+                  , subq_1.booking__ds__day AS booking__ds__day
+                  , subq_1.booking__ds__week AS booking__ds__week
+                  , subq_1.booking__ds__month AS booking__ds__month
+                  , subq_1.booking__ds__quarter AS booking__ds__quarter
+                  , subq_1.booking__ds__year AS booking__ds__year
+                  , subq_1.booking__ds__extract_year AS booking__ds__extract_year
+                  , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
+                  , subq_1.booking__ds__extract_month AS booking__ds__extract_month
+                  , subq_1.booking__ds__extract_day AS booking__ds__extract_day
+                  , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
+                  , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
+                  , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
+                  , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
+                  , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
+                  , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+                  , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
+                  , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+                  , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+                  , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+                  , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+                  , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+                  , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+                  , subq_1.booking__paid_at__day AS booking__paid_at__day
+                  , subq_1.booking__paid_at__week AS booking__paid_at__week
+                  , subq_1.booking__paid_at__month AS booking__paid_at__month
+                  , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
+                  , subq_1.booking__paid_at__year AS booking__paid_at__year
+                  , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
+                  , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+                  , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
+                  , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
+                  , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+                  , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                  , subq_1.metric_time__day AS metric_time__day
+                  , subq_1.metric_time__week AS metric_time__week
+                  , subq_1.metric_time__month AS metric_time__month
+                  , subq_1.metric_time__quarter AS metric_time__quarter
+                  , subq_1.metric_time__year AS metric_time__year
+                  , subq_1.metric_time__extract_year AS metric_time__extract_year
+                  , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+                  , subq_1.metric_time__extract_month AS metric_time__extract_month
+                  , subq_1.metric_time__extract_day AS metric_time__extract_day
+                  , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+                  , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+                  , subq_1.listing AS listing
+                  , subq_1.guest AS guest
+                  , subq_1.host AS host
+                  , subq_1.booking__listing AS booking__listing
+                  , subq_1.booking__guest AS booking__guest
+                  , subq_1.booking__host AS booking__host
+                  , subq_1.is_instant AS is_instant
+                  , subq_1.booking__is_instant AS booking__is_instant
+                  , subq_1.__bookings AS __bookings
+                  , subq_1.__average_booking_value AS __average_booking_value
+                  , subq_1.__instant_bookings AS __instant_bookings
+                  , subq_1.__booking_value AS __booking_value
+                  , subq_1.__max_booking_value AS __max_booking_value
+                  , subq_1.__min_booking_value AS __min_booking_value
+                  , subq_1.__instant_booking_value AS __instant_booking_value
+                  , subq_1.__average_instant_booking_value AS __average_instant_booking_value
+                  , subq_1.__booking_value_for_non_null_listing_id AS __booking_value_for_non_null_listing_id
+                  , subq_1.__bookers AS __bookers
+                  , subq_1.__referred_bookings AS __referred_bookings
+                  , subq_1.__median_booking_value AS __median_booking_value
+                  , subq_1.__booking_value_p99 AS __booking_value_p99
+                  , subq_1.__discrete_booking_value_p99 AS __discrete_booking_value_p99
+                  , subq_1.__approximate_continuous_booking_value_p99 AS __approximate_continuous_booking_value_p99
+                  , subq_1.__approximate_discrete_booking_value_p99 AS __approximate_discrete_booking_value_p99
+                  , subq_1.__bookings_join_to_time_spine AS __bookings_join_to_time_spine
+                  , subq_1.__bookings_fill_nulls_with_0_without_time_spine AS __bookings_fill_nulls_with_0_without_time_spine
+                  , subq_1.__bookings_fill_nulls_with_0 AS __bookings_fill_nulls_with_0
+                  , subq_1.__instant_bookings_with_measure_filter AS __instant_bookings_with_measure_filter
+                  , subq_1.__bookings_join_to_time_spine_with_tiered_filters AS __bookings_join_to_time_spine_with_tiered_filters
+                  , subq_1.__bookers_fill_nulls_with_0_join_to_timespine AS __bookers_fill_nulls_with_0_join_to_timespine
+                FROM (
+                  -- Metric Time Dimension 'ds'
+                  SELECT
+                    subq_0.ds__day
+                    , subq_0.ds__week
+                    , subq_0.ds__month
+                    , subq_0.ds__quarter
+                    , subq_0.ds__year
+                    , subq_0.ds__extract_year
+                    , subq_0.ds__extract_quarter
+                    , subq_0.ds__extract_month
+                    , subq_0.ds__extract_day
+                    , subq_0.ds__extract_dow
+                    , subq_0.ds__extract_doy
+                    , subq_0.ds_partitioned__day
+                    , subq_0.ds_partitioned__week
+                    , subq_0.ds_partitioned__month
+                    , subq_0.ds_partitioned__quarter
+                    , subq_0.ds_partitioned__year
+                    , subq_0.ds_partitioned__extract_year
+                    , subq_0.ds_partitioned__extract_quarter
+                    , subq_0.ds_partitioned__extract_month
+                    , subq_0.ds_partitioned__extract_day
+                    , subq_0.ds_partitioned__extract_dow
+                    , subq_0.ds_partitioned__extract_doy
+                    , subq_0.paid_at__day
+                    , subq_0.paid_at__week
+                    , subq_0.paid_at__month
+                    , subq_0.paid_at__quarter
+                    , subq_0.paid_at__year
+                    , subq_0.paid_at__extract_year
+                    , subq_0.paid_at__extract_quarter
+                    , subq_0.paid_at__extract_month
+                    , subq_0.paid_at__extract_day
+                    , subq_0.paid_at__extract_dow
+                    , subq_0.paid_at__extract_doy
+                    , subq_0.booking__ds__day
+                    , subq_0.booking__ds__week
+                    , subq_0.booking__ds__month
+                    , subq_0.booking__ds__quarter
+                    , subq_0.booking__ds__year
+                    , subq_0.booking__ds__extract_year
+                    , subq_0.booking__ds__extract_quarter
+                    , subq_0.booking__ds__extract_month
+                    , subq_0.booking__ds__extract_day
+                    , subq_0.booking__ds__extract_dow
+                    , subq_0.booking__ds__extract_doy
+                    , subq_0.booking__ds_partitioned__day
+                    , subq_0.booking__ds_partitioned__week
+                    , subq_0.booking__ds_partitioned__month
+                    , subq_0.booking__ds_partitioned__quarter
+                    , subq_0.booking__ds_partitioned__year
+                    , subq_0.booking__ds_partitioned__extract_year
+                    , subq_0.booking__ds_partitioned__extract_quarter
+                    , subq_0.booking__ds_partitioned__extract_month
+                    , subq_0.booking__ds_partitioned__extract_day
+                    , subq_0.booking__ds_partitioned__extract_dow
+                    , subq_0.booking__ds_partitioned__extract_doy
+                    , subq_0.booking__paid_at__day
+                    , subq_0.booking__paid_at__week
+                    , subq_0.booking__paid_at__month
+                    , subq_0.booking__paid_at__quarter
+                    , subq_0.booking__paid_at__year
+                    , subq_0.booking__paid_at__extract_year
+                    , subq_0.booking__paid_at__extract_quarter
+                    , subq_0.booking__paid_at__extract_month
+                    , subq_0.booking__paid_at__extract_day
+                    , subq_0.booking__paid_at__extract_dow
+                    , subq_0.booking__paid_at__extract_doy
+                    , subq_0.ds__day AS metric_time__day
+                    , subq_0.ds__week AS metric_time__week
+                    , subq_0.ds__month AS metric_time__month
+                    , subq_0.ds__quarter AS metric_time__quarter
+                    , subq_0.ds__year AS metric_time__year
+                    , subq_0.ds__extract_year AS metric_time__extract_year
+                    , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                    , subq_0.ds__extract_month AS metric_time__extract_month
+                    , subq_0.ds__extract_day AS metric_time__extract_day
+                    , subq_0.ds__extract_dow AS metric_time__extract_dow
+                    , subq_0.ds__extract_doy AS metric_time__extract_doy
+                    , subq_0.listing
+                    , subq_0.guest
+                    , subq_0.host
+                    , subq_0.booking__listing
+                    , subq_0.booking__guest
+                    , subq_0.booking__host
+                    , subq_0.is_instant
+                    , subq_0.booking__is_instant
+                    , subq_0.__bookings
+                    , subq_0.__average_booking_value
+                    , subq_0.__instant_bookings
+                    , subq_0.__booking_value
+                    , subq_0.__max_booking_value
+                    , subq_0.__min_booking_value
+                    , subq_0.__instant_booking_value
+                    , subq_0.__average_instant_booking_value
+                    , subq_0.__booking_value_for_non_null_listing_id
+                    , subq_0.__bookers
+                    , subq_0.__referred_bookings
+                    , subq_0.__median_booking_value
+                    , subq_0.__booking_value_p99
+                    , subq_0.__discrete_booking_value_p99
+                    , subq_0.__approximate_continuous_booking_value_p99
+                    , subq_0.__approximate_discrete_booking_value_p99
+                    , subq_0.__bookings_join_to_time_spine
+                    , subq_0.__bookings_fill_nulls_with_0_without_time_spine
+                    , subq_0.__bookings_fill_nulls_with_0
+                    , subq_0.__instant_bookings_with_measure_filter
+                    , subq_0.__bookings_join_to_time_spine_with_tiered_filters
+                    , subq_0.__bookers_fill_nulls_with_0_join_to_timespine
+                  FROM (
+                    -- Read Elements From Semantic Model 'bookings_source'
+                    SELECT
+                      1 AS __bookings
+                      , bookings_source_src_28000.booking_value AS __average_booking_value
+                      , CASE WHEN is_instant THEN 1 ELSE 0 END AS __instant_bookings
+                      , bookings_source_src_28000.booking_value AS __booking_value
+                      , bookings_source_src_28000.booking_value AS __max_booking_value
+                      , bookings_source_src_28000.booking_value AS __min_booking_value
+                      , bookings_source_src_28000.booking_value AS __instant_booking_value
+                      , bookings_source_src_28000.booking_value AS __average_instant_booking_value
+                      , bookings_source_src_28000.booking_value AS __booking_value_for_non_null_listing_id
+                      , bookings_source_src_28000.guest_id AS __bookers
+                      , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS __referred_bookings
+                      , bookings_source_src_28000.booking_value AS __median_booking_value
+                      , bookings_source_src_28000.booking_value AS __booking_value_p99
+                      , bookings_source_src_28000.booking_value AS __discrete_booking_value_p99
+                      , bookings_source_src_28000.booking_value AS __approximate_continuous_booking_value_p99
+                      , bookings_source_src_28000.booking_value AS __approximate_discrete_booking_value_p99
+                      , 1 AS __bookings_join_to_time_spine
+                      , 1 AS __bookings_fill_nulls_with_0_without_time_spine
+                      , 1 AS __bookings_fill_nulls_with_0
+                      , 1 AS __instant_bookings_with_measure_filter
+                      , 1 AS __bookings_join_to_time_spine_with_tiered_filters
+                      , bookings_source_src_28000.guest_id AS __bookers_fill_nulls_with_0_join_to_timespine
+                      , bookings_source_src_28000.booking_value AS __booking_payments
+                      , bookings_source_src_28000.is_instant
+                      , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                      , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                      , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                      , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                      , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                      , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                      , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                      , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                      , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                      , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                      , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                      , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                      , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                      , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                      , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                      , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                      , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                      , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                      , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                      , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                      , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                      , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                      , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                      , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                      , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                      , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                      , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                      , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                      , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                      , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                      , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                      , bookings_source_src_28000.is_instant AS booking__is_instant
+                      , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                      , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                      , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                      , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                      , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                      , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                      , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                      , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                      , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                      , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                      , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                      , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                      , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                      , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                      , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                      , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                      , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                      , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                      , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                      , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                      , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                      , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                      , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                      , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                      , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                      , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                      , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                      , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                      , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                      , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                      , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                      , bookings_source_src_28000.listing_id AS listing
+                      , bookings_source_src_28000.guest_id AS guest
+                      , bookings_source_src_28000.host_id AS host
+                      , bookings_source_src_28000.listing_id AS booking__listing
+                      , bookings_source_src_28000.guest_id AS booking__guest
+                      , bookings_source_src_28000.host_id AS booking__host
+                    FROM ***************************.fct_bookings bookings_source_src_28000
+                  ) subq_0
+                ) subq_1
+                LEFT OUTER JOIN (
+                  -- Select: ['country_latest', 'listing']
+                  SELECT
+                    subq_3.listing
+                    , subq_3.country_latest
+                  FROM (
+                    -- Metric Time Dimension 'ds'
+                    SELECT
+                      subq_2.ds__day
+                      , subq_2.ds__week
+                      , subq_2.ds__month
+                      , subq_2.ds__quarter
+                      , subq_2.ds__year
+                      , subq_2.ds__extract_year
+                      , subq_2.ds__extract_quarter
+                      , subq_2.ds__extract_month
+                      , subq_2.ds__extract_day
+                      , subq_2.ds__extract_dow
+                      , subq_2.ds__extract_doy
+                      , subq_2.created_at__day
+                      , subq_2.created_at__week
+                      , subq_2.created_at__month
+                      , subq_2.created_at__quarter
+                      , subq_2.created_at__year
+                      , subq_2.created_at__extract_year
+                      , subq_2.created_at__extract_quarter
+                      , subq_2.created_at__extract_month
+                      , subq_2.created_at__extract_day
+                      , subq_2.created_at__extract_dow
+                      , subq_2.created_at__extract_doy
+                      , subq_2.listing__ds__day
+                      , subq_2.listing__ds__week
+                      , subq_2.listing__ds__month
+                      , subq_2.listing__ds__quarter
+                      , subq_2.listing__ds__year
+                      , subq_2.listing__ds__extract_year
+                      , subq_2.listing__ds__extract_quarter
+                      , subq_2.listing__ds__extract_month
+                      , subq_2.listing__ds__extract_day
+                      , subq_2.listing__ds__extract_dow
+                      , subq_2.listing__ds__extract_doy
+                      , subq_2.listing__created_at__day
+                      , subq_2.listing__created_at__week
+                      , subq_2.listing__created_at__month
+                      , subq_2.listing__created_at__quarter
+                      , subq_2.listing__created_at__year
+                      , subq_2.listing__created_at__extract_year
+                      , subq_2.listing__created_at__extract_quarter
+                      , subq_2.listing__created_at__extract_month
+                      , subq_2.listing__created_at__extract_day
+                      , subq_2.listing__created_at__extract_dow
+                      , subq_2.listing__created_at__extract_doy
+                      , subq_2.ds__day AS metric_time__day
+                      , subq_2.ds__week AS metric_time__week
+                      , subq_2.ds__month AS metric_time__month
+                      , subq_2.ds__quarter AS metric_time__quarter
+                      , subq_2.ds__year AS metric_time__year
+                      , subq_2.ds__extract_year AS metric_time__extract_year
+                      , subq_2.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_2.ds__extract_month AS metric_time__extract_month
+                      , subq_2.ds__extract_day AS metric_time__extract_day
+                      , subq_2.ds__extract_dow AS metric_time__extract_dow
+                      , subq_2.ds__extract_doy AS metric_time__extract_doy
+                      , subq_2.listing
+                      , subq_2.user
+                      , subq_2.listing__user
+                      , subq_2.country_latest
+                      , subq_2.is_lux_latest
+                      , subq_2.capacity_latest
+                      , subq_2.listing__country_latest
+                      , subq_2.listing__is_lux_latest
+                      , subq_2.listing__capacity_latest
+                      , subq_2.__listings
+                      , subq_2.__lux_listings
+                      , subq_2.__smallest_listing
+                      , subq_2.__largest_listing
+                      , subq_2.__active_listings
+                    FROM (
+                      -- Read Elements From Semantic Model 'listings_latest'
+                      SELECT
+                        1 AS __listings
+                        , 1 AS __lux_listings
+                        , listings_latest_src_28000.capacity AS __smallest_listing
+                        , listings_latest_src_28000.capacity AS __largest_listing
+                        , 1 AS __active_listings
+                        , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS ds__day
+                        , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS ds__week
+                        , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS ds__month
+                        , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS ds__quarter
+                        , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS ds__year
+                        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS ds__extract_year
+                        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS ds__extract_quarter
+                        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS ds__extract_month
+                        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS ds__extract_day
+                        , EXTRACT(isodow FROM listings_latest_src_28000.created_at) AS ds__extract_dow
+                        , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS ds__extract_doy
+                        , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS created_at__day
+                        , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS created_at__week
+                        , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS created_at__month
+                        , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS created_at__quarter
+                        , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS created_at__year
+                        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS created_at__extract_year
+                        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS created_at__extract_quarter
+                        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS created_at__extract_month
+                        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS created_at__extract_day
+                        , EXTRACT(isodow FROM listings_latest_src_28000.created_at) AS created_at__extract_dow
+                        , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS created_at__extract_doy
+                        , listings_latest_src_28000.country AS country_latest
+                        , listings_latest_src_28000.is_lux AS is_lux_latest
+                        , listings_latest_src_28000.capacity AS capacity_latest
+                        , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__ds__day
+                        , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__ds__week
+                        , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__ds__month
+                        , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__ds__quarter
+                        , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__ds__year
+                        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__ds__extract_year
+                        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__ds__extract_quarter
+                        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__ds__extract_month
+                        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__ds__extract_day
+                        , EXTRACT(isodow FROM listings_latest_src_28000.created_at) AS listing__ds__extract_dow
+                        , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__ds__extract_doy
+                        , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__created_at__day
+                        , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__created_at__week
+                        , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__created_at__month
+                        , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__created_at__quarter
+                        , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__created_at__year
+                        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_year
+                        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_quarter
+                        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_month
+                        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_day
+                        , EXTRACT(isodow FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_dow
+                        , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_doy
+                        , listings_latest_src_28000.country AS listing__country_latest
+                        , listings_latest_src_28000.is_lux AS listing__is_lux_latest
+                        , listings_latest_src_28000.capacity AS listing__capacity_latest
+                        , listings_latest_src_28000.listing_id AS listing
+                        , listings_latest_src_28000.user_id AS user
+                        , listings_latest_src_28000.user_id AS listing__user
+                      FROM ***************************.dim_listings_latest listings_latest_src_28000
+                    ) subq_2
+                  ) subq_3
+                ) subq_4
+                ON
+                  subq_1.listing = subq_4.listing
+              ) subq_5
+            ) subq_6
+            WHERE listing__country_latest == 'us'
+          ) subq_7
+        ) subq_8
+        GROUP BY
+          subq_8.metric_time__day
+      ) subq_9
+      ON
+        subq_14.metric_time__day - INTERVAL 5 day = subq_9.metric_time__day
+    ) subq_15
+  ) subq_16
+) subq_17

--- a/tests_metricflow/snapshots/test_offset_metrics_with_filters.py/SqlPlan/DuckDB/test_offset_metric_with_separate_metric_time_and_dimension_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_offset_metrics_with_filters.py/SqlPlan/DuckDB/test_offset_metric_with_separate_metric_time_and_dimension_filters__plan0_optimized.sql
@@ -1,0 +1,73 @@
+test_name: test_offset_metric_with_separate_metric_time_and_dimension_filters
+test_filename: test_offset_metrics_with_filters.py
+docstring:
+  Test querying a time-offset metric with separate filters that allow for different filter placement.
+sql_engine: DuckDB
+expectation_description:
+  The metric_time portion of the filter (`{{ TimeDimension('metric_time', 'day')
+  }} = '2020-01-01'`) should be applied on the time spine / output side of the
+  offset join, ideally by pushing it to the time spine before the join, while the
+  dimension portion (`{{ Dimension('listing__country_latest') }} == 'us'`) should
+  stay on the pre-offset metric input.
+---
+-- Compute Metrics via Expressions
+-- Write to DataTable
+SELECT
+  metric_time__day
+  , 2 * bookings AS bookings_offset_once
+FROM (
+  -- Join to Time Spine Dataset
+  -- Compute Metrics via Expressions
+  SELECT
+    subq_32.metric_time__day AS metric_time__day
+    , subq_27.__bookings AS bookings
+  FROM (
+    -- Constrain Output with WHERE
+    -- Select: ['metric_time__day']
+    SELECT
+      metric_time__day
+    FROM (
+      -- Read From Time Spine 'mf_time_spine'
+      -- Change Column Aliases
+      -- Select: ['metric_time__day']
+      SELECT
+        ds AS metric_time__day
+      FROM ***************************.mf_time_spine time_spine_src_28006
+    ) subq_30
+    WHERE metric_time__day = '2020-01-01'
+  ) subq_32
+  INNER JOIN (
+    -- Constrain Output with WHERE
+    -- Select: ['__bookings', 'metric_time__day']
+    -- Aggregate Inputs for Simple Metrics
+    SELECT
+      metric_time__day
+      , SUM(bookings) AS __bookings
+    FROM (
+      -- Join Standard Outputs
+      -- Select: ['__bookings', 'listing__country_latest', 'metric_time__day']
+      SELECT
+        subq_19.metric_time__day AS metric_time__day
+        , listings_latest_src_28000.country AS listing__country_latest
+        , subq_19.__bookings AS bookings
+      FROM (
+        -- Read Elements From Semantic Model 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        SELECT
+          DATE_TRUNC('day', ds) AS metric_time__day
+          , listing_id AS listing
+          , 1 AS __bookings
+        FROM ***************************.fct_bookings bookings_source_src_28000
+      ) subq_19
+      LEFT OUTER JOIN
+        ***************************.dim_listings_latest listings_latest_src_28000
+      ON
+        subq_19.listing = listings_latest_src_28000.listing_id
+    ) subq_24
+    WHERE listing__country_latest == 'us'
+    GROUP BY
+      metric_time__day
+  ) subq_27
+  ON
+    subq_32.metric_time__day - INTERVAL 5 day = subq_27.metric_time__day
+) subq_34

--- a/tests_metricflow/snapshots/test_passthrough_planner.py/str/test_cases_with_passthrough_planner__07__time_offset_metric_with_metric_time_filter__result.txt
+++ b/tests_metricflow/snapshots/test_passthrough_planner.py/str/test_cases_with_passthrough_planner__07__time_offset_metric_with_metric_time_filter__result.txt
@@ -124,8 +124,8 @@ Query for a time offset metric with a `metric_time` filter
       , 2 * bookings AS bookings_offset_once
     FROM (
       SELECT
-        subq_10.metric_time__day AS metric_time__day
-        , subq_5.__bookings AS bookings
+        subq_9.metric_time__day AS metric_time__day
+        , subq_4.__bookings AS bookings
       FROM (
         SELECT
           metric_time__day
@@ -133,23 +133,22 @@ Query for a time offset metric with a `metric_time` filter
           SELECT
             ds AS metric_time__day
           FROM ***************************.mf_time_spine time_spine_src_28006
-        ) subq_8
+        ) subq_7
         WHERE metric_time__day = '2020-01-01' 
-      ) subq_10
+      ) subq_9
       INNER JOIN (
         SELECT
           metric_time__day
-          , SUM(bookings) AS __bookings
+          , SUM(__bookings) AS __bookings
         FROM (
           SELECT
             DATE_TRUNC('day', ds) AS metric_time__day
-            , 1 AS bookings
+            , 1 AS __bookings
           FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_2
-        WHERE metric_time__day = '2020-01-01' 
+        ) subq_3
         GROUP BY
           metric_time__day
-      ) subq_5
+      ) subq_4
       ON
-        subq_10.metric_time__day - INTERVAL 5 day = subq_5.metric_time__day
-    ) subq_12
+        subq_9.metric_time__day - INTERVAL 5 day = subq_4.metric_time__day
+    ) subq_11


### PR DESCRIPTION
This PR fixes an issue for time-offset metrics where filters on aggregation time dimensions are applied before the time spine join. Applying the filter before the time-offset results in incorrect filtering of the source as the date specified in the filter refers to the value after the time offset.