### PR TITLE
Update supported Python versions to `>=3.10, <3.14`

### DIFF
--- a/.changes/unreleased/Dependencies-20260415-154508.yaml
+++ b/.changes/unreleased/Dependencies-20260415-154508.yaml
@@ -1,0 +1,6 @@
+kind: Dependencies
+body: Update supported Python versions to `>=3.10, <3.14`
+time: 2026-04-15T15:45:08.34745-07:00
+custom:
+  Author: plypaul
+  Issue: "2020"

--- a/.github/actions/run-mf-tests/action.yaml
+++ b/.github/actions/run-mf-tests/action.yaml
@@ -5,7 +5,7 @@ inputs:
   python-version:
     description: "Version of Python to use for testing."
     required: False
-    default: "3.9"
+    default: "3.10"
   mf_sql_engine_url:
     description: "URL for configuring SQL engine connection."
     required: false

--- a/.github/actions/setup-python-env/action.yaml
+++ b/.github/actions/setup-python-env/action.yaml
@@ -5,7 +5,7 @@ inputs:
   python-version:
     description: "Version of Python to use for testing"
     required: false
-    default: "3.9"
+    default: "3.10"
   hatch-environment-cache-config-json:
     description: "Configuration JSON to be passed into the script to install `hatch` environments for caching."
     required: false

--- a/.github/workflows/ci-cache-environments.yaml
+++ b/.github/workflows/ci-cache-environments.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.12"]
+        python-version: ["3.10", "3.13"]
     steps:
       - name: Check-out the repo
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # actions/checkout@v4

--- a/.github/workflows/ci-metricflow-unit-tests.yaml
+++ b/.github/workflows/ci-metricflow-unit-tests.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.12"]
+        python-version: ["3.10", "3.13"]
     steps:
       - name: Check-out the repo
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # actions/checkout@v4
@@ -73,7 +73,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "3.9", "3.12" ]
+        python-version: [ "3.10", "3.13" ]
     steps:
 
       - name: Check-out the repo

--- a/dbt-metricflow/tests_dbt_metricflow/snapshots/test_cli.py/str/test_tutorial_message__result.txt
+++ b/dbt-metricflow/tests_dbt_metricflow/snapshots/test_cli.py/str/test_tutorial_message__result.txt
@@ -3,13 +3,13 @@ test_filename: test_cli.py
 docstring:
   Tests the message output of the tutorial.
 
-      The tutorial now essentially compiles a semantic manifest and then asks the user to run dbt seed,
-      so from an end user perspective it's little more than the output with -m.
+  The tutorial now essentially compiles a semantic manifest and then asks the user to run dbt seed,
+  so from an end user perspective it's little more than the output with -m.
 
-      The tutorial currently requires execution from a dbt project path. Rather than go all the way on testing the
-      tutorial given the path and dbt project requirements, we simply check the message output. When we allow for
-      project path overrides it might warrant a more complete test of the semantic manifest building steps in the
-      tutorial flow.
+  The tutorial currently requires execution from a dbt project path. Rather than go all the way on testing the
+  tutorial given the path and dbt project requirements, we simply check the message output. When we allow for
+  project path overrides it might warrant a more complete test of the semantic manifest building steps in the
+  tutorial flow.
 ---
 🤓 Please run the following steps:
 

--- a/dbt-metricflow/tests_dbt_metricflow/snapshots/test_output_format.py/str/test_single_large_number_with_decimals_option__result.txt
+++ b/dbt-metricflow/tests_dbt_metricflow/snapshots/test_output_format.py/str/test_single_large_number_with_decimals_option__result.txt
@@ -3,7 +3,7 @@ test_filename: test_output_format.py
 docstring:
   Tests how a large number in a single row is displayed as the result of `mf query`.
 
-      Originally added to reproduce a bug with how large numbers were displayed due to use of `tabulate`.
+  Originally added to reproduce a bug with how large numbers were displayed due to use of `tabulate`.
 expectation_description:
   Non-integer numeric values should not be displayed in exponent notation and should have 2 decimals.
 ---

--- a/metricflow_semantics/test_helpers/snapshot_helpers.py
+++ b/metricflow_semantics/test_helpers/snapshot_helpers.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import difflib
+import inspect
 import logging
 import os
 import pathlib
@@ -84,14 +85,14 @@ def assert_snapshot_text_equal(
     # Add a header with context about the snapshot.
     if include_headers:
         path_to_test_file = pathlib.Path(request.node.fspath)
-        test_doc_string = request.function.__doc__
+        test_doc_string = inspect.getdoc(request.function)
         header_lines = [
             f"test_name: {request.node.name}",
             f"test_filename: {path_to_test_file.name}",
         ]
         if test_doc_string is not None:
             header_lines.append("docstring:")
-            header_lines.append(mf_indent(test_doc_string.rstrip()))
+            header_lines.append(mf_indent(test_doc_string))
         if additional_header_fields is not None:
             for header_field_name, header_field_value in additional_header_fields.items():
                 header_lines.append(f"{header_field_name}: {header_field_value}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "metricflow"
 description = "Translates a simple metric definition into reusable SQL and executes it against the SQL engine of your choice."
 readme = "README.md"
-requires-python = ">=3.9,<3.13"
+requires-python = ">=3.10,<3.14"
 license = "Apache-2.0"
 keywords = []
 authors = [
@@ -16,10 +16,10 @@ authors = [
 classifiers = [
   "Development Status :: 4 - Beta",
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]

--- a/tests_metricflow/snapshots/test_common_dataflow_branches.py/str/test_shared_metric_query__result.txt
+++ b/tests_metricflow/snapshots/test_common_dataflow_branches.py/str/test_shared_metric_query__result.txt
@@ -3,8 +3,8 @@ test_filename: test_common_dataflow_branches.py
 docstring:
   For a known case, test that a metric computation node is identified as a common branch.
 
-      A query for `bookings` and `bookings_per_booker` should have the computation for `bookings` as a common branch in
-      the dataflow plan.
+  A query for `bookings` and `bookings_per_booker` should have the computation for `bookings` as a common branch in
+  the dataflow plan.
 ---
 dataflow_plan:
   <DataflowPlan>

--- a/tests_metricflow/snapshots/test_convert_semantic_model.py/SqlPlan/DuckDB/test_convert_table_semantic_model_with_simple_metrics__plan0.sql
+++ b/tests_metricflow/snapshots/test_convert_semantic_model.py/SqlPlan/DuckDB/test_convert_table_semantic_model_with_simple_metrics__plan0.sql
@@ -3,8 +3,8 @@ test_filename: test_convert_semantic_model.py
 docstring:
   Complete test of table semantic model conversion. This includes the full set of simple-metric inputs/entities/dimensions.
 
-      Measures trigger a primary time dimension validation. Additionally, this includes both categorical and time
-      dimension types, which should cover most, if not all, of the table source branches in the target class.
+  Measures trigger a primary time dimension validation. Additionally, this includes both categorical and time
+  dimension types, which should cover most, if not all, of the table source branches in the target class.
 sql_engine: DuckDB
 ---
 -- Read Elements From Semantic Model 'id_verifications'

--- a/tests_metricflow/snapshots/test_convert_semantic_model.py/list/test_convert_table_semantic_model_with_simple_metrics__result0.txt
+++ b/tests_metricflow/snapshots/test_convert_semantic_model.py/list/test_convert_table_semantic_model_with_simple_metrics__result0.txt
@@ -3,8 +3,8 @@ test_filename: test_convert_semantic_model.py
 docstring:
   Complete test of table semantic model conversion. This includes the full set of simple-metric inputs/entities/dimensions.
 
-      Measures trigger a primary time dimension validation. Additionally, this includes both categorical and time
-      dimension types, which should cover most, if not all, of the table source branches in the target class.
+  Measures trigger a primary time dimension validation. Additionally, this includes both categorical and time
+  dimension types, which should cover most, if not all, of the table source branches in the target class.
 ---
 [
   'ds__day',

--- a/tests_metricflow/snapshots/test_cte_sql.py/str/test_nested_cte__result.txt
+++ b/tests_metricflow/snapshots/test_cte_sql.py/str/test_nested_cte__result.txt
@@ -3,9 +3,9 @@ test_filename: test_cte_sql.py
 docstring:
   Check generation of nested CTEs.
 
-      `metric_level_1_index_0` and `metric_level_1_index_1` share input metrics `metric_level_0_index_0` and
-      `metric_level_0_index_1`. This checks that CTEs are generated for `metric_level_0_index_0` and
-      `metric_level_0_index_1`. In addition, a CTE can be generated for `bookings` since it's an input metric to both.
+  `metric_level_1_index_0` and `metric_level_1_index_1` share input metrics `metric_level_0_index_0` and
+  `metric_level_0_index_1`. This checks that CTEs are generated for `metric_level_0_index_0` and
+  `metric_level_0_index_1`. In addition, a CTE can be generated for `bookings` since it's an input metric to both.
 ---
 sql_without_cte:
   -- Combine Aggregated Outputs

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/BigQuery/test_all_time_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/BigQuery/test_all_time_metric_with_non_default_grains__plan0.sql
@@ -3,7 +3,7 @@ test_filename: test_cumulative_metric_rendering.py
 docstring:
   Tests rendering a query for a cumulative all-time metric queried with non-default grains.
 
-      Uses only metric_time. Excludes default grain.
+  Uses only metric_time. Excludes default grain.
 sql_engine: BigQuery
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/BigQuery/test_all_time_metric_with_non_default_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/BigQuery/test_all_time_metric_with_non_default_grains__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_cumulative_metric_rendering.py
 docstring:
   Tests rendering a query for a cumulative all-time metric queried with non-default grains.
 
-      Uses only metric_time. Excludes default grain.
+  Uses only metric_time. Excludes default grain.
 sql_engine: BigQuery
 ---
 -- Re-aggregate Metric via Group By

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/BigQuery/test_cumulative_metric_with_non_adjustable_time_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/BigQuery/test_cumulative_metric_with_non_adjustable_time_filter__plan0.sql
@@ -3,9 +3,9 @@ test_filename: test_cumulative_metric_rendering.py
 docstring:
   Tests rendering a cumulative metric query with a time filter that cannot be automatically adjusted.
 
-      Not all query inputs with time constraint filters allow us to adjust the time constraint to include the full
-      span of input data for a cumulative metric. When we do not have an adjustable time filter we must include all
-      input data in order to ensure the cumulative metric is correct.
+  Not all query inputs with time constraint filters allow us to adjust the time constraint to include the full
+  span of input data for a cumulative metric. When we do not have an adjustable time filter we must include all
+  input data in order to ensure the cumulative metric is correct.
 sql_engine: BigQuery
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/BigQuery/test_cumulative_metric_with_non_adjustable_time_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/BigQuery/test_cumulative_metric_with_non_adjustable_time_filter__plan0_optimized.sql
@@ -3,9 +3,9 @@ test_filename: test_cumulative_metric_rendering.py
 docstring:
   Tests rendering a cumulative metric query with a time filter that cannot be automatically adjusted.
 
-      Not all query inputs with time constraint filters allow us to adjust the time constraint to include the full
-      span of input data for a cumulative metric. When we do not have an adjustable time filter we must include all
-      input data in order to ensure the cumulative metric is correct.
+  Not all query inputs with time constraint filters allow us to adjust the time constraint to include the full
+  span of input data for a cumulative metric. When we do not have an adjustable time filter we must include all
+  input data in order to ensure the cumulative metric is correct.
 sql_engine: BigQuery
 ---
 -- Constrain Output with WHERE

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/BigQuery/test_cumulative_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/BigQuery/test_cumulative_metric_with_time_constraint__plan0.sql
@@ -3,9 +3,9 @@ test_filename: test_cumulative_metric_rendering.py
 docstring:
   Tests rendering a cumulative metric query with an adjustable time constraint.
 
-      Not all query inputs with time constraint filters allow us to adjust the time constraint to include the full
-      span of input data for a cumulative metric, but when we receive a time constraint filter expression we can
-      automatically adjust it should render a query similar to this one.
+  Not all query inputs with time constraint filters allow us to adjust the time constraint to include the full
+  span of input data for a cumulative metric, but when we receive a time constraint filter expression we can
+  automatically adjust it should render a query similar to this one.
 sql_engine: BigQuery
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/BigQuery/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/BigQuery/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
@@ -3,9 +3,9 @@ test_filename: test_cumulative_metric_rendering.py
 docstring:
   Tests rendering a cumulative metric query with an adjustable time constraint.
 
-      Not all query inputs with time constraint filters allow us to adjust the time constraint to include the full
-      span of input data for a cumulative metric, but when we receive a time constraint filter expression we can
-      automatically adjust it should render a query similar to this one.
+  Not all query inputs with time constraint filters allow us to adjust the time constraint to include the full
+  span of input data for a cumulative metric, but when we receive a time constraint filter expression we can
+  automatically adjust it should render a query similar to this one.
 sql_engine: BigQuery
 ---
 -- Join Self Over Time Range

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/BigQuery/test_grain_to_date_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/BigQuery/test_grain_to_date_metric_with_non_default_grains__plan0.sql
@@ -3,7 +3,7 @@ test_filename: test_cumulative_metric_rendering.py
 docstring:
   Tests rendering a query for a cumulative grain to date metric queried with non-default grains.
 
-      Uses agg time dimension instead of metric_time. Excludes default grain.
+  Uses agg time dimension instead of metric_time. Excludes default grain.
 sql_engine: BigQuery
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/BigQuery/test_grain_to_date_metric_with_non_default_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/BigQuery/test_grain_to_date_metric_with_non_default_grains__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_cumulative_metric_rendering.py
 docstring:
   Tests rendering a query for a cumulative grain to date metric queried with non-default grains.
 
-      Uses agg time dimension instead of metric_time. Excludes default grain.
+  Uses agg time dimension instead of metric_time. Excludes default grain.
 sql_engine: BigQuery
 ---
 -- Re-aggregate Metric via Group By

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/BigQuery/test_window_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/BigQuery/test_window_metric_with_non_default_grains__plan0.sql
@@ -3,7 +3,7 @@ test_filename: test_cumulative_metric_rendering.py
 docstring:
   Tests rendering a query for a cumulative window metric queried with non-default grains.
 
-      Uses both metric_time and agg_time_dimension. Excludes default grain.
+  Uses both metric_time and agg_time_dimension. Excludes default grain.
 sql_engine: BigQuery
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/BigQuery/test_window_metric_with_non_default_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/BigQuery/test_window_metric_with_non_default_grains__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_cumulative_metric_rendering.py
 docstring:
   Tests rendering a query for a cumulative window metric queried with non-default grains.
 
-      Uses both metric_time and agg_time_dimension. Excludes default grain.
+  Uses both metric_time and agg_time_dimension. Excludes default grain.
 sql_engine: BigQuery
 ---
 -- Re-aggregate Metric via Group By

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Databricks/test_all_time_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Databricks/test_all_time_metric_with_non_default_grains__plan0.sql
@@ -3,7 +3,7 @@ test_filename: test_cumulative_metric_rendering.py
 docstring:
   Tests rendering a query for a cumulative all-time metric queried with non-default grains.
 
-      Uses only metric_time. Excludes default grain.
+  Uses only metric_time. Excludes default grain.
 sql_engine: Databricks
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Databricks/test_all_time_metric_with_non_default_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Databricks/test_all_time_metric_with_non_default_grains__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_cumulative_metric_rendering.py
 docstring:
   Tests rendering a query for a cumulative all-time metric queried with non-default grains.
 
-      Uses only metric_time. Excludes default grain.
+  Uses only metric_time. Excludes default grain.
 sql_engine: Databricks
 ---
 -- Re-aggregate Metric via Group By

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Databricks/test_cumulative_metric_with_non_adjustable_time_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Databricks/test_cumulative_metric_with_non_adjustable_time_filter__plan0.sql
@@ -3,9 +3,9 @@ test_filename: test_cumulative_metric_rendering.py
 docstring:
   Tests rendering a cumulative metric query with a time filter that cannot be automatically adjusted.
 
-      Not all query inputs with time constraint filters allow us to adjust the time constraint to include the full
-      span of input data for a cumulative metric. When we do not have an adjustable time filter we must include all
-      input data in order to ensure the cumulative metric is correct.
+  Not all query inputs with time constraint filters allow us to adjust the time constraint to include the full
+  span of input data for a cumulative metric. When we do not have an adjustable time filter we must include all
+  input data in order to ensure the cumulative metric is correct.
 sql_engine: Databricks
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Databricks/test_cumulative_metric_with_non_adjustable_time_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Databricks/test_cumulative_metric_with_non_adjustable_time_filter__plan0_optimized.sql
@@ -3,9 +3,9 @@ test_filename: test_cumulative_metric_rendering.py
 docstring:
   Tests rendering a cumulative metric query with a time filter that cannot be automatically adjusted.
 
-      Not all query inputs with time constraint filters allow us to adjust the time constraint to include the full
-      span of input data for a cumulative metric. When we do not have an adjustable time filter we must include all
-      input data in order to ensure the cumulative metric is correct.
+  Not all query inputs with time constraint filters allow us to adjust the time constraint to include the full
+  span of input data for a cumulative metric. When we do not have an adjustable time filter we must include all
+  input data in order to ensure the cumulative metric is correct.
 sql_engine: Databricks
 ---
 -- Constrain Output with WHERE

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Databricks/test_cumulative_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Databricks/test_cumulative_metric_with_time_constraint__plan0.sql
@@ -3,9 +3,9 @@ test_filename: test_cumulative_metric_rendering.py
 docstring:
   Tests rendering a cumulative metric query with an adjustable time constraint.
 
-      Not all query inputs with time constraint filters allow us to adjust the time constraint to include the full
-      span of input data for a cumulative metric, but when we receive a time constraint filter expression we can
-      automatically adjust it should render a query similar to this one.
+  Not all query inputs with time constraint filters allow us to adjust the time constraint to include the full
+  span of input data for a cumulative metric, but when we receive a time constraint filter expression we can
+  automatically adjust it should render a query similar to this one.
 sql_engine: Databricks
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Databricks/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Databricks/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
@@ -3,9 +3,9 @@ test_filename: test_cumulative_metric_rendering.py
 docstring:
   Tests rendering a cumulative metric query with an adjustable time constraint.
 
-      Not all query inputs with time constraint filters allow us to adjust the time constraint to include the full
-      span of input data for a cumulative metric, but when we receive a time constraint filter expression we can
-      automatically adjust it should render a query similar to this one.
+  Not all query inputs with time constraint filters allow us to adjust the time constraint to include the full
+  span of input data for a cumulative metric, but when we receive a time constraint filter expression we can
+  automatically adjust it should render a query similar to this one.
 sql_engine: Databricks
 ---
 -- Join Self Over Time Range

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Databricks/test_grain_to_date_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Databricks/test_grain_to_date_metric_with_non_default_grains__plan0.sql
@@ -3,7 +3,7 @@ test_filename: test_cumulative_metric_rendering.py
 docstring:
   Tests rendering a query for a cumulative grain to date metric queried with non-default grains.
 
-      Uses agg time dimension instead of metric_time. Excludes default grain.
+  Uses agg time dimension instead of metric_time. Excludes default grain.
 sql_engine: Databricks
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Databricks/test_grain_to_date_metric_with_non_default_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Databricks/test_grain_to_date_metric_with_non_default_grains__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_cumulative_metric_rendering.py
 docstring:
   Tests rendering a query for a cumulative grain to date metric queried with non-default grains.
 
-      Uses agg time dimension instead of metric_time. Excludes default grain.
+  Uses agg time dimension instead of metric_time. Excludes default grain.
 sql_engine: Databricks
 ---
 -- Re-aggregate Metric via Group By

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Databricks/test_window_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Databricks/test_window_metric_with_non_default_grains__plan0.sql
@@ -3,7 +3,7 @@ test_filename: test_cumulative_metric_rendering.py
 docstring:
   Tests rendering a query for a cumulative window metric queried with non-default grains.
 
-      Uses both metric_time and agg_time_dimension. Excludes default grain.
+  Uses both metric_time and agg_time_dimension. Excludes default grain.
 sql_engine: Databricks
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Databricks/test_window_metric_with_non_default_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Databricks/test_window_metric_with_non_default_grains__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_cumulative_metric_rendering.py
 docstring:
   Tests rendering a query for a cumulative window metric queried with non-default grains.
 
-      Uses both metric_time and agg_time_dimension. Excludes default grain.
+  Uses both metric_time and agg_time_dimension. Excludes default grain.
 sql_engine: Databricks
 ---
 -- Re-aggregate Metric via Group By

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/DuckDB/test_all_time_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/DuckDB/test_all_time_metric_with_non_default_grains__plan0.sql
@@ -3,7 +3,7 @@ test_filename: test_cumulative_metric_rendering.py
 docstring:
   Tests rendering a query for a cumulative all-time metric queried with non-default grains.
 
-      Uses only metric_time. Excludes default grain.
+  Uses only metric_time. Excludes default grain.
 sql_engine: DuckDB
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/DuckDB/test_all_time_metric_with_non_default_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/DuckDB/test_all_time_metric_with_non_default_grains__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_cumulative_metric_rendering.py
 docstring:
   Tests rendering a query for a cumulative all-time metric queried with non-default grains.
 
-      Uses only metric_time. Excludes default grain.
+  Uses only metric_time. Excludes default grain.
 sql_engine: DuckDB
 ---
 -- Re-aggregate Metric via Group By

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/DuckDB/test_cumulative_metric_with_non_adjustable_time_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/DuckDB/test_cumulative_metric_with_non_adjustable_time_filter__plan0.sql
@@ -3,9 +3,9 @@ test_filename: test_cumulative_metric_rendering.py
 docstring:
   Tests rendering a cumulative metric query with a time filter that cannot be automatically adjusted.
 
-      Not all query inputs with time constraint filters allow us to adjust the time constraint to include the full
-      span of input data for a cumulative metric. When we do not have an adjustable time filter we must include all
-      input data in order to ensure the cumulative metric is correct.
+  Not all query inputs with time constraint filters allow us to adjust the time constraint to include the full
+  span of input data for a cumulative metric. When we do not have an adjustable time filter we must include all
+  input data in order to ensure the cumulative metric is correct.
 sql_engine: DuckDB
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/DuckDB/test_cumulative_metric_with_non_adjustable_time_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/DuckDB/test_cumulative_metric_with_non_adjustable_time_filter__plan0_optimized.sql
@@ -3,9 +3,9 @@ test_filename: test_cumulative_metric_rendering.py
 docstring:
   Tests rendering a cumulative metric query with a time filter that cannot be automatically adjusted.
 
-      Not all query inputs with time constraint filters allow us to adjust the time constraint to include the full
-      span of input data for a cumulative metric. When we do not have an adjustable time filter we must include all
-      input data in order to ensure the cumulative metric is correct.
+  Not all query inputs with time constraint filters allow us to adjust the time constraint to include the full
+  span of input data for a cumulative metric. When we do not have an adjustable time filter we must include all
+  input data in order to ensure the cumulative metric is correct.
 sql_engine: DuckDB
 ---
 -- Constrain Output with WHERE

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/DuckDB/test_cumulative_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/DuckDB/test_cumulative_metric_with_time_constraint__plan0.sql
@@ -3,9 +3,9 @@ test_filename: test_cumulative_metric_rendering.py
 docstring:
   Tests rendering a cumulative metric query with an adjustable time constraint.
 
-      Not all query inputs with time constraint filters allow us to adjust the time constraint to include the full
-      span of input data for a cumulative metric, but when we receive a time constraint filter expression we can
-      automatically adjust it should render a query similar to this one.
+  Not all query inputs with time constraint filters allow us to adjust the time constraint to include the full
+  span of input data for a cumulative metric, but when we receive a time constraint filter expression we can
+  automatically adjust it should render a query similar to this one.
 sql_engine: DuckDB
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/DuckDB/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/DuckDB/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
@@ -3,9 +3,9 @@ test_filename: test_cumulative_metric_rendering.py
 docstring:
   Tests rendering a cumulative metric query with an adjustable time constraint.
 
-      Not all query inputs with time constraint filters allow us to adjust the time constraint to include the full
-      span of input data for a cumulative metric, but when we receive a time constraint filter expression we can
-      automatically adjust it should render a query similar to this one.
+  Not all query inputs with time constraint filters allow us to adjust the time constraint to include the full
+  span of input data for a cumulative metric, but when we receive a time constraint filter expression we can
+  automatically adjust it should render a query similar to this one.
 sql_engine: DuckDB
 ---
 -- Join Self Over Time Range

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/DuckDB/test_grain_to_date_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/DuckDB/test_grain_to_date_metric_with_non_default_grains__plan0.sql
@@ -3,7 +3,7 @@ test_filename: test_cumulative_metric_rendering.py
 docstring:
   Tests rendering a query for a cumulative grain to date metric queried with non-default grains.
 
-      Uses agg time dimension instead of metric_time. Excludes default grain.
+  Uses agg time dimension instead of metric_time. Excludes default grain.
 sql_engine: DuckDB
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/DuckDB/test_grain_to_date_metric_with_non_default_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/DuckDB/test_grain_to_date_metric_with_non_default_grains__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_cumulative_metric_rendering.py
 docstring:
   Tests rendering a query for a cumulative grain to date metric queried with non-default grains.
 
-      Uses agg time dimension instead of metric_time. Excludes default grain.
+  Uses agg time dimension instead of metric_time. Excludes default grain.
 sql_engine: DuckDB
 ---
 -- Re-aggregate Metric via Group By

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/DuckDB/test_window_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/DuckDB/test_window_metric_with_non_default_grains__plan0.sql
@@ -3,7 +3,7 @@ test_filename: test_cumulative_metric_rendering.py
 docstring:
   Tests rendering a query for a cumulative window metric queried with non-default grains.
 
-      Uses both metric_time and agg_time_dimension. Excludes default grain.
+  Uses both metric_time and agg_time_dimension. Excludes default grain.
 sql_engine: DuckDB
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/DuckDB/test_window_metric_with_non_default_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/DuckDB/test_window_metric_with_non_default_grains__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_cumulative_metric_rendering.py
 docstring:
   Tests rendering a query for a cumulative window metric queried with non-default grains.
 
-      Uses both metric_time and agg_time_dimension. Excludes default grain.
+  Uses both metric_time and agg_time_dimension. Excludes default grain.
 sql_engine: DuckDB
 ---
 -- Re-aggregate Metric via Group By

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Postgres/test_all_time_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Postgres/test_all_time_metric_with_non_default_grains__plan0.sql
@@ -3,7 +3,7 @@ test_filename: test_cumulative_metric_rendering.py
 docstring:
   Tests rendering a query for a cumulative all-time metric queried with non-default grains.
 
-      Uses only metric_time. Excludes default grain.
+  Uses only metric_time. Excludes default grain.
 sql_engine: Postgres
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Postgres/test_all_time_metric_with_non_default_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Postgres/test_all_time_metric_with_non_default_grains__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_cumulative_metric_rendering.py
 docstring:
   Tests rendering a query for a cumulative all-time metric queried with non-default grains.
 
-      Uses only metric_time. Excludes default grain.
+  Uses only metric_time. Excludes default grain.
 sql_engine: Postgres
 ---
 -- Re-aggregate Metric via Group By

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Postgres/test_cumulative_metric_with_non_adjustable_time_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Postgres/test_cumulative_metric_with_non_adjustable_time_filter__plan0.sql
@@ -3,9 +3,9 @@ test_filename: test_cumulative_metric_rendering.py
 docstring:
   Tests rendering a cumulative metric query with a time filter that cannot be automatically adjusted.
 
-      Not all query inputs with time constraint filters allow us to adjust the time constraint to include the full
-      span of input data for a cumulative metric. When we do not have an adjustable time filter we must include all
-      input data in order to ensure the cumulative metric is correct.
+  Not all query inputs with time constraint filters allow us to adjust the time constraint to include the full
+  span of input data for a cumulative metric. When we do not have an adjustable time filter we must include all
+  input data in order to ensure the cumulative metric is correct.
 sql_engine: Postgres
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Postgres/test_cumulative_metric_with_non_adjustable_time_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Postgres/test_cumulative_metric_with_non_adjustable_time_filter__plan0_optimized.sql
@@ -3,9 +3,9 @@ test_filename: test_cumulative_metric_rendering.py
 docstring:
   Tests rendering a cumulative metric query with a time filter that cannot be automatically adjusted.
 
-      Not all query inputs with time constraint filters allow us to adjust the time constraint to include the full
-      span of input data for a cumulative metric. When we do not have an adjustable time filter we must include all
-      input data in order to ensure the cumulative metric is correct.
+  Not all query inputs with time constraint filters allow us to adjust the time constraint to include the full
+  span of input data for a cumulative metric. When we do not have an adjustable time filter we must include all
+  input data in order to ensure the cumulative metric is correct.
 sql_engine: Postgres
 ---
 -- Constrain Output with WHERE

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Postgres/test_cumulative_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Postgres/test_cumulative_metric_with_time_constraint__plan0.sql
@@ -3,9 +3,9 @@ test_filename: test_cumulative_metric_rendering.py
 docstring:
   Tests rendering a cumulative metric query with an adjustable time constraint.
 
-      Not all query inputs with time constraint filters allow us to adjust the time constraint to include the full
-      span of input data for a cumulative metric, but when we receive a time constraint filter expression we can
-      automatically adjust it should render a query similar to this one.
+  Not all query inputs with time constraint filters allow us to adjust the time constraint to include the full
+  span of input data for a cumulative metric, but when we receive a time constraint filter expression we can
+  automatically adjust it should render a query similar to this one.
 sql_engine: Postgres
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Postgres/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Postgres/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
@@ -3,9 +3,9 @@ test_filename: test_cumulative_metric_rendering.py
 docstring:
   Tests rendering a cumulative metric query with an adjustable time constraint.
 
-      Not all query inputs with time constraint filters allow us to adjust the time constraint to include the full
-      span of input data for a cumulative metric, but when we receive a time constraint filter expression we can
-      automatically adjust it should render a query similar to this one.
+  Not all query inputs with time constraint filters allow us to adjust the time constraint to include the full
+  span of input data for a cumulative metric, but when we receive a time constraint filter expression we can
+  automatically adjust it should render a query similar to this one.
 sql_engine: Postgres
 ---
 -- Join Self Over Time Range

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Postgres/test_grain_to_date_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Postgres/test_grain_to_date_metric_with_non_default_grains__plan0.sql
@@ -3,7 +3,7 @@ test_filename: test_cumulative_metric_rendering.py
 docstring:
   Tests rendering a query for a cumulative grain to date metric queried with non-default grains.
 
-      Uses agg time dimension instead of metric_time. Excludes default grain.
+  Uses agg time dimension instead of metric_time. Excludes default grain.
 sql_engine: Postgres
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Postgres/test_grain_to_date_metric_with_non_default_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Postgres/test_grain_to_date_metric_with_non_default_grains__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_cumulative_metric_rendering.py
 docstring:
   Tests rendering a query for a cumulative grain to date metric queried with non-default grains.
 
-      Uses agg time dimension instead of metric_time. Excludes default grain.
+  Uses agg time dimension instead of metric_time. Excludes default grain.
 sql_engine: Postgres
 ---
 -- Re-aggregate Metric via Group By

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Postgres/test_window_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Postgres/test_window_metric_with_non_default_grains__plan0.sql
@@ -3,7 +3,7 @@ test_filename: test_cumulative_metric_rendering.py
 docstring:
   Tests rendering a query for a cumulative window metric queried with non-default grains.
 
-      Uses both metric_time and agg_time_dimension. Excludes default grain.
+  Uses both metric_time and agg_time_dimension. Excludes default grain.
 sql_engine: Postgres
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Postgres/test_window_metric_with_non_default_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Postgres/test_window_metric_with_non_default_grains__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_cumulative_metric_rendering.py
 docstring:
   Tests rendering a query for a cumulative window metric queried with non-default grains.
 
-      Uses both metric_time and agg_time_dimension. Excludes default grain.
+  Uses both metric_time and agg_time_dimension. Excludes default grain.
 sql_engine: Postgres
 ---
 -- Re-aggregate Metric via Group By

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Redshift/test_all_time_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Redshift/test_all_time_metric_with_non_default_grains__plan0.sql
@@ -3,7 +3,7 @@ test_filename: test_cumulative_metric_rendering.py
 docstring:
   Tests rendering a query for a cumulative all-time metric queried with non-default grains.
 
-      Uses only metric_time. Excludes default grain.
+  Uses only metric_time. Excludes default grain.
 sql_engine: Redshift
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Redshift/test_all_time_metric_with_non_default_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Redshift/test_all_time_metric_with_non_default_grains__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_cumulative_metric_rendering.py
 docstring:
   Tests rendering a query for a cumulative all-time metric queried with non-default grains.
 
-      Uses only metric_time. Excludes default grain.
+  Uses only metric_time. Excludes default grain.
 sql_engine: Redshift
 ---
 -- Re-aggregate Metric via Group By

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Redshift/test_cumulative_metric_with_non_adjustable_time_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Redshift/test_cumulative_metric_with_non_adjustable_time_filter__plan0.sql
@@ -3,9 +3,9 @@ test_filename: test_cumulative_metric_rendering.py
 docstring:
   Tests rendering a cumulative metric query with a time filter that cannot be automatically adjusted.
 
-      Not all query inputs with time constraint filters allow us to adjust the time constraint to include the full
-      span of input data for a cumulative metric. When we do not have an adjustable time filter we must include all
-      input data in order to ensure the cumulative metric is correct.
+  Not all query inputs with time constraint filters allow us to adjust the time constraint to include the full
+  span of input data for a cumulative metric. When we do not have an adjustable time filter we must include all
+  input data in order to ensure the cumulative metric is correct.
 sql_engine: Redshift
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Redshift/test_cumulative_metric_with_non_adjustable_time_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Redshift/test_cumulative_metric_with_non_adjustable_time_filter__plan0_optimized.sql
@@ -3,9 +3,9 @@ test_filename: test_cumulative_metric_rendering.py
 docstring:
   Tests rendering a cumulative metric query with a time filter that cannot be automatically adjusted.
 
-      Not all query inputs with time constraint filters allow us to adjust the time constraint to include the full
-      span of input data for a cumulative metric. When we do not have an adjustable time filter we must include all
-      input data in order to ensure the cumulative metric is correct.
+  Not all query inputs with time constraint filters allow us to adjust the time constraint to include the full
+  span of input data for a cumulative metric. When we do not have an adjustable time filter we must include all
+  input data in order to ensure the cumulative metric is correct.
 sql_engine: Redshift
 ---
 -- Constrain Output with WHERE

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Redshift/test_cumulative_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Redshift/test_cumulative_metric_with_time_constraint__plan0.sql
@@ -3,9 +3,9 @@ test_filename: test_cumulative_metric_rendering.py
 docstring:
   Tests rendering a cumulative metric query with an adjustable time constraint.
 
-      Not all query inputs with time constraint filters allow us to adjust the time constraint to include the full
-      span of input data for a cumulative metric, but when we receive a time constraint filter expression we can
-      automatically adjust it should render a query similar to this one.
+  Not all query inputs with time constraint filters allow us to adjust the time constraint to include the full
+  span of input data for a cumulative metric, but when we receive a time constraint filter expression we can
+  automatically adjust it should render a query similar to this one.
 sql_engine: Redshift
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Redshift/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Redshift/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
@@ -3,9 +3,9 @@ test_filename: test_cumulative_metric_rendering.py
 docstring:
   Tests rendering a cumulative metric query with an adjustable time constraint.
 
-      Not all query inputs with time constraint filters allow us to adjust the time constraint to include the full
-      span of input data for a cumulative metric, but when we receive a time constraint filter expression we can
-      automatically adjust it should render a query similar to this one.
+  Not all query inputs with time constraint filters allow us to adjust the time constraint to include the full
+  span of input data for a cumulative metric, but when we receive a time constraint filter expression we can
+  automatically adjust it should render a query similar to this one.
 sql_engine: Redshift
 ---
 -- Join Self Over Time Range

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Redshift/test_grain_to_date_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Redshift/test_grain_to_date_metric_with_non_default_grains__plan0.sql
@@ -3,7 +3,7 @@ test_filename: test_cumulative_metric_rendering.py
 docstring:
   Tests rendering a query for a cumulative grain to date metric queried with non-default grains.
 
-      Uses agg time dimension instead of metric_time. Excludes default grain.
+  Uses agg time dimension instead of metric_time. Excludes default grain.
 sql_engine: Redshift
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Redshift/test_grain_to_date_metric_with_non_default_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Redshift/test_grain_to_date_metric_with_non_default_grains__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_cumulative_metric_rendering.py
 docstring:
   Tests rendering a query for a cumulative grain to date metric queried with non-default grains.
 
-      Uses agg time dimension instead of metric_time. Excludes default grain.
+  Uses agg time dimension instead of metric_time. Excludes default grain.
 sql_engine: Redshift
 ---
 -- Re-aggregate Metric via Group By

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Redshift/test_window_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Redshift/test_window_metric_with_non_default_grains__plan0.sql
@@ -3,7 +3,7 @@ test_filename: test_cumulative_metric_rendering.py
 docstring:
   Tests rendering a query for a cumulative window metric queried with non-default grains.
 
-      Uses both metric_time and agg_time_dimension. Excludes default grain.
+  Uses both metric_time and agg_time_dimension. Excludes default grain.
 sql_engine: Redshift
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Redshift/test_window_metric_with_non_default_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Redshift/test_window_metric_with_non_default_grains__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_cumulative_metric_rendering.py
 docstring:
   Tests rendering a query for a cumulative window metric queried with non-default grains.
 
-      Uses both metric_time and agg_time_dimension. Excludes default grain.
+  Uses both metric_time and agg_time_dimension. Excludes default grain.
 sql_engine: Redshift
 ---
 -- Re-aggregate Metric via Group By

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Snowflake/test_all_time_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Snowflake/test_all_time_metric_with_non_default_grains__plan0.sql
@@ -3,7 +3,7 @@ test_filename: test_cumulative_metric_rendering.py
 docstring:
   Tests rendering a query for a cumulative all-time metric queried with non-default grains.
 
-      Uses only metric_time. Excludes default grain.
+  Uses only metric_time. Excludes default grain.
 sql_engine: Snowflake
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Snowflake/test_all_time_metric_with_non_default_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Snowflake/test_all_time_metric_with_non_default_grains__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_cumulative_metric_rendering.py
 docstring:
   Tests rendering a query for a cumulative all-time metric queried with non-default grains.
 
-      Uses only metric_time. Excludes default grain.
+  Uses only metric_time. Excludes default grain.
 sql_engine: Snowflake
 ---
 -- Re-aggregate Metric via Group By

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Snowflake/test_cumulative_metric_with_non_adjustable_time_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Snowflake/test_cumulative_metric_with_non_adjustable_time_filter__plan0.sql
@@ -3,9 +3,9 @@ test_filename: test_cumulative_metric_rendering.py
 docstring:
   Tests rendering a cumulative metric query with a time filter that cannot be automatically adjusted.
 
-      Not all query inputs with time constraint filters allow us to adjust the time constraint to include the full
-      span of input data for a cumulative metric. When we do not have an adjustable time filter we must include all
-      input data in order to ensure the cumulative metric is correct.
+  Not all query inputs with time constraint filters allow us to adjust the time constraint to include the full
+  span of input data for a cumulative metric. When we do not have an adjustable time filter we must include all
+  input data in order to ensure the cumulative metric is correct.
 sql_engine: Snowflake
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Snowflake/test_cumulative_metric_with_non_adjustable_time_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Snowflake/test_cumulative_metric_with_non_adjustable_time_filter__plan0_optimized.sql
@@ -3,9 +3,9 @@ test_filename: test_cumulative_metric_rendering.py
 docstring:
   Tests rendering a cumulative metric query with a time filter that cannot be automatically adjusted.
 
-      Not all query inputs with time constraint filters allow us to adjust the time constraint to include the full
-      span of input data for a cumulative metric. When we do not have an adjustable time filter we must include all
-      input data in order to ensure the cumulative metric is correct.
+  Not all query inputs with time constraint filters allow us to adjust the time constraint to include the full
+  span of input data for a cumulative metric. When we do not have an adjustable time filter we must include all
+  input data in order to ensure the cumulative metric is correct.
 sql_engine: Snowflake
 ---
 -- Constrain Output with WHERE

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Snowflake/test_cumulative_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Snowflake/test_cumulative_metric_with_time_constraint__plan0.sql
@@ -3,9 +3,9 @@ test_filename: test_cumulative_metric_rendering.py
 docstring:
   Tests rendering a cumulative metric query with an adjustable time constraint.
 
-      Not all query inputs with time constraint filters allow us to adjust the time constraint to include the full
-      span of input data for a cumulative metric, but when we receive a time constraint filter expression we can
-      automatically adjust it should render a query similar to this one.
+  Not all query inputs with time constraint filters allow us to adjust the time constraint to include the full
+  span of input data for a cumulative metric, but when we receive a time constraint filter expression we can
+  automatically adjust it should render a query similar to this one.
 sql_engine: Snowflake
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Snowflake/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Snowflake/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
@@ -3,9 +3,9 @@ test_filename: test_cumulative_metric_rendering.py
 docstring:
   Tests rendering a cumulative metric query with an adjustable time constraint.
 
-      Not all query inputs with time constraint filters allow us to adjust the time constraint to include the full
-      span of input data for a cumulative metric, but when we receive a time constraint filter expression we can
-      automatically adjust it should render a query similar to this one.
+  Not all query inputs with time constraint filters allow us to adjust the time constraint to include the full
+  span of input data for a cumulative metric, but when we receive a time constraint filter expression we can
+  automatically adjust it should render a query similar to this one.
 sql_engine: Snowflake
 ---
 -- Join Self Over Time Range

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Snowflake/test_grain_to_date_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Snowflake/test_grain_to_date_metric_with_non_default_grains__plan0.sql
@@ -3,7 +3,7 @@ test_filename: test_cumulative_metric_rendering.py
 docstring:
   Tests rendering a query for a cumulative grain to date metric queried with non-default grains.
 
-      Uses agg time dimension instead of metric_time. Excludes default grain.
+  Uses agg time dimension instead of metric_time. Excludes default grain.
 sql_engine: Snowflake
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Snowflake/test_grain_to_date_metric_with_non_default_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Snowflake/test_grain_to_date_metric_with_non_default_grains__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_cumulative_metric_rendering.py
 docstring:
   Tests rendering a query for a cumulative grain to date metric queried with non-default grains.
 
-      Uses agg time dimension instead of metric_time. Excludes default grain.
+  Uses agg time dimension instead of metric_time. Excludes default grain.
 sql_engine: Snowflake
 ---
 -- Re-aggregate Metric via Group By

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Snowflake/test_window_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Snowflake/test_window_metric_with_non_default_grains__plan0.sql
@@ -3,7 +3,7 @@ test_filename: test_cumulative_metric_rendering.py
 docstring:
   Tests rendering a query for a cumulative window metric queried with non-default grains.
 
-      Uses both metric_time and agg_time_dimension. Excludes default grain.
+  Uses both metric_time and agg_time_dimension. Excludes default grain.
 sql_engine: Snowflake
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Snowflake/test_window_metric_with_non_default_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Snowflake/test_window_metric_with_non_default_grains__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_cumulative_metric_rendering.py
 docstring:
   Tests rendering a query for a cumulative window metric queried with non-default grains.
 
-      Uses both metric_time and agg_time_dimension. Excludes default grain.
+  Uses both metric_time and agg_time_dimension. Excludes default grain.
 sql_engine: Snowflake
 ---
 -- Re-aggregate Metric via Group By

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Trino/test_all_time_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Trino/test_all_time_metric_with_non_default_grains__plan0.sql
@@ -3,7 +3,7 @@ test_filename: test_cumulative_metric_rendering.py
 docstring:
   Tests rendering a query for a cumulative all-time metric queried with non-default grains.
 
-      Uses only metric_time. Excludes default grain.
+  Uses only metric_time. Excludes default grain.
 sql_engine: Trino
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Trino/test_all_time_metric_with_non_default_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Trino/test_all_time_metric_with_non_default_grains__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_cumulative_metric_rendering.py
 docstring:
   Tests rendering a query for a cumulative all-time metric queried with non-default grains.
 
-      Uses only metric_time. Excludes default grain.
+  Uses only metric_time. Excludes default grain.
 sql_engine: Trino
 ---
 -- Re-aggregate Metric via Group By

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Trino/test_cumulative_metric_with_non_adjustable_time_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Trino/test_cumulative_metric_with_non_adjustable_time_filter__plan0.sql
@@ -3,9 +3,9 @@ test_filename: test_cumulative_metric_rendering.py
 docstring:
   Tests rendering a cumulative metric query with a time filter that cannot be automatically adjusted.
 
-      Not all query inputs with time constraint filters allow us to adjust the time constraint to include the full
-      span of input data for a cumulative metric. When we do not have an adjustable time filter we must include all
-      input data in order to ensure the cumulative metric is correct.
+  Not all query inputs with time constraint filters allow us to adjust the time constraint to include the full
+  span of input data for a cumulative metric. When we do not have an adjustable time filter we must include all
+  input data in order to ensure the cumulative metric is correct.
 sql_engine: Trino
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Trino/test_cumulative_metric_with_non_adjustable_time_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Trino/test_cumulative_metric_with_non_adjustable_time_filter__plan0_optimized.sql
@@ -3,9 +3,9 @@ test_filename: test_cumulative_metric_rendering.py
 docstring:
   Tests rendering a cumulative metric query with a time filter that cannot be automatically adjusted.
 
-      Not all query inputs with time constraint filters allow us to adjust the time constraint to include the full
-      span of input data for a cumulative metric. When we do not have an adjustable time filter we must include all
-      input data in order to ensure the cumulative metric is correct.
+  Not all query inputs with time constraint filters allow us to adjust the time constraint to include the full
+  span of input data for a cumulative metric. When we do not have an adjustable time filter we must include all
+  input data in order to ensure the cumulative metric is correct.
 sql_engine: Trino
 ---
 -- Constrain Output with WHERE

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Trino/test_cumulative_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Trino/test_cumulative_metric_with_time_constraint__plan0.sql
@@ -3,9 +3,9 @@ test_filename: test_cumulative_metric_rendering.py
 docstring:
   Tests rendering a cumulative metric query with an adjustable time constraint.
 
-      Not all query inputs with time constraint filters allow us to adjust the time constraint to include the full
-      span of input data for a cumulative metric, but when we receive a time constraint filter expression we can
-      automatically adjust it should render a query similar to this one.
+  Not all query inputs with time constraint filters allow us to adjust the time constraint to include the full
+  span of input data for a cumulative metric, but when we receive a time constraint filter expression we can
+  automatically adjust it should render a query similar to this one.
 sql_engine: Trino
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Trino/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Trino/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
@@ -3,9 +3,9 @@ test_filename: test_cumulative_metric_rendering.py
 docstring:
   Tests rendering a cumulative metric query with an adjustable time constraint.
 
-      Not all query inputs with time constraint filters allow us to adjust the time constraint to include the full
-      span of input data for a cumulative metric, but when we receive a time constraint filter expression we can
-      automatically adjust it should render a query similar to this one.
+  Not all query inputs with time constraint filters allow us to adjust the time constraint to include the full
+  span of input data for a cumulative metric, but when we receive a time constraint filter expression we can
+  automatically adjust it should render a query similar to this one.
 sql_engine: Trino
 ---
 -- Join Self Over Time Range

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Trino/test_grain_to_date_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Trino/test_grain_to_date_metric_with_non_default_grains__plan0.sql
@@ -3,7 +3,7 @@ test_filename: test_cumulative_metric_rendering.py
 docstring:
   Tests rendering a query for a cumulative grain to date metric queried with non-default grains.
 
-      Uses agg time dimension instead of metric_time. Excludes default grain.
+  Uses agg time dimension instead of metric_time. Excludes default grain.
 sql_engine: Trino
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Trino/test_grain_to_date_metric_with_non_default_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Trino/test_grain_to_date_metric_with_non_default_grains__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_cumulative_metric_rendering.py
 docstring:
   Tests rendering a query for a cumulative grain to date metric queried with non-default grains.
 
-      Uses agg time dimension instead of metric_time. Excludes default grain.
+  Uses agg time dimension instead of metric_time. Excludes default grain.
 sql_engine: Trino
 ---
 -- Re-aggregate Metric via Group By

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Trino/test_window_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Trino/test_window_metric_with_non_default_grains__plan0.sql
@@ -3,7 +3,7 @@ test_filename: test_cumulative_metric_rendering.py
 docstring:
   Tests rendering a query for a cumulative window metric queried with non-default grains.
 
-      Uses both metric_time and agg_time_dimension. Excludes default grain.
+  Uses both metric_time and agg_time_dimension. Excludes default grain.
 sql_engine: Trino
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Trino/test_window_metric_with_non_default_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlPlan/Trino/test_window_metric_with_non_default_grains__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_cumulative_metric_rendering.py
 docstring:
   Tests rendering a query for a cumulative window metric queried with non-default grains.
 
-      Uses both metric_time and agg_time_dimension. Excludes default grain.
+  Uses both metric_time and agg_time_dimension. Excludes default grain.
 sql_engine: Trino
 ---
 -- Re-aggregate Metric via Group By

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/DuckDB/test_nested_offsets_with_custom_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/DuckDB/test_nested_offsets_with_custom_grain__plan0.sql
@@ -3,7 +3,7 @@ test_filename: test_custom_granularity.py
 docstring:
   Check that a query for a nested offset metric does not select `metric_time` at different grains if not requested.
 
-      It should not have `metric_time__day` in the output query.
+  It should not have `metric_time__day` in the output query.
 sql_engine: DuckDB
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/DuckDB/test_nested_offsets_with_custom_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlPlan/DuckDB/test_nested_offsets_with_custom_grain__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_custom_granularity.py
 docstring:
   Check that a query for a nested offset metric does not select `metric_time` at different grains if not requested.
 
-      It should not have `metric_time__day` in the output query.
+  It should not have `metric_time__day` in the output query.
 sql_engine: DuckDB
 ---
 -- Compute Metrics via Expressions

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/DuckDB/test_simple_metric_aggregation_node__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/DuckDB/test_simple_metric_aggregation_node__plan0.sql
@@ -3,7 +3,7 @@ test_filename: test_dataflow_to_sql_plan.py
 docstring:
   Tests converting a dataflow plan to a SQL query plan where there is a leaf simple-metric input aggregation node.
 
-      Covers SUM, AVERAGE, SUM_BOOLEAN (transformed to SUM upstream), and COUNT_DISTINCT agg types
+  Covers SUM, AVERAGE, SUM_BOOLEAN (transformed to SUM upstream), and COUNT_DISTINCT agg types
 sql_engine: DuckDB
 ---
 -- Aggregate Inputs for Simple Metrics

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/DuckDB/test_simple_metric_aggregation_node__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/DuckDB/test_simple_metric_aggregation_node__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_dataflow_to_sql_plan.py
 docstring:
   Tests converting a dataflow plan to a SQL query plan where there is a leaf simple-metric input aggregation node.
 
-      Covers SUM, AVERAGE, SUM_BOOLEAN (transformed to SUM upstream), and COUNT_DISTINCT agg types
+  Covers SUM, AVERAGE, SUM_BOOLEAN (transformed to SUM upstream), and COUNT_DISTINCT agg types
 sql_engine: DuckDB
 ---
 -- Read Elements From Semantic Model 'bookings_source'

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/test_simple_metric_aggregation_node__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/test_simple_metric_aggregation_node__plan0.xml
@@ -3,7 +3,7 @@ test_filename: test_dataflow_to_sql_plan.py
 docstring:
   Tests converting a dataflow plan to a SQL query plan where there is a leaf simple-metric input aggregation node.
 
-      Covers SUM, AVERAGE, SUM_BOOLEAN (transformed to SUM upstream), and COUNT_DISTINCT agg types
+  Covers SUM, AVERAGE, SUM_BOOLEAN (transformed to SUM upstream), and COUNT_DISTINCT agg types
 ---
 <SqlPlan>
     <SqlSelectStatementNode>

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/BigQuery/test_query_with_cumulative_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/BigQuery/test_query_with_cumulative_metric_in_where_filter__plan0.sql
@@ -3,7 +3,7 @@ test_filename: test_metric_filter_rendering.py
 docstring:
   Tests a query with a cumulative metric in the query-level where filter.
 
-      Note this cumulative metric has no window / grain to date.
+  Note this cumulative metric has no window / grain to date.
 sql_engine: BigQuery
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/BigQuery/test_query_with_cumulative_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/BigQuery/test_query_with_cumulative_metric_in_where_filter__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_metric_filter_rendering.py
 docstring:
   Tests a query with a cumulative metric in the query-level where filter.
 
-      Note this cumulative metric has no window / grain to date.
+  Note this cumulative metric has no window / grain to date.
 sql_engine: BigQuery
 ---
 -- Constrain Output with WHERE

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Databricks/test_query_with_cumulative_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Databricks/test_query_with_cumulative_metric_in_where_filter__plan0.sql
@@ -3,7 +3,7 @@ test_filename: test_metric_filter_rendering.py
 docstring:
   Tests a query with a cumulative metric in the query-level where filter.
 
-      Note this cumulative metric has no window / grain to date.
+  Note this cumulative metric has no window / grain to date.
 sql_engine: Databricks
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Databricks/test_query_with_cumulative_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Databricks/test_query_with_cumulative_metric_in_where_filter__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_metric_filter_rendering.py
 docstring:
   Tests a query with a cumulative metric in the query-level where filter.
 
-      Note this cumulative metric has no window / grain to date.
+  Note this cumulative metric has no window / grain to date.
 sql_engine: Databricks
 ---
 -- Constrain Output with WHERE

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/DuckDB/test_query_with_cumulative_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/DuckDB/test_query_with_cumulative_metric_in_where_filter__plan0.sql
@@ -3,7 +3,7 @@ test_filename: test_metric_filter_rendering.py
 docstring:
   Tests a query with a cumulative metric in the query-level where filter.
 
-      Note this cumulative metric has no window / grain to date.
+  Note this cumulative metric has no window / grain to date.
 sql_engine: DuckDB
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/DuckDB/test_query_with_cumulative_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/DuckDB/test_query_with_cumulative_metric_in_where_filter__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_metric_filter_rendering.py
 docstring:
   Tests a query with a cumulative metric in the query-level where filter.
 
-      Note this cumulative metric has no window / grain to date.
+  Note this cumulative metric has no window / grain to date.
 sql_engine: DuckDB
 ---
 -- Constrain Output with WHERE

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Postgres/test_query_with_cumulative_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Postgres/test_query_with_cumulative_metric_in_where_filter__plan0.sql
@@ -3,7 +3,7 @@ test_filename: test_metric_filter_rendering.py
 docstring:
   Tests a query with a cumulative metric in the query-level where filter.
 
-      Note this cumulative metric has no window / grain to date.
+  Note this cumulative metric has no window / grain to date.
 sql_engine: Postgres
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Postgres/test_query_with_cumulative_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Postgres/test_query_with_cumulative_metric_in_where_filter__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_metric_filter_rendering.py
 docstring:
   Tests a query with a cumulative metric in the query-level where filter.
 
-      Note this cumulative metric has no window / grain to date.
+  Note this cumulative metric has no window / grain to date.
 sql_engine: Postgres
 ---
 -- Constrain Output with WHERE

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Redshift/test_query_with_cumulative_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Redshift/test_query_with_cumulative_metric_in_where_filter__plan0.sql
@@ -3,7 +3,7 @@ test_filename: test_metric_filter_rendering.py
 docstring:
   Tests a query with a cumulative metric in the query-level where filter.
 
-      Note this cumulative metric has no window / grain to date.
+  Note this cumulative metric has no window / grain to date.
 sql_engine: Redshift
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Redshift/test_query_with_cumulative_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Redshift/test_query_with_cumulative_metric_in_where_filter__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_metric_filter_rendering.py
 docstring:
   Tests a query with a cumulative metric in the query-level where filter.
 
-      Note this cumulative metric has no window / grain to date.
+  Note this cumulative metric has no window / grain to date.
 sql_engine: Redshift
 ---
 -- Constrain Output with WHERE

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Snowflake/test_query_with_cumulative_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Snowflake/test_query_with_cumulative_metric_in_where_filter__plan0.sql
@@ -3,7 +3,7 @@ test_filename: test_metric_filter_rendering.py
 docstring:
   Tests a query with a cumulative metric in the query-level where filter.
 
-      Note this cumulative metric has no window / grain to date.
+  Note this cumulative metric has no window / grain to date.
 sql_engine: Snowflake
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Snowflake/test_query_with_cumulative_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Snowflake/test_query_with_cumulative_metric_in_where_filter__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_metric_filter_rendering.py
 docstring:
   Tests a query with a cumulative metric in the query-level where filter.
 
-      Note this cumulative metric has no window / grain to date.
+  Note this cumulative metric has no window / grain to date.
 sql_engine: Snowflake
 ---
 -- Constrain Output with WHERE

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Trino/test_query_with_cumulative_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Trino/test_query_with_cumulative_metric_in_where_filter__plan0.sql
@@ -3,7 +3,7 @@ test_filename: test_metric_filter_rendering.py
 docstring:
   Tests a query with a cumulative metric in the query-level where filter.
 
-      Note this cumulative metric has no window / grain to date.
+  Note this cumulative metric has no window / grain to date.
 sql_engine: Trino
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Trino/test_query_with_cumulative_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlPlan/Trino/test_query_with_cumulative_metric_in_where_filter__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_metric_filter_rendering.py
 docstring:
   Tests a query with a cumulative metric in the query-level where filter.
 
-      Note this cumulative metric has no window / grain to date.
+  Note this cumulative metric has no window / grain to date.
 sql_engine: Trino
 ---
 -- Constrain Output with WHERE

--- a/tests_metricflow/snapshots/test_offset_metrics.py/str/DuckDB/test_non_default_grain_where_constraint_with_cumulative_offset_to_grain__query_output.txt
+++ b/tests_metricflow/snapshots/test_offset_metrics.py/str/DuckDB/test_non_default_grain_where_constraint_with_cumulative_offset_to_grain__query_output.txt
@@ -3,7 +3,7 @@ test_filename: test_offset_metrics.py
 docstring:
   Test offset to grain metric queried with non-default grain and where constraint.
 
-      Tests that where constraints work properly with JoinOverTimeRangeNode and JoinToTimeSpineNode.
+  Tests that where constraints work properly with JoinOverTimeRangeNode and JoinToTimeSpineNode.
 ---
 metric_time__month      bookings_all_time    bookings_all_time_at_start_of_month    bookings_since_start_of_month
 --------------------  -------------------  -------------------------------------  -------------------------------

--- a/tests_metricflow/snapshots/test_offset_metrics.py/str/DuckDB/test_offset_to_grain_with_custom_grain__query_output.txt
+++ b/tests_metricflow/snapshots/test_offset_metrics.py/str/DuckDB/test_offset_to_grain_with_custom_grain__query_output.txt
@@ -3,7 +3,7 @@ test_filename: test_offset_metrics.py
 docstring:
   Test offset to grain metric queried with custom grain.
 
-      Not a very useful query, but still demonstrates that we can handle this query.
+  Not a very useful query, but still demonstrates that we can handle this query.
 ---
 metric_time__alien_day      bookings_all_time    bookings_all_time_at_start_of_month    bookings_since_start_of_month
 ------------------------  -------------------  -------------------------------------  -------------------------------

--- a/tests_metricflow/snapshots/test_offset_metrics.py/str/DuckDB/test_offset_to_grain_with_grain_larger_than_offset__query_output.txt
+++ b/tests_metricflow/snapshots/test_offset_metrics.py/str/DuckDB/test_offset_to_grain_with_grain_larger_than_offset__query_output.txt
@@ -3,7 +3,7 @@ test_filename: test_offset_metrics.py
 docstring:
   Test offset to grain metric queried with grain larger than offset grain.
 
-      Not likely a useful query, but still demonstrates that we do this correctly.
+  Not likely a useful query, but still demonstrates that we do this correctly.
 ---
 metric_time__year      bookings_all_time    bookings_all_time_at_start_of_month    bookings_since_start_of_month
 -------------------  -------------------  -------------------------------------  -------------------------------

--- a/tests_metricflow/snapshots/test_offset_metrics.py/str/DuckDB/test_offset_to_grain_with_grain_matching_offset__query_output.txt
+++ b/tests_metricflow/snapshots/test_offset_metrics.py/str/DuckDB/test_offset_to_grain_with_grain_matching_offset__query_output.txt
@@ -3,7 +3,7 @@ test_filename: test_offset_metrics.py
 docstring:
   Test offset to grain metric queried with grain matching offset grain.
 
-      Not likely a useful query, but still demonstrates that we do this correctly.
+  Not likely a useful query, but still demonstrates that we do this correctly.
 ---
 metric_time__month      bookings_all_time    bookings_all_time_at_start_of_month    bookings_since_start_of_month
 --------------------  -------------------  -------------------------------------  -------------------------------

--- a/tests_metricflow/snapshots/test_offset_metrics.py/str/DuckDB/test_offset_window_with_custom_grain__query_output.txt
+++ b/tests_metricflow/snapshots/test_offset_metrics.py/str/DuckDB/test_offset_window_with_custom_grain__query_output.txt
@@ -3,7 +3,7 @@ test_filename: test_offset_metrics.py
 docstring:
   Test offset window metric queried with custom grain.
 
-      Not a very useful query, but still demonstrates that we can handle this query.
+  Not a very useful query, but still demonstrates that we can handle this query.
 ---
 metric_time__alien_day      bookings    bookings_1_month_ago    bookings_mom
 ------------------------  ----------  ----------------------  --------------

--- a/tests_metricflow/snapshots/test_offset_metrics.py/str/DuckDB/test_offset_window_with_date_part_only__query_output.txt
+++ b/tests_metricflow/snapshots/test_offset_metrics.py/str/DuckDB/test_offset_window_with_date_part_only__query_output.txt
@@ -3,8 +3,8 @@ test_filename: test_offset_metrics.py
 docstring:
   Test offset window metric queried with date part only (no grain specified).
 
-      Not a very useful query, but still demonstrates that we can handle this query.
-      Note: date part is allowed for offset_window but not for offset_to_grain.
+  Not a very useful query, but still demonstrates that we can handle this query.
+  Note: date part is allowed for offset_window but not for offset_to_grain.
 ---
   metric_time__extract_month    bookings    bookings_1_month_ago    bookings_mom
 ----------------------------  ----------  ----------------------  --------------

--- a/tests_metricflow/snapshots/test_offset_metrics.py/str/DuckDB/test_offset_window_with_grain_larger_than_offset__query_output.txt
+++ b/tests_metricflow/snapshots/test_offset_metrics.py/str/DuckDB/test_offset_window_with_grain_larger_than_offset__query_output.txt
@@ -3,7 +3,7 @@ test_filename: test_offset_metrics.py
 docstring:
   Test offset window metric queried with grain larger than offset grain.
 
-      Not a very useful query, but still demonstrates that we can handle these params.
+  Not a very useful query, but still demonstrates that we can handle these params.
 ---
 metric_time__year      bookings    bookings_1_month_ago    bookings_mom
 -------------------  ----------  ----------------------  --------------

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/BigQuery/test_cumulative_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/BigQuery/test_cumulative_metric_with_query_time_filters__plan0.sql
@@ -3,7 +3,7 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests pushdown optimizer behavior for a query against a cumulative metric.
 
-      TODO: support metric time filters
+  TODO: support metric time filters
 sql_engine: BigQuery
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/BigQuery/test_cumulative_metric_with_query_time_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/BigQuery/test_cumulative_metric_with_query_time_filters__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests pushdown optimizer behavior for a query against a cumulative metric.
 
-      TODO: support metric time filters
+  TODO: support metric time filters
 sql_engine: BigQuery
 ---
 -- Constrain Output with WHERE

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/BigQuery/test_different_filters_on_same_simple_metric_source_categorical_dimension__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/BigQuery/test_different_filters_on_same_simple_metric_source_categorical_dimension__plan0.sql
@@ -3,13 +3,13 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests rendering a query where multiple filters against the same simple-metric input dimension need to be an effective OR.
 
-      This can be an issue where a derived metric takes in two filters that refer to the same dimension from the input
-      measure source. If these filters are disjoint the predicate pushdown needs to ensure that all matching rows are
-      returned, so we cannot simply push one filter or the other down, nor can we push them down as an AND - they
-      must be an OR, since all relevant rows need to be returned to the requesting metrics.
+  This can be an issue where a derived metric takes in two filters that refer to the same dimension from the input
+  measure source. If these filters are disjoint the predicate pushdown needs to ensure that all matching rows are
+  returned, so we cannot simply push one filter or the other down, nor can we push them down as an AND - they
+  must be an OR, since all relevant rows need to be returned to the requesting metrics.
 
-      The metric listed here has one input that filters on bookings__is_instant and another that does not, which means
-      the source input for the latter input must NOT have the filter applied to it.
+  The metric listed here has one input that filters on bookings__is_instant and another that does not, which means
+  the source input for the latter input must NOT have the filter applied to it.
 sql_engine: BigQuery
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/BigQuery/test_different_filters_on_same_simple_metric_source_categorical_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/BigQuery/test_different_filters_on_same_simple_metric_source_categorical_dimension__plan0_optimized.sql
@@ -3,13 +3,13 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests rendering a query where multiple filters against the same simple-metric input dimension need to be an effective OR.
 
-      This can be an issue where a derived metric takes in two filters that refer to the same dimension from the input
-      measure source. If these filters are disjoint the predicate pushdown needs to ensure that all matching rows are
-      returned, so we cannot simply push one filter or the other down, nor can we push them down as an AND - they
-      must be an OR, since all relevant rows need to be returned to the requesting metrics.
+  This can be an issue where a derived metric takes in two filters that refer to the same dimension from the input
+  measure source. If these filters are disjoint the predicate pushdown needs to ensure that all matching rows are
+  returned, so we cannot simply push one filter or the other down, nor can we push them down as an AND - they
+  must be an OR, since all relevant rows need to be returned to the requesting metrics.
 
-      The metric listed here has one input that filters on bookings__is_instant and another that does not, which means
-      the source input for the latter input must NOT have the filter applied to it.
+  The metric listed here has one input that filters on bookings__is_instant and another that does not, which means
+  the source input for the latter input must NOT have the filter applied to it.
 sql_engine: BigQuery
 ---
 -- Compute Metrics via Expressions

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/BigQuery/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/BigQuery/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
@@ -3,7 +3,7 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests pushdown optimizer behavior for a metric with a time spine and fill_nulls_with enabled.
 
-      TODO: support metric time filters
+  TODO: support metric time filters
 sql_engine: BigQuery
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/BigQuery/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/BigQuery/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests pushdown optimizer behavior for a metric with a time spine and fill_nulls_with enabled.
 
-      TODO: support metric time filters
+  TODO: support metric time filters
 sql_engine: BigQuery
 ---
 -- Compute Metrics via Expressions

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/BigQuery/test_metric_time_filter_with_two_targets__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/BigQuery/test_metric_time_filter_with_two_targets__plan0.sql
@@ -3,8 +3,8 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests pushdown optimization for a simple metric time predicate through a single join.
 
-      This is currently a no-op for the pushdown optimizer.
-      TODO: support metric time pushdown
+  This is currently a no-op for the pushdown optimizer.
+  TODO: support metric time pushdown
 sql_engine: BigQuery
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/BigQuery/test_metric_time_filter_with_two_targets__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/BigQuery/test_metric_time_filter_with_two_targets__plan0_optimized.sql
@@ -3,8 +3,8 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests pushdown optimization for a simple metric time predicate through a single join.
 
-      This is currently a no-op for the pushdown optimizer.
-      TODO: support metric time pushdown
+  This is currently a no-op for the pushdown optimizer.
+  TODO: support metric time pushdown
 sql_engine: BigQuery
 ---
 -- Constrain Output with WHERE

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/BigQuery/test_offset_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/BigQuery/test_offset_metric_with_query_time_filters__plan0.sql
@@ -3,7 +3,7 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests pushdown optimizer behavior for a query against a derived offset metric.
 
-      TODO: support metric time filters
+  TODO: support metric time filters
 sql_engine: BigQuery
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/BigQuery/test_offset_metric_with_query_time_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/BigQuery/test_offset_metric_with_query_time_filters__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests pushdown optimizer behavior for a query against a derived offset metric.
 
-      TODO: support metric time filters
+  TODO: support metric time filters
 sql_engine: BigQuery
 ---
 -- Compute Metrics via Expressions

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/BigQuery/test_saved_query_with_metric_joins_and_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/BigQuery/test_saved_query_with_metric_joins_and_filter__plan0.sql
@@ -3,7 +3,7 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests rendering a query where we join to a time spine and query the filter input.
 
-      This should produce a SQL query that applies the filter outside of the time spine join.
+  This should produce a SQL query that applies the filter outside of the time spine join.
 sql_engine: BigQuery
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/BigQuery/test_saved_query_with_metric_joins_and_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/BigQuery/test_saved_query_with_metric_joins_and_filter__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests rendering a query where we join to a time spine and query the filter input.
 
-      This should produce a SQL query that applies the filter outside of the time spine join.
+  This should produce a SQL query that applies the filter outside of the time spine join.
 sql_engine: BigQuery
 ---
 -- Combine Aggregated Outputs

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/BigQuery/test_simple_join_to_time_spine_pushdown_filter_application__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/BigQuery/test_simple_join_to_time_spine_pushdown_filter_application__plan0.sql
@@ -3,7 +3,7 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests rendering a query where we join to a time spine and query the filter input.
 
-      This should produce a SQL query that applies the filter outside of the time spine join.
+  This should produce a SQL query that applies the filter outside of the time spine join.
 sql_engine: BigQuery
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/BigQuery/test_simple_join_to_time_spine_pushdown_filter_application__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/BigQuery/test_simple_join_to_time_spine_pushdown_filter_application__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests rendering a query where we join to a time spine and query the filter input.
 
-      This should produce a SQL query that applies the filter outside of the time spine join.
+  This should produce a SQL query that applies the filter outside of the time spine join.
 sql_engine: BigQuery
 ---
 -- Constrain Output with WHERE

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/BigQuery/test_skipped_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/BigQuery/test_skipped_pushdown__plan0.sql
@@ -3,10 +3,10 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests rendering a query where we expect to skip predicate pushdown because it is unsafe.
 
-      This is the query rendering test for the scenarios where the push down evaluation indicates that we should
-      skip pushdown, typically due to a lack of certainty over whether or not the query will return the same results.
+  This is the query rendering test for the scenarios where the push down evaluation indicates that we should
+  skip pushdown, typically due to a lack of certainty over whether or not the query will return the same results.
 
-      The specific scenario is less important here than that it match one that should not be pushed down.
+  The specific scenario is less important here than that it match one that should not be pushed down.
 sql_engine: BigQuery
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/BigQuery/test_skipped_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/BigQuery/test_skipped_pushdown__plan0_optimized.sql
@@ -3,10 +3,10 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests rendering a query where we expect to skip predicate pushdown because it is unsafe.
 
-      This is the query rendering test for the scenarios where the push down evaluation indicates that we should
-      skip pushdown, typically due to a lack of certainty over whether or not the query will return the same results.
+  This is the query rendering test for the scenarios where the push down evaluation indicates that we should
+  skip pushdown, typically due to a lack of certainty over whether or not the query will return the same results.
 
-      The specific scenario is less important here than that it match one that should not be pushed down.
+  The specific scenario is less important here than that it match one that should not be pushed down.
 sql_engine: BigQuery
 ---
 -- Constrain Output with WHERE

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Databricks/test_cumulative_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Databricks/test_cumulative_metric_with_query_time_filters__plan0.sql
@@ -3,7 +3,7 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests pushdown optimizer behavior for a query against a cumulative metric.
 
-      TODO: support metric time filters
+  TODO: support metric time filters
 sql_engine: Databricks
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Databricks/test_cumulative_metric_with_query_time_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Databricks/test_cumulative_metric_with_query_time_filters__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests pushdown optimizer behavior for a query against a cumulative metric.
 
-      TODO: support metric time filters
+  TODO: support metric time filters
 sql_engine: Databricks
 ---
 -- Constrain Output with WHERE

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Databricks/test_different_filters_on_same_simple_metric_source_categorical_dimension__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Databricks/test_different_filters_on_same_simple_metric_source_categorical_dimension__plan0.sql
@@ -3,13 +3,13 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests rendering a query where multiple filters against the same simple-metric input dimension need to be an effective OR.
 
-      This can be an issue where a derived metric takes in two filters that refer to the same dimension from the input
-      measure source. If these filters are disjoint the predicate pushdown needs to ensure that all matching rows are
-      returned, so we cannot simply push one filter or the other down, nor can we push them down as an AND - they
-      must be an OR, since all relevant rows need to be returned to the requesting metrics.
+  This can be an issue where a derived metric takes in two filters that refer to the same dimension from the input
+  measure source. If these filters are disjoint the predicate pushdown needs to ensure that all matching rows are
+  returned, so we cannot simply push one filter or the other down, nor can we push them down as an AND - they
+  must be an OR, since all relevant rows need to be returned to the requesting metrics.
 
-      The metric listed here has one input that filters on bookings__is_instant and another that does not, which means
-      the source input for the latter input must NOT have the filter applied to it.
+  The metric listed here has one input that filters on bookings__is_instant and another that does not, which means
+  the source input for the latter input must NOT have the filter applied to it.
 sql_engine: Databricks
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Databricks/test_different_filters_on_same_simple_metric_source_categorical_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Databricks/test_different_filters_on_same_simple_metric_source_categorical_dimension__plan0_optimized.sql
@@ -3,13 +3,13 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests rendering a query where multiple filters against the same simple-metric input dimension need to be an effective OR.
 
-      This can be an issue where a derived metric takes in two filters that refer to the same dimension from the input
-      measure source. If these filters are disjoint the predicate pushdown needs to ensure that all matching rows are
-      returned, so we cannot simply push one filter or the other down, nor can we push them down as an AND - they
-      must be an OR, since all relevant rows need to be returned to the requesting metrics.
+  This can be an issue where a derived metric takes in two filters that refer to the same dimension from the input
+  measure source. If these filters are disjoint the predicate pushdown needs to ensure that all matching rows are
+  returned, so we cannot simply push one filter or the other down, nor can we push them down as an AND - they
+  must be an OR, since all relevant rows need to be returned to the requesting metrics.
 
-      The metric listed here has one input that filters on bookings__is_instant and another that does not, which means
-      the source input for the latter input must NOT have the filter applied to it.
+  The metric listed here has one input that filters on bookings__is_instant and another that does not, which means
+  the source input for the latter input must NOT have the filter applied to it.
 sql_engine: Databricks
 ---
 -- Compute Metrics via Expressions

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Databricks/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Databricks/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
@@ -3,7 +3,7 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests pushdown optimizer behavior for a metric with a time spine and fill_nulls_with enabled.
 
-      TODO: support metric time filters
+  TODO: support metric time filters
 sql_engine: Databricks
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Databricks/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Databricks/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests pushdown optimizer behavior for a metric with a time spine and fill_nulls_with enabled.
 
-      TODO: support metric time filters
+  TODO: support metric time filters
 sql_engine: Databricks
 ---
 -- Compute Metrics via Expressions

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Databricks/test_metric_time_filter_with_two_targets__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Databricks/test_metric_time_filter_with_two_targets__plan0.sql
@@ -3,8 +3,8 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests pushdown optimization for a simple metric time predicate through a single join.
 
-      This is currently a no-op for the pushdown optimizer.
-      TODO: support metric time pushdown
+  This is currently a no-op for the pushdown optimizer.
+  TODO: support metric time pushdown
 sql_engine: Databricks
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Databricks/test_metric_time_filter_with_two_targets__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Databricks/test_metric_time_filter_with_two_targets__plan0_optimized.sql
@@ -3,8 +3,8 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests pushdown optimization for a simple metric time predicate through a single join.
 
-      This is currently a no-op for the pushdown optimizer.
-      TODO: support metric time pushdown
+  This is currently a no-op for the pushdown optimizer.
+  TODO: support metric time pushdown
 sql_engine: Databricks
 ---
 -- Constrain Output with WHERE

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Databricks/test_offset_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Databricks/test_offset_metric_with_query_time_filters__plan0.sql
@@ -3,7 +3,7 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests pushdown optimizer behavior for a query against a derived offset metric.
 
-      TODO: support metric time filters
+  TODO: support metric time filters
 sql_engine: Databricks
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Databricks/test_offset_metric_with_query_time_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Databricks/test_offset_metric_with_query_time_filters__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests pushdown optimizer behavior for a query against a derived offset metric.
 
-      TODO: support metric time filters
+  TODO: support metric time filters
 sql_engine: Databricks
 ---
 -- Compute Metrics via Expressions

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Databricks/test_saved_query_with_metric_joins_and_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Databricks/test_saved_query_with_metric_joins_and_filter__plan0.sql
@@ -3,7 +3,7 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests rendering a query where we join to a time spine and query the filter input.
 
-      This should produce a SQL query that applies the filter outside of the time spine join.
+  This should produce a SQL query that applies the filter outside of the time spine join.
 sql_engine: Databricks
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Databricks/test_saved_query_with_metric_joins_and_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Databricks/test_saved_query_with_metric_joins_and_filter__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests rendering a query where we join to a time spine and query the filter input.
 
-      This should produce a SQL query that applies the filter outside of the time spine join.
+  This should produce a SQL query that applies the filter outside of the time spine join.
 sql_engine: Databricks
 ---
 -- Combine Aggregated Outputs

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Databricks/test_simple_join_to_time_spine_pushdown_filter_application__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Databricks/test_simple_join_to_time_spine_pushdown_filter_application__plan0.sql
@@ -3,7 +3,7 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests rendering a query where we join to a time spine and query the filter input.
 
-      This should produce a SQL query that applies the filter outside of the time spine join.
+  This should produce a SQL query that applies the filter outside of the time spine join.
 sql_engine: Databricks
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Databricks/test_simple_join_to_time_spine_pushdown_filter_application__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Databricks/test_simple_join_to_time_spine_pushdown_filter_application__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests rendering a query where we join to a time spine and query the filter input.
 
-      This should produce a SQL query that applies the filter outside of the time spine join.
+  This should produce a SQL query that applies the filter outside of the time spine join.
 sql_engine: Databricks
 ---
 -- Constrain Output with WHERE

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Databricks/test_skipped_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Databricks/test_skipped_pushdown__plan0.sql
@@ -3,10 +3,10 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests rendering a query where we expect to skip predicate pushdown because it is unsafe.
 
-      This is the query rendering test for the scenarios where the push down evaluation indicates that we should
-      skip pushdown, typically due to a lack of certainty over whether or not the query will return the same results.
+  This is the query rendering test for the scenarios where the push down evaluation indicates that we should
+  skip pushdown, typically due to a lack of certainty over whether or not the query will return the same results.
 
-      The specific scenario is less important here than that it match one that should not be pushed down.
+  The specific scenario is less important here than that it match one that should not be pushed down.
 sql_engine: Databricks
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Databricks/test_skipped_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Databricks/test_skipped_pushdown__plan0_optimized.sql
@@ -3,10 +3,10 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests rendering a query where we expect to skip predicate pushdown because it is unsafe.
 
-      This is the query rendering test for the scenarios where the push down evaluation indicates that we should
-      skip pushdown, typically due to a lack of certainty over whether or not the query will return the same results.
+  This is the query rendering test for the scenarios where the push down evaluation indicates that we should
+  skip pushdown, typically due to a lack of certainty over whether or not the query will return the same results.
 
-      The specific scenario is less important here than that it match one that should not be pushed down.
+  The specific scenario is less important here than that it match one that should not be pushed down.
 sql_engine: Databricks
 ---
 -- Constrain Output with WHERE

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/DuckDB/test_cumulative_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/DuckDB/test_cumulative_metric_with_query_time_filters__plan0.sql
@@ -3,7 +3,7 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests pushdown optimizer behavior for a query against a cumulative metric.
 
-      TODO: support metric time filters
+  TODO: support metric time filters
 sql_engine: DuckDB
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/DuckDB/test_cumulative_metric_with_query_time_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/DuckDB/test_cumulative_metric_with_query_time_filters__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests pushdown optimizer behavior for a query against a cumulative metric.
 
-      TODO: support metric time filters
+  TODO: support metric time filters
 sql_engine: DuckDB
 ---
 -- Constrain Output with WHERE

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/DuckDB/test_different_filters_on_same_simple_metric_source_categorical_dimension__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/DuckDB/test_different_filters_on_same_simple_metric_source_categorical_dimension__plan0.sql
@@ -3,13 +3,13 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests rendering a query where multiple filters against the same simple-metric input dimension need to be an effective OR.
 
-      This can be an issue where a derived metric takes in two filters that refer to the same dimension from the input
-      measure source. If these filters are disjoint the predicate pushdown needs to ensure that all matching rows are
-      returned, so we cannot simply push one filter or the other down, nor can we push them down as an AND - they
-      must be an OR, since all relevant rows need to be returned to the requesting metrics.
+  This can be an issue where a derived metric takes in two filters that refer to the same dimension from the input
+  measure source. If these filters are disjoint the predicate pushdown needs to ensure that all matching rows are
+  returned, so we cannot simply push one filter or the other down, nor can we push them down as an AND - they
+  must be an OR, since all relevant rows need to be returned to the requesting metrics.
 
-      The metric listed here has one input that filters on bookings__is_instant and another that does not, which means
-      the source input for the latter input must NOT have the filter applied to it.
+  The metric listed here has one input that filters on bookings__is_instant and another that does not, which means
+  the source input for the latter input must NOT have the filter applied to it.
 sql_engine: DuckDB
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/DuckDB/test_different_filters_on_same_simple_metric_source_categorical_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/DuckDB/test_different_filters_on_same_simple_metric_source_categorical_dimension__plan0_optimized.sql
@@ -3,13 +3,13 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests rendering a query where multiple filters against the same simple-metric input dimension need to be an effective OR.
 
-      This can be an issue where a derived metric takes in two filters that refer to the same dimension from the input
-      measure source. If these filters are disjoint the predicate pushdown needs to ensure that all matching rows are
-      returned, so we cannot simply push one filter or the other down, nor can we push them down as an AND - they
-      must be an OR, since all relevant rows need to be returned to the requesting metrics.
+  This can be an issue where a derived metric takes in two filters that refer to the same dimension from the input
+  measure source. If these filters are disjoint the predicate pushdown needs to ensure that all matching rows are
+  returned, so we cannot simply push one filter or the other down, nor can we push them down as an AND - they
+  must be an OR, since all relevant rows need to be returned to the requesting metrics.
 
-      The metric listed here has one input that filters on bookings__is_instant and another that does not, which means
-      the source input for the latter input must NOT have the filter applied to it.
+  The metric listed here has one input that filters on bookings__is_instant and another that does not, which means
+  the source input for the latter input must NOT have the filter applied to it.
 sql_engine: DuckDB
 ---
 -- Compute Metrics via Expressions

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/DuckDB/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/DuckDB/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
@@ -3,7 +3,7 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests pushdown optimizer behavior for a metric with a time spine and fill_nulls_with enabled.
 
-      TODO: support metric time filters
+  TODO: support metric time filters
 sql_engine: DuckDB
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/DuckDB/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/DuckDB/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests pushdown optimizer behavior for a metric with a time spine and fill_nulls_with enabled.
 
-      TODO: support metric time filters
+  TODO: support metric time filters
 sql_engine: DuckDB
 ---
 -- Compute Metrics via Expressions

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/DuckDB/test_metric_time_filter_with_two_targets__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/DuckDB/test_metric_time_filter_with_two_targets__plan0.sql
@@ -3,8 +3,8 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests pushdown optimization for a simple metric time predicate through a single join.
 
-      This is currently a no-op for the pushdown optimizer.
-      TODO: support metric time pushdown
+  This is currently a no-op for the pushdown optimizer.
+  TODO: support metric time pushdown
 sql_engine: DuckDB
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/DuckDB/test_metric_time_filter_with_two_targets__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/DuckDB/test_metric_time_filter_with_two_targets__plan0_optimized.sql
@@ -3,8 +3,8 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests pushdown optimization for a simple metric time predicate through a single join.
 
-      This is currently a no-op for the pushdown optimizer.
-      TODO: support metric time pushdown
+  This is currently a no-op for the pushdown optimizer.
+  TODO: support metric time pushdown
 sql_engine: DuckDB
 ---
 -- Constrain Output with WHERE

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/DuckDB/test_offset_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/DuckDB/test_offset_metric_with_query_time_filters__plan0.sql
@@ -3,7 +3,7 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests pushdown optimizer behavior for a query against a derived offset metric.
 
-      TODO: support metric time filters
+  TODO: support metric time filters
 sql_engine: DuckDB
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/DuckDB/test_offset_metric_with_query_time_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/DuckDB/test_offset_metric_with_query_time_filters__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests pushdown optimizer behavior for a query against a derived offset metric.
 
-      TODO: support metric time filters
+  TODO: support metric time filters
 sql_engine: DuckDB
 ---
 -- Compute Metrics via Expressions

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/DuckDB/test_saved_query_with_metric_joins_and_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/DuckDB/test_saved_query_with_metric_joins_and_filter__plan0.sql
@@ -3,7 +3,7 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests rendering a query where we join to a time spine and query the filter input.
 
-      This should produce a SQL query that applies the filter outside of the time spine join.
+  This should produce a SQL query that applies the filter outside of the time spine join.
 sql_engine: DuckDB
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/DuckDB/test_saved_query_with_metric_joins_and_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/DuckDB/test_saved_query_with_metric_joins_and_filter__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests rendering a query where we join to a time spine and query the filter input.
 
-      This should produce a SQL query that applies the filter outside of the time spine join.
+  This should produce a SQL query that applies the filter outside of the time spine join.
 sql_engine: DuckDB
 ---
 -- Combine Aggregated Outputs

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/DuckDB/test_simple_join_to_time_spine_pushdown_filter_application__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/DuckDB/test_simple_join_to_time_spine_pushdown_filter_application__plan0.sql
@@ -3,7 +3,7 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests rendering a query where we join to a time spine and query the filter input.
 
-      This should produce a SQL query that applies the filter outside of the time spine join.
+  This should produce a SQL query that applies the filter outside of the time spine join.
 sql_engine: DuckDB
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/DuckDB/test_simple_join_to_time_spine_pushdown_filter_application__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/DuckDB/test_simple_join_to_time_spine_pushdown_filter_application__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests rendering a query where we join to a time spine and query the filter input.
 
-      This should produce a SQL query that applies the filter outside of the time spine join.
+  This should produce a SQL query that applies the filter outside of the time spine join.
 sql_engine: DuckDB
 ---
 -- Constrain Output with WHERE

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/DuckDB/test_skipped_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/DuckDB/test_skipped_pushdown__plan0.sql
@@ -3,10 +3,10 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests rendering a query where we expect to skip predicate pushdown because it is unsafe.
 
-      This is the query rendering test for the scenarios where the push down evaluation indicates that we should
-      skip pushdown, typically due to a lack of certainty over whether or not the query will return the same results.
+  This is the query rendering test for the scenarios where the push down evaluation indicates that we should
+  skip pushdown, typically due to a lack of certainty over whether or not the query will return the same results.
 
-      The specific scenario is less important here than that it match one that should not be pushed down.
+  The specific scenario is less important here than that it match one that should not be pushed down.
 sql_engine: DuckDB
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/DuckDB/test_skipped_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/DuckDB/test_skipped_pushdown__plan0_optimized.sql
@@ -3,10 +3,10 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests rendering a query where we expect to skip predicate pushdown because it is unsafe.
 
-      This is the query rendering test for the scenarios where the push down evaluation indicates that we should
-      skip pushdown, typically due to a lack of certainty over whether or not the query will return the same results.
+  This is the query rendering test for the scenarios where the push down evaluation indicates that we should
+  skip pushdown, typically due to a lack of certainty over whether or not the query will return the same results.
 
-      The specific scenario is less important here than that it match one that should not be pushed down.
+  The specific scenario is less important here than that it match one that should not be pushed down.
 sql_engine: DuckDB
 ---
 -- Constrain Output with WHERE

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Postgres/test_cumulative_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Postgres/test_cumulative_metric_with_query_time_filters__plan0.sql
@@ -3,7 +3,7 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests pushdown optimizer behavior for a query against a cumulative metric.
 
-      TODO: support metric time filters
+  TODO: support metric time filters
 sql_engine: Postgres
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Postgres/test_cumulative_metric_with_query_time_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Postgres/test_cumulative_metric_with_query_time_filters__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests pushdown optimizer behavior for a query against a cumulative metric.
 
-      TODO: support metric time filters
+  TODO: support metric time filters
 sql_engine: Postgres
 ---
 -- Constrain Output with WHERE

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Postgres/test_different_filters_on_same_simple_metric_source_categorical_dimension__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Postgres/test_different_filters_on_same_simple_metric_source_categorical_dimension__plan0.sql
@@ -3,13 +3,13 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests rendering a query where multiple filters against the same simple-metric input dimension need to be an effective OR.
 
-      This can be an issue where a derived metric takes in two filters that refer to the same dimension from the input
-      measure source. If these filters are disjoint the predicate pushdown needs to ensure that all matching rows are
-      returned, so we cannot simply push one filter or the other down, nor can we push them down as an AND - they
-      must be an OR, since all relevant rows need to be returned to the requesting metrics.
+  This can be an issue where a derived metric takes in two filters that refer to the same dimension from the input
+  measure source. If these filters are disjoint the predicate pushdown needs to ensure that all matching rows are
+  returned, so we cannot simply push one filter or the other down, nor can we push them down as an AND - they
+  must be an OR, since all relevant rows need to be returned to the requesting metrics.
 
-      The metric listed here has one input that filters on bookings__is_instant and another that does not, which means
-      the source input for the latter input must NOT have the filter applied to it.
+  The metric listed here has one input that filters on bookings__is_instant and another that does not, which means
+  the source input for the latter input must NOT have the filter applied to it.
 sql_engine: Postgres
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Postgres/test_different_filters_on_same_simple_metric_source_categorical_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Postgres/test_different_filters_on_same_simple_metric_source_categorical_dimension__plan0_optimized.sql
@@ -3,13 +3,13 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests rendering a query where multiple filters against the same simple-metric input dimension need to be an effective OR.
 
-      This can be an issue where a derived metric takes in two filters that refer to the same dimension from the input
-      measure source. If these filters are disjoint the predicate pushdown needs to ensure that all matching rows are
-      returned, so we cannot simply push one filter or the other down, nor can we push them down as an AND - they
-      must be an OR, since all relevant rows need to be returned to the requesting metrics.
+  This can be an issue where a derived metric takes in two filters that refer to the same dimension from the input
+  measure source. If these filters are disjoint the predicate pushdown needs to ensure that all matching rows are
+  returned, so we cannot simply push one filter or the other down, nor can we push them down as an AND - they
+  must be an OR, since all relevant rows need to be returned to the requesting metrics.
 
-      The metric listed here has one input that filters on bookings__is_instant and another that does not, which means
-      the source input for the latter input must NOT have the filter applied to it.
+  The metric listed here has one input that filters on bookings__is_instant and another that does not, which means
+  the source input for the latter input must NOT have the filter applied to it.
 sql_engine: Postgres
 ---
 -- Compute Metrics via Expressions

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Postgres/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Postgres/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
@@ -3,7 +3,7 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests pushdown optimizer behavior for a metric with a time spine and fill_nulls_with enabled.
 
-      TODO: support metric time filters
+  TODO: support metric time filters
 sql_engine: Postgres
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Postgres/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Postgres/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests pushdown optimizer behavior for a metric with a time spine and fill_nulls_with enabled.
 
-      TODO: support metric time filters
+  TODO: support metric time filters
 sql_engine: Postgres
 ---
 -- Compute Metrics via Expressions

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Postgres/test_metric_time_filter_with_two_targets__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Postgres/test_metric_time_filter_with_two_targets__plan0.sql
@@ -3,8 +3,8 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests pushdown optimization for a simple metric time predicate through a single join.
 
-      This is currently a no-op for the pushdown optimizer.
-      TODO: support metric time pushdown
+  This is currently a no-op for the pushdown optimizer.
+  TODO: support metric time pushdown
 sql_engine: Postgres
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Postgres/test_metric_time_filter_with_two_targets__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Postgres/test_metric_time_filter_with_two_targets__plan0_optimized.sql
@@ -3,8 +3,8 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests pushdown optimization for a simple metric time predicate through a single join.
 
-      This is currently a no-op for the pushdown optimizer.
-      TODO: support metric time pushdown
+  This is currently a no-op for the pushdown optimizer.
+  TODO: support metric time pushdown
 sql_engine: Postgres
 ---
 -- Constrain Output with WHERE

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Postgres/test_offset_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Postgres/test_offset_metric_with_query_time_filters__plan0.sql
@@ -3,7 +3,7 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests pushdown optimizer behavior for a query against a derived offset metric.
 
-      TODO: support metric time filters
+  TODO: support metric time filters
 sql_engine: Postgres
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Postgres/test_offset_metric_with_query_time_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Postgres/test_offset_metric_with_query_time_filters__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests pushdown optimizer behavior for a query against a derived offset metric.
 
-      TODO: support metric time filters
+  TODO: support metric time filters
 sql_engine: Postgres
 ---
 -- Compute Metrics via Expressions

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Postgres/test_saved_query_with_metric_joins_and_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Postgres/test_saved_query_with_metric_joins_and_filter__plan0.sql
@@ -3,7 +3,7 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests rendering a query where we join to a time spine and query the filter input.
 
-      This should produce a SQL query that applies the filter outside of the time spine join.
+  This should produce a SQL query that applies the filter outside of the time spine join.
 sql_engine: Postgres
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Postgres/test_saved_query_with_metric_joins_and_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Postgres/test_saved_query_with_metric_joins_and_filter__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests rendering a query where we join to a time spine and query the filter input.
 
-      This should produce a SQL query that applies the filter outside of the time spine join.
+  This should produce a SQL query that applies the filter outside of the time spine join.
 sql_engine: Postgres
 ---
 -- Combine Aggregated Outputs

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Postgres/test_simple_join_to_time_spine_pushdown_filter_application__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Postgres/test_simple_join_to_time_spine_pushdown_filter_application__plan0.sql
@@ -3,7 +3,7 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests rendering a query where we join to a time spine and query the filter input.
 
-      This should produce a SQL query that applies the filter outside of the time spine join.
+  This should produce a SQL query that applies the filter outside of the time spine join.
 sql_engine: Postgres
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Postgres/test_simple_join_to_time_spine_pushdown_filter_application__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Postgres/test_simple_join_to_time_spine_pushdown_filter_application__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests rendering a query where we join to a time spine and query the filter input.
 
-      This should produce a SQL query that applies the filter outside of the time spine join.
+  This should produce a SQL query that applies the filter outside of the time spine join.
 sql_engine: Postgres
 ---
 -- Constrain Output with WHERE

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Postgres/test_skipped_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Postgres/test_skipped_pushdown__plan0.sql
@@ -3,10 +3,10 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests rendering a query where we expect to skip predicate pushdown because it is unsafe.
 
-      This is the query rendering test for the scenarios where the push down evaluation indicates that we should
-      skip pushdown, typically due to a lack of certainty over whether or not the query will return the same results.
+  This is the query rendering test for the scenarios where the push down evaluation indicates that we should
+  skip pushdown, typically due to a lack of certainty over whether or not the query will return the same results.
 
-      The specific scenario is less important here than that it match one that should not be pushed down.
+  The specific scenario is less important here than that it match one that should not be pushed down.
 sql_engine: Postgres
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Postgres/test_skipped_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Postgres/test_skipped_pushdown__plan0_optimized.sql
@@ -3,10 +3,10 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests rendering a query where we expect to skip predicate pushdown because it is unsafe.
 
-      This is the query rendering test for the scenarios where the push down evaluation indicates that we should
-      skip pushdown, typically due to a lack of certainty over whether or not the query will return the same results.
+  This is the query rendering test for the scenarios where the push down evaluation indicates that we should
+  skip pushdown, typically due to a lack of certainty over whether or not the query will return the same results.
 
-      The specific scenario is less important here than that it match one that should not be pushed down.
+  The specific scenario is less important here than that it match one that should not be pushed down.
 sql_engine: Postgres
 ---
 -- Constrain Output with WHERE

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Redshift/test_cumulative_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Redshift/test_cumulative_metric_with_query_time_filters__plan0.sql
@@ -3,7 +3,7 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests pushdown optimizer behavior for a query against a cumulative metric.
 
-      TODO: support metric time filters
+  TODO: support metric time filters
 sql_engine: Redshift
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Redshift/test_cumulative_metric_with_query_time_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Redshift/test_cumulative_metric_with_query_time_filters__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests pushdown optimizer behavior for a query against a cumulative metric.
 
-      TODO: support metric time filters
+  TODO: support metric time filters
 sql_engine: Redshift
 ---
 -- Constrain Output with WHERE

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Redshift/test_different_filters_on_same_simple_metric_source_categorical_dimension__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Redshift/test_different_filters_on_same_simple_metric_source_categorical_dimension__plan0.sql
@@ -3,13 +3,13 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests rendering a query where multiple filters against the same simple-metric input dimension need to be an effective OR.
 
-      This can be an issue where a derived metric takes in two filters that refer to the same dimension from the input
-      measure source. If these filters are disjoint the predicate pushdown needs to ensure that all matching rows are
-      returned, so we cannot simply push one filter or the other down, nor can we push them down as an AND - they
-      must be an OR, since all relevant rows need to be returned to the requesting metrics.
+  This can be an issue where a derived metric takes in two filters that refer to the same dimension from the input
+  measure source. If these filters are disjoint the predicate pushdown needs to ensure that all matching rows are
+  returned, so we cannot simply push one filter or the other down, nor can we push them down as an AND - they
+  must be an OR, since all relevant rows need to be returned to the requesting metrics.
 
-      The metric listed here has one input that filters on bookings__is_instant and another that does not, which means
-      the source input for the latter input must NOT have the filter applied to it.
+  The metric listed here has one input that filters on bookings__is_instant and another that does not, which means
+  the source input for the latter input must NOT have the filter applied to it.
 sql_engine: Redshift
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Redshift/test_different_filters_on_same_simple_metric_source_categorical_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Redshift/test_different_filters_on_same_simple_metric_source_categorical_dimension__plan0_optimized.sql
@@ -3,13 +3,13 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests rendering a query where multiple filters against the same simple-metric input dimension need to be an effective OR.
 
-      This can be an issue where a derived metric takes in two filters that refer to the same dimension from the input
-      measure source. If these filters are disjoint the predicate pushdown needs to ensure that all matching rows are
-      returned, so we cannot simply push one filter or the other down, nor can we push them down as an AND - they
-      must be an OR, since all relevant rows need to be returned to the requesting metrics.
+  This can be an issue where a derived metric takes in two filters that refer to the same dimension from the input
+  measure source. If these filters are disjoint the predicate pushdown needs to ensure that all matching rows are
+  returned, so we cannot simply push one filter or the other down, nor can we push them down as an AND - they
+  must be an OR, since all relevant rows need to be returned to the requesting metrics.
 
-      The metric listed here has one input that filters on bookings__is_instant and another that does not, which means
-      the source input for the latter input must NOT have the filter applied to it.
+  The metric listed here has one input that filters on bookings__is_instant and another that does not, which means
+  the source input for the latter input must NOT have the filter applied to it.
 sql_engine: Redshift
 ---
 -- Compute Metrics via Expressions

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Redshift/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Redshift/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
@@ -3,7 +3,7 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests pushdown optimizer behavior for a metric with a time spine and fill_nulls_with enabled.
 
-      TODO: support metric time filters
+  TODO: support metric time filters
 sql_engine: Redshift
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Redshift/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Redshift/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests pushdown optimizer behavior for a metric with a time spine and fill_nulls_with enabled.
 
-      TODO: support metric time filters
+  TODO: support metric time filters
 sql_engine: Redshift
 ---
 -- Compute Metrics via Expressions

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Redshift/test_metric_time_filter_with_two_targets__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Redshift/test_metric_time_filter_with_two_targets__plan0.sql
@@ -3,8 +3,8 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests pushdown optimization for a simple metric time predicate through a single join.
 
-      This is currently a no-op for the pushdown optimizer.
-      TODO: support metric time pushdown
+  This is currently a no-op for the pushdown optimizer.
+  TODO: support metric time pushdown
 sql_engine: Redshift
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Redshift/test_metric_time_filter_with_two_targets__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Redshift/test_metric_time_filter_with_two_targets__plan0_optimized.sql
@@ -3,8 +3,8 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests pushdown optimization for a simple metric time predicate through a single join.
 
-      This is currently a no-op for the pushdown optimizer.
-      TODO: support metric time pushdown
+  This is currently a no-op for the pushdown optimizer.
+  TODO: support metric time pushdown
 sql_engine: Redshift
 ---
 -- Constrain Output with WHERE

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Redshift/test_offset_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Redshift/test_offset_metric_with_query_time_filters__plan0.sql
@@ -3,7 +3,7 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests pushdown optimizer behavior for a query against a derived offset metric.
 
-      TODO: support metric time filters
+  TODO: support metric time filters
 sql_engine: Redshift
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Redshift/test_offset_metric_with_query_time_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Redshift/test_offset_metric_with_query_time_filters__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests pushdown optimizer behavior for a query against a derived offset metric.
 
-      TODO: support metric time filters
+  TODO: support metric time filters
 sql_engine: Redshift
 ---
 -- Compute Metrics via Expressions

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Redshift/test_saved_query_with_metric_joins_and_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Redshift/test_saved_query_with_metric_joins_and_filter__plan0.sql
@@ -3,7 +3,7 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests rendering a query where we join to a time spine and query the filter input.
 
-      This should produce a SQL query that applies the filter outside of the time spine join.
+  This should produce a SQL query that applies the filter outside of the time spine join.
 sql_engine: Redshift
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Redshift/test_saved_query_with_metric_joins_and_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Redshift/test_saved_query_with_metric_joins_and_filter__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests rendering a query where we join to a time spine and query the filter input.
 
-      This should produce a SQL query that applies the filter outside of the time spine join.
+  This should produce a SQL query that applies the filter outside of the time spine join.
 sql_engine: Redshift
 ---
 -- Combine Aggregated Outputs

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Redshift/test_simple_join_to_time_spine_pushdown_filter_application__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Redshift/test_simple_join_to_time_spine_pushdown_filter_application__plan0.sql
@@ -3,7 +3,7 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests rendering a query where we join to a time spine and query the filter input.
 
-      This should produce a SQL query that applies the filter outside of the time spine join.
+  This should produce a SQL query that applies the filter outside of the time spine join.
 sql_engine: Redshift
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Redshift/test_simple_join_to_time_spine_pushdown_filter_application__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Redshift/test_simple_join_to_time_spine_pushdown_filter_application__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests rendering a query where we join to a time spine and query the filter input.
 
-      This should produce a SQL query that applies the filter outside of the time spine join.
+  This should produce a SQL query that applies the filter outside of the time spine join.
 sql_engine: Redshift
 ---
 -- Constrain Output with WHERE

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Redshift/test_skipped_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Redshift/test_skipped_pushdown__plan0.sql
@@ -3,10 +3,10 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests rendering a query where we expect to skip predicate pushdown because it is unsafe.
 
-      This is the query rendering test for the scenarios where the push down evaluation indicates that we should
-      skip pushdown, typically due to a lack of certainty over whether or not the query will return the same results.
+  This is the query rendering test for the scenarios where the push down evaluation indicates that we should
+  skip pushdown, typically due to a lack of certainty over whether or not the query will return the same results.
 
-      The specific scenario is less important here than that it match one that should not be pushed down.
+  The specific scenario is less important here than that it match one that should not be pushed down.
 sql_engine: Redshift
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Redshift/test_skipped_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Redshift/test_skipped_pushdown__plan0_optimized.sql
@@ -3,10 +3,10 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests rendering a query where we expect to skip predicate pushdown because it is unsafe.
 
-      This is the query rendering test for the scenarios where the push down evaluation indicates that we should
-      skip pushdown, typically due to a lack of certainty over whether or not the query will return the same results.
+  This is the query rendering test for the scenarios where the push down evaluation indicates that we should
+  skip pushdown, typically due to a lack of certainty over whether or not the query will return the same results.
 
-      The specific scenario is less important here than that it match one that should not be pushed down.
+  The specific scenario is less important here than that it match one that should not be pushed down.
 sql_engine: Redshift
 ---
 -- Constrain Output with WHERE

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Snowflake/test_cumulative_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Snowflake/test_cumulative_metric_with_query_time_filters__plan0.sql
@@ -3,7 +3,7 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests pushdown optimizer behavior for a query against a cumulative metric.
 
-      TODO: support metric time filters
+  TODO: support metric time filters
 sql_engine: Snowflake
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Snowflake/test_cumulative_metric_with_query_time_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Snowflake/test_cumulative_metric_with_query_time_filters__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests pushdown optimizer behavior for a query against a cumulative metric.
 
-      TODO: support metric time filters
+  TODO: support metric time filters
 sql_engine: Snowflake
 ---
 -- Constrain Output with WHERE

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Snowflake/test_different_filters_on_same_simple_metric_source_categorical_dimension__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Snowflake/test_different_filters_on_same_simple_metric_source_categorical_dimension__plan0.sql
@@ -3,13 +3,13 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests rendering a query where multiple filters against the same simple-metric input dimension need to be an effective OR.
 
-      This can be an issue where a derived metric takes in two filters that refer to the same dimension from the input
-      measure source. If these filters are disjoint the predicate pushdown needs to ensure that all matching rows are
-      returned, so we cannot simply push one filter or the other down, nor can we push them down as an AND - they
-      must be an OR, since all relevant rows need to be returned to the requesting metrics.
+  This can be an issue where a derived metric takes in two filters that refer to the same dimension from the input
+  measure source. If these filters are disjoint the predicate pushdown needs to ensure that all matching rows are
+  returned, so we cannot simply push one filter or the other down, nor can we push them down as an AND - they
+  must be an OR, since all relevant rows need to be returned to the requesting metrics.
 
-      The metric listed here has one input that filters on bookings__is_instant and another that does not, which means
-      the source input for the latter input must NOT have the filter applied to it.
+  The metric listed here has one input that filters on bookings__is_instant and another that does not, which means
+  the source input for the latter input must NOT have the filter applied to it.
 sql_engine: Snowflake
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Snowflake/test_different_filters_on_same_simple_metric_source_categorical_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Snowflake/test_different_filters_on_same_simple_metric_source_categorical_dimension__plan0_optimized.sql
@@ -3,13 +3,13 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests rendering a query where multiple filters against the same simple-metric input dimension need to be an effective OR.
 
-      This can be an issue where a derived metric takes in two filters that refer to the same dimension from the input
-      measure source. If these filters are disjoint the predicate pushdown needs to ensure that all matching rows are
-      returned, so we cannot simply push one filter or the other down, nor can we push them down as an AND - they
-      must be an OR, since all relevant rows need to be returned to the requesting metrics.
+  This can be an issue where a derived metric takes in two filters that refer to the same dimension from the input
+  measure source. If these filters are disjoint the predicate pushdown needs to ensure that all matching rows are
+  returned, so we cannot simply push one filter or the other down, nor can we push them down as an AND - they
+  must be an OR, since all relevant rows need to be returned to the requesting metrics.
 
-      The metric listed here has one input that filters on bookings__is_instant and another that does not, which means
-      the source input for the latter input must NOT have the filter applied to it.
+  The metric listed here has one input that filters on bookings__is_instant and another that does not, which means
+  the source input for the latter input must NOT have the filter applied to it.
 sql_engine: Snowflake
 ---
 -- Compute Metrics via Expressions

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Snowflake/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Snowflake/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
@@ -3,7 +3,7 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests pushdown optimizer behavior for a metric with a time spine and fill_nulls_with enabled.
 
-      TODO: support metric time filters
+  TODO: support metric time filters
 sql_engine: Snowflake
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Snowflake/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Snowflake/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests pushdown optimizer behavior for a metric with a time spine and fill_nulls_with enabled.
 
-      TODO: support metric time filters
+  TODO: support metric time filters
 sql_engine: Snowflake
 ---
 -- Compute Metrics via Expressions

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Snowflake/test_metric_time_filter_with_two_targets__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Snowflake/test_metric_time_filter_with_two_targets__plan0.sql
@@ -3,8 +3,8 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests pushdown optimization for a simple metric time predicate through a single join.
 
-      This is currently a no-op for the pushdown optimizer.
-      TODO: support metric time pushdown
+  This is currently a no-op for the pushdown optimizer.
+  TODO: support metric time pushdown
 sql_engine: Snowflake
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Snowflake/test_metric_time_filter_with_two_targets__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Snowflake/test_metric_time_filter_with_two_targets__plan0_optimized.sql
@@ -3,8 +3,8 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests pushdown optimization for a simple metric time predicate through a single join.
 
-      This is currently a no-op for the pushdown optimizer.
-      TODO: support metric time pushdown
+  This is currently a no-op for the pushdown optimizer.
+  TODO: support metric time pushdown
 sql_engine: Snowflake
 ---
 -- Constrain Output with WHERE

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Snowflake/test_offset_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Snowflake/test_offset_metric_with_query_time_filters__plan0.sql
@@ -3,7 +3,7 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests pushdown optimizer behavior for a query against a derived offset metric.
 
-      TODO: support metric time filters
+  TODO: support metric time filters
 sql_engine: Snowflake
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Snowflake/test_offset_metric_with_query_time_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Snowflake/test_offset_metric_with_query_time_filters__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests pushdown optimizer behavior for a query against a derived offset metric.
 
-      TODO: support metric time filters
+  TODO: support metric time filters
 sql_engine: Snowflake
 ---
 -- Compute Metrics via Expressions

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Snowflake/test_saved_query_with_metric_joins_and_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Snowflake/test_saved_query_with_metric_joins_and_filter__plan0.sql
@@ -3,7 +3,7 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests rendering a query where we join to a time spine and query the filter input.
 
-      This should produce a SQL query that applies the filter outside of the time spine join.
+  This should produce a SQL query that applies the filter outside of the time spine join.
 sql_engine: Snowflake
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Snowflake/test_saved_query_with_metric_joins_and_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Snowflake/test_saved_query_with_metric_joins_and_filter__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests rendering a query where we join to a time spine and query the filter input.
 
-      This should produce a SQL query that applies the filter outside of the time spine join.
+  This should produce a SQL query that applies the filter outside of the time spine join.
 sql_engine: Snowflake
 ---
 -- Combine Aggregated Outputs

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Snowflake/test_simple_join_to_time_spine_pushdown_filter_application__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Snowflake/test_simple_join_to_time_spine_pushdown_filter_application__plan0.sql
@@ -3,7 +3,7 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests rendering a query where we join to a time spine and query the filter input.
 
-      This should produce a SQL query that applies the filter outside of the time spine join.
+  This should produce a SQL query that applies the filter outside of the time spine join.
 sql_engine: Snowflake
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Snowflake/test_simple_join_to_time_spine_pushdown_filter_application__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Snowflake/test_simple_join_to_time_spine_pushdown_filter_application__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests rendering a query where we join to a time spine and query the filter input.
 
-      This should produce a SQL query that applies the filter outside of the time spine join.
+  This should produce a SQL query that applies the filter outside of the time spine join.
 sql_engine: Snowflake
 ---
 -- Constrain Output with WHERE

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Snowflake/test_skipped_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Snowflake/test_skipped_pushdown__plan0.sql
@@ -3,10 +3,10 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests rendering a query where we expect to skip predicate pushdown because it is unsafe.
 
-      This is the query rendering test for the scenarios where the push down evaluation indicates that we should
-      skip pushdown, typically due to a lack of certainty over whether or not the query will return the same results.
+  This is the query rendering test for the scenarios where the push down evaluation indicates that we should
+  skip pushdown, typically due to a lack of certainty over whether or not the query will return the same results.
 
-      The specific scenario is less important here than that it match one that should not be pushed down.
+  The specific scenario is less important here than that it match one that should not be pushed down.
 sql_engine: Snowflake
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Snowflake/test_skipped_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Snowflake/test_skipped_pushdown__plan0_optimized.sql
@@ -3,10 +3,10 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests rendering a query where we expect to skip predicate pushdown because it is unsafe.
 
-      This is the query rendering test for the scenarios where the push down evaluation indicates that we should
-      skip pushdown, typically due to a lack of certainty over whether or not the query will return the same results.
+  This is the query rendering test for the scenarios where the push down evaluation indicates that we should
+  skip pushdown, typically due to a lack of certainty over whether or not the query will return the same results.
 
-      The specific scenario is less important here than that it match one that should not be pushed down.
+  The specific scenario is less important here than that it match one that should not be pushed down.
 sql_engine: Snowflake
 ---
 -- Constrain Output with WHERE

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Trino/test_cumulative_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Trino/test_cumulative_metric_with_query_time_filters__plan0.sql
@@ -3,7 +3,7 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests pushdown optimizer behavior for a query against a cumulative metric.
 
-      TODO: support metric time filters
+  TODO: support metric time filters
 sql_engine: Trino
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Trino/test_cumulative_metric_with_query_time_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Trino/test_cumulative_metric_with_query_time_filters__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests pushdown optimizer behavior for a query against a cumulative metric.
 
-      TODO: support metric time filters
+  TODO: support metric time filters
 sql_engine: Trino
 ---
 -- Constrain Output with WHERE

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Trino/test_different_filters_on_same_simple_metric_source_categorical_dimension__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Trino/test_different_filters_on_same_simple_metric_source_categorical_dimension__plan0.sql
@@ -3,13 +3,13 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests rendering a query where multiple filters against the same simple-metric input dimension need to be an effective OR.
 
-      This can be an issue where a derived metric takes in two filters that refer to the same dimension from the input
-      measure source. If these filters are disjoint the predicate pushdown needs to ensure that all matching rows are
-      returned, so we cannot simply push one filter or the other down, nor can we push them down as an AND - they
-      must be an OR, since all relevant rows need to be returned to the requesting metrics.
+  This can be an issue where a derived metric takes in two filters that refer to the same dimension from the input
+  measure source. If these filters are disjoint the predicate pushdown needs to ensure that all matching rows are
+  returned, so we cannot simply push one filter or the other down, nor can we push them down as an AND - they
+  must be an OR, since all relevant rows need to be returned to the requesting metrics.
 
-      The metric listed here has one input that filters on bookings__is_instant and another that does not, which means
-      the source input for the latter input must NOT have the filter applied to it.
+  The metric listed here has one input that filters on bookings__is_instant and another that does not, which means
+  the source input for the latter input must NOT have the filter applied to it.
 sql_engine: Trino
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Trino/test_different_filters_on_same_simple_metric_source_categorical_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Trino/test_different_filters_on_same_simple_metric_source_categorical_dimension__plan0_optimized.sql
@@ -3,13 +3,13 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests rendering a query where multiple filters against the same simple-metric input dimension need to be an effective OR.
 
-      This can be an issue where a derived metric takes in two filters that refer to the same dimension from the input
-      measure source. If these filters are disjoint the predicate pushdown needs to ensure that all matching rows are
-      returned, so we cannot simply push one filter or the other down, nor can we push them down as an AND - they
-      must be an OR, since all relevant rows need to be returned to the requesting metrics.
+  This can be an issue where a derived metric takes in two filters that refer to the same dimension from the input
+  measure source. If these filters are disjoint the predicate pushdown needs to ensure that all matching rows are
+  returned, so we cannot simply push one filter or the other down, nor can we push them down as an AND - they
+  must be an OR, since all relevant rows need to be returned to the requesting metrics.
 
-      The metric listed here has one input that filters on bookings__is_instant and another that does not, which means
-      the source input for the latter input must NOT have the filter applied to it.
+  The metric listed here has one input that filters on bookings__is_instant and another that does not, which means
+  the source input for the latter input must NOT have the filter applied to it.
 sql_engine: Trino
 ---
 -- Compute Metrics via Expressions

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Trino/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Trino/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
@@ -3,7 +3,7 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests pushdown optimizer behavior for a metric with a time spine and fill_nulls_with enabled.
 
-      TODO: support metric time filters
+  TODO: support metric time filters
 sql_engine: Trino
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Trino/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Trino/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests pushdown optimizer behavior for a metric with a time spine and fill_nulls_with enabled.
 
-      TODO: support metric time filters
+  TODO: support metric time filters
 sql_engine: Trino
 ---
 -- Compute Metrics via Expressions

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Trino/test_metric_time_filter_with_two_targets__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Trino/test_metric_time_filter_with_two_targets__plan0.sql
@@ -3,8 +3,8 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests pushdown optimization for a simple metric time predicate through a single join.
 
-      This is currently a no-op for the pushdown optimizer.
-      TODO: support metric time pushdown
+  This is currently a no-op for the pushdown optimizer.
+  TODO: support metric time pushdown
 sql_engine: Trino
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Trino/test_metric_time_filter_with_two_targets__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Trino/test_metric_time_filter_with_two_targets__plan0_optimized.sql
@@ -3,8 +3,8 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests pushdown optimization for a simple metric time predicate through a single join.
 
-      This is currently a no-op for the pushdown optimizer.
-      TODO: support metric time pushdown
+  This is currently a no-op for the pushdown optimizer.
+  TODO: support metric time pushdown
 sql_engine: Trino
 ---
 -- Constrain Output with WHERE

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Trino/test_offset_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Trino/test_offset_metric_with_query_time_filters__plan0.sql
@@ -3,7 +3,7 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests pushdown optimizer behavior for a query against a derived offset metric.
 
-      TODO: support metric time filters
+  TODO: support metric time filters
 sql_engine: Trino
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Trino/test_offset_metric_with_query_time_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Trino/test_offset_metric_with_query_time_filters__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests pushdown optimizer behavior for a query against a derived offset metric.
 
-      TODO: support metric time filters
+  TODO: support metric time filters
 sql_engine: Trino
 ---
 -- Compute Metrics via Expressions

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Trino/test_saved_query_with_metric_joins_and_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Trino/test_saved_query_with_metric_joins_and_filter__plan0.sql
@@ -3,7 +3,7 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests rendering a query where we join to a time spine and query the filter input.
 
-      This should produce a SQL query that applies the filter outside of the time spine join.
+  This should produce a SQL query that applies the filter outside of the time spine join.
 sql_engine: Trino
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Trino/test_saved_query_with_metric_joins_and_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Trino/test_saved_query_with_metric_joins_and_filter__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests rendering a query where we join to a time spine and query the filter input.
 
-      This should produce a SQL query that applies the filter outside of the time spine join.
+  This should produce a SQL query that applies the filter outside of the time spine join.
 sql_engine: Trino
 ---
 -- Combine Aggregated Outputs

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Trino/test_simple_join_to_time_spine_pushdown_filter_application__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Trino/test_simple_join_to_time_spine_pushdown_filter_application__plan0.sql
@@ -3,7 +3,7 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests rendering a query where we join to a time spine and query the filter input.
 
-      This should produce a SQL query that applies the filter outside of the time spine join.
+  This should produce a SQL query that applies the filter outside of the time spine join.
 sql_engine: Trino
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Trino/test_simple_join_to_time_spine_pushdown_filter_application__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Trino/test_simple_join_to_time_spine_pushdown_filter_application__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests rendering a query where we join to a time spine and query the filter input.
 
-      This should produce a SQL query that applies the filter outside of the time spine join.
+  This should produce a SQL query that applies the filter outside of the time spine join.
 sql_engine: Trino
 ---
 -- Constrain Output with WHERE

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Trino/test_skipped_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Trino/test_skipped_pushdown__plan0.sql
@@ -3,10 +3,10 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests rendering a query where we expect to skip predicate pushdown because it is unsafe.
 
-      This is the query rendering test for the scenarios where the push down evaluation indicates that we should
-      skip pushdown, typically due to a lack of certainty over whether or not the query will return the same results.
+  This is the query rendering test for the scenarios where the push down evaluation indicates that we should
+  skip pushdown, typically due to a lack of certainty over whether or not the query will return the same results.
 
-      The specific scenario is less important here than that it match one that should not be pushed down.
+  The specific scenario is less important here than that it match one that should not be pushed down.
 sql_engine: Trino
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Trino/test_skipped_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlPlan/Trino/test_skipped_pushdown__plan0_optimized.sql
@@ -3,10 +3,10 @@ test_filename: test_predicate_pushdown_rendering.py
 docstring:
   Tests rendering a query where we expect to skip predicate pushdown because it is unsafe.
 
-      This is the query rendering test for the scenarios where the push down evaluation indicates that we should
-      skip pushdown, typically due to a lack of certainty over whether or not the query will return the same results.
+  This is the query rendering test for the scenarios where the push down evaluation indicates that we should
+  skip pushdown, typically due to a lack of certainty over whether or not the query will return the same results.
 
-      The specific scenario is less important here than that it match one that should not be pushed down.
+  The specific scenario is less important here than that it match one that should not be pushed down.
 sql_engine: Trino
 ---
 -- Constrain Output with WHERE

--- a/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_2_metrics_from_1_semantic_model__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_2_metrics_from_1_semantic_model__dfp_0.xml
@@ -3,7 +3,7 @@ test_filename: test_source_scan_optimizer.py
 docstring:
   Tests optimizing the plan for 2 simple-metrics that are defined from the same model.
 
-      Since they are defined from the same model, the number of scans should be halved.
+  Since they are defined from the same model, the number of scans should be halved.
 ---
 <DataflowPlan>
     <WriteToResultDataTableNode>

--- a/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_2_metrics_from_1_semantic_model__dfpo_0.xml
+++ b/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_2_metrics_from_1_semantic_model__dfpo_0.xml
@@ -3,7 +3,7 @@ test_filename: test_source_scan_optimizer.py
 docstring:
   Tests optimizing the plan for 2 simple-metrics that are defined from the same model.
 
-      Since they are defined from the same model, the number of scans should be halved.
+  Since they are defined from the same model, the number of scans should be halved.
 ---
 <DataflowPlan>
     <WriteToResultDataTableNode>

--- a/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_constrained_metric_not_combined__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_constrained_metric_not_combined__dfp_0.xml
@@ -3,8 +3,8 @@ test_filename: test_source_scan_optimizer.py
 docstring:
   Tests that 2 metrics from the same semantic model but where 1 is constrained results in 2 scans.
 
-      If there is a constraint for a metric, it needs to be handled in a separate query because the constraint applies to
-      all rows.
+  If there is a constraint for a metric, it needs to be handled in a separate query because the constraint applies to
+  all rows.
 ---
 <DataflowPlan>
     <WriteToResultDataTableNode>

--- a/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_constrained_metric_not_combined__dfpo_0.xml
+++ b/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_constrained_metric_not_combined__dfpo_0.xml
@@ -3,8 +3,8 @@ test_filename: test_source_scan_optimizer.py
 docstring:
   Tests that 2 metrics from the same semantic model but where 1 is constrained results in 2 scans.
 
-      If there is a constraint for a metric, it needs to be handled in a separate query because the constraint applies to
-      all rows.
+  If there is a constraint for a metric, it needs to be handled in a separate query because the constraint applies to
+  all rows.
 ---
 <DataflowPlan>
     <WriteToResultDataTableNode>

--- a/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_derived_metric__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_derived_metric__dfp_0.xml
@@ -3,7 +3,7 @@ test_filename: test_source_scan_optimizer.py
 docstring:
   Tests optimization of a query that use a derived metrics with simple-metric inputs coming from a single semantic model.
 
-      non_referred_bookings_pct is a derived metric that uses simple metrics `[bookings, referred_bookings]`
+  non_referred_bookings_pct is a derived metric that uses simple metrics `[bookings, referred_bookings]`
 ---
 <DataflowPlan>
     <WriteToResultDataTableNode>

--- a/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_derived_metric__dfpo_0.xml
+++ b/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_derived_metric__dfpo_0.xml
@@ -3,7 +3,7 @@ test_filename: test_source_scan_optimizer.py
 docstring:
   Tests optimization of a query that use a derived metrics with simple-metric inputs coming from a single semantic model.
 
-      non_referred_bookings_pct is a derived metric that uses simple metrics `[bookings, referred_bookings]`
+  non_referred_bookings_pct is a derived metric that uses simple metrics `[bookings, referred_bookings]`
 ---
 <DataflowPlan>
     <WriteToResultDataTableNode>

--- a/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_derived_metric_same_alias_components_combined__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_derived_metric_same_alias_components_combined__dfp_0.xml
@@ -3,8 +3,8 @@ test_filename: test_source_scan_optimizer.py
 docstring:
   Tests optimization of querying 2 metrics which give the same alias to the same thing in their components.
 
-      In this case we DO combine source nodes, since the components are the same exact thing so we don't need to
-      scan over it twice
+  In this case we DO combine source nodes, since the components are the same exact thing so we don't need to
+  scan over it twice
 ---
 <DataflowPlan>
     <WriteToResultDataTableNode>

--- a/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_derived_metric_same_alias_components_combined__dfpo_0.xml
+++ b/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_derived_metric_same_alias_components_combined__dfpo_0.xml
@@ -3,8 +3,8 @@ test_filename: test_source_scan_optimizer.py
 docstring:
   Tests optimization of querying 2 metrics which give the same alias to the same thing in their components.
 
-      In this case we DO combine source nodes, since the components are the same exact thing so we don't need to
-      scan over it twice
+  In this case we DO combine source nodes, since the components are the same exact thing so we don't need to
+  scan over it twice
 ---
 <DataflowPlan>
     <WriteToResultDataTableNode>

--- a/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_derived_metric_same_alias_components_not_combined__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_derived_metric_same_alias_components_not_combined__dfp_0.xml
@@ -3,8 +3,8 @@ test_filename: test_source_scan_optimizer.py
 docstring:
   Tests optimization of querying 2 metrics which give the same alias different things in their components.
 
-      In this case we should NOT combine source nodes, since this would generate two columns with
-      the same alias.
+  In this case we should NOT combine source nodes, since this would generate two columns with
+  the same alias.
 ---
 <DataflowPlan>
     <WriteToResultDataTableNode>

--- a/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_derived_metric_same_alias_components_not_combined__dfpo_0.xml
+++ b/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_derived_metric_same_alias_components_not_combined__dfpo_0.xml
@@ -3,8 +3,8 @@ test_filename: test_source_scan_optimizer.py
 docstring:
   Tests optimization of querying 2 metrics which give the same alias different things in their components.
 
-      In this case we should NOT combine source nodes, since this would generate two columns with
-      the same alias.
+  In this case we should NOT combine source nodes, since this would generate two columns with
+  the same alias.
 ---
 <DataflowPlan>
     <WriteToResultDataTableNode>

--- a/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_derived_metric_with_non_derived_metric__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_derived_metric_with_non_derived_metric__dfp_0.xml
@@ -3,13 +3,13 @@ test_filename: test_source_scan_optimizer.py
 docstring:
   Tests optimization of queries that use derived metrics and non-derived metrics.
 
-      `non_referred_bookings_pct` is a derived metric that uses metrics [bookings, referred_bookings]
-      `booking_value` is a simple metric.
+  `non_referred_bookings_pct` is a derived metric that uses metrics [bookings, referred_bookings]
+  `booking_value` is a simple metric.
 
-      All of these simple metrics are defined from a common semantic model.
+  All of these simple metrics are defined from a common semantic model.
 
-      Computation of `non_referred_bookings_pct` can be optimized to a single source, but isn't combined with the
-      computation for `booking_value` as it's not yet supported e.g. alias needed to be handled.
+  Computation of `non_referred_bookings_pct` can be optimized to a single source, but isn't combined with the
+  computation for `booking_value` as it's not yet supported e.g. alias needed to be handled.
 ---
 <DataflowPlan>
     <WriteToResultDataTableNode>

--- a/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_derived_metric_with_non_derived_metric__dfpo_0.xml
+++ b/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_derived_metric_with_non_derived_metric__dfpo_0.xml
@@ -3,13 +3,13 @@ test_filename: test_source_scan_optimizer.py
 docstring:
   Tests optimization of queries that use derived metrics and non-derived metrics.
 
-      `non_referred_bookings_pct` is a derived metric that uses metrics [bookings, referred_bookings]
-      `booking_value` is a simple metric.
+  `non_referred_bookings_pct` is a derived metric that uses metrics [bookings, referred_bookings]
+  `booking_value` is a simple metric.
 
-      All of these simple metrics are defined from a common semantic model.
+  All of these simple metrics are defined from a common semantic model.
 
-      Computation of `non_referred_bookings_pct` can be optimized to a single source, but isn't combined with the
-      computation for `booking_value` as it's not yet supported e.g. alias needed to be handled.
+  Computation of `non_referred_bookings_pct` can be optimized to a single source, but isn't combined with the
+  computation for `booking_value` as it's not yet supported e.g. alias needed to be handled.
 ---
 <DataflowPlan>
     <WriteToResultDataTableNode>

--- a/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_nested_derived_metric__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_nested_derived_metric__dfp_0.xml
@@ -3,8 +3,8 @@ test_filename: test_source_scan_optimizer.py
 docstring:
   Tests optimization of a query that use a nested derived metric from a single semantic model.
 
-      The optimal solution would reduce this to 1 source scan, but there are challenges with derived metrics e.g. aliases,
-      so that is left as a future improvement.
+  The optimal solution would reduce this to 1 source scan, but there are challenges with derived metrics e.g. aliases,
+  so that is left as a future improvement.
 ---
 <DataflowPlan>
     <WriteToResultDataTableNode>

--- a/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_nested_derived_metric__dfpo_0.xml
+++ b/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_nested_derived_metric__dfpo_0.xml
@@ -3,8 +3,8 @@ test_filename: test_source_scan_optimizer.py
 docstring:
   Tests optimization of a query that use a nested derived metric from a single semantic model.
 
-      The optimal solution would reduce this to 1 source scan, but there are challenges with derived metrics e.g. aliases,
-      so that is left as a future improvement.
+  The optimal solution would reduce this to 1 source scan, but there are challenges with derived metrics e.g. aliases,
+  so that is left as a future improvement.
 ---
 <DataflowPlan>
     <WriteToResultDataTableNode>

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/BigQuery/test_join_to_time_spine_with_input_simple_metric_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/BigQuery/test_join_to_time_spine_with_input_simple_metric_constraint__plan0.sql
@@ -3,7 +3,7 @@ test_filename: test_time_spine_join_rendering.py
 docstring:
   Check filter hierarchy.
 
-      Ensure that the measure filter 'booking__is_instant' doesn't get applied again post-aggregation.
+  Ensure that the measure filter 'booking__is_instant' doesn't get applied again post-aggregation.
 sql_engine: BigQuery
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/BigQuery/test_join_to_time_spine_with_input_simple_metric_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/BigQuery/test_join_to_time_spine_with_input_simple_metric_constraint__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_time_spine_join_rendering.py
 docstring:
   Check filter hierarchy.
 
-      Ensure that the measure filter 'booking__is_instant' doesn't get applied again post-aggregation.
+  Ensure that the measure filter 'booking__is_instant' doesn't get applied again post-aggregation.
 sql_engine: BigQuery
 ---
 -- Join to Time Spine Dataset

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Databricks/test_join_to_time_spine_with_input_simple_metric_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Databricks/test_join_to_time_spine_with_input_simple_metric_constraint__plan0.sql
@@ -3,7 +3,7 @@ test_filename: test_time_spine_join_rendering.py
 docstring:
   Check filter hierarchy.
 
-      Ensure that the measure filter 'booking__is_instant' doesn't get applied again post-aggregation.
+  Ensure that the measure filter 'booking__is_instant' doesn't get applied again post-aggregation.
 sql_engine: Databricks
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Databricks/test_join_to_time_spine_with_input_simple_metric_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Databricks/test_join_to_time_spine_with_input_simple_metric_constraint__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_time_spine_join_rendering.py
 docstring:
   Check filter hierarchy.
 
-      Ensure that the measure filter 'booking__is_instant' doesn't get applied again post-aggregation.
+  Ensure that the measure filter 'booking__is_instant' doesn't get applied again post-aggregation.
 sql_engine: Databricks
 ---
 -- Join to Time Spine Dataset

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/DuckDB/test_join_to_time_spine_with_input_simple_metric_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/DuckDB/test_join_to_time_spine_with_input_simple_metric_constraint__plan0.sql
@@ -3,7 +3,7 @@ test_filename: test_time_spine_join_rendering.py
 docstring:
   Check filter hierarchy.
 
-      Ensure that the measure filter 'booking__is_instant' doesn't get applied again post-aggregation.
+  Ensure that the measure filter 'booking__is_instant' doesn't get applied again post-aggregation.
 sql_engine: DuckDB
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/DuckDB/test_join_to_time_spine_with_input_simple_metric_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/DuckDB/test_join_to_time_spine_with_input_simple_metric_constraint__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_time_spine_join_rendering.py
 docstring:
   Check filter hierarchy.
 
-      Ensure that the measure filter 'booking__is_instant' doesn't get applied again post-aggregation.
+  Ensure that the measure filter 'booking__is_instant' doesn't get applied again post-aggregation.
 sql_engine: DuckDB
 ---
 -- Join to Time Spine Dataset

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Postgres/test_join_to_time_spine_with_input_simple_metric_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Postgres/test_join_to_time_spine_with_input_simple_metric_constraint__plan0.sql
@@ -3,7 +3,7 @@ test_filename: test_time_spine_join_rendering.py
 docstring:
   Check filter hierarchy.
 
-      Ensure that the measure filter 'booking__is_instant' doesn't get applied again post-aggregation.
+  Ensure that the measure filter 'booking__is_instant' doesn't get applied again post-aggregation.
 sql_engine: Postgres
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Postgres/test_join_to_time_spine_with_input_simple_metric_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Postgres/test_join_to_time_spine_with_input_simple_metric_constraint__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_time_spine_join_rendering.py
 docstring:
   Check filter hierarchy.
 
-      Ensure that the measure filter 'booking__is_instant' doesn't get applied again post-aggregation.
+  Ensure that the measure filter 'booking__is_instant' doesn't get applied again post-aggregation.
 sql_engine: Postgres
 ---
 -- Join to Time Spine Dataset

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Redshift/test_join_to_time_spine_with_input_simple_metric_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Redshift/test_join_to_time_spine_with_input_simple_metric_constraint__plan0.sql
@@ -3,7 +3,7 @@ test_filename: test_time_spine_join_rendering.py
 docstring:
   Check filter hierarchy.
 
-      Ensure that the measure filter 'booking__is_instant' doesn't get applied again post-aggregation.
+  Ensure that the measure filter 'booking__is_instant' doesn't get applied again post-aggregation.
 sql_engine: Redshift
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Redshift/test_join_to_time_spine_with_input_simple_metric_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Redshift/test_join_to_time_spine_with_input_simple_metric_constraint__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_time_spine_join_rendering.py
 docstring:
   Check filter hierarchy.
 
-      Ensure that the measure filter 'booking__is_instant' doesn't get applied again post-aggregation.
+  Ensure that the measure filter 'booking__is_instant' doesn't get applied again post-aggregation.
 sql_engine: Redshift
 ---
 -- Join to Time Spine Dataset

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Snowflake/test_join_to_time_spine_with_input_simple_metric_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Snowflake/test_join_to_time_spine_with_input_simple_metric_constraint__plan0.sql
@@ -3,7 +3,7 @@ test_filename: test_time_spine_join_rendering.py
 docstring:
   Check filter hierarchy.
 
-      Ensure that the measure filter 'booking__is_instant' doesn't get applied again post-aggregation.
+  Ensure that the measure filter 'booking__is_instant' doesn't get applied again post-aggregation.
 sql_engine: Snowflake
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Snowflake/test_join_to_time_spine_with_input_simple_metric_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Snowflake/test_join_to_time_spine_with_input_simple_metric_constraint__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_time_spine_join_rendering.py
 docstring:
   Check filter hierarchy.
 
-      Ensure that the measure filter 'booking__is_instant' doesn't get applied again post-aggregation.
+  Ensure that the measure filter 'booking__is_instant' doesn't get applied again post-aggregation.
 sql_engine: Snowflake
 ---
 -- Join to Time Spine Dataset

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Trino/test_join_to_time_spine_with_input_simple_metric_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Trino/test_join_to_time_spine_with_input_simple_metric_constraint__plan0.sql
@@ -3,7 +3,7 @@ test_filename: test_time_spine_join_rendering.py
 docstring:
   Check filter hierarchy.
 
-      Ensure that the measure filter 'booking__is_instant' doesn't get applied again post-aggregation.
+  Ensure that the measure filter 'booking__is_instant' doesn't get applied again post-aggregation.
 sql_engine: Trino
 ---
 -- Write to DataTable

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Trino/test_join_to_time_spine_with_input_simple_metric_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlPlan/Trino/test_join_to_time_spine_with_input_simple_metric_constraint__plan0_optimized.sql
@@ -3,7 +3,7 @@ test_filename: test_time_spine_join_rendering.py
 docstring:
   Check filter hierarchy.
 
-      Ensure that the measure filter 'booking__is_instant' doesn't get applied again post-aggregation.
+  Ensure that the measure filter 'booking__is_instant' doesn't get applied again post-aggregation.
 sql_engine: Trino
 ---
 -- Join to Time Spine Dataset

--- a/tests_metricflow_semantics/snapshots/test_ambiguous_entity_path.py/str/test_non_resolvable_ambiguous_entity_path_due_to_mismatch__result_0.txt
+++ b/tests_metricflow_semantics/snapshots/test_ambiguous_entity_path.py/str/test_non_resolvable_ambiguous_entity_path_due_to_mismatch__result_0.txt
@@ -3,7 +3,7 @@ test_filename: test_ambiguous_entity_path.py
 docstring:
   Tests an input with an ambiguous entity-path that can't be resolved due to a mismatch between metrics.
 
-      'entity_0__country' matches ['entity_1__entity_0__country', 'entity_0__country']
+  'entity_0__country' matches ['entity_1__entity_0__country', 'entity_0__country']
 ---
 Got error(s) during query resolution.
 

--- a/tests_metricflow_semantics/snapshots/test_ambiguous_entity_path.py/str/test_non_resolvable_ambiguous_entity_path_due_to_multiple_matches__result_0.txt
+++ b/tests_metricflow_semantics/snapshots/test_ambiguous_entity_path.py/str/test_non_resolvable_ambiguous_entity_path_due_to_multiple_matches__result_0.txt
@@ -3,7 +3,7 @@ test_filename: test_ambiguous_entity_path.py
 docstring:
   Tests an input with an ambiguous entity-path that can't be resolved due to multiple matches.
 
-      'entity_0__country' matches ['entity_1__entity_0__country', 'entity_2__entity_0__country']
+  'entity_0__country' matches ['entity_1__entity_0__country', 'entity_2__entity_0__country']
 ---
 Got error(s) during query resolution.
 

--- a/tests_metricflow_semantics/snapshots/test_dimension_lookup.py/dict/test_get_invariant__obj_0.txt
+++ b/tests_metricflow_semantics/snapshots/test_dimension_lookup.py/dict/test_get_invariant__obj_0.txt
@@ -3,7 +3,7 @@ test_filename: test_dimension_lookup.py
 docstring:
   Test invariants for all dimensions.
 
-      Uses `partitioned_multi_hop_join_semantic_manifest` to show an example of different `is_partition` values.
+  Uses `partitioned_multi_hop_join_semantic_manifest` to show an example of different `is_partition` values.
 ---
 {
   'account_month': DimensionInvariant(dimension_type=CATEGORICAL, is_partition=False),

--- a/tests_metricflow_semantics/snapshots/test_matching_item_for_querying.py/AvailableGroupByItemsResolution/test_missing_parent_for_metric__result.txt
+++ b/tests_metricflow_semantics/snapshots/test_matching_item_for_querying.py/AvailableGroupByItemsResolution/test_missing_parent_for_metric__result.txt
@@ -3,10 +3,10 @@ test_filename: test_matching_item_for_querying.py
 docstring:
   Tests a search for a group by item with a metric stub with no parents.
 
-      We operate under the logical assumption that metric and query items have parent nodes - for a query,
-      these are the inputs (group by items, metrics, etc.). For metrics, these are the metric inputs (metrics
-      or measures). However, in the event of a validation gap upstream, we sometimes encounter inscrutable errors
-      caused by missing parent nodes for these input types, so we add a more informative error and test for it here.
+  We operate under the logical assumption that metric and query items have parent nodes - for a query,
+  these are the inputs (group by items, metrics, etc.). For metrics, these are the metric inputs (metrics
+  or measures). However, in the event of a validation gap upstream, we sometimes encounter inscrutable errors
+  caused by missing parent nodes for these input types, so we add a more informative error and test for it here.
 ---
 AvailableGroupByItemsResolution(
   issue_set=MetricFlowQueryResolutionIssueSet(

--- a/tests_metricflow_semantics/snapshots/test_metric_time_granularity.py/MetricFlowQuerySpec/test_derived_metric_with_defined_metric_time_filter_on_input_metric__result_0.txt
+++ b/tests_metricflow_semantics/snapshots/test_metric_time_granularity.py/MetricFlowQuerySpec/test_derived_metric_with_defined_metric_time_filter_on_input_metric__result_0.txt
@@ -3,8 +3,8 @@ test_filename: test_metric_time_granularity.py
 docstring:
   Tests a derived metric with a metric_time filter on its input metric.
 
-      Should use the outer metric's default granularity.
-      Should always use the default granularity for the object where the filter is defined.
+  Should use the outer metric's default granularity.
+  Should always use the default granularity for the object where the filter is defined.
 ---
 MetricFlowQuerySpec(
   metric_specs=(MetricSpec(element_name='derived_metric_with_time_granularity_and_inner_metric_time_filter'),),

--- a/tests_metricflow_semantics/snapshots/test_metric_time_granularity.py/MetricFlowQuerySpec/test_derived_metric_without_explicit_time_granularity__result_0.txt
+++ b/tests_metricflow_semantics/snapshots/test_metric_time_granularity.py/MetricFlowQuerySpec/test_derived_metric_without_explicit_time_granularity__result_0.txt
@@ -3,7 +3,7 @@ test_filename: test_metric_time_granularity.py
 docstring:
   Tests a derived metric without explicit default granularity.
 
-      Should ignore the default granularities set on its input metrics.
+  Should ignore the default granularities set on its input metrics.
 ---
 MetricFlowQuerySpec(
   metric_specs=(MetricSpec(element_name='derived_metric_without_time_granularity'),),

--- a/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_order_by_granularity_conversion__result.txt
+++ b/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_order_by_granularity_conversion__result.txt
@@ -3,8 +3,8 @@ test_filename: test_query_parser.py
 docstring:
   Test that the granularity of the primary time dimension in the order by is returned appropriately.
 
-      In the case where the primary time dimension is specified in the order by without a granularity suffix, the order
-      by spec returned by the parser should have a granularity appropriate for the queried metrics.
+  In the case where the primary time dimension is specified in the order by without a granularity suffix, the order
+  by spec returned by the parser should have a granularity appropriate for the queried metrics.
 ---
 ParseQueryResult(
   query_spec=MetricFlowQuerySpec(

--- a/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_resolution_for_derived_metrics_with_common_filtered_metric__result.txt
+++ b/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_resolution_for_derived_metrics_with_common_filtered_metric__result.txt
@@ -3,7 +3,7 @@ test_filename: test_spec_lookup.py
 docstring:
   Checks that there are 2 filter spec resolutions even if the metric + filter combination is repeated.
 
-      The resolutions will have a different filter_location_path.
+  The resolutions will have a different filter_location_path.
 ---
 FilterSpecResolutionLookUp(
   spec_resolutions=(

--- a/tests_metricflow_semantics/snapshots/test_subgraph_3_entity_key.py/str/test_minimal_manifest__result.txt
+++ b/tests_metricflow_semantics/snapshots/test_subgraph_3_entity_key.py/str/test_minimal_manifest__result.txt
@@ -3,7 +3,7 @@ test_filename: test_subgraph_3_entity_key.py
 docstring:
   Test generation of the entity-key subgraph using the minimal manifest.
 
-      The `EntityJoinSubgraphGenerator` is included in the graphs to show how the keys relate to the configured entities.
+  The `EntityJoinSubgraphGenerator` is included in the graphs to show how the keys relate to the configured entities.
 expectation_description:
   The graph should show an edge to the primary entity.
 ---

--- a/tests_metricflow_semantics/toolkit/test_fast_frozen_dataclass.py
+++ b/tests_metricflow_semantics/toolkit/test_fast_frozen_dataclass.py
@@ -63,7 +63,7 @@ def test_create(setup_statement: str) -> None:
         left_statement="create_group('left')",
         right_setup=setup_statement,
         right_statement="create_fast_group('left')",
-        min_performance_factor=1.5,
+        min_performance_factor=1.4,
     )
 
 

--- a/tests_metricflow_semantics/toolkit/test_singleton.py
+++ b/tests_metricflow_semantics/toolkit/test_singleton.py
@@ -54,7 +54,7 @@ def test_set_equals(setup_statement: str) -> None:
             ),
         ),
         right_statement="left == right",
-        min_performance_factor=35.0,
+        min_performance_factor=20.0,
     )
 
 
@@ -72,7 +72,7 @@ def test_set_in(setup_statement: str) -> None:
             f"singleton_id_set = create_singleton_id_set({size})",
         ),
         right_statement="FIRST_SINGLETON_ID in singleton_id_set",
-        min_performance_factor=5.0,
+        min_performance_factor=4.0,
     )
 
 
@@ -100,7 +100,7 @@ def test_tuple_equals(setup_statement: str) -> None:
             ),
         ),
         right_statement="left == right",
-        min_performance_factor=55.0,
+        min_performance_factor=30.0,
     )
 
 


### PR DESCRIPTION
As Python 3.9 has reached EOL, this PR updates the supported versions to `>=3.10, <3.14`. Note that the docstring snapshot behavior was updated due to: https://docs.python.org/3/whatsnew/3.13.html#:~:text=The%20compiler%20now,as%20doctest.