### PR TITLE
Update `ruff.toml` and `AGENTS.md` for Python 3.10

### DIFF
--- a/.changes/unreleased/Under the Hood-20260417-094143.yaml
+++ b/.changes/unreleased/Under the Hood-20260417-094143.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Update `ruff.toml` and `AGENTS.md` for Python 3.10
+time: 2026-04-17T09:41:43.151272-07:00
+custom:
+  Author: plypaul
+  Issue: "2022"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,9 @@ This project uses **hatch** for dependency management and testing:
   - Identify and fix correctness issues.
   - Make updates to improve readability and clarity.
   - Make updates to follow code standards.
+- Code should be compatible with the lowest Python version supported by this
+  project.
+
 
 ## Python Code Standards
 
@@ -30,6 +33,7 @@ This project uses **hatch** for dependency management and testing:
 - Include `from __future__ import annotations` at the top of Python files.
 - Include `logger = logging.getLogger(__name__)` in Python files.
 - Avoid the use of `isinstance()`.
+- Avoid dynamic field access with `getattr`.
 - Prefer to use immutable data types.
 - Prioritize code clarity and readability.
 - Docstrings should be concise, capture behavior, capture assumptions, and

--- a/ruff.toml
+++ b/ruff.toml
@@ -69,8 +69,8 @@ line-length = 120
 # Allow unused variables when underscore-prefixed.
 lint.dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 
-# Assume Python 3.8, the lowest version that MF supports.
-target-version = "py38"
+# Assume Python 3.10, the lowest version that MF supports.
+target-version = "py310"
 
 [lint.mccabe]
 # Unlike Flake8, default to a complexity level of 10.


### PR DESCRIPTION
This PR updates `ruff.toml` and `AGENTS.md` to align with the update to use Python 3.10 as the lowest compatible version.