### PR TITLE
Update `dbt-metricflow` version to 0.13.0.dev0

### DIFF
--- a/dbt-metricflow/dbt_metricflow/__about__.py
+++ b/dbt-metricflow/dbt_metricflow/__about__.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-__version__ = "0.12.0"
+__version__ = "0.13.0.dev0"


### PR DESCRIPTION
Update `dbt-metricflow` version to 0.13.0.dev0 to reflect in-progress development.