### PR TITLE
Expand Support to 1.11

### DIFF
--- a/.changes/unreleased/Under the Hood-20260415-100608.yaml
+++ b/.changes/unreleased/Under the Hood-20260415-100608.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Expand dbt-core support to <1.12
+time: 2026-04-15T10:06:08.681284-04:00
+custom:
+    Author: TTMichaelA
+    Issue: '#2018'

--- a/dbt-metricflow/requirements-files/dev-env-requirements.txt
+++ b/dbt-metricflow/requirements-files/dev-env-requirements.txt
@@ -2,7 +2,7 @@ halo>=0.0.31, <0.1.0
 update-checker>=0.18.0, <0.19.0
 # Bug with mypy: https://github.com/pallets/click/issues/2558#issuecomment-1656546003
 click>=8.1.6
-dbt-core>=1.10.4, <1.11.0
+dbt-core>=1.10.4, <1.12.0
 dbt-duckdb>=1.8.0, <1.9.0
 # Excluding 1.2.1 due to window functions returning incorrect results:
 # https://github.com/duckdb/duckdb/issues/16617

--- a/dbt-metricflow/requirements-files/requirements-cli.txt
+++ b/dbt-metricflow/requirements-files/requirements-cli.txt
@@ -1,5 +1,5 @@
 # Internal dependencies
-dbt-core>=1.10.4, <1.11.0
+dbt-core>=1.10.4, <1.12.0
 
 # CLI-related
 Jinja2>=3.1.6, <3.7.0

--- a/dbt-metricflow/tests_dbt_metricflow/snapshots/test_cli.py/str/test_tutorial_message__result.txt
+++ b/dbt-metricflow/tests_dbt_metricflow/snapshots/test_cli.py/str/test_tutorial_message__result.txt
@@ -37,7 +37,7 @@ docstring:
         --start-time 2022-03-20 --end-time 2022-04-01
 12. Before integrating metrics into your project, read up on adding a time spine.
     (<Control>+<Left Click> may work in your terminal to follow the link)
-       https://docs.getdbt.com/docs/build/metricflow-time-spine?version=1.10
+       https://docs.getdbt.com/docs/build/metricflow-time-spine?version=1.11
 
 If you found MetricFlow to be helpful, consider adding a Github star to promote the project:
        https://github.com/dbt-labs/metricflow


### PR DESCRIPTION
This PR swaps the requirements to support versions up to `1.11.X`.

Testing in a minimal project using the forked repo appears to produce the desired results.

<img width="1519" height="668" alt="image" src="https://github.com/user-attachments/assets/dcd1a821-3cee-4656-b60e-5a675a3c2b6b" />

<img width="1523" height="590" alt="image" src="https://github.com/user-attachments/assets/c5bb0f98-2229-45e1-807f-f6fb24ab8a25" />
