### PR TITLE
Remove `graphviz` dependency from `dbt-metricflow`

### DIFF
--- a/.changes/unreleased/Dependencies-20260428-125848.yaml
+++ b/.changes/unreleased/Dependencies-20260428-125848.yaml
@@ -1,0 +1,6 @@
+kind: Dependencies
+body: Remove `graphviz` dependency from `dbt-metricflow`
+time: 2026-04-28T12:58:48.498579-07:00
+custom:
+    Author: plypaul
+    Issue: "2038"

--- a/dbt-metricflow/dbt_metricflow/cli/graph_svg_rendering.py
+++ b/dbt-metricflow/dbt_metricflow/cli/graph_svg_rendering.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import logging
+import os
+
+from metricflow_semantics.toolkit.id_helpers import mf_random_id
+from metricflow_semantics.toolkit.mf_graph.formatting.dag_visualization import DagGraphT, render_via_graphviz
+
+logger = logging.getLogger(__name__)
+
+
+def display_dag_as_svg(dag_graph: DagGraphT, directory_path: str) -> str:
+    """Create and display the plan as an SVG in the browser.
+
+    Returns the path where the SVG file was created within "mf_config_dir".
+    """
+    svg_dir = os.path.join(directory_path, "generated_svg")
+    random_file_path = os.path.join(svg_dir, f"dag_{mf_random_id()}")
+    render_via_graphviz(dag_graph=dag_graph, file_path_without_svg_suffix=random_file_path)
+    return random_file_path + ".svg"

--- a/dbt-metricflow/dbt_metricflow/cli/main.py
+++ b/dbt-metricflow/dbt_metricflow/cli/main.py
@@ -16,7 +16,6 @@ from typing import Callable, List, Optional, Sequence
 import click
 import jinja2
 from halo import Halo
-from metricflow_semantics.dag.dag_visualization import display_dag_as_svg
 from update_checker import UpdateChecker
 
 import dbt_metricflow.cli.custom_click_types as click_custom
@@ -24,6 +23,7 @@ from dbt_metricflow.cli import PACKAGE_NAME
 from dbt_metricflow.cli.cli_configuration import CLIConfiguration
 from dbt_metricflow.cli.constants import MAX_LIST_OBJECT_ELEMENTS
 from dbt_metricflow.cli.dbt_connectors.dbt_config_accessor import dbtArtifacts
+from dbt_metricflow.cli.graph_svg_rendering import display_dag_as_svg
 from dbt_metricflow.cli.tutorial import (
     dbtMetricFlowTutorialHelper,
 )

--- a/dbt-metricflow/requirements-files/requirements-cli.txt
+++ b/dbt-metricflow/requirements-files/requirements-cli.txt
@@ -2,7 +2,6 @@
 dbt-core>=1.10.4, <1.12.0
 
 # CLI-related
-graphviz>=0.18.2, <0.21
 Jinja2>=3.1.6, <3.7.0
 halo>=0.0.31, <0.1.0
 update-checker>=0.18.0, <0.19.0

--- a/dbt-metricflow/requirements-files/requirements-metricflow.txt
+++ b/dbt-metricflow/requirements-files/requirements-metricflow.txt
@@ -1,1 +1,1 @@
-metricflow==0.210.0
+metricflow @ {root:parent:uri}

--- a/metricflow_semantics/dag/dag_visualization.py
+++ b/metricflow_semantics/dag/dag_visualization.py
@@ -51,7 +51,7 @@ def render_via_graphviz(dag_graph: DagGraphT, file_path_without_svg_suffix: str)
     # Since it's optional, import it locally only when needed.
     try:
         import graphviz
-    except ImportError as error:
+    except ModuleNotFoundError as error:
         raise RuntimeError(
             "The `graphviz` Python package is required for DAG visualization."
             " It can be installed with `pip install graphviz` or similar."

--- a/metricflow_semantics/toolkit/mf_graph/formatting/dag_visualization.py
+++ b/metricflow_semantics/toolkit/mf_graph/formatting/dag_visualization.py
@@ -11,10 +11,10 @@ logger = logging.getLogger(__name__)
 DagNodeT = TypeVar("DagNodeT", bound=DagNode)
 
 
-def add_nodes_to_digraph(node: DagNodeT, dot: graphviz.Digraph) -> None:
+def _add_nodes_to_digraph(node: DagNodeT, dot: graphviz.Digraph) -> None:
     """Adds the node (and parent nodes) to the dot for visualization."""
     for parent_node in node.parent_nodes:
-        add_nodes_to_digraph(parent_node, dot)
+        _add_nodes_to_digraph(parent_node, dot)
 
     dot.node(name=node.node_id.id_str, label=node.graphviz_label)
     for parent_node in node.parent_nodes:
@@ -47,6 +47,6 @@ def render_via_graphviz(dag_graph: DagGraphT, file_path_without_svg_suffix: str)
     dot = graphviz.Digraph(comment=dag_graph.dag_id, node_attr={"shape": "box", "fontname": "Courier"})
     # Not quite correct if there are shared nodes.
     for sink_node in dag_graph.sink_nodes:
-        add_nodes_to_digraph(sink_node, dot)
+        _add_nodes_to_digraph(sink_node, dot)
     dot.format = "svg"
     dot.render(file_path_without_svg_suffix, view=True, format="svg", cleanup=True)

--- a/metricflow_semantics/toolkit/mf_graph/formatting/dag_visualization.py
+++ b/metricflow_semantics/toolkit/mf_graph/formatting/dag_visualization.py
@@ -1,13 +1,11 @@
 from __future__ import annotations
 
 import logging
-import os
 from typing import TYPE_CHECKING, TypeVar
 
 if TYPE_CHECKING:
     import graphviz
 from metricflow_semantics.dag.mf_dag import DagNode, MetricFlowDag
-from metricflow_semantics.toolkit.id_helpers import mf_random_id
 
 logger = logging.getLogger(__name__)
 DagNodeT = TypeVar("DagNodeT", bound=DagNode)
@@ -24,17 +22,6 @@ def add_nodes_to_digraph(node: DagNodeT, dot: graphviz.Digraph) -> None:
 
 
 DagGraphT = TypeVar("DagGraphT", bound=MetricFlowDag)
-
-
-def display_dag_as_svg(dag_graph: DagGraphT, directory_path: str) -> str:
-    """Create and display the plan as an SVG in the browser.
-
-    Returns the path where the SVG file was created within "mf_config_dir".
-    """
-    svg_dir = os.path.join(directory_path, "generated_svg")
-    random_file_path = os.path.join(svg_dir, f"dag_{mf_random_id()}")
-    render_via_graphviz(dag_graph=dag_graph, file_path_without_svg_suffix=random_file_path)
-    return random_file_path + ".svg"
 
 
 def render_via_graphviz(dag_graph: DagGraphT, file_path_without_svg_suffix: str) -> None:

--- a/metricflow_semantics/toolkit/mf_graph/formatting/mf_to_dot.py
+++ b/metricflow_semantics/toolkit/mf_graph/formatting/mf_to_dot.py
@@ -8,8 +8,6 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Optional, Sequence
 
-import graphviz
-from graphviz import Digraph
 from metricflow_semantics.toolkit.mf_graph.formatting.dot_attributes import (
     DotEdgeAttributeSet,
     DotGraphAttributeSet,
@@ -24,6 +22,7 @@ from metricflow_semantics.toolkit.syntactic_sugar import (
 from typing_extensions import override
 
 if typing.TYPE_CHECKING:
+    import graphviz
     from metricflow_semantics.toolkit.mf_graph.mf_graph import (
         MetricFlowGraph,
     )
@@ -35,7 +34,7 @@ logger = logging.getLogger(__name__)
 class DotGraphConversionResult:
     """The results of converting to a DOT graph."""
 
-    dot_graph: Digraph
+    dot_graph: graphviz.Digraph
     # For debugging context.
     dot_element_set: DotAttributeSet
 
@@ -116,6 +115,17 @@ class MetricFlowGraphToDotConverter(MetricFlowGraphConverter[DotGraphConversionR
             name=dot_attribute_set.graph_attributes.name, additional_kwargs=converter_arguments.graph_attributes
         ).merge(dot_attribute_set.graph_attributes)
 
+        # `graphviz` is an optional dependency as rendering graphs is more of a debugging feature in tests / CLI.
+        # Since it's optional, import it locally only when needed.
+        try:
+            import graphviz
+        except ModuleNotFoundError as error:
+            raise RuntimeError(
+                "The `graphviz` Python package is required for DAG visualization."
+                " It can be installed with `pip install graphviz` or similar."
+                " Rendering may also require the `dot` executable from https://www.graphviz.org/ to be on your PATH."
+            ) from error
+
         dot = graphviz.Digraph(
             graph_attr=dot_graph.dot_graph_attrs,
             node_attr=converter_arguments.node_attributes,
@@ -153,7 +163,9 @@ class MetricFlowGraphToDotConverter(MetricFlowGraphConverter[DotGraphConversionR
 
     @staticmethod
     def _add_nodes_with_rank(
-        converter_arguments: DotConversionArgumentSet, dot_graph: Digraph, dot_nodes: Sequence[DotNodeAttributeSet]
+        converter_arguments: DotConversionArgumentSet,
+        dot_graph: graphviz.Digraph,
+        dot_nodes: Sequence[DotNodeAttributeSet],
     ) -> Sequence[DotNodeAttributeSet]:
         added_dot_nodes: list[DotNodeAttributeSet] = []
         if not converter_arguments.include_graphical_attributes:

--- a/tests_metricflow/dataflow_plan_to_svg.py
+++ b/tests_metricflow/dataflow_plan_to_svg.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 import os
 
 from _pytest.fixtures import FixtureRequest
-from metricflow_semantics.dag.dag_visualization import DagGraphT, render_via_graphviz
 from metricflow_semantics.test_helpers.config_helpers import MetricFlowTestConfiguration
 from metricflow_semantics.test_helpers.snapshot_helpers import snapshot_path_prefix
+from metricflow_semantics.toolkit.mf_graph.formatting.dag_visualization import DagGraphT, render_via_graphviz
 
 
 def display_graph_if_requested(


### PR DESCRIPTION
This PR removes the `graphviz` dependency from `dbt-metricflow` as it should be handled as an optional one.