### PR TITLE
Surface information loss from MSI→OSI conversion via ConverterResult

### DIFF
--- a/.changes/unreleased/Features-20260424-161424.yaml
+++ b/.changes/unreleased/Features-20260424-161424.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Return results from OSI<>MSI converters as a ConverterResult object
+time: 2026-04-24T16:14:24.492143-05:00
+custom:
+  Author: QMalcolm
+  Issue: "2031"

--- a/metricflow/converters/converter_issues.py
+++ b/metricflow/converters/converter_issues.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import List
+
+from metricflow.converters.models import OSIDocument
+
+
+class ConverterIssueType(Enum):
+    """Identifies the kind of information loss that occurred during conversion."""
+
+    CONVERSION_METRIC_DROPPED = "CONVERSION_METRIC_DROPPED"
+    PRIVATE_METRIC_DROPPED = "PRIVATE_METRIC_DROPPED"
+    NATURAL_ENTITY_DROPPED = "NATURAL_ENTITY_DROPPED"
+    CUMULATIVE_SEMANTICS_LOSS = "CUMULATIVE_SEMANTICS_LOSS"
+
+
+@dataclass(frozen=True)
+class ConverterIssue:
+    """Records a single instance of information loss during MSI→OSI conversion."""
+
+    issue_type: ConverterIssueType
+    element_name: str
+
+
+@dataclass(frozen=True)
+class ConverterResult:
+    """Return value of MSIToOSIConverter.convert(), pairing the output document with any conversion issues."""
+
+    document: OSIDocument
+    issues: List[ConverterIssue]

--- a/metricflow/converters/converter_issues.py
+++ b/metricflow/converters/converter_issues.py
@@ -2,9 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import List
-
-from metricflow.converters.models import OSIDocument
+from typing import Generic, List, TypeVar
 
 
 class ConverterIssueType(Enum):
@@ -18,15 +16,18 @@ class ConverterIssueType(Enum):
 
 @dataclass(frozen=True)
 class ConverterIssue:
-    """Records a single instance of information loss during MSI→OSI conversion."""
+    """Records a single instance of information loss during conversion."""
 
     issue_type: ConverterIssueType
     element_name: str
 
 
-@dataclass(frozen=True)
-class ConverterResult:
-    """Return value of MSIToOSIConverter.convert(), pairing the output document with any conversion issues."""
+T = TypeVar("T")
 
-    document: OSIDocument
+
+@dataclass(frozen=True)
+class ConverterResult(Generic[T]):
+    """Return value of a converter's convert() method, pairing the output with any conversion issues."""
+
+    output: T
     issues: List[ConverterIssue]

--- a/metricflow/converters/msi_to_osi.py
+++ b/metricflow/converters/msi_to_osi.py
@@ -8,6 +8,7 @@ from typing import Dict, List, Optional, Sequence, Tuple
 
 from metricflow_semantics.toolkit.mf_logging.lazy_formattable import LazyFormat
 
+from metricflow.converters.converter_issues import ConverterIssue, ConverterIssueType, ConverterResult
 from metricflow.converters.filter_utils import _collect_filter_sql, _merge_filter_sqls
 from metricflow.converters.models import (
     OSIDataset,
@@ -66,12 +67,14 @@ class MSIToOSIConverter:
 
     def convert(  # noqa: D102
         self, manifest: PydanticSemanticManifest, osi_model_name: str = "semantic_model"
-    ) -> OSIDocument:
+    ) -> ConverterResult:
         manifest = PydanticSemanticManifestTransformer.transform(manifest)
+        issues: List[ConverterIssue] = []
 
         datasets = [self._convert_semantic_model(sm) for sm in manifest.semantic_models]
 
-        entity_index = self._build_entity_index(manifest.semantic_models)
+        entity_index, entity_issues = self._build_entity_index(manifest.semantic_models)
+        issues.extend(entity_issues)
         relationships = self._build_relationships(entity_index)
 
         metric_index = self._build_metric_index(manifest.metrics)
@@ -80,9 +83,19 @@ class MSIToOSIConverter:
         osi_metrics: List[OSIMetric] = []
         for metric in manifest.metrics:
             if metric.type is MetricType.CONVERSION:
+                issues.append(
+                    ConverterIssue(issue_type=ConverterIssueType.CONVERSION_METRIC_DROPPED, element_name=metric.name)
+                )
                 continue
             if metric.type_params.is_private:
+                issues.append(
+                    ConverterIssue(issue_type=ConverterIssueType.PRIVATE_METRIC_DROPPED, element_name=metric.name)
+                )
                 continue
+            if metric.type is MetricType.CUMULATIVE:
+                issues.append(
+                    ConverterIssue(issue_type=ConverterIssueType.CUMULATIVE_SEMANTICS_LOSS, element_name=metric.name)
+                )
             expr = self._resolve_metric_expression(metric, metric_index, expression_cache)
             osi_metrics.append(
                 OSIMetric(
@@ -92,17 +105,20 @@ class MSIToOSIConverter:
                 )
             )
 
-        return OSIDocument(
-            version="0.1.1",
-            dialects=[self._dialect],
-            semantic_model=[
-                OSISemanticModel(
-                    name=osi_model_name,
-                    datasets=datasets,
-                    relationships=relationships if relationships else None,
-                    metrics=osi_metrics if osi_metrics else None,
-                )
-            ],
+        return ConverterResult(
+            document=OSIDocument(
+                version="0.1.1",
+                dialects=[self._dialect],
+                semantic_model=[
+                    OSISemanticModel(
+                        name=osi_model_name,
+                        datasets=datasets,
+                        relationships=relationships if relationships else None,
+                        metrics=osi_metrics if osi_metrics else None,
+                    )
+                ],
+            ),
+            issues=issues,
         )
 
     def _convert_semantic_model(self, sm: SemanticModel) -> OSIDataset:
@@ -334,16 +350,20 @@ class MSIToOSIConverter:
     @staticmethod
     def _build_entity_index(
         semantic_models: Sequence[SemanticModel],
-    ) -> Dict[str, List[_EntityEntry]]:
+    ) -> Tuple[Dict[str, List[_EntityEntry]], List[ConverterIssue]]:
         """Map each entity name to the _EntityEntry objects that declare it."""
         index: Dict[str, List[_EntityEntry]] = defaultdict(list)
+        issues: List[ConverterIssue] = []
         for sm in semantic_models:
             for entity in sm.entities:
                 if entity.type is EntityType.NATURAL:
+                    issues.append(
+                        ConverterIssue(issue_type=ConverterIssueType.NATURAL_ENTITY_DROPPED, element_name=entity.name)
+                    )
                     continue
                 col = entity.expr if entity.expr is not None else entity.name
                 index[entity.name].append(_EntityEntry(dataset=sm.name, col=col, entity_type=entity.type))
-        return dict(index)
+        return dict(index), issues
 
     @staticmethod
     def _relationship_direction(

--- a/metricflow/converters/msi_to_osi.py
+++ b/metricflow/converters/msi_to_osi.py
@@ -67,7 +67,7 @@ class MSIToOSIConverter:
 
     def convert(  # noqa: D102
         self, manifest: PydanticSemanticManifest, osi_model_name: str = "semantic_model"
-    ) -> ConverterResult:
+    ) -> ConverterResult[OSIDocument]:
         manifest = PydanticSemanticManifestTransformer.transform(manifest)
         issues: List[ConverterIssue] = []
 
@@ -106,7 +106,7 @@ class MSIToOSIConverter:
             )
 
         return ConverterResult(
-            document=OSIDocument(
+            output=OSIDocument(
                 version="0.1.1",
                 dialects=[self._dialect],
                 semantic_model=[

--- a/metricflow/converters/osi_to_msi.py
+++ b/metricflow/converters/osi_to_msi.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import List, Optional, Set
 
+from metricflow.converters.converter_issues import ConverterResult
 from metricflow.converters.expression_utils import (
     _extract_agg_info,
     _get_raw_inner_col,
@@ -80,7 +81,7 @@ class OSIToMSIConverter:
     def __init__(self, dialect: OSIDialect = OSIDialect.ANSI_SQL) -> None:  # noqa: D107
         self._dialect = dialect
 
-    def convert(self, document: OSIDocument) -> PydanticSemanticManifest:  # noqa: D102
+    def convert(self, document: OSIDocument) -> ConverterResult[PydanticSemanticManifest]:  # noqa: D102
         semantic_models: List[PydanticSemanticModel] = []
         metrics: List[PydanticMetric] = []
 
@@ -89,10 +90,13 @@ class OSIToMSIConverter:
                 semantic_models.append(self._convert_dataset(dataset, osi_sm))
             metrics.extend(self._convert_metrics(osi_sm))
 
-        return PydanticSemanticManifest(
-            semantic_models=semantic_models,
-            metrics=metrics,
-            project_configuration=PydanticProjectConfiguration(),
+        return ConverterResult(
+            output=PydanticSemanticManifest(
+                semantic_models=semantic_models,
+                metrics=metrics,
+                project_configuration=PydanticProjectConfiguration(),
+            ),
+            issues=[],
         )
 
     # ------------------------------------------------------------------

--- a/tests_metricflow_semantic_interfaces/osi/test_msi_to_osi.py
+++ b/tests_metricflow_semantic_interfaces/osi/test_msi_to_osi.py
@@ -75,7 +75,7 @@ def _osi_metrics(result: OSIDocument) -> list:
 
 class TestBasicConversion:  # noqa: D101
     def test_empty_manifest_produces_empty_datasets(self) -> None:  # noqa: D102
-        result = MSIToOSIConverter().convert(_manifest(), osi_model_name="test")
+        result = MSIToOSIConverter().convert(_manifest(), osi_model_name="test").document
 
         assert result.version == "0.1.1"
         assert len(result.semantic_model) == 1
@@ -90,7 +90,7 @@ class TestBasicConversion:  # noqa: D101
             description="Order data",
             node_relation=PydanticNodeRelation(schema_name="analytics", alias="orders_table"),
         )
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm]))
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm])).document
 
         dataset = result.semantic_model[0].datasets[0]
         assert dataset.name == "orders"
@@ -102,14 +102,14 @@ class TestBasicConversion:  # noqa: D101
             name="orders",
             node_relation=PydanticNodeRelation(schema_name="analytics", alias="orders_table", database="prod"),
         )
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm]))
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm])).document
 
         assert result.semantic_model[0].datasets[0].source == "prod.analytics.orders_table"
 
     def test_multiple_semantic_models_become_multiple_datasets(self) -> None:  # noqa: D102
         sm_a = semantic_model_with_guaranteed_meta(name="orders")
         sm_b = semantic_model_with_guaranteed_meta(name="users")
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm_a, sm_b]))
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm_a, sm_b])).document
 
         names = [ds.name for ds in result.semantic_model[0].datasets]
         assert names == ["orders", "users"]
@@ -121,7 +121,7 @@ class TestDimensionConversion:  # noqa: D101
             name="orders",
             dimensions=[_dimension("status", dim_type=DimensionType.CATEGORICAL)],
         )
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm]))
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm])).document
 
         field = _fields(result)[0]
         assert field.name == "status"
@@ -133,7 +133,7 @@ class TestDimensionConversion:  # noqa: D101
             name="orders",
             dimensions=[_dimension("ds", dim_type=DimensionType.TIME, granularity=TimeGranularity.DAY)],
         )
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm]))
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm])).document
 
         field = _fields(result)[0]
         assert field.dimension is not None
@@ -144,7 +144,7 @@ class TestDimensionConversion:  # noqa: D101
             name="orders",
             dimensions=[_dimension("order_date", expr="DATE(created_at)")],
         )
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm]))
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm])).document
 
         assert _field_expr(result) == "DATE(created_at)"
 
@@ -153,7 +153,7 @@ class TestDimensionConversion:  # noqa: D101
             name="orders",
             dimensions=[_dimension("status")],
         )
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm]))
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm])).document
 
         assert _field_expr(result) == "status"
 
@@ -162,7 +162,7 @@ class TestDimensionConversion:  # noqa: D101
             name="orders",
             dimensions=[_dimension("status", description="Order status", label="Status")],
         )
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm]))
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm])).document
 
         field = _fields(result)[0]
         assert field.description == "Order status"
@@ -175,7 +175,7 @@ class TestMeasureConversion:  # noqa: D101
             name="orders",
             measures=[_measure("revenue", agg=AggregationType.SUM, expr="amount")],
         )
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm]))
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm])).document
 
         field = _fields(result)[0]
         assert field.name == "revenue"
@@ -187,7 +187,7 @@ class TestMeasureConversion:  # noqa: D101
             name="orders",
             measures=[_measure("num_orders", agg=AggregationType.SUM)],
         )
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm]))
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm])).document
 
         assert _field_expr(result) == "num_orders"
 
@@ -196,7 +196,7 @@ class TestMeasureConversion:  # noqa: D101
             name="orders",
             measures=[_measure("revenue", description="Total revenue", label="Revenue")],
         )
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm]))
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm])).document
 
         field = _fields(result)[0]
         assert field.description == "Total revenue"
@@ -209,7 +209,7 @@ class TestEntityConversion:  # noqa: D101
             name="orders",
             entities=[_entity("order_id", entity_type=EntityType.PRIMARY)],
         )
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm]))
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm])).document
 
         field = _fields(result)[0]
         assert field.name == "order_id"
@@ -221,7 +221,7 @@ class TestEntityConversion:  # noqa: D101
             name="orders",
             entities=[_entity("order_id", entity_type=EntityType.PRIMARY, expr="id")],
         )
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm]))
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm])).document
 
         field = _fields(result)[0]
         assert field.name == "order_id"
@@ -232,7 +232,7 @@ class TestEntityConversion:  # noqa: D101
             name="orders",
             entities=[_entity("user_id", entity_type=EntityType.FOREIGN)],
         )
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm]))
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm])).document
 
         assert _fields(result)[0].name == "user_id"
 
@@ -259,7 +259,7 @@ class TestEntityKeyExtraction:  # noqa: D101
             name="orders",
             entities=[_entity(name, entity_type=entity_type, expr=expr)],
         )
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm]))
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm])).document
 
         dataset = result.semantic_model[0].datasets[0]
         assert dataset.primary_key == expected_pk
@@ -274,7 +274,7 @@ class TestFieldOrdering:  # noqa: D101
             dimensions=[_dimension("status")],
             measures=[_measure("revenue", expr="amount")],
         )
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm]))
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm])).document
 
         fields = _fields(result)
         assert fields[0].name == "order_id"
@@ -288,7 +288,7 @@ class TestDialectConfiguration:  # noqa: D101
             name="orders",
             dimensions=[_dimension("status")],
         )
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm]))
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm])).document
 
         assert result.dialects == [OSIDialect.ANSI_SQL]
         assert _fields(result)[0].expression.dialects[0].dialect == OSIDialect.ANSI_SQL
@@ -298,7 +298,7 @@ class TestDialectConfiguration:  # noqa: D101
             name="orders",
             dimensions=[_dimension("status")],
         )
-        result = MSIToOSIConverter(dialect=OSIDialect.SNOWFLAKE).convert(_manifest(semantic_models=[sm]))
+        result = MSIToOSIConverter(dialect=OSIDialect.SNOWFLAKE).convert(_manifest(semantic_models=[sm])).document
 
         assert result.dialects == [OSIDialect.SNOWFLAKE]
         assert _fields(result)[0].expression.dialects[0].dialect == OSIDialect.SNOWFLAKE
@@ -314,7 +314,7 @@ class TestRelationshipConversion:  # noqa: D101
             name="bookings",
             entities=[_entity("listing", entity_type=EntityType.FOREIGN, expr="listing_id")],
         )
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[listings, bookings]))
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[listings, bookings])).document
 
         rels = result.semantic_model[0].relationships
         assert rels is not None
@@ -334,7 +334,7 @@ class TestRelationshipConversion:  # noqa: D101
             name="users_b",
             entities=[_entity("user", entity_type=EntityType.PRIMARY, expr="uid")],
         )
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[users_a, users_b]))
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[users_a, users_b])).document
 
         rels = result.semantic_model[0].relationships
         assert rels is not None
@@ -347,7 +347,7 @@ class TestRelationshipConversion:  # noqa: D101
             name="bookings",
             entities=[_entity("listing", entity_type=EntityType.FOREIGN, expr="listing_id")],
         )
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[bookings]))
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[bookings])).document
 
         assert result.semantic_model[0].relationships is None
 
@@ -359,7 +359,7 @@ class TestRelationshipConversion:  # noqa: D101
                 _entity("order", entity_type=EntityType.FOREIGN, expr="order_id"),
             ],
         )
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[orders]))
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[orders])).document
 
         assert result.semantic_model[0].relationships is None
 
@@ -378,7 +378,7 @@ class TestRelationshipConversion:  # noqa: D101
             name="orders",
             entities=[_entity("user", entity_type=EntityType.FOREIGN, expr="user_id")],
         )
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[users_a, users_b, orders]))
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[users_a, users_b, orders])).document
 
         rels = result.semantic_model[0].relationships
         assert rels is not None
@@ -400,7 +400,7 @@ class TestRelationshipConversion:  # noqa: D101
             name="bookings",
             entities=[_entity("listing", entity_type=EntityType.FOREIGN, expr="fk_lid")],
         )
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[listings, bookings]))
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[listings, bookings])).document
 
         rels = result.semantic_model[0].relationships
         assert rels is not None
@@ -417,7 +417,7 @@ class TestRelationshipConversion:  # noqa: D101
             name="bookings",
             entities=[_entity("listing", entity_type=EntityType.FOREIGN)],
         )
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[listings, bookings]))
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[listings, bookings])).document
 
         rels = result.semantic_model[0].relationships
         assert rels is not None
@@ -437,7 +437,7 @@ class TestRelationshipConversion:  # noqa: D101
             name="orders",
             entities=[_entity("booking", entity_type=EntityType.FOREIGN, expr="booking_id")],
         )
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[bookings, orders]))
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[bookings, orders])).document
 
         assert result.semantic_model[0].relationships is None
 
@@ -450,7 +450,7 @@ class TestRelationshipConversion:  # noqa: D101
             name="bookings",
             entities=[_entity("listing", entity_type=EntityType.FOREIGN, expr="listing_id")],
         )
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[listings, bookings]))
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[listings, bookings])).document
 
         rels = result.semantic_model[0].relationships
         assert rels is not None
@@ -465,7 +465,7 @@ class TestRelationshipConversion:  # noqa: D101
             name="orders",
             entities=[_entity("user", entity_type=EntityType.FOREIGN, expr="user_id")],
         )
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[users, orders]))
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[users, orders])).document
 
         assert result.semantic_model[0].relationships is None
 
@@ -478,7 +478,7 @@ class TestRelationshipConversion:  # noqa: D101
             name="alpha",
             entities=[_entity("shared", entity_type=EntityType.FOREIGN, expr="col_a")],
         )
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[beta, alpha]))
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[beta, alpha])).document
 
         rels = result.semantic_model[0].relationships
         assert rels is not None
@@ -495,7 +495,7 @@ class TestMetricConversion:  # noqa: D101
             measures=[_measure("revenue", agg=AggregationType.SUM, expr="amount")],
         )
         metric = _simple_metric("revenue", measure_name="revenue")
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm], metrics=[metric]))
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm], metrics=[metric])).document
 
         metrics = _osi_metrics(result)
         assert len(metrics) == 1
@@ -508,7 +508,7 @@ class TestMetricConversion:  # noqa: D101
             measures=[_measure("revenue", agg=AggregationType.SUM, expr="amount")],
         )
         metric = _simple_metric("revenue", measure_name="revenue", description="Total revenue")
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm], metrics=[metric]))
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm], metrics=[metric])).document
 
         assert _osi_metrics(result)[0].description == "Total revenue"
 
@@ -532,7 +532,7 @@ class TestMetricConversion:  # noqa: D101
             metadata=default_meta(),
             config=None,
         )
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm], metrics=[metric]))
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm], metrics=[metric])).document
 
         assert _osi_metrics(result)[0].expression.dialects[0].expression == "AVG(orders.price)"
 
@@ -562,7 +562,11 @@ class TestMetricConversion:  # noqa: D101
             metadata=default_meta(),
             config=None,
         )
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm], metrics=[revenue_m, order_count_m, arpu]))
+        result = (
+            MSIToOSIConverter()
+            .convert(_manifest(semantic_models=[sm], metrics=[revenue_m, order_count_m, arpu]))
+            .document
+        )
 
         arpu_osi = next(m for m in _osi_metrics(result) if m.name == "arpu")
         assert arpu_osi.expression.dialects[0].expression == (
@@ -601,7 +605,9 @@ class TestMetricConversion:  # noqa: D101
             metadata=default_meta(),
             config=None,
         )
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm], metrics=[revenue_m, cost_m, profit]))
+        result = (
+            MSIToOSIConverter().convert(_manifest(semantic_models=[sm], metrics=[revenue_m, cost_m, profit])).document
+        )
 
         profit_osi = next(m for m in _osi_metrics(result) if m.name == "profit")
         assert profit_osi.expression.dialects[0].expression == "SUM(orders.amount) - SUM(orders.cost_amount)"
@@ -631,7 +637,9 @@ class TestMetricConversion:  # noqa: D101
             metadata=default_meta(),
             config=None,
         )
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm], metrics=[revenue_m, cost_m, profit]))
+        result = (
+            MSIToOSIConverter().convert(_manifest(semantic_models=[sm], metrics=[revenue_m, cost_m, profit])).document
+        )
 
         profit_osi = next(m for m in _osi_metrics(result) if m.name == "profit")
         assert profit_osi.expression.dialects[0].expression == "SUM(orders.amount) - SUM(orders.cost_amount)"
@@ -680,11 +688,15 @@ class TestMetricConversion:  # noqa: D101
             metadata=default_meta(),
             config=None,
         )
-        result = MSIToOSIConverter().convert(
-            _manifest(
-                semantic_models=[sm],
-                metrics=[revenue_m, cost_m, expenses_m, gross_profit, net_profit],
+        result = (
+            MSIToOSIConverter()
+            .convert(
+                _manifest(
+                    semantic_models=[sm],
+                    metrics=[revenue_m, cost_m, expenses_m, gross_profit, net_profit],
+                )
             )
+            .document
         )
 
         net_osi = next(m for m in _osi_metrics(result) if m.name == "net_profit")
@@ -724,8 +736,10 @@ class TestMetricConversion:  # noqa: D101
             metadata=default_meta(),
             config=None,
         )
-        result = MSIToOSIConverter().convert(
-            _manifest(semantic_models=[sm], metrics=[revenue_m, revenue_adjusted_m, derived])
+        result = (
+            MSIToOSIConverter()
+            .convert(_manifest(semantic_models=[sm], metrics=[revenue_m, revenue_adjusted_m, derived]))
+            .document
         )
 
         derived_osi = next(m for m in _osi_metrics(result) if m.name == "revenue_delta")
@@ -752,7 +766,7 @@ class TestMetricConversion:  # noqa: D101
             metadata=default_meta(),
             config=None,
         )
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm], metrics=[cumulative]))
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm], metrics=[cumulative])).document
 
         metrics = _osi_metrics(result)
         assert len(metrics) == 1
@@ -786,7 +800,7 @@ class TestMetricConversion:  # noqa: D101
             metadata=default_meta(),
             config=None,
         )
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm], metrics=[base, cumulative]))
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm], metrics=[base, cumulative])).document
 
         cumulative_osi = next(m for m in _osi_metrics(result) if m.name == "cumulative_revenue")
         assert cumulative_osi.expression.dialects[0].expression == "SUM(orders.amount)"
@@ -795,7 +809,7 @@ class TestMetricConversion:  # noqa: D101
 
     def test_no_metrics_produces_no_osi_metrics(self) -> None:  # noqa: D102
         sm = semantic_model_with_guaranteed_meta(name="orders")
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm]))
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm])).document
 
         assert result.semantic_model[0].metrics is None
 
@@ -807,14 +821,18 @@ class TestMetricConversion:  # noqa: D101
                 _measure("order_count", agg=AggregationType.COUNT, expr="order_id"),
             ],
         )
-        result = MSIToOSIConverter().convert(
-            _manifest(
-                semantic_models=[sm],
-                metrics=[
-                    _simple_metric("revenue", "revenue"),
-                    _simple_metric("order_count", "order_count"),
-                ],
+        result = (
+            MSIToOSIConverter()
+            .convert(
+                _manifest(
+                    semantic_models=[sm],
+                    metrics=[
+                        _simple_metric("revenue", "revenue"),
+                        _simple_metric("order_count", "order_count"),
+                    ],
+                )
             )
+            .document
         )
 
         metrics = _osi_metrics(result)
@@ -844,7 +862,7 @@ class TestMetricConversion:  # noqa: D101
             metadata=default_meta(),
             config=None,
         )
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm], metrics=[conversion]))
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm], metrics=[conversion])).document
 
         assert result.semantic_model[0].metrics is None
 
@@ -891,7 +909,7 @@ class TestMetricFilterFlattening:  # noqa: D101
             metadata=default_meta(),
             config=None,
         )
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm], metrics=[metric]))
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm], metrics=[metric])).document
 
         assert (
             _osi_metrics(result)[0].expression.dialects[0].expression
@@ -914,7 +932,7 @@ class TestMetricFilterFlattening:  # noqa: D101
             metadata=default_meta(),
             config=None,
         )
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm], metrics=[metric]))
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm], metrics=[metric])).document
 
         assert (
             _osi_metrics(result)[0].expression.dialects[0].expression
@@ -939,7 +957,7 @@ class TestMetricFilterFlattening:  # noqa: D101
             metadata=default_meta(),
             config=None,
         )
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm], metrics=[metric]))
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm], metrics=[metric])).document
 
         assert _osi_metrics(result)[0].expression.dialects[0].expression == (
             "SUM(CASE WHEN (status = 'paid') AND (region = 'intl') THEN orders.amount END)"
@@ -964,7 +982,7 @@ class TestMetricFilterFlattening:  # noqa: D101
             metadata=default_meta(),
             config=None,
         )
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm], metrics=[metric]))
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm], metrics=[metric])).document
 
         assert (
             _osi_metrics(result)[0].expression.dialects[0].expression
@@ -993,7 +1011,11 @@ class TestMetricFilterFlattening:  # noqa: D101
             metadata=default_meta(),
             config=None,
         )
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm], metrics=[revenue_m, order_count_m, arpu]))
+        result = (
+            MSIToOSIConverter()
+            .convert(_manifest(semantic_models=[sm], metrics=[revenue_m, order_count_m, arpu]))
+            .document
+        )
 
         paid_arpu = next(m for m in _osi_metrics(result) if m.name == "paid_arpu")
         assert paid_arpu.expression.dialects[0].expression == (
@@ -1024,7 +1046,9 @@ class TestMetricFilterFlattening:  # noqa: D101
             metadata=default_meta(),
             config=None,
         )
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm], metrics=[revenue_m, cost_m, profit]))
+        result = (
+            MSIToOSIConverter().convert(_manifest(semantic_models=[sm], metrics=[revenue_m, cost_m, profit])).document
+        )
 
         paid_profit = next(m for m in _osi_metrics(result) if m.name == "paid_profit")
         assert paid_profit.expression.dialects[0].expression == (
@@ -1038,8 +1062,10 @@ class TestMetricFilterFlattening:  # noqa: D101
             name="orders",
             measures=[_measure("revenue", agg=AggregationType.SUM, expr="amount")],
         )
-        result = MSIToOSIConverter().convert(
-            _manifest(semantic_models=[sm], metrics=[_simple_metric("revenue", "revenue")])
+        result = (
+            MSIToOSIConverter()
+            .convert(_manifest(semantic_models=[sm], metrics=[_simple_metric("revenue", "revenue")]))
+            .document
         )
 
         assert _osi_metrics(result)[0].expression.dialects[0].expression == "SUM(orders.amount)"
@@ -1054,7 +1080,7 @@ class TestOSIJsonSerialization:  # noqa: D101
             measures=[_measure("revenue", expr="amount")],
             entities=[_entity("order_id", entity_type=EntityType.PRIMARY)],
         )
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm]), osi_model_name="my_project")
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm]), osi_model_name="my_project").document
         parsed = json.loads(result.to_osi_json())
 
         assert parsed["version"] == "0.1.1"
@@ -1063,7 +1089,7 @@ class TestOSIJsonSerialization:  # noqa: D101
 
     def test_to_osi_json_excludes_none_fields(self) -> None:  # noqa: D102
         sm = semantic_model_with_guaranteed_meta(name="orders")
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm]))
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm])).document
         parsed = json.loads(result.to_osi_json())
 
         dataset = parsed["semantic_model"][0]["datasets"][0]

--- a/tests_metricflow_semantic_interfaces/osi/test_msi_to_osi.py
+++ b/tests_metricflow_semantic_interfaces/osi/test_msi_to_osi.py
@@ -75,7 +75,7 @@ def _osi_metrics(result: OSIDocument) -> list:
 
 class TestBasicConversion:  # noqa: D101
     def test_empty_manifest_produces_empty_datasets(self) -> None:  # noqa: D102
-        result = MSIToOSIConverter().convert(_manifest(), osi_model_name="test").document
+        result = MSIToOSIConverter().convert(_manifest(), osi_model_name="test").output
 
         assert result.version == "0.1.1"
         assert len(result.semantic_model) == 1
@@ -90,7 +90,7 @@ class TestBasicConversion:  # noqa: D101
             description="Order data",
             node_relation=PydanticNodeRelation(schema_name="analytics", alias="orders_table"),
         )
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm])).document
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm])).output
 
         dataset = result.semantic_model[0].datasets[0]
         assert dataset.name == "orders"
@@ -102,14 +102,14 @@ class TestBasicConversion:  # noqa: D101
             name="orders",
             node_relation=PydanticNodeRelation(schema_name="analytics", alias="orders_table", database="prod"),
         )
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm])).document
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm])).output
 
         assert result.semantic_model[0].datasets[0].source == "prod.analytics.orders_table"
 
     def test_multiple_semantic_models_become_multiple_datasets(self) -> None:  # noqa: D102
         sm_a = semantic_model_with_guaranteed_meta(name="orders")
         sm_b = semantic_model_with_guaranteed_meta(name="users")
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm_a, sm_b])).document
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm_a, sm_b])).output
 
         names = [ds.name for ds in result.semantic_model[0].datasets]
         assert names == ["orders", "users"]
@@ -121,7 +121,7 @@ class TestDimensionConversion:  # noqa: D101
             name="orders",
             dimensions=[_dimension("status", dim_type=DimensionType.CATEGORICAL)],
         )
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm])).document
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm])).output
 
         field = _fields(result)[0]
         assert field.name == "status"
@@ -133,7 +133,7 @@ class TestDimensionConversion:  # noqa: D101
             name="orders",
             dimensions=[_dimension("ds", dim_type=DimensionType.TIME, granularity=TimeGranularity.DAY)],
         )
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm])).document
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm])).output
 
         field = _fields(result)[0]
         assert field.dimension is not None
@@ -144,7 +144,7 @@ class TestDimensionConversion:  # noqa: D101
             name="orders",
             dimensions=[_dimension("order_date", expr="DATE(created_at)")],
         )
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm])).document
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm])).output
 
         assert _field_expr(result) == "DATE(created_at)"
 
@@ -153,7 +153,7 @@ class TestDimensionConversion:  # noqa: D101
             name="orders",
             dimensions=[_dimension("status")],
         )
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm])).document
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm])).output
 
         assert _field_expr(result) == "status"
 
@@ -162,7 +162,7 @@ class TestDimensionConversion:  # noqa: D101
             name="orders",
             dimensions=[_dimension("status", description="Order status", label="Status")],
         )
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm])).document
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm])).output
 
         field = _fields(result)[0]
         assert field.description == "Order status"
@@ -175,7 +175,7 @@ class TestMeasureConversion:  # noqa: D101
             name="orders",
             measures=[_measure("revenue", agg=AggregationType.SUM, expr="amount")],
         )
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm])).document
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm])).output
 
         field = _fields(result)[0]
         assert field.name == "revenue"
@@ -187,7 +187,7 @@ class TestMeasureConversion:  # noqa: D101
             name="orders",
             measures=[_measure("num_orders", agg=AggregationType.SUM)],
         )
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm])).document
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm])).output
 
         assert _field_expr(result) == "num_orders"
 
@@ -196,7 +196,7 @@ class TestMeasureConversion:  # noqa: D101
             name="orders",
             measures=[_measure("revenue", description="Total revenue", label="Revenue")],
         )
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm])).document
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm])).output
 
         field = _fields(result)[0]
         assert field.description == "Total revenue"
@@ -209,7 +209,7 @@ class TestEntityConversion:  # noqa: D101
             name="orders",
             entities=[_entity("order_id", entity_type=EntityType.PRIMARY)],
         )
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm])).document
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm])).output
 
         field = _fields(result)[0]
         assert field.name == "order_id"
@@ -221,7 +221,7 @@ class TestEntityConversion:  # noqa: D101
             name="orders",
             entities=[_entity("order_id", entity_type=EntityType.PRIMARY, expr="id")],
         )
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm])).document
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm])).output
 
         field = _fields(result)[0]
         assert field.name == "order_id"
@@ -232,7 +232,7 @@ class TestEntityConversion:  # noqa: D101
             name="orders",
             entities=[_entity("user_id", entity_type=EntityType.FOREIGN)],
         )
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm])).document
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm])).output
 
         assert _fields(result)[0].name == "user_id"
 
@@ -259,7 +259,7 @@ class TestEntityKeyExtraction:  # noqa: D101
             name="orders",
             entities=[_entity(name, entity_type=entity_type, expr=expr)],
         )
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm])).document
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm])).output
 
         dataset = result.semantic_model[0].datasets[0]
         assert dataset.primary_key == expected_pk
@@ -274,7 +274,7 @@ class TestFieldOrdering:  # noqa: D101
             dimensions=[_dimension("status")],
             measures=[_measure("revenue", expr="amount")],
         )
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm])).document
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm])).output
 
         fields = _fields(result)
         assert fields[0].name == "order_id"
@@ -288,7 +288,7 @@ class TestDialectConfiguration:  # noqa: D101
             name="orders",
             dimensions=[_dimension("status")],
         )
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm])).document
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm])).output
 
         assert result.dialects == [OSIDialect.ANSI_SQL]
         assert _fields(result)[0].expression.dialects[0].dialect == OSIDialect.ANSI_SQL
@@ -298,7 +298,7 @@ class TestDialectConfiguration:  # noqa: D101
             name="orders",
             dimensions=[_dimension("status")],
         )
-        result = MSIToOSIConverter(dialect=OSIDialect.SNOWFLAKE).convert(_manifest(semantic_models=[sm])).document
+        result = MSIToOSIConverter(dialect=OSIDialect.SNOWFLAKE).convert(_manifest(semantic_models=[sm])).output
 
         assert result.dialects == [OSIDialect.SNOWFLAKE]
         assert _fields(result)[0].expression.dialects[0].dialect == OSIDialect.SNOWFLAKE
@@ -314,7 +314,7 @@ class TestRelationshipConversion:  # noqa: D101
             name="bookings",
             entities=[_entity("listing", entity_type=EntityType.FOREIGN, expr="listing_id")],
         )
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[listings, bookings])).document
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[listings, bookings])).output
 
         rels = result.semantic_model[0].relationships
         assert rels is not None
@@ -334,7 +334,7 @@ class TestRelationshipConversion:  # noqa: D101
             name="users_b",
             entities=[_entity("user", entity_type=EntityType.PRIMARY, expr="uid")],
         )
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[users_a, users_b])).document
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[users_a, users_b])).output
 
         rels = result.semantic_model[0].relationships
         assert rels is not None
@@ -347,7 +347,7 @@ class TestRelationshipConversion:  # noqa: D101
             name="bookings",
             entities=[_entity("listing", entity_type=EntityType.FOREIGN, expr="listing_id")],
         )
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[bookings])).document
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[bookings])).output
 
         assert result.semantic_model[0].relationships is None
 
@@ -359,7 +359,7 @@ class TestRelationshipConversion:  # noqa: D101
                 _entity("order", entity_type=EntityType.FOREIGN, expr="order_id"),
             ],
         )
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[orders])).document
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[orders])).output
 
         assert result.semantic_model[0].relationships is None
 
@@ -378,7 +378,7 @@ class TestRelationshipConversion:  # noqa: D101
             name="orders",
             entities=[_entity("user", entity_type=EntityType.FOREIGN, expr="user_id")],
         )
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[users_a, users_b, orders])).document
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[users_a, users_b, orders])).output
 
         rels = result.semantic_model[0].relationships
         assert rels is not None
@@ -400,7 +400,7 @@ class TestRelationshipConversion:  # noqa: D101
             name="bookings",
             entities=[_entity("listing", entity_type=EntityType.FOREIGN, expr="fk_lid")],
         )
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[listings, bookings])).document
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[listings, bookings])).output
 
         rels = result.semantic_model[0].relationships
         assert rels is not None
@@ -417,7 +417,7 @@ class TestRelationshipConversion:  # noqa: D101
             name="bookings",
             entities=[_entity("listing", entity_type=EntityType.FOREIGN)],
         )
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[listings, bookings])).document
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[listings, bookings])).output
 
         rels = result.semantic_model[0].relationships
         assert rels is not None
@@ -437,7 +437,7 @@ class TestRelationshipConversion:  # noqa: D101
             name="orders",
             entities=[_entity("booking", entity_type=EntityType.FOREIGN, expr="booking_id")],
         )
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[bookings, orders])).document
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[bookings, orders])).output
 
         assert result.semantic_model[0].relationships is None
 
@@ -450,7 +450,7 @@ class TestRelationshipConversion:  # noqa: D101
             name="bookings",
             entities=[_entity("listing", entity_type=EntityType.FOREIGN, expr="listing_id")],
         )
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[listings, bookings])).document
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[listings, bookings])).output
 
         rels = result.semantic_model[0].relationships
         assert rels is not None
@@ -465,7 +465,7 @@ class TestRelationshipConversion:  # noqa: D101
             name="orders",
             entities=[_entity("user", entity_type=EntityType.FOREIGN, expr="user_id")],
         )
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[users, orders])).document
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[users, orders])).output
 
         assert result.semantic_model[0].relationships is None
 
@@ -478,7 +478,7 @@ class TestRelationshipConversion:  # noqa: D101
             name="alpha",
             entities=[_entity("shared", entity_type=EntityType.FOREIGN, expr="col_a")],
         )
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[beta, alpha])).document
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[beta, alpha])).output
 
         rels = result.semantic_model[0].relationships
         assert rels is not None
@@ -495,7 +495,7 @@ class TestMetricConversion:  # noqa: D101
             measures=[_measure("revenue", agg=AggregationType.SUM, expr="amount")],
         )
         metric = _simple_metric("revenue", measure_name="revenue")
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm], metrics=[metric])).document
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm], metrics=[metric])).output
 
         metrics = _osi_metrics(result)
         assert len(metrics) == 1
@@ -508,7 +508,7 @@ class TestMetricConversion:  # noqa: D101
             measures=[_measure("revenue", agg=AggregationType.SUM, expr="amount")],
         )
         metric = _simple_metric("revenue", measure_name="revenue", description="Total revenue")
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm], metrics=[metric])).document
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm], metrics=[metric])).output
 
         assert _osi_metrics(result)[0].description == "Total revenue"
 
@@ -532,7 +532,7 @@ class TestMetricConversion:  # noqa: D101
             metadata=default_meta(),
             config=None,
         )
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm], metrics=[metric])).document
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm], metrics=[metric])).output
 
         assert _osi_metrics(result)[0].expression.dialects[0].expression == "AVG(orders.price)"
 
@@ -565,7 +565,7 @@ class TestMetricConversion:  # noqa: D101
         result = (
             MSIToOSIConverter()
             .convert(_manifest(semantic_models=[sm], metrics=[revenue_m, order_count_m, arpu]))
-            .document
+            .output
         )
 
         arpu_osi = next(m for m in _osi_metrics(result) if m.name == "arpu")
@@ -606,7 +606,7 @@ class TestMetricConversion:  # noqa: D101
             config=None,
         )
         result = (
-            MSIToOSIConverter().convert(_manifest(semantic_models=[sm], metrics=[revenue_m, cost_m, profit])).document
+            MSIToOSIConverter().convert(_manifest(semantic_models=[sm], metrics=[revenue_m, cost_m, profit])).output
         )
 
         profit_osi = next(m for m in _osi_metrics(result) if m.name == "profit")
@@ -638,7 +638,7 @@ class TestMetricConversion:  # noqa: D101
             config=None,
         )
         result = (
-            MSIToOSIConverter().convert(_manifest(semantic_models=[sm], metrics=[revenue_m, cost_m, profit])).document
+            MSIToOSIConverter().convert(_manifest(semantic_models=[sm], metrics=[revenue_m, cost_m, profit])).output
         )
 
         profit_osi = next(m for m in _osi_metrics(result) if m.name == "profit")
@@ -696,7 +696,7 @@ class TestMetricConversion:  # noqa: D101
                     metrics=[revenue_m, cost_m, expenses_m, gross_profit, net_profit],
                 )
             )
-            .document
+            .output
         )
 
         net_osi = next(m for m in _osi_metrics(result) if m.name == "net_profit")
@@ -739,7 +739,7 @@ class TestMetricConversion:  # noqa: D101
         result = (
             MSIToOSIConverter()
             .convert(_manifest(semantic_models=[sm], metrics=[revenue_m, revenue_adjusted_m, derived]))
-            .document
+            .output
         )
 
         derived_osi = next(m for m in _osi_metrics(result) if m.name == "revenue_delta")
@@ -766,7 +766,7 @@ class TestMetricConversion:  # noqa: D101
             metadata=default_meta(),
             config=None,
         )
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm], metrics=[cumulative])).document
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm], metrics=[cumulative])).output
 
         metrics = _osi_metrics(result)
         assert len(metrics) == 1
@@ -800,7 +800,7 @@ class TestMetricConversion:  # noqa: D101
             metadata=default_meta(),
             config=None,
         )
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm], metrics=[base, cumulative])).document
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm], metrics=[base, cumulative])).output
 
         cumulative_osi = next(m for m in _osi_metrics(result) if m.name == "cumulative_revenue")
         assert cumulative_osi.expression.dialects[0].expression == "SUM(orders.amount)"
@@ -809,7 +809,7 @@ class TestMetricConversion:  # noqa: D101
 
     def test_no_metrics_produces_no_osi_metrics(self) -> None:  # noqa: D102
         sm = semantic_model_with_guaranteed_meta(name="orders")
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm])).document
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm])).output
 
         assert result.semantic_model[0].metrics is None
 
@@ -832,7 +832,7 @@ class TestMetricConversion:  # noqa: D101
                     ],
                 )
             )
-            .document
+            .output
         )
 
         metrics = _osi_metrics(result)
@@ -862,7 +862,7 @@ class TestMetricConversion:  # noqa: D101
             metadata=default_meta(),
             config=None,
         )
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm], metrics=[conversion])).document
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm], metrics=[conversion])).output
 
         assert result.semantic_model[0].metrics is None
 
@@ -909,7 +909,7 @@ class TestMetricFilterFlattening:  # noqa: D101
             metadata=default_meta(),
             config=None,
         )
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm], metrics=[metric])).document
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm], metrics=[metric])).output
 
         assert (
             _osi_metrics(result)[0].expression.dialects[0].expression
@@ -932,7 +932,7 @@ class TestMetricFilterFlattening:  # noqa: D101
             metadata=default_meta(),
             config=None,
         )
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm], metrics=[metric])).document
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm], metrics=[metric])).output
 
         assert (
             _osi_metrics(result)[0].expression.dialects[0].expression
@@ -957,7 +957,7 @@ class TestMetricFilterFlattening:  # noqa: D101
             metadata=default_meta(),
             config=None,
         )
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm], metrics=[metric])).document
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm], metrics=[metric])).output
 
         assert _osi_metrics(result)[0].expression.dialects[0].expression == (
             "SUM(CASE WHEN (status = 'paid') AND (region = 'intl') THEN orders.amount END)"
@@ -982,7 +982,7 @@ class TestMetricFilterFlattening:  # noqa: D101
             metadata=default_meta(),
             config=None,
         )
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm], metrics=[metric])).document
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm], metrics=[metric])).output
 
         assert (
             _osi_metrics(result)[0].expression.dialects[0].expression
@@ -1014,7 +1014,7 @@ class TestMetricFilterFlattening:  # noqa: D101
         result = (
             MSIToOSIConverter()
             .convert(_manifest(semantic_models=[sm], metrics=[revenue_m, order_count_m, arpu]))
-            .document
+            .output
         )
 
         paid_arpu = next(m for m in _osi_metrics(result) if m.name == "paid_arpu")
@@ -1047,7 +1047,7 @@ class TestMetricFilterFlattening:  # noqa: D101
             config=None,
         )
         result = (
-            MSIToOSIConverter().convert(_manifest(semantic_models=[sm], metrics=[revenue_m, cost_m, profit])).document
+            MSIToOSIConverter().convert(_manifest(semantic_models=[sm], metrics=[revenue_m, cost_m, profit])).output
         )
 
         paid_profit = next(m for m in _osi_metrics(result) if m.name == "paid_profit")
@@ -1065,7 +1065,7 @@ class TestMetricFilterFlattening:  # noqa: D101
         result = (
             MSIToOSIConverter()
             .convert(_manifest(semantic_models=[sm], metrics=[_simple_metric("revenue", "revenue")]))
-            .document
+            .output
         )
 
         assert _osi_metrics(result)[0].expression.dialects[0].expression == "SUM(orders.amount)"
@@ -1080,7 +1080,7 @@ class TestOSIJsonSerialization:  # noqa: D101
             measures=[_measure("revenue", expr="amount")],
             entities=[_entity("order_id", entity_type=EntityType.PRIMARY)],
         )
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm]), osi_model_name="my_project").document
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm]), osi_model_name="my_project").output
         parsed = json.loads(result.to_osi_json())
 
         assert parsed["version"] == "0.1.1"
@@ -1089,7 +1089,7 @@ class TestOSIJsonSerialization:  # noqa: D101
 
     def test_to_osi_json_excludes_none_fields(self) -> None:  # noqa: D102
         sm = semantic_model_with_guaranteed_meta(name="orders")
-        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm])).document
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm])).output
         parsed = json.loads(result.to_osi_json())
 
         dataset = parsed["semantic_model"][0]["datasets"][0]

--- a/tests_metricflow_semantic_interfaces/osi/test_msi_to_osi.py
+++ b/tests_metricflow_semantic_interfaces/osi/test_msi_to_osi.py
@@ -10,6 +10,7 @@ from metricflow_semantics.test_helpers.snapshot_helpers import (
     assert_object_snapshot_equal,
 )
 
+from metricflow.converters.converter_issues import ConverterIssueType
 from metricflow.converters.filter_utils import _render_filter_template
 from metricflow.converters.models import OSIDialect, OSIDocument
 from metricflow.converters.msi_to_osi import MSIToOSIConverter
@@ -865,6 +866,97 @@ class TestMetricConversion:  # noqa: D101
         result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm], metrics=[conversion])).output
 
         assert result.semantic_model[0].metrics is None
+
+
+class TestConverterIssues:  # noqa: D101
+    def test_conversion_metric_emits_issue(self) -> None:  # noqa: D102
+        sm = semantic_model_with_guaranteed_meta(
+            name="orders",
+            measures=[
+                _measure("visits", agg=AggregationType.COUNT, expr="visit_id"),
+                _measure("purchases", agg=AggregationType.COUNT, expr="purchase_id"),
+            ],
+        )
+        conversion = PydanticMetric(
+            name="purchase_rate",
+            description=None,
+            type=MetricType.CONVERSION,
+            type_params=PydanticMetricTypeParams(
+                conversion_type_params=PydanticConversionTypeParams(
+                    base_measure=PydanticMetricInputMeasure(name="visits"),
+                    conversion_measure=PydanticMetricInputMeasure(name="purchases"),
+                    entity="user",
+                ),
+            ),
+            filter=None,
+            metadata=default_meta(),
+            config=None,
+        )
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm], metrics=[conversion]))
+
+        dropped = [i for i in result.issues if i.issue_type == ConverterIssueType.CONVERSION_METRIC_DROPPED]
+        assert len(dropped) == 1
+        assert dropped[0].element_name == "purchase_rate"
+
+    def test_private_metric_emits_issue(self) -> None:  # noqa: D102
+        sm = semantic_model_with_guaranteed_meta(
+            name="orders",
+            measures=[_measure("revenue", agg=AggregationType.SUM, expr="amount")],
+        )
+        private_metric = PydanticMetric(
+            name="revenue_internal",
+            description=None,
+            type=MetricType.SIMPLE,
+            type_params=PydanticMetricTypeParams(
+                measure=PydanticMetricInputMeasure(name="revenue"),
+                is_private=True,
+            ),
+            filter=None,
+            metadata=default_meta(),
+            config=None,
+        )
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm], metrics=[private_metric]))
+
+        assert len(result.issues) == 1
+        assert result.issues[0].issue_type == ConverterIssueType.PRIVATE_METRIC_DROPPED
+        assert result.issues[0].element_name == "revenue_internal"
+
+    def test_natural_entity_emits_issue(self) -> None:  # noqa: D102
+        sm = semantic_model_with_guaranteed_meta(
+            name="users",
+            entities=[_entity("user", entity_type=EntityType.NATURAL, expr="user_id")],
+        )
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm]))
+
+        assert len(result.issues) == 1
+        assert result.issues[0].issue_type == ConverterIssueType.NATURAL_ENTITY_DROPPED
+        assert result.issues[0].element_name == "user"
+
+    def test_cumulative_metric_emits_issue(self) -> None:  # noqa: D102
+        sm = semantic_model_with_guaranteed_meta(
+            name="orders",
+            measures=[_measure("revenue", agg=AggregationType.SUM, expr="amount")],
+        )
+        base = _simple_metric("revenue", "revenue")
+        cumulative = PydanticMetric(
+            name="cumulative_revenue",
+            description=None,
+            type=MetricType.CUMULATIVE,
+            type_params=PydanticMetricTypeParams(
+                measure=PydanticMetricInputMeasure(name="revenue"),
+                cumulative_type_params=PydanticCumulativeTypeParams(
+                    window=PydanticMetricTimeWindow(count=7, granularity="day"),
+                ),
+            ),
+            filter=None,
+            metadata=default_meta(),
+            config=None,
+        )
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm], metrics=[base, cumulative]))
+
+        cumulative_issues = [i for i in result.issues if i.issue_type == ConverterIssueType.CUMULATIVE_SEMANTICS_LOSS]
+        assert len(cumulative_issues) == 1
+        assert cumulative_issues[0].element_name == "cumulative_revenue"
 
 
 class TestFilterRendering:  # noqa: D101

--- a/tests_metricflow_semantic_interfaces/osi/test_osi_to_msi.py
+++ b/tests_metricflow_semantic_interfaces/osi/test_osi_to_msi.py
@@ -360,7 +360,7 @@ class TestOSIToMSIRoundTrip:  # noqa: D101
         msi = OSIToMSIConverter().convert(original)
         assert msi.semantic_models[0].measures == []
 
-        osi_doc = MSIToOSIConverter().convert(msi)
+        osi_doc = MSIToOSIConverter().convert(msi).document
 
         dataset = osi_doc.semantic_model[0].datasets[0]
         assert dataset.name == "orders"

--- a/tests_metricflow_semantic_interfaces/osi/test_osi_to_msi.py
+++ b/tests_metricflow_semantic_interfaces/osi/test_osi_to_msi.py
@@ -27,14 +27,14 @@ from tests_metricflow_semantic_interfaces.osi.helpers import (
 
 class TestOSIToMSIBasicConversion:  # noqa: D101
     def test_empty_document_produces_empty_manifest(self) -> None:  # noqa: D102
-        result = OSIToMSIConverter().convert(_osi_doc())
+        result = OSIToMSIConverter().convert(_osi_doc()).output
 
         assert result.semantic_models == []
         assert result.metrics == []
 
     def test_single_dataset_becomes_semantic_model(self) -> None:  # noqa: D102
         doc = _osi_doc(datasets=[_osi_dataset("orders", source="analytics.orders_table")])
-        result = OSIToMSIConverter().convert(doc)
+        result = OSIToMSIConverter().convert(doc).output
 
         assert len(result.semantic_models) == 1
         sm = result.semantic_models[0]
@@ -45,13 +45,13 @@ class TestOSIToMSIBasicConversion:  # noqa: D101
 
     def test_description_carried_over(self) -> None:  # noqa: D102
         doc = _osi_doc(datasets=[_osi_dataset("orders", description="Order data")])
-        result = OSIToMSIConverter().convert(doc)
+        result = OSIToMSIConverter().convert(doc).output
 
         assert result.semantic_models[0].description == "Order data"
 
     def test_source_two_parts(self) -> None:  # noqa: D102
         doc = _osi_doc(datasets=[_osi_dataset("t", source="myschema.mytable")])
-        sm = OSIToMSIConverter().convert(doc).semantic_models[0]
+        sm = OSIToMSIConverter().convert(doc).output.semantic_models[0]
 
         assert sm.node_relation.schema_name == "myschema"
         assert sm.node_relation.alias == "mytable"
@@ -59,7 +59,7 @@ class TestOSIToMSIBasicConversion:  # noqa: D101
 
     def test_source_three_parts(self) -> None:  # noqa: D102
         doc = _osi_doc(datasets=[_osi_dataset("t", source="mydb.myschema.mytable")])
-        sm = OSIToMSIConverter().convert(doc).semantic_models[0]
+        sm = OSIToMSIConverter().convert(doc).output.semantic_models[0]
 
         assert sm.node_relation.database == "mydb"
         assert sm.node_relation.schema_name == "myschema"
@@ -67,14 +67,14 @@ class TestOSIToMSIBasicConversion:  # noqa: D101
 
     def test_source_bare_name(self) -> None:  # noqa: D102
         doc = _osi_doc(datasets=[_osi_dataset("t", source="mytable")])
-        sm = OSIToMSIConverter().convert(doc).semantic_models[0]
+        sm = OSIToMSIConverter().convert(doc).output.semantic_models[0]
 
         assert sm.node_relation.alias == "mytable"
         assert sm.node_relation.schema_name == ""
 
     def test_multiple_datasets_become_multiple_models(self) -> None:  # noqa: D102
         doc = _osi_doc(datasets=[_osi_dataset("orders"), _osi_dataset("users")])
-        result = OSIToMSIConverter().convert(doc)
+        result = OSIToMSIConverter().convert(doc).output
 
         names = [sm.name for sm in result.semantic_models]
         assert names == ["orders", "users"]
@@ -91,7 +91,7 @@ class TestOSIToMSIFieldClassification:  # noqa: D101
                 )
             ]
         )
-        sm = OSIToMSIConverter().convert(doc).semantic_models[0]
+        sm = OSIToMSIConverter().convert(doc).output.semantic_models[0]
 
         assert len(sm.entities) == 1
         assert sm.entities[0].name == "order_id"
@@ -107,7 +107,7 @@ class TestOSIToMSIFieldClassification:  # noqa: D101
                 )
             ]
         )
-        sm = OSIToMSIConverter().convert(doc).semantic_models[0]
+        sm = OSIToMSIConverter().convert(doc).output.semantic_models[0]
 
         assert len(sm.entities) == 1
         assert sm.entities[0].name == "email"
@@ -121,7 +121,7 @@ class TestOSIToMSIFieldClassification:  # noqa: D101
             ],
             relationships=[_osi_relationship("r", "orders", "users", ["user_id"], ["user_id"])],
         )
-        orders_sm = OSIToMSIConverter().convert(doc).semantic_models[0]
+        orders_sm = OSIToMSIConverter().convert(doc).output.semantic_models[0]
 
         assert len(orders_sm.entities) == 1
         assert orders_sm.entities[0].name == "user_id"
@@ -139,7 +139,7 @@ class TestOSIToMSIFieldClassification:  # noqa: D101
         self, field_name: str, is_time: bool | None, expected_type: DimensionType
     ) -> None:
         doc = _osi_doc(datasets=[_osi_dataset("orders", fields=[_osi_field(field_name, is_time=is_time)])])
-        sm = OSIToMSIConverter().convert(doc).semantic_models[0]
+        sm = OSIToMSIConverter().convert(doc).output.semantic_models[0]
 
         assert len(sm.dimensions) == 1
         assert sm.dimensions[0].name == field_name
@@ -151,7 +151,7 @@ class TestOSIToMSIFieldClassification:  # noqa: D101
             datasets=[_osi_dataset("orders", fields=[_osi_field("amount")])],
             metrics=[_osi_metric("revenue", "SUM(amount)")],
         )
-        sm = OSIToMSIConverter().convert(doc).semantic_models[0]
+        sm = OSIToMSIConverter().convert(doc).output.semantic_models[0]
 
         assert len(sm.measures) == 0
         assert len(sm.dimensions) == 1
@@ -167,7 +167,7 @@ class TestOSIToMSIFieldClassification:  # noqa: D101
                 )
             ]
         )
-        sm = OSIToMSIConverter().convert(doc).semantic_models[0]
+        sm = OSIToMSIConverter().convert(doc).output.semantic_models[0]
 
         assert sm.entities[0].expr == "id"
 
@@ -181,7 +181,7 @@ class TestOSIToMSIFieldClassification:  # noqa: D101
                 )
             ]
         )
-        sm = OSIToMSIConverter().convert(doc).semantic_models[0]
+        sm = OSIToMSIConverter().convert(doc).output.semantic_models[0]
 
         assert sm.entities[0].expr is None
 
@@ -194,7 +194,7 @@ class TestOSIToMSIFieldClassification:  # noqa: D101
                 )
             ]
         )
-        sm = OSIToMSIConverter().convert(doc).semantic_models[0]
+        sm = OSIToMSIConverter().convert(doc).output.semantic_models[0]
 
         dim = sm.dimensions[0]
         assert dim.description == "Order status"
@@ -207,7 +207,7 @@ class TestOSIToMSIMetricConversion:  # noqa: D101
             datasets=[_osi_dataset("orders", fields=[_osi_field("amount")])],
             metrics=[_osi_metric("revenue", "SUM(amount)")],
         )
-        result = OSIToMSIConverter().convert(doc)
+        result = OSIToMSIConverter().convert(doc).output
 
         assert len(result.metrics) == 1
         m = result.metrics[0]
@@ -224,7 +224,7 @@ class TestOSIToMSIMetricConversion:  # noqa: D101
             datasets=[_osi_dataset("orders", fields=[_osi_field("user_id")])],
             metrics=[_osi_metric("unique_users", "COUNT(DISTINCT user_id)")],
         )
-        result = OSIToMSIConverter().convert(doc)
+        result = OSIToMSIConverter().convert(doc).output
 
         m = result.metrics[0]
         assert m.type_params.measure is None
@@ -244,7 +244,7 @@ class TestOSIToMSIMetricConversion:  # noqa: D101
             ],
             metrics=[_osi_metric("arpu", "(SUM(amount)) / (COUNT(order_id))")],
         )
-        result = OSIToMSIConverter().convert(doc)
+        result = OSIToMSIConverter().convert(doc).output
 
         ratio = next(m for m in result.metrics if m.type == MetricType.RATIO)
         assert ratio.name == "arpu"
@@ -258,7 +258,7 @@ class TestOSIToMSIMetricConversion:  # noqa: D101
             datasets=[_osi_dataset("orders", fields=[_osi_field("amount"), _osi_field("cnt")])],
             metrics=[_osi_metric("ratio", "(SUM(amount)) / (COUNT(cnt))")],
         )
-        result = OSIToMSIConverter().convert(doc)
+        result = OSIToMSIConverter().convert(doc).output
 
         simple_metrics = [m for m in result.metrics if m.type == MetricType.SIMPLE]
         assert len(simple_metrics) == 2
@@ -270,7 +270,7 @@ class TestOSIToMSIMetricConversion:  # noqa: D101
             datasets=[_osi_dataset("orders")],
             metrics=[_osi_metric("complex", "SUM(a) + SUM(b)")],
         )
-        result = OSIToMSIConverter().convert(doc)
+        result = OSIToMSIConverter().convert(doc).output
 
         assert len(result.metrics) == 1
         m = result.metrics[0]
@@ -284,13 +284,13 @@ class TestOSIToMSIMetricConversion:  # noqa: D101
             datasets=[_osi_dataset("orders", fields=[_osi_field("amount")])],
             metrics=[_osi_metric("revenue", "SUM(amount)", description="Total revenue")],
         )
-        result = OSIToMSIConverter().convert(doc)
+        result = OSIToMSIConverter().convert(doc).output
 
         assert result.metrics[0].description == "Total revenue"
 
     def test_no_metrics_produces_empty_list(self) -> None:  # noqa: D102
         doc = _osi_doc(datasets=[_osi_dataset("orders")])
-        result = OSIToMSIConverter().convert(doc)
+        result = OSIToMSIConverter().convert(doc).output
 
         assert result.metrics == []
 
@@ -300,7 +300,7 @@ class TestOSIToMSIMetricConversion:  # noqa: D101
             datasets=[_osi_dataset("orders", fields=[_osi_field("amount")])],
             metrics=[_osi_metric("revenue", "SUM(orders.amount)")],
         )
-        result = OSIToMSIConverter().convert(doc)
+        result = OSIToMSIConverter().convert(doc).output
 
         m = result.metrics[0]
         assert m.type_params.metric_aggregation_params is not None
@@ -312,7 +312,7 @@ class TestOSIToMSIMetricConversion:  # noqa: D101
             datasets=[_osi_dataset("orders", fields=[_osi_field("amount")])],
             metrics=[_osi_metric("median_amount", "PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY amount)")],
         )
-        result = OSIToMSIConverter().convert(doc)
+        result = OSIToMSIConverter().convert(doc).output
 
         m = result.metrics[0]
         assert m.type_params.metric_aggregation_params is not None
@@ -325,7 +325,7 @@ class TestOSIToMSIMetricConversion:  # noqa: D101
             datasets=[_osi_dataset("orders", fields=[_osi_field("amount")])],
             metrics=[_osi_metric("p95_amount", "PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY amount)")],
         )
-        result = OSIToMSIConverter().convert(doc)
+        result = OSIToMSIConverter().convert(doc).output
 
         m = result.metrics[0]
         assert m.type_params.metric_aggregation_params is not None
@@ -357,10 +357,10 @@ class TestOSIToMSIRoundTrip:  # noqa: D101
             metrics=[_osi_metric("revenue", "SUM(orders.amount)")],
         )
 
-        msi = OSIToMSIConverter().convert(original)
+        msi = OSIToMSIConverter().convert(original).output
         assert msi.semantic_models[0].measures == []
 
-        osi_doc = MSIToOSIConverter().convert(msi).document
+        osi_doc = MSIToOSIConverter().convert(msi).output
 
         dataset = osi_doc.semantic_model[0].datasets[0]
         assert dataset.name == "orders"


### PR DESCRIPTION
# Problem

OSI <> MSI converters are currently lossy, specifically when going from MSI to OSI as not all MSI can be represented in OSI today. However, there are no warnings given when this happens.

# Solution

Converters return a `ConverterResult` which has an `output` (generic) and `issues` (a list of converter issues)