### PR TITLE
decouple CI and make metricflow package 3.14 compat

### DIFF
--- a/.changes/unreleased/Features-20260506-235808.yaml
+++ b/.changes/unreleased/Features-20260506-235808.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Add support for Python 3.14 for metricflow package
+time: 2026-05-06T23:58:08.703752+05:30
+custom:
+    Author: ash2shukla
+    Issue: "1916"

--- a/.github/workflows/ci-cache-environments.yaml
+++ b/.github/workflows/ci-cache-environments.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.13"]
+        python-version: ["3.10", "3.13", "3.14"]
     steps:
       - name: Check-out the repo
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # actions/checkout@v4

--- a/.github/workflows/ci-metricflow-unit-tests.yaml
+++ b/.github/workflows/ci-metricflow-unit-tests.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.13"]
+        python-version: ["3.10", "3.13", "3.14"]
     steps:
       - name: Check-out the repo
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # actions/checkout@v4
@@ -22,7 +22,7 @@ jobs:
       - uses: ./.github/actions/run-mf-tests
         with:
           python-version: ${{ matrix.python-version }}
-          make-target: "test-include-slow"
+          make-target: "test-include-slow-metricflow"
 
   metricflow-unit-tests-postgres:
     name: MetricFlow Tests (PostgreSQL)
@@ -56,6 +56,32 @@ jobs:
               ]
             }
 
+  metricflow-package-tests:
+    name: MetricFlow Packages Tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [ "3.10", "3.13", "3.14" ]
+    steps:
+
+      - name: Check-out the repo
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # actions/checkout@v4
+
+      - name: Setup Python ${{ matrix.python-version }} Environment
+        uses: ./.github/actions/setup-python-env
+        with:
+          python-version: "${{ matrix.python-version }}"
+          hatch-environment-cache-config-json: >-
+            {
+              "configs": [
+                {"hatch_project_directory": ".", "hatch_environment_name": "dev-env"}
+              ]
+            }
+
+      - name: Run Package-Build Tests
+        shell: bash
+        run: "make test-build-packages-metricflow"
+
   metricflow-unit-tests:
     # This step is used to simplify setup for branch protection. Branch protection is configured to check if this step
     # fails vs. checking all test steps.
@@ -68,8 +94,23 @@ jobs:
       - name: Check success
         run: test ${{ needs.metricflow-unit-tests-duckdb.result }} = 'success' -a ${{ needs.metricflow-unit-tests-postgres.result }} = 'success'
 
-  metricflow-package-tests:
-    name: MetricFlow Packages Tests
+  dbt-metricflow-unit-tests-duckdb:
+    name: dbt-MetricFlow Tests (DuckDB)
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.13"]
+    steps:
+      - name: Check-out the repo
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # actions/checkout@v4
+
+      - uses: ./.github/actions/run-mf-tests
+        with:
+          python-version: ${{ matrix.python-version }}
+          make-target: "test-include-slow-dbt-metricflow"
+
+  dbt-metricflow-package-tests:
+    name: dbt-MetricFlow Packages Tests
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -92,4 +133,15 @@ jobs:
 
       - name: Run Package-Build Tests
         shell: bash
-        run: "make test-build-packages"
+        run: "make test-build-packages-dbt-metricflow"
+
+  dbt-metricflow-unit-tests:
+    # Aggregator for branch protection — gates dbt-metricflow checks independently of metricflow.
+    name: dbt-MetricFlow Unit Tests
+    runs-on: ubuntu-latest
+    if: ${{ always() }}
+    needs: [dbt-metricflow-unit-tests-duckdb]
+    steps:
+
+      - name: Check success
+        run: test ${{ needs.dbt-metricflow-unit-tests-duckdb.result }} = 'success'

--- a/Makefile
+++ b/Makefile
@@ -41,12 +41,18 @@ test:
 	hatch -v run dev-env:pytest -vv -n $(PARALLELISM) $(ADDITIONAL_PYTEST_OPTIONS) $(TESTS_METRICFLOW_SEMANTIC_INTERFACES)/
 	hatch -v run dev-env:pytest -vv -n $(PARALLELISM) -m "not slow" $(ADDITIONAL_PYTEST_OPTIONS) $(TESTS_METRICFLOW)/
 
-.PHONY: test-include-slow
-test-include-slow:
+.PHONY: test-include-slow-metricflow
+test-include-slow-metricflow:
 	hatch -v run dev-env:pytest -vv -n $(PARALLELISM) $(ADDITIONAL_PYTEST_OPTIONS) $(TESTS_METRICFLOW_SEMANTICS)/
 	hatch -v run dev-env:pytest -vv -n $(PARALLELISM) $(ADDITIONAL_PYTEST_OPTIONS) $(TESTS_METRICFLOW_SEMANTIC_INTERFACES)/
 	hatch -v run dev-env:pytest -vv -n $(PARALLELISM) $(ADDITIONAL_PYTEST_OPTIONS) $(TESTS_METRICFLOW)/
+
+.PHONY: test-include-slow-dbt-metricflow
+test-include-slow-dbt-metricflow:
 	cd dbt-metricflow && hatch -v run dev-env:pytest -vv -n $(PARALLELISM) $(ADDITIONAL_PYTEST_OPTIONS) $(TESTS_DBT_METRICFLOW)/
+
+.PHONY: test-include-slow
+test-include-slow: test-include-slow-metricflow test-include-slow-dbt-metricflow
 
 .PHONY: test-postgresql
 test-postgresql:
@@ -139,6 +145,13 @@ test-snap-slow:
 	hatch -v run dev-env:pytest -vv -n $(PARALLELISM) --overwrite-snapshots $(TESTS_METRICFLOW_SEMANTIC_INTERFACES)/
 	hatch -v run dev-env:pytest -vv -n $(PARALLELISM) --overwrite-snapshots $(TESTS_METRICFLOW)/
 
+.PHONY: test-build-packages-metricflow
+test-build-packages-metricflow:
+	PYTHONPATH=. python scripts/ci_tests/run_package_build_tests.py --metricflow-repo-directory=. --package metricflow
+
+.PHONY: test-build-packages-dbt-metricflow
+test-build-packages-dbt-metricflow:
+	PYTHONPATH=. python scripts/ci_tests/run_package_build_tests.py --metricflow-repo-directory=. --package dbt-metricflow
+
 .PHONY: test-build-packages
-test-build-packages:
-	PYTHONPATH=. python scripts/ci_tests/run_package_build_tests.py --metricflow-repo-directory=.
+test-build-packages: test-build-packages-metricflow test-build-packages-dbt-metricflow

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "metricflow"
 description = "Translates a simple metric definition into reusable SQL and executes it against the SQL engine of your choice."
 readme = "README.md"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10,<3.15"
 license = "Apache-2.0"
 keywords = []
 authors = [
@@ -20,6 +20,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]

--- a/scripts/ci_tests/run_package_build_tests.py
+++ b/scripts/ci_tests/run_package_build_tests.py
@@ -105,26 +105,32 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()
     parser.add_argument("--metricflow-repo-directory", help="Path to the `metricflow` repo.", required=True)
+    parser.add_argument(
+        "--package",
+        choices=("metricflow", "dbt-metricflow", "both"),
+        default="both",
+        help="Which package(s) to test. Defaults to 'both' for back-compat.",
+    )
     args = parser.parse_args()
 
     metricflow_repo_directory = Path(args.metricflow_repo_directory).resolve()
 
     logger.info(f"Using {metricflow_repo_directory=}")
 
-    # Test the `metricflow` package.
-    _run_package_test(
-        package_directory=metricflow_repo_directory,
-        package_test_script=metricflow_repo_directory.joinpath("scripts/ci_tests/metricflow_package_test.py"),
-        build_wheel=True,
-    )
+    if args.package in ("metricflow", "both"):
+        _run_package_test(
+            package_directory=metricflow_repo_directory,
+            package_test_script=metricflow_repo_directory.joinpath("scripts/ci_tests/metricflow_package_test.py"),
+            build_wheel=True,
+        )
 
-    # Test the `dbt-metricflow` package.
-    dbt_metricflow_package_directory = metricflow_repo_directory.joinpath("dbt-metricflow")
-    _run_package_test(
-        package_directory=dbt_metricflow_package_directory,
-        package_test_script=dbt_metricflow_package_directory.joinpath(
-            "scripts/ci_tests/dbt_metricflow_package_test.py"
-        ),
-        optional_package_dependencies_to_install=("dbt-duckdb",),
-        build_wheel=False,
-    )
+    if args.package in ("dbt-metricflow", "both"):
+        dbt_metricflow_package_directory = metricflow_repo_directory.joinpath("dbt-metricflow")
+        _run_package_test(
+            package_directory=dbt_metricflow_package_directory,
+            package_test_script=dbt_metricflow_package_directory.joinpath(
+                "scripts/ci_tests/dbt_metricflow_package_test.py"
+            ),
+            optional_package_dependencies_to_install=("dbt-duckdb",),
+            build_wheel=False,
+        )


### PR DESCRIPTION
Decouples CI for metricflow and dbt-metricflow package. Required for independently bumping metricflow to support 3.14