### PR TITLE
Run lint / tests for `dbt-metricflow` in a separate environment

### DIFF
--- a/.changes/unreleased/Under the Hood-20260428-125822.yaml
+++ b/.changes/unreleased/Under the Hood-20260428-125822.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Run lint / tests for `dbt-metricflow` in a separate environment
+time: 2026-04-28T12:58:22.154966-07:00
+custom:
+    Author: plypaul
+    Issue: "2039"

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ test-include-slow:
 	hatch -v run dev-env:pytest -vv -n $(PARALLELISM) $(ADDITIONAL_PYTEST_OPTIONS) $(TESTS_METRICFLOW_SEMANTICS)/
 	hatch -v run dev-env:pytest -vv -n $(PARALLELISM) $(ADDITIONAL_PYTEST_OPTIONS) $(TESTS_METRICFLOW_SEMANTIC_INTERFACES)/
 	hatch -v run dev-env:pytest -vv -n $(PARALLELISM) $(ADDITIONAL_PYTEST_OPTIONS) $(TESTS_METRICFLOW)/
+	cd dbt-metricflow && hatch -v run dev-env:pytest -vv -n $(PARALLELISM) $(ADDITIONAL_PYTEST_OPTIONS) $(TESTS_DBT_METRICFLOW)/
 
 .PHONY: test-postgresql
 test-postgresql:
@@ -92,6 +93,7 @@ test-trino:
 .PHONY: lint
 lint:
 	hatch -v run dev-env:pre-commit run --verbose --all-files $(ADDITIONAL_PRECOMMIT_OPTIONS)
+	cd dbt-metricflow && hatch -v run dev-env:pre-commit run --verbose --all-files $(ADDITIONAL_PRECOMMIT_OPTIONS)
 
 # Running data warehouses locally
 .PHONY: postgresql postgres

--- a/dbt-metricflow/.pre-commit-config.yaml
+++ b/dbt-metricflow/.pre-commit-config.yaml
@@ -1,6 +1,7 @@
-# Exclude dbt-metricflow/ as that is handled by a separate call in `make lint`.
+# Note: this follows the configuration for the `metricflow` package.
+# Exclude files not in `dbt-metricflow`.
 # Exclude snapshots as they can represent specific output and formatting hooks may strip newlines.
-exclude: "^(?:tests_metricflow/snapshots/|tests_metricflow_semantics/snapshots/|dbt-metricflow/)"
+exclude: "^(?:(?!dbt-metricflow/).*|dbt-metricflow/tests_dbt_metricflow/snapshots/).*$"
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.2.0
@@ -34,18 +35,9 @@ repos:
     rev: v1.3.0
     hooks:
       - id: mypy
-        # dbt-metricflow requires dbt-core, which is not installed in the main metricflow dev environment.
-        # We typecheck dbt-metricflow separately via direct invocation inside the `make lint` command
-        exclude: "^dbt-metricflow/"
         args: [--show-error-codes]
         verbose: true
         # "system" means that the current environment will be used to run the hook, not the environment installed by
         # pre-commit. This is set for mypy to use the specified package dependencies in Hatch (assuming pre-commit is
         # run with hatch run ...). Seems like pre-commit calls the mypy on the command line with this settings.
         language: system
-
-  - repo: https://github.com/rhysd/actionlint
-    rev: v1.7.6
-    hooks:
-      - id: actionlint
-        files: ^\.github/workflows/


### PR DESCRIPTION
This PR updates the lint and test flow for `dbt-metricflow` to use the hatch environment for the package. Previously, the environment for `metricflow` was used, which could cause issues since `dbt-metricflow` depends on a specific of `metricflow`.