### PR TITLE
Allow order-by items to omit the alias

### DIFF
--- a/.changes/unreleased/Under the Hood-20260423-095843.yaml
+++ b/.changes/unreleased/Under the Hood-20260423-095843.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Allow order-by items to omit the alias
+time: 2026-04-23T09:58:43.775492-07:00
+custom:
+  Author: plypaul
+  Issue: "2030"

--- a/metricflow_semantics/query/order_by_helper.py
+++ b/metricflow_semantics/query/order_by_helper.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+from collections.abc import Iterable
+from functools import cached_property
+
+from metricflow_semantics.specs.instance_spec import LinkableInstanceSpec
+from metricflow_semantics.specs.metric_spec import MetricSpec
+from metricflow_semantics.toolkit.collections.ordered_set import FrozenOrderedSet, MutableOrderedSet, OrderedSet
+
+logger = logging.getLogger(__name__)
+
+
+class OrderByHelper:
+    """Helper to resolve specs for matching order-by items."""
+
+    def __init__(
+        self,
+        metric_specs: Iterable[MetricSpec],
+        group_by_item_specs: Iterable[LinkableInstanceSpec],
+    ) -> None:
+        """Initializer.
+
+        Args:
+            metric_specs: The metrics in the query with the alias set based on query input.
+            group_by_item_specs: The group-by items in the query with the alias set based on query input.
+        """
+        specs_with_alias_context: list[MetricSpec | LinkableInstanceSpec] = list(metric_specs)
+        specs_with_alias_context.extend(group_by_item_specs)
+        self._alias_to_specs: defaultdict[
+            str | None, MutableOrderedSet[MetricSpec | LinkableInstanceSpec]
+        ] = defaultdict(MutableOrderedSet)
+
+        for spec in specs_with_alias_context:
+            self._alias_to_specs[spec.alias].add(spec.with_alias(None))
+
+    def specs_with_alias(self, alias: str | None) -> OrderedSet[MetricSpec | LinkableInstanceSpec]:
+        """Returns the specs in the query that were specified with the given alias.
+
+        Specs are returned with the alias stripped for matching using spec patterns.
+        """
+        return self._alias_to_specs[alias]
+
+    @cached_property
+    def all_specs(self) -> OrderedSet[MetricSpec | LinkableInstanceSpec]:
+        """Returns all specs in the query.
+
+        Specs are returned with the alias stripped for matching using spec patterns.
+        """
+        return FrozenOrderedSet(spec for specs in self._alias_to_specs.values() for spec in specs)

--- a/metricflow_semantics/query/query_resolver.py
+++ b/metricflow_semantics/query/query_resolver.py
@@ -38,6 +38,7 @@ from metricflow_semantics.query.issues.parsing.invalid_metric import InvalidMetr
 from metricflow_semantics.query.issues.parsing.invalid_min_max_only import InvalidMinMaxOnlyIssue
 from metricflow_semantics.query.issues.parsing.invalid_order import InvalidOrderByItemIssue
 from metricflow_semantics.query.issues.parsing.no_metric_or_group_by import NoMetricOrGroupByIssue
+from metricflow_semantics.query.order_by_helper import OrderByHelper
 from metricflow_semantics.query.query_resolution import (
     InputToIssueSetMapping,
     InputToIssueSetMappingItem,
@@ -321,19 +322,21 @@ class MetricFlowQueryResolver:
         # The pattern needs to be used because there are cases where the order-by-item is specified in a different way
         # from the group-by-item, so an equality comparison won't work.
 
-        # Group the specs by the alias to aid later matching.
-        alias_to_specs: defaultdict[str | None, list[MetricSpec | LinkableInstanceSpec]] = defaultdict(list)
-
-        for metric_spec in metric_specs:
-            alias_to_specs[metric_spec.alias].append(metric_spec)
-        for group_by_item_spec in group_by_item_specs:
-            alias_to_specs[group_by_item_spec.alias].append(group_by_item_spec)
+        order_by_helper = OrderByHelper(metric_specs, group_by_item_specs)
 
         for resolver_input_for_order_by in resolver_inputs_for_order_by_items:
             specs_matching_order_by: set[InstanceSpec] = set()
             for possible_input in resolver_input_for_order_by.possible_inputs:
-                specs_matching_alias = alias_to_specs[possible_input.alias]
-                specs_matching_order_by.update(possible_input.spec_pattern.match(specs_matching_alias))
+
+                # If the order-by does not specify an alias, the matching can be done with all specs in the query.
+                if possible_input.alias is None:
+                    specs_matching_order_by.update(possible_input.spec_pattern.match(order_by_helper.all_specs))
+                # If an order-by specifies an alias, the matching can only be done with specs in the query that
+                # have the same alias.
+                else:
+                    specs_matching_order_by.update(
+                        possible_input.spec_pattern.match(order_by_helper.specs_with_alias(possible_input.alias))
+                    )
 
             if len(specs_matching_order_by) != 1:
                 mapping_items.append(
@@ -350,8 +353,7 @@ class MetricFlowQueryResolver:
             else:
                 order_by_specs.add(
                     OrderBySpec(
-                        # Ignore aliases in the order by since we'll render the expression instead of the alias.
-                        instance_spec=mf_first_item(specs_matching_order_by).with_alias(None),
+                        instance_spec=mf_first_item(specs_matching_order_by),
                         descending=resolver_input_for_order_by.descending,
                     )
                 )

--- a/metricflow_semantics/query/query_resolver.py
+++ b/metricflow_semantics/query/query_resolver.py
@@ -327,7 +327,6 @@ class MetricFlowQueryResolver:
         for resolver_input_for_order_by in resolver_inputs_for_order_by_items:
             specs_matching_order_by: set[InstanceSpec] = set()
             for possible_input in resolver_input_for_order_by.possible_inputs:
-
                 # If the order-by does not specify an alias, the matching can be done with all specs in the query.
                 if possible_input.alias is None:
                     specs_matching_order_by.update(possible_input.spec_pattern.match(order_by_helper.all_specs))

--- a/metricflow_semantics/specs/patterns/entity_link_pattern.py
+++ b/metricflow_semantics/specs/patterns/entity_link_pattern.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, FrozenSet, List, Optional, Sequence, Tuple
+from typing import Any, FrozenSet, Iterable, List, Optional, Sequence, Tuple
 
 from metricflow_semantics.model.linkable_element_property import GroupByItemProperty
 from metricflow_semantics.model.semantics.element_filter import GroupByItemSetFilter
@@ -130,7 +130,7 @@ class EntityLinkPattern(SpecPattern):
         return matching_specs
 
     @override
-    def match(self, candidate_specs: Sequence[InstanceSpec]) -> Sequence[LinkableInstanceSpec]:
+    def match(self, candidate_specs: Iterable[InstanceSpec]) -> Sequence[LinkableInstanceSpec]:
         filtered_candidate_specs = group_specs_by_type(candidate_specs).linkable_specs
         # Checks that SpecPatternParameterSetField is valid wrt to the parameter set.
 

--- a/metricflow_semantics/specs/patterns/match_list_pattern.py
+++ b/metricflow_semantics/specs/patterns/match_list_pattern.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Sequence, Tuple
+from typing import Iterable, Sequence, Tuple
 
 from metricflow_semantics.specs.instance_spec import InstanceSpec
 from metricflow_semantics.specs.patterns.spec_pattern import SpecPattern
@@ -22,5 +22,5 @@ class MatchListSpecPattern(SpecPattern):
         return MatchListSpecPattern(tuple(listed_specs))
 
     @override
-    def match(self, candidate_specs: Sequence[InstanceSpec]) -> Sequence[InstanceSpec]:
+    def match(self, candidate_specs: Iterable[InstanceSpec]) -> Sequence[InstanceSpec]:
         return tuple(spec for spec in candidate_specs if spec in self.listed_specs)

--- a/metricflow_semantics/specs/patterns/metric_pattern.py
+++ b/metricflow_semantics/specs/patterns/metric_pattern.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Optional, Sequence
+from typing import Iterable, Optional, Sequence
 
 from metricflow_semantics.specs.instance_spec import InstanceSpec
 from metricflow_semantics.specs.metric_spec import MetricSpec
@@ -20,7 +20,7 @@ class MetricSpecPattern(SpecPattern):
     descending: Optional[bool] = None
 
     @override
-    def match(self, candidate_specs: Sequence[InstanceSpec]) -> Sequence[MetricSpec]:
+    def match(self, candidate_specs: Iterable[InstanceSpec]) -> Sequence[MetricSpec]:
         spec_set = group_specs_by_type(candidate_specs)
         return tuple(
             metric_name for metric_name in spec_set.metric_specs if metric_name.reference == self.metric_reference

--- a/metricflow_semantics/specs/patterns/metric_time_default_granularity.py
+++ b/metricflow_semantics/specs/patterns/metric_time_default_granularity.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import Dict, Optional, Sequence, Set, Tuple
+from typing import Dict, Iterable, Optional, Sequence, Set, Tuple
 
 from metricflow_semantics.specs.instance_spec import InstanceSpec, LinkableInstanceSpec
 from metricflow_semantics.specs.patterns.spec_pattern import SpecPattern
@@ -47,11 +47,12 @@ class MetricTimeDefaultGranularityPattern(SpecPattern):
     max_metric_default_time_granularity: Optional[TimeGranularity]
 
     @override
-    def match(self, candidate_specs: Sequence[InstanceSpec]) -> Sequence[InstanceSpec]:
-        spec_set = group_specs_by_type(candidate_specs)
+    def match(self, candidate_specs: Iterable[InstanceSpec]) -> Sequence[InstanceSpec]:
+        candidate_specs_tuple = tuple(candidate_specs)
+        spec_set = group_specs_by_type(candidate_specs_tuple)
         # If there are no metric_time specs in the query, skip this filter.
         if not spec_set.metric_time_specs:
-            return candidate_specs
+            return candidate_specs_tuple
 
         # If there are metrics in the query, use max metric default. For no-metric queries, use standard default.
         # TODO: [custom granularity] allow custom granularities to be used as defaults if appropriate

--- a/metricflow_semantics/specs/patterns/metric_time_pattern.py
+++ b/metricflow_semantics/specs/patterns/metric_time_pattern.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Sequence
+from typing import Iterable, Sequence
 
 from metricflow_semantics.specs.instance_spec import InstanceSpec
 from metricflow_semantics.specs.patterns.spec_pattern import SpecPattern
@@ -21,7 +21,7 @@ class MetricTimePattern(SpecPattern):
     """
 
     @override
-    def match(self, candidate_specs: Sequence[InstanceSpec]) -> Sequence[TimeDimensionSpec]:
+    def match(self, candidate_specs: Iterable[InstanceSpec]) -> Sequence[TimeDimensionSpec]:
         spec_set = group_specs_by_type(candidate_specs)
         return tuple(
             time_dimension_spec

--- a/metricflow_semantics/specs/patterns/minimum_time_grain.py
+++ b/metricflow_semantics/specs/patterns/minimum_time_grain.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import Dict, List, Sequence, Set, Tuple
+from typing import Dict, Iterable, List, Sequence, Set, Tuple
 
 from metricflow_semantics.specs.instance_spec import InstanceSpec, LinkableInstanceSpec
 from metricflow_semantics.specs.patterns.spec_pattern import SpecPattern
@@ -43,7 +43,7 @@ class MinimumTimeGrainPattern(SpecPattern):
     """
 
     @override
-    def match(self, candidate_specs: Sequence[InstanceSpec]) -> Sequence[InstanceSpec]:
+    def match(self, candidate_specs: Iterable[InstanceSpec]) -> Sequence[InstanceSpec]:
         spec_set = group_specs_by_type(candidate_specs)
 
         time_dimension_specs_with_no_grain: Tuple[TimeDimensionSpec, ...] = ()

--- a/metricflow_semantics/specs/patterns/no_group_by_metric.py
+++ b/metricflow_semantics/specs/patterns/no_group_by_metric.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import List, Sequence
+from typing import Iterable, List, Sequence
 
 from metricflow_semantics.model.linkable_element_property import GroupByItemProperty
 from metricflow_semantics.model.semantics.element_filter import GroupByItemSetFilter
@@ -19,7 +19,7 @@ class NoGroupByMetricPattern(SpecPattern):
     """
 
     @override
-    def match(self, candidate_specs: Sequence[InstanceSpec]) -> Sequence[LinkableInstanceSpec]:
+    def match(self, candidate_specs: Iterable[InstanceSpec]) -> Sequence[LinkableInstanceSpec]:
         specs_to_return: List[LinkableInstanceSpec] = []
         spec_set = group_specs_by_type(candidate_specs)
         specs_to_return.extend(spec_set.time_dimension_specs)

--- a/metricflow_semantics/specs/patterns/none_date_part.py
+++ b/metricflow_semantics/specs/patterns/none_date_part.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import List, Sequence
+from typing import Iterable, List, Sequence
 
 from metricflow_semantics.specs.instance_spec import InstanceSpec, LinkableInstanceSpec
 from metricflow_semantics.specs.patterns.spec_pattern import SpecPattern
@@ -17,7 +17,7 @@ class NoneDatePartPattern(SpecPattern):
     """
 
     @override
-    def match(self, candidate_specs: Sequence[InstanceSpec]) -> Sequence[LinkableInstanceSpec]:
+    def match(self, candidate_specs: Iterable[InstanceSpec]) -> Sequence[LinkableInstanceSpec]:
         specs_to_return: List[LinkableInstanceSpec] = []
         spec_set = group_specs_by_type(candidate_specs)
         for time_dimension_spec in spec_set.time_dimension_specs:

--- a/metricflow_semantics/specs/patterns/spec_pattern.py
+++ b/metricflow_semantics/specs/patterns/spec_pattern.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Sequence
+from typing import TYPE_CHECKING, Iterable, Sequence
 
 from metricflow_semantics.model.semantics.element_filter import GroupByItemSetFilter
 
@@ -16,11 +16,11 @@ class SpecPattern(ABC):
     """
 
     @abstractmethod
-    def match(self, candidate_specs: Sequence[InstanceSpec]) -> Sequence[InstanceSpec]:
+    def match(self, candidate_specs: Iterable[InstanceSpec]) -> Sequence[InstanceSpec]:
         """Given candidate specs, return the ones that match this pattern."""
         raise NotImplementedError
 
-    def matches_any(self, candidate_specs: Sequence[InstanceSpec]) -> bool:
+    def matches_any(self, candidate_specs: Iterable[InstanceSpec]) -> bool:
         """Returns true if this spec matches any of the given specs."""
         return len(self.match(candidate_specs)) > 0
 

--- a/metricflow_semantics/specs/patterns/typed_patterns.py
+++ b/metricflow_semantics/specs/patterns/typed_patterns.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Optional, Sequence, Tuple
+from typing import Iterable, Optional, Sequence, Tuple
 
 from metricflow_semantics.errors.error_classes import UnableToSatisfyQueryError
 from metricflow_semantics.model.linkable_element_property import GroupByItemProperty
@@ -36,7 +36,7 @@ class DimensionPattern(EntityLinkPattern):
     include_time_dimensions: bool = True
 
     @override
-    def match(self, candidate_specs: Sequence[InstanceSpec]) -> Sequence[LinkableInstanceSpec]:
+    def match(self, candidate_specs: Iterable[InstanceSpec]) -> Sequence[LinkableInstanceSpec]:
         spec_set = group_specs_by_type(candidate_specs)
         filtered_specs: Tuple[LinkableInstanceSpec, ...] = spec_set.dimension_specs
         if self.include_time_dimensions:
@@ -78,7 +78,7 @@ class TimeDimensionPattern(EntityLinkPattern):
     """
 
     @override
-    def match(self, candidate_specs: Sequence[InstanceSpec]) -> Sequence[LinkableInstanceSpec]:
+    def match(self, candidate_specs: Iterable[InstanceSpec]) -> Sequence[LinkableInstanceSpec]:
         spec_set = group_specs_by_type(candidate_specs)
         return super().match(spec_set.time_dimension_specs)
 
@@ -139,7 +139,7 @@ class EntityPattern(EntityLinkPattern):
     """
 
     @override
-    def match(self, candidate_specs: Sequence[InstanceSpec]) -> Sequence[LinkableInstanceSpec]:
+    def match(self, candidate_specs: Iterable[InstanceSpec]) -> Sequence[LinkableInstanceSpec]:
         spec_set = group_specs_by_type(candidate_specs)
         return super().match(spec_set.entity_specs)
 
@@ -168,7 +168,7 @@ class GroupByMetricPattern(EntityLinkPattern):
     """A pattern that matches metrics using the group by specifications."""
 
     @override
-    def match(self, candidate_specs: Sequence[InstanceSpec]) -> Sequence[LinkableInstanceSpec]:
+    def match(self, candidate_specs: Iterable[InstanceSpec]) -> Sequence[LinkableInstanceSpec]:
         spec_set = group_specs_by_type(candidate_specs)
         return super().match(spec_set.group_by_metric_specs)
 

--- a/tests_metricflow/query_rendering/test_alias_rendering.py
+++ b/tests_metricflow/query_rendering/test_alias_rendering.py
@@ -6,6 +6,7 @@ import logging
 
 import pytest
 from _pytest.fixtures import FixtureRequest
+from metricflow_semantics.errors.error_classes import InvalidQueryException
 from metricflow_semantics.query.query_parser import MetricFlowQueryParser
 from metricflow_semantics.specs.query_param_implementations import (
     DimensionOrEntityParameter,
@@ -181,3 +182,64 @@ def test_items_with_and_without_alias(
         dataflow_plan_builder=dataflow_plan_builder,
         query_spec=query_spec,
     )
+
+
+@pytest.mark.sql_engine_snapshot
+@pytest.mark.duckdb_only
+def test_aliased_item_with_non_aliased_order_by(
+    request: FixtureRequest,
+    mf_test_configuration: MetricFlowTestConfiguration,
+    dataflow_plan_builder: DataflowPlanBuilder,
+    sql_client: SqlClient,
+    query_parser: MetricFlowQueryParser,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
+) -> None:
+    """Tests querying an item with an alias, but not specifying the alias in the order-by."""
+    metric_param = MetricParameter(
+        name="bookings",
+    )
+    dimension_param = DimensionOrEntityParameter(
+        name="booking__is_instant",
+    )
+    aliased_dimension_param = DimensionOrEntityParameter(name="booking__is_instant", alias="aliased_is_instant")
+    query_spec = query_parser.parse_and_validate_query(
+        metrics=(metric_param,),
+        group_by=(aliased_dimension_param,),
+        order_by=(OrderByParameter(dimension_param),),
+    ).query_spec
+
+    render_and_check(
+        request=request,
+        mf_test_configuration=mf_test_configuration,
+        dataflow_to_sql_converter=dataflow_to_sql_converter,
+        sql_client=sql_client,
+        dataflow_plan_builder=dataflow_plan_builder,
+        query_spec=query_spec,
+    )
+
+
+def test_order_by_alias_mismatch(
+    mf_test_configuration: MetricFlowTestConfiguration,
+    dataflow_plan_builder: DataflowPlanBuilder,
+    sql_client: SqlClient,
+    query_parser: MetricFlowQueryParser,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
+) -> None:
+    """Tests querying an item without an alias, but specifying an alias in the order-by.
+
+    This should raise an error as the order-by item doesn't correspond to one of inputs.
+    """
+    metric_param = MetricParameter(
+        name="bookings",
+    )
+    dimension_param = DimensionOrEntityParameter(
+        name="booking__is_instant",
+    )
+    aliased_dimension_param = DimensionOrEntityParameter(name="booking__is_instant", alias="aliased_is_instant")
+
+    with pytest.raises(InvalidQueryException):
+        query_parser.parse_and_validate_query(
+            metrics=(metric_param,),
+            group_by=(dimension_param,),
+            order_by=(OrderByParameter(aliased_dimension_param),),
+        )

--- a/tests_metricflow/snapshots/test_alias_rendering.py/SqlPlan/DuckDB/test_aliased_item_with_non_aliased_order_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_alias_rendering.py/SqlPlan/DuckDB/test_aliased_item_with_non_aliased_order_by__plan0.sql
@@ -1,0 +1,262 @@
+test_name: test_aliased_item_with_non_aliased_order_by
+test_filename: test_alias_rendering.py
+docstring:
+  Tests querying an item with an alias, but not specifying the alias in the order-by.
+sql_engine: DuckDB
+---
+-- Write to DataTable
+SELECT
+  subq_7.aliased_is_instant
+  , subq_7.bookings
+FROM (
+  -- Change Column Aliases
+  SELECT
+    subq_6.booking__is_instant AS aliased_is_instant
+    , subq_6.bookings
+  FROM (
+    -- Order By ['booking__is_instant']
+    SELECT
+      subq_5.booking__is_instant
+      , subq_5.bookings
+    FROM (
+      -- Compute Metrics via Expressions
+      SELECT
+        subq_4.booking__is_instant
+        , subq_4.__bookings AS bookings
+      FROM (
+        -- Aggregate Inputs for Simple Metrics
+        SELECT
+          subq_3.booking__is_instant
+          , SUM(subq_3.__bookings) AS __bookings
+        FROM (
+          -- Select: ['__bookings', 'booking__is_instant']
+          SELECT
+            subq_2.booking__is_instant
+            , subq_2.__bookings
+          FROM (
+            -- Select: ['__bookings', 'booking__is_instant']
+            SELECT
+              subq_1.booking__is_instant
+              , subq_1.__bookings
+            FROM (
+              -- Metric Time Dimension 'ds'
+              SELECT
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.__bookings
+                , subq_0.__average_booking_value
+                , subq_0.__instant_bookings
+                , subq_0.__booking_value
+                , subq_0.__max_booking_value
+                , subq_0.__min_booking_value
+                , subq_0.__instant_booking_value
+                , subq_0.__average_instant_booking_value
+                , subq_0.__booking_value_for_non_null_listing_id
+                , subq_0.__bookers
+                , subq_0.__referred_bookings
+                , subq_0.__median_booking_value
+                , subq_0.__booking_value_p99
+                , subq_0.__discrete_booking_value_p99
+                , subq_0.__approximate_continuous_booking_value_p99
+                , subq_0.__approximate_discrete_booking_value_p99
+                , subq_0.__bookings_join_to_time_spine
+                , subq_0.__bookings_fill_nulls_with_0_without_time_spine
+                , subq_0.__bookings_fill_nulls_with_0
+                , subq_0.__instant_bookings_with_measure_filter
+                , subq_0.__bookings_join_to_time_spine_with_tiered_filters
+                , subq_0.__bookers_fill_nulls_with_0_join_to_timespine
+              FROM (
+                -- Read Elements From Semantic Model 'bookings_source'
+                SELECT
+                  1 AS __bookings
+                  , bookings_source_src_28000.booking_value AS __average_booking_value
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS __instant_bookings
+                  , bookings_source_src_28000.booking_value AS __booking_value
+                  , bookings_source_src_28000.booking_value AS __max_booking_value
+                  , bookings_source_src_28000.booking_value AS __min_booking_value
+                  , bookings_source_src_28000.booking_value AS __instant_booking_value
+                  , bookings_source_src_28000.booking_value AS __average_instant_booking_value
+                  , bookings_source_src_28000.booking_value AS __booking_value_for_non_null_listing_id
+                  , bookings_source_src_28000.guest_id AS __bookers
+                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS __referred_bookings
+                  , bookings_source_src_28000.booking_value AS __median_booking_value
+                  , bookings_source_src_28000.booking_value AS __booking_value_p99
+                  , bookings_source_src_28000.booking_value AS __discrete_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS __approximate_continuous_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS __approximate_discrete_booking_value_p99
+                  , 1 AS __bookings_join_to_time_spine
+                  , 1 AS __bookings_fill_nulls_with_0_without_time_spine
+                  , 1 AS __bookings_fill_nulls_with_0
+                  , 1 AS __instant_bookings_with_measure_filter
+                  , 1 AS __bookings_join_to_time_spine_with_tiered_filters
+                  , bookings_source_src_28000.guest_id AS __bookers_fill_nulls_with_0_join_to_timespine
+                  , bookings_source_src_28000.booking_value AS __booking_payments
+                  , bookings_source_src_28000.is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                  , bookings_source_src_28000.is_instant AS booking__is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                  , bookings_source_src_28000.listing_id AS listing
+                  , bookings_source_src_28000.guest_id AS guest
+                  , bookings_source_src_28000.host_id AS host
+                  , bookings_source_src_28000.listing_id AS booking__listing
+                  , bookings_source_src_28000.guest_id AS booking__guest
+                  , bookings_source_src_28000.host_id AS booking__host
+                FROM ***************************.fct_bookings bookings_source_src_28000
+              ) subq_0
+            ) subq_1
+          ) subq_2
+        ) subq_3
+        GROUP BY
+          subq_3.booking__is_instant
+      ) subq_4
+    ) subq_5
+    ORDER BY subq_5.booking__is_instant
+  ) subq_6
+) subq_7

--- a/tests_metricflow/snapshots/test_alias_rendering.py/SqlPlan/DuckDB/test_aliased_item_with_non_aliased_order_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_alias_rendering.py/SqlPlan/DuckDB/test_aliased_item_with_non_aliased_order_by__plan0_optimized.sql
@@ -1,0 +1,27 @@
+test_name: test_aliased_item_with_non_aliased_order_by
+test_filename: test_alias_rendering.py
+docstring:
+  Tests querying an item with an alias, but not specifying the alias in the order-by.
+sql_engine: DuckDB
+---
+-- Aggregate Inputs for Simple Metrics
+-- Compute Metrics via Expressions
+-- Order By ['booking__is_instant']
+-- Change Column Aliases
+-- Write to DataTable
+SELECT
+  booking__is_instant AS aliased_is_instant
+  , SUM(__bookings) AS bookings
+FROM (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  -- Select: ['__bookings', 'booking__is_instant']
+  -- Select: ['__bookings', 'booking__is_instant']
+  SELECT
+    is_instant AS booking__is_instant
+    , 1 AS __bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+) subq_11
+GROUP BY
+  booking__is_instant
+ORDER BY aliased_is_instant


### PR DESCRIPTION
A query can specify a column alias for the items (e.g. metrics / dimensions) in a query. To match prior behavior, this PR updates the resolver to allow order-by items that don't specify an alias to match with query items that specify an alias. 

e.g.
```
Metrics: [MetricParameter(name="bookings")]
Dimensions: [DimensionOrEntityParameter(name="booking__is_instant", alias="aliased_is_instant")]
Order-Bys: [DimensionOrEntityParameter(name="booking__is_instant")]
```

This behavior may be revised later if it turns out to be an uncommon pattern as it's easier to maintain a contract that order-by items need to match one of the queried items in the same form.