### PR TITLE
Release `dbt-metricflow` 0.12.0

### DIFF
--- a/dbt-metricflow/dbt_metricflow/__about__.py
+++ b/dbt-metricflow/dbt_metricflow/__about__.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-__version__ = "0.11.0"
+__version__ = "0.12.0"

--- a/dbt-metricflow/requirements-files/requirements-cli.txt
+++ b/dbt-metricflow/requirements-files/requirements-cli.txt
@@ -2,6 +2,7 @@
 dbt-core>=1.10.4, <1.12.0
 
 # CLI-related
+graphviz>=0.18.2, <0.21
 Jinja2>=3.1.6, <3.7.0
 halo>=0.0.31, <0.1.0
 update-checker>=0.18.0, <0.19.0

--- a/dbt-metricflow/requirements-files/requirements-metricflow.txt
+++ b/dbt-metricflow/requirements-files/requirements-metricflow.txt
@@ -1,1 +1,1 @@
-metricflow==0.209.0
+metricflow==0.210.0


### PR DESCRIPTION
Release `dbt-metricflow` 0.12.0 with updated dependency `metricflow==0.210.0`.