### PR TITLE
Fix queries mixing aliased and non-aliased versions of the same dimension

### DIFF
--- a/.changes/unreleased/Fixes-20260420-124704.yaml
+++ b/.changes/unreleased/Fixes-20260420-124704.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix queries mixing aliased and non-aliased versions of the same dimension
+time: 2026-04-20T12:47:04.853739-07:00
+custom:
+  Author: plypaul
+  Issue: "2025"

--- a/metricflow/dataflow/builder/dataflow_plan_builder.py
+++ b/metricflow/dataflow/builder/dataflow_plan_builder.py
@@ -991,6 +991,14 @@ class DataflowPlanBuilder:
                 input_spec = desired_output_spec.with_alias(None)
                 alias_changes.append(SpecToAlias(input_spec=input_spec, output_spec=desired_output_spec))
 
+                # It's possible to query an item with and without an alias.
+                # Since `AliasSpecsNode` does not pass the query item without the alias when making an
+                # alias change, add the query item without the alias as an identity operation.
+                if input_spec in desired_output_specs:
+                    alias_changes.append(
+                        SpecToAlias(input_spec=input_spec, output_spec=input_spec),
+                    )
+
         return AliasSpecsNode.create(parent_node, alias_changes)
 
     @staticmethod

--- a/metricflow/dataflow/builder/dataflow_plan_builder.py
+++ b/metricflow/dataflow/builder/dataflow_plan_builder.py
@@ -231,8 +231,6 @@ class DataflowPlanBuilder:
                     f"The metric specs in the query spec should not contain any metric modifiers. Got: {metric_spec}"
                 )
 
-        query_spec = query_spec.without_aliases()
-
         filter_spec_factory = WhereFilterSpecFactory(
             column_association_resolver=self._column_association_resolver,
             spec_resolution_lookup=query_spec.filter_spec_resolution_lookup,
@@ -262,7 +260,7 @@ class DataflowPlanBuilder:
             for metric_spec in query_spec.metric_specs
         )
 
-        queried_linkable_specs = query_spec.linkable_specs
+        group_by_item_specs_without_aliases = query_spec.linkable_specs.without_aliases
 
         if me_plan_override is None:
             me_planner: MetricEvaluationPlanner
@@ -281,7 +279,7 @@ class DataflowPlanBuilder:
 
             me_plan_override = me_planner.build_plan(
                 metric_specs=metric_specs,
-                group_by_item_specs=queried_linkable_specs.as_tuple,
+                group_by_item_specs=group_by_item_specs_without_aliases.as_tuple,
                 predicate_pushdown_state=predicate_pushdown_state,
                 filter_spec_factory=filter_spec_factory,
             )
@@ -861,28 +859,27 @@ class DataflowPlanBuilder:
         assert not query_spec.metric_specs, "Can't build distinct values plan with metrics."
 
         # Remove aliases for easier spec-matching. Will be added back in sink node.
-        base_query_spec = query_spec.without_aliases()
-        final_query_spec = query_spec
+        group_by_item_specs_without_aliases = query_spec.linkable_specs.without_aliases
 
         query_level_filter_specs: Sequence[WhereFilterSpec] = ()
-        if len(base_query_spec.filter_intersection.where_filters) > 0:
+        if len(query_spec.filter_intersection.where_filters) > 0:
             filter_spec_factory = WhereFilterSpecFactory(
                 column_association_resolver=self._column_association_resolver,
-                spec_resolution_lookup=base_query_spec.filter_spec_resolution_lookup
+                spec_resolution_lookup=query_spec.filter_spec_resolution_lookup
                 or FilterSpecResolutionLookUp.empty_instance(),
                 custom_grain_names=self._semantic_model_lookup.custom_granularity_names,
             )
 
             query_level_filter_specs = filter_spec_factory.create_from_where_filter_intersection(
                 filter_location=WhereFilterLocation.for_query(metric_references=tuple()),
-                filter_intersection=base_query_spec.filter_intersection,
+                filter_intersection=query_spec.filter_intersection,
             )
 
         required_linkable_specs = self.__get_required_linkable_specs(
-            queried_linkable_specs=base_query_spec.linkable_specs, filter_specs=query_level_filter_specs
+            queried_linkable_specs=group_by_item_specs_without_aliases, filter_specs=query_level_filter_specs
         )
         predicate_pushdown_state = PredicatePushdownState.create(
-            time_range_constraint=base_query_spec.time_range_constraint,
+            time_range_constraint=query_spec.time_range_constraint,
             where_filter_specs=tuple(query_level_filter_specs),
         )
         dataflow_recipe = self._find_source_node_recipe(
@@ -899,24 +896,26 @@ class DataflowPlanBuilder:
         output_node = self._build_pre_aggregation_plan(
             source_node=dataflow_recipe.source_node,
             join_targets=dataflow_recipe.join_targets,
-            specs_to_keep_for_aggregation=InstanceSpecSet.create_from_specs(base_query_spec.linkable_specs.as_tuple),
+            specs_to_keep_for_aggregation=InstanceSpecSet.create_from_specs(
+                group_by_item_specs_without_aliases.as_tuple
+            ),
             custom_granularity_specs=required_linkable_specs.time_dimension_specs_with_custom_grain,
             where_filter_specs=query_level_filter_specs,
-            time_range_constraint=base_query_spec.time_range_constraint,
-            distinct=base_query_spec.apply_group_by,
+            time_range_constraint=query_spec.time_range_constraint,
+            distinct=query_spec.apply_group_by,
         )
 
-        if base_query_spec.min_max_only:
+        if query_spec.min_max_only:
             output_node = MinMaxNode.create(parent_node=output_node)
 
         sink_node = self.build_sink_node(
             parent_node=output_node,
-            order_by_specs=final_query_spec.order_by_specs,
-            desired_output_metric_specs=final_query_spec.metric_specs,
+            order_by_specs=query_spec.order_by_specs,
+            desired_output_metric_specs=query_spec.metric_specs,
             desired_output_group_by_item_specs=(
-                final_query_spec.dimension_specs + final_query_spec.time_dimension_specs + final_query_spec.entity_specs
+                query_spec.dimension_specs + query_spec.time_dimension_specs + query_spec.entity_specs
             ),
-            limit=final_query_spec.limit,
+            limit=query_spec.limit,
         )
         plan = DataflowPlan(sink_nodes=[sink_node])
         return self._optimize_plan(plan=plan, option_set=option_set)

--- a/metricflow_semantics/query/query_resolver.py
+++ b/metricflow_semantics/query/query_resolver.py
@@ -72,6 +72,7 @@ from metricflow_semantics.toolkit.collections.ordered_set import MutableOrderedS
 from metricflow_semantics.toolkit.mf_logging.lazy_formattable import LazyFormat
 from metricflow_semantics.toolkit.mf_logging.pretty_print import mf_pformat
 from metricflow_semantics.toolkit.mf_logging.runtime import log_runtime
+from metricflow_semantics.toolkit.syntactic_sugar import mf_first_item
 
 from metricflow_semantic_interfaces.references import MetricReference, SemanticModelReference
 
@@ -314,19 +315,27 @@ class MetricFlowQueryResolver:
         query_resolution_path: MetricFlowQueryResolutionPath,
     ) -> ResolveOrderByResult:
         mapping_items: List[InputToIssueSetMappingItem] = []
-        order_by_specs: List[OrderBySpec] = []
+        order_by_specs: MutableOrderedSet[OrderBySpec] = MutableOrderedSet()
 
         # Match the pattern from the order by input to one of the metric or group-by-item specs.
         # The pattern needs to be used because there are cases where the order-by-item is specified in a different way
         # from the group-by-item, so an equality comparison won't work.
-        for resolver_input_for_order_by in resolver_inputs_for_order_by_items:
-            matching_specs: set[InstanceSpec] = set()
-            for possible_input in resolver_input_for_order_by.possible_inputs:
-                spec_pattern = possible_input.spec_pattern
-                matching_specs.update(spec_pattern.match(metric_specs))
-                matching_specs.update(spec_pattern.match(group_by_item_specs))
 
-            if len(matching_specs) != 1:
+        # Group the specs by the alias to aid later matching.
+        alias_to_specs: defaultdict[str | None, list[MetricSpec | LinkableInstanceSpec]] = defaultdict(list)
+
+        for metric_spec in metric_specs:
+            alias_to_specs[metric_spec.alias].append(metric_spec)
+        for group_by_item_spec in group_by_item_specs:
+            alias_to_specs[group_by_item_spec.alias].append(group_by_item_spec)
+
+        for resolver_input_for_order_by in resolver_inputs_for_order_by_items:
+            specs_matching_order_by: set[InstanceSpec] = set()
+            for possible_input in resolver_input_for_order_by.possible_inputs:
+                specs_matching_alias = alias_to_specs[possible_input.alias]
+                specs_matching_order_by.update(possible_input.spec_pattern.match(specs_matching_alias))
+
+            if len(specs_matching_order_by) != 1:
                 mapping_items.append(
                     InputToIssueSetMappingItem(
                         resolver_input=resolver_input_for_order_by,
@@ -339,10 +348,10 @@ class MetricFlowQueryResolver:
                     )
                 )
             else:
-                order_by_specs.append(
+                order_by_specs.add(
                     OrderBySpec(
                         # Ignore aliases in the order by since we'll render the expression instead of the alias.
-                        instance_spec=matching_specs.pop().with_alias(None),
+                        instance_spec=mf_first_item(specs_matching_order_by).with_alias(None),
                         descending=resolver_input_for_order_by.descending,
                     )
                 )

--- a/metricflow_semantics/specs/linkable_spec_set.py
+++ b/metricflow_semantics/specs/linkable_spec_set.py
@@ -166,6 +166,15 @@ class LinkableSpecSet(Mergeable, SerializableDataclass, Collection[LinkableInsta
     def __contains__(self, x: object, /) -> bool:
         return x in self._item_set
 
+    @cached_property
+    def without_aliases(self) -> LinkableSpecSet:  # noqa: D102
+        return LinkableSpecSet(
+            dimension_specs=tuple(spec.with_alias(None) for spec in self.dimension_specs),
+            time_dimension_specs=tuple(spec.with_alias(None) for spec in self.time_dimension_specs),
+            entity_specs=tuple(spec.with_alias(None) for spec in self.entity_specs),
+            group_by_metric_specs=tuple(spec.with_alias(None) for spec in self.group_by_metric_specs),
+        )
+
 
 @dataclass
 class _GroupSpecByTypeVisitor(InstanceSpecVisitor[None]):

--- a/metricflow_semantics/specs/query_spec.py
+++ b/metricflow_semantics/specs/query_spec.py
@@ -100,28 +100,3 @@ class MetricFlowQuerySpec(SerializableDataclass):
             apply_group_by=self.apply_group_by,
             input_spec_order=self.input_spec_order,
         )
-
-    def without_aliases(self) -> MetricFlowQuerySpec:
-        """Return a query spec that's the same as self but with all aliases removed."""
-        return MetricFlowQuerySpec(
-            metric_specs=tuple(metric_spec.with_alias(None) for metric_spec in self.metric_specs),
-            dimension_specs=tuple(dimension_spec.with_alias(None) for dimension_spec in self.dimension_specs),
-            entity_specs=tuple(entity_spec.with_alias(None) for entity_spec in self.entity_specs),
-            time_dimension_specs=tuple(
-                time_dimension_spec.with_alias(None) for time_dimension_spec in self.time_dimension_specs
-            ),
-            group_by_metric_specs=tuple(
-                group_by_metric_spec.with_alias(None) for group_by_metric_spec in self.group_by_metric_specs
-            ),
-            order_by_specs=tuple(order_by_spec.with_alias(None) for order_by_spec in self.order_by_specs),
-            time_range_constraint=self.time_range_constraint,
-            limit=self.limit,
-            filter_intersection=self.filter_intersection,
-            filter_spec_resolution_lookup=self.filter_spec_resolution_lookup,
-            min_max_only=self.min_max_only,
-            apply_group_by=self.apply_group_by,
-            input_spec_order=InputSpecOrder(
-                group_by_item_specs=tuple(spec.with_alias(None) for spec in self.input_spec_order.group_by_item_specs),
-                metric_specs=tuple(metric_spec.with_alias(None) for metric_spec in self.input_spec_order.metric_specs),
-            ),
-        )

--- a/tests_metricflow/query_rendering/test_alias_rendering.py
+++ b/tests_metricflow/query_rendering/test_alias_rendering.py
@@ -143,3 +143,41 @@ def test_derived_metric_alias(
         dataflow_plan_builder=dataflow_plan_builder,
         query_spec=query_spec,
     )
+
+
+@pytest.mark.sql_engine_snapshot
+@pytest.mark.duckdb_only
+def test_items_with_and_without_alias(
+    request: FixtureRequest,
+    mf_test_configuration: MetricFlowTestConfiguration,
+    dataflow_plan_builder: DataflowPlanBuilder,
+    sql_client: SqlClient,
+    query_parser: MetricFlowQueryParser,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
+) -> None:
+    """Tests querying the same query item with and without an alias."""
+    metric_param = MetricParameter(
+        name="bookings",
+    )
+    dimension_param = DimensionOrEntityParameter(
+        name="booking__is_instant",
+    )
+    aliased_dimension_param = DimensionOrEntityParameter(name="booking__is_instant", alias="aliased_is_instant")
+    query_spec = query_parser.parse_and_validate_query(
+        metrics=(metric_param,),
+        group_by=(dimension_param, aliased_dimension_param),
+        order_by=(
+            OrderByParameter(metric_param),
+            OrderByParameter(dimension_param),
+            OrderByParameter(aliased_dimension_param),
+        ),
+    ).query_spec
+
+    render_and_check(
+        request=request,
+        mf_test_configuration=mf_test_configuration,
+        dataflow_to_sql_converter=dataflow_to_sql_converter,
+        sql_client=sql_client,
+        dataflow_plan_builder=dataflow_plan_builder,
+        query_spec=query_spec,
+    )

--- a/tests_metricflow/snapshots/test_alias_rendering.py/SqlPlan/DuckDB/test_items_with_and_without_alias__plan0.sql
+++ b/tests_metricflow/snapshots/test_alias_rendering.py/SqlPlan/DuckDB/test_items_with_and_without_alias__plan0.sql
@@ -1,0 +1,264 @@
+test_name: test_items_with_and_without_alias
+test_filename: test_alias_rendering.py
+docstring:
+  Tests querying the same query item with and without an alias.
+sql_engine: DuckDB
+---
+-- Write to DataTable
+SELECT
+  subq_7.aliased_is_instant
+  , subq_7.booking__is_instant
+  , subq_7.bookings
+FROM (
+  -- Change Column Aliases
+  SELECT
+    subq_6.booking__is_instant AS aliased_is_instant
+    , subq_6.booking__is_instant
+    , subq_6.bookings
+  FROM (
+    -- Order By ['bookings', 'booking__is_instant']
+    SELECT
+      subq_5.booking__is_instant
+      , subq_5.bookings
+    FROM (
+      -- Compute Metrics via Expressions
+      SELECT
+        subq_4.booking__is_instant
+        , subq_4.__bookings AS bookings
+      FROM (
+        -- Aggregate Inputs for Simple Metrics
+        SELECT
+          subq_3.booking__is_instant
+          , SUM(subq_3.__bookings) AS __bookings
+        FROM (
+          -- Select: ['__bookings', 'booking__is_instant']
+          SELECT
+            subq_2.booking__is_instant
+            , subq_2.__bookings
+          FROM (
+            -- Select: ['__bookings', 'booking__is_instant']
+            SELECT
+              subq_1.booking__is_instant
+              , subq_1.__bookings
+            FROM (
+              -- Metric Time Dimension 'ds'
+              SELECT
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.__bookings
+                , subq_0.__average_booking_value
+                , subq_0.__instant_bookings
+                , subq_0.__booking_value
+                , subq_0.__max_booking_value
+                , subq_0.__min_booking_value
+                , subq_0.__instant_booking_value
+                , subq_0.__average_instant_booking_value
+                , subq_0.__booking_value_for_non_null_listing_id
+                , subq_0.__bookers
+                , subq_0.__referred_bookings
+                , subq_0.__median_booking_value
+                , subq_0.__booking_value_p99
+                , subq_0.__discrete_booking_value_p99
+                , subq_0.__approximate_continuous_booking_value_p99
+                , subq_0.__approximate_discrete_booking_value_p99
+                , subq_0.__bookings_join_to_time_spine
+                , subq_0.__bookings_fill_nulls_with_0_without_time_spine
+                , subq_0.__bookings_fill_nulls_with_0
+                , subq_0.__instant_bookings_with_measure_filter
+                , subq_0.__bookings_join_to_time_spine_with_tiered_filters
+                , subq_0.__bookers_fill_nulls_with_0_join_to_timespine
+              FROM (
+                -- Read Elements From Semantic Model 'bookings_source'
+                SELECT
+                  1 AS __bookings
+                  , bookings_source_src_28000.booking_value AS __average_booking_value
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS __instant_bookings
+                  , bookings_source_src_28000.booking_value AS __booking_value
+                  , bookings_source_src_28000.booking_value AS __max_booking_value
+                  , bookings_source_src_28000.booking_value AS __min_booking_value
+                  , bookings_source_src_28000.booking_value AS __instant_booking_value
+                  , bookings_source_src_28000.booking_value AS __average_instant_booking_value
+                  , bookings_source_src_28000.booking_value AS __booking_value_for_non_null_listing_id
+                  , bookings_source_src_28000.guest_id AS __bookers
+                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS __referred_bookings
+                  , bookings_source_src_28000.booking_value AS __median_booking_value
+                  , bookings_source_src_28000.booking_value AS __booking_value_p99
+                  , bookings_source_src_28000.booking_value AS __discrete_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS __approximate_continuous_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS __approximate_discrete_booking_value_p99
+                  , 1 AS __bookings_join_to_time_spine
+                  , 1 AS __bookings_fill_nulls_with_0_without_time_spine
+                  , 1 AS __bookings_fill_nulls_with_0
+                  , 1 AS __instant_bookings_with_measure_filter
+                  , 1 AS __bookings_join_to_time_spine_with_tiered_filters
+                  , bookings_source_src_28000.guest_id AS __bookers_fill_nulls_with_0_join_to_timespine
+                  , bookings_source_src_28000.booking_value AS __booking_payments
+                  , bookings_source_src_28000.is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                  , bookings_source_src_28000.is_instant AS booking__is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                  , bookings_source_src_28000.listing_id AS listing
+                  , bookings_source_src_28000.guest_id AS guest
+                  , bookings_source_src_28000.host_id AS host
+                  , bookings_source_src_28000.listing_id AS booking__listing
+                  , bookings_source_src_28000.guest_id AS booking__guest
+                  , bookings_source_src_28000.host_id AS booking__host
+                FROM ***************************.fct_bookings bookings_source_src_28000
+              ) subq_0
+            ) subq_1
+          ) subq_2
+        ) subq_3
+        GROUP BY
+          subq_3.booking__is_instant
+      ) subq_4
+    ) subq_5
+    ORDER BY subq_5.bookings, subq_5.booking__is_instant
+  ) subq_6
+) subq_7

--- a/tests_metricflow/snapshots/test_alias_rendering.py/SqlPlan/DuckDB/test_items_with_and_without_alias__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_alias_rendering.py/SqlPlan/DuckDB/test_items_with_and_without_alias__plan0_optimized.sql
@@ -1,0 +1,28 @@
+test_name: test_items_with_and_without_alias
+test_filename: test_alias_rendering.py
+docstring:
+  Tests querying the same query item with and without an alias.
+sql_engine: DuckDB
+---
+-- Aggregate Inputs for Simple Metrics
+-- Compute Metrics via Expressions
+-- Order By ['bookings', 'booking__is_instant']
+-- Change Column Aliases
+-- Write to DataTable
+SELECT
+  booking__is_instant AS aliased_is_instant
+  , booking__is_instant
+  , SUM(__bookings) AS bookings
+FROM (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  -- Select: ['__bookings', 'booking__is_instant']
+  -- Select: ['__bookings', 'booking__is_instant']
+  SELECT
+    is_instant AS booking__is_instant
+    , 1 AS __bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+) subq_11
+GROUP BY
+  booking__is_instant
+ORDER BY bookings, aliased_is_instant


### PR DESCRIPTION
This PR fixes an error that is thrown when querying a given dimension with and without an alias. The main issue is that the node that does the alias change does not keep the original item in the output. e.g. if the node is supposed to change A to B, then the output only contains B, not A, B. This is usually the desired behavior, but in cases where a dimension is queried with and without an alias, the desired behavior is to change A to A, B. Some additional fixes were required, so please view by commit.