### PR TITLE
Update handling of optional graphviz import

### DIFF
--- a/dbt-metricflow/pyproject.toml
+++ b/dbt-metricflow/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "dbt-metricflow"
 description = "Execute commands against the MetricFlow semantic layer with dbt."
 readme = "README.md"
-requires-python = ">=3.9,<3.13"
+requires-python = ">=3.10,<3.14"
 license = "Apache-2.0"
 authors = [
   { name = "dbt Labs", email = "info@dbtlabs.com" },
@@ -15,10 +15,10 @@ authors = [
 classifiers = [
   "Development Status :: 4 - Beta",
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]

--- a/metricflow_semantics/dag/dag_visualization.py
+++ b/metricflow_semantics/dag/dag_visualization.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import TypeVar
+from typing import TYPE_CHECKING, TypeVar
 
-import graphviz
+if TYPE_CHECKING:
+    import graphviz
 from metricflow_semantics.dag.mf_dag import DagNode, MetricFlowDag
 from metricflow_semantics.toolkit.id_helpers import mf_random_id
 
@@ -42,7 +43,20 @@ def render_via_graphviz(dag_graph: DagGraphT, file_path_without_svg_suffix: str)
     Args:
         dag_graph: The DAG to render.
         file_path_without_svg_suffix: Path to the SVG file that should be created, without ".svg" suffix.
+
+    Raises:
+        RuntimeError: If the ``graphviz`` package is not installed.
     """
+    # `graphviz` is an optional dependency as rendering graphs is more of a debugging feature in tests / CLI.
+    # Since it's optional, import it locally only when needed.
+    try:
+        import graphviz
+    except ImportError as error:
+        raise RuntimeError(
+            "The `graphviz` Python package is required for DAG visualization."
+            " It can be installed with `pip install graphviz` or similar."
+            " Rendering may also require the `dot` executable from https://www.graphviz.org/ to be on your PATH."
+        ) from error
     dot = graphviz.Digraph(comment=dag_graph.dag_id, node_attr={"shape": "box", "fontname": "Courier"})
     # Not quite correct if there are shared nodes.
     for sink_node in dag_graph.sink_nodes:


### PR DESCRIPTION
This PR updates the import of graphviz to be local as it's an optional dependency and only needed for demo / development / debugging cases. 