### PR TITLE
Fix changelog entry 20260415-100608

### DIFF
--- a/.changes/unreleased/Under the Hood-20260415-100608.yaml
+++ b/.changes/unreleased/Under the Hood-20260415-100608.yaml
@@ -1,4 +1,4 @@
-kind: Under the Hood
+kind: Dependencies
 body: Expand dbt-core support to <1.12
 time: 2026-04-15T10:06:08.681284-04:00
 custom:


### PR DESCRIPTION
This PR changes the categorization of changelog entry 20260415-100608 to `Dependencies` as it updates the supported versions of `dbt-core`.