### PR TITLE
Assorted refinements to the release tool

### DIFF
--- a/.changes/unreleased/Under the Hood-20260508-103711.yaml
+++ b/.changes/unreleased/Under the Hood-20260508-103711.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Assorted refinements to the release tool
+time: 2026-05-08T10:37:11.227322-07:00
+custom:
+    Author: plypaul
+    Issue: "2045"

--- a/scripts/release_tool/mf_release_tool.py
+++ b/scripts/release_tool/mf_release_tool.py
@@ -102,6 +102,11 @@ class _ClickReleaseConsole(ReleaseHelperConsole):
         click.secho(message, fg="green")
         self._flush_output()
 
+    def warning(self, message: str) -> None:
+        """Write a styled release-tool warning to stdout and flush immediately."""
+        click.secho(message, fg="yellow")
+        self._flush_output()
+
     def confirm(self, message: str) -> None:
         """Prompt for confirmation and flush immediately."""
         self._flush_output()

--- a/scripts/release_tool/mf_release_tool.py
+++ b/scripts/release_tool/mf_release_tool.py
@@ -97,9 +97,9 @@ class _ClickReleaseConsole(ReleaseHelperConsole):
         sys.stdout.flush()
         sys.stderr.flush()
 
-    def echo(self, message: str) -> None:
+    def echo(self, message: str, color: str = "green") -> None:
         """Write a styled release-tool message to stdout and flush immediately."""
-        click.secho(message, fg="green")
+        click.secho(message, fg=color)
         self._flush_output()
 
     def warning(self, message: str) -> None:
@@ -429,6 +429,7 @@ def step_1(ctx: click.Context, metricflow_version: str) -> None:
     base_state = existing_release_tool_state if existing_release_tool_state is not None else ReleaseToolState()
     release_tool_state = base_state.with_step_state(updated_step_1=step_1_state)
     _save_release_tool_state(state_file_path=state_file_path, state=release_tool_state, console=console)
+    release_helper.echo_pull_request_review_banner(pr_link=step_1_state.pr_link)
 
 
 @cli.command(CLI_COMMAND_STEP_2)
@@ -468,6 +469,7 @@ def step_2(ctx: click.Context) -> None:
 
     updated_state = release_tool_state.with_step_state(updated_step_2=step_2_state)
     _save_release_tool_state(state_file_path=state_file_path, state=updated_state, console=console)
+    release_helper.echo_pull_request_review_banner(pr_link=step_2_state.pr_link)
 
 
 @cli.command(CLI_COMMAND_STEP_3)
@@ -507,6 +509,9 @@ def step_3(ctx: click.Context) -> None:
 
     updated_state = release_tool_state.with_step_state(updated_step_3=step_3_state)
     _save_release_tool_state(state_file_path=state_file_path, state=updated_state, console=console)
+    release_helper.echo_github_actions_workflow_approval_banner(
+        workflow_file_name=ReleaseHelper.CD_PUSH_METRICFLOW_TO_PYPI_WORKFLOW_FILE_NAME,
+    )
 
 
 @cli.command(CLI_COMMAND_STEP_4)
@@ -560,6 +565,7 @@ def step_4(ctx: click.Context, dbt_metricflow_version: str) -> None:
 
     updated_state = release_tool_state.with_step_state(updated_step_4=step_4_state)
     _save_release_tool_state(state_file_path=state_file_path, state=updated_state, console=console)
+    release_helper.echo_pull_request_review_banner(pr_link=step_4_state.pr_link)
 
 
 @cli.command(CLI_COMMAND_STEP_5)
@@ -602,6 +608,7 @@ def step_5(ctx: click.Context) -> None:
 
     updated_state = release_tool_state.with_step_state(updated_step_5=step_5_state)
     _save_release_tool_state(state_file_path=state_file_path, state=updated_state, console=console)
+    release_helper.echo_pull_request_review_banner(pr_link=step_5_state.pr_link)
 
 
 @cli.command(CLI_COMMAND_STEP_6)
@@ -641,6 +648,9 @@ def step_6(ctx: click.Context) -> None:
 
     updated_state = release_tool_state.with_step_state(updated_step_6=step_6_state)
     _save_release_tool_state(state_file_path=state_file_path, state=updated_state, console=console)
+    release_helper.echo_github_actions_workflow_approval_banner(
+        workflow_file_name=ReleaseHelper.CD_PUSH_DBT_METRICFLOW_TO_PYPI_WORKFLOW_FILE_NAME,
+    )
 
 
 @cli.command(CLI_COMMAND_STEP_7)

--- a/scripts/release_tool/mf_release_tool.py
+++ b/scripts/release_tool/mf_release_tool.py
@@ -343,6 +343,15 @@ def _load_release_tool_state(state_file_path: Path) -> ReleaseToolState:
     return ReleaseToolState.parse_raw(state_file_path.read_text())
 
 
+def _warn_if_step_previously_run(step_name: str, step_state: object | None, console: ReleaseHelperConsole) -> None:
+    """Warn if saved release-tool state indicates the step has already run."""
+    if step_state is not None:
+        console.warning(
+            f"Warning: {step_name} has already been run according to the release state file. "
+            f"Re-running {step_name} may update existing release work."
+        )
+
+
 def _run_release_step_prechecks(context: ReleaseToolContext) -> GitManager:
     """Run common release-step prechecks and return a Git manager."""
     _check_required_environment_variables(environment=context.environment)
@@ -397,6 +406,7 @@ def step_1(ctx: click.Context, metricflow_repo: Path, metricflow_version: str) -
     state_file_path = _release_tool_state_file_path(current_directory=context.current_directory)
     existing_release_tool_state = _load_release_tool_state(state_file_path) if state_file_path.exists() else None
     existing_step_1_state = existing_release_tool_state.step_1 if existing_release_tool_state is not None else None
+    _warn_if_step_previously_run(CLI_COMMAND_STEP_1, existing_step_1_state, console)
     github_client = context.github_client_factory(context.environment["GITHUB_API_TOKEN"], GITHUB_REPOSITORY_NAME)
 
     release_helper = ReleaseHelper(
@@ -437,6 +447,7 @@ def step_2(ctx: click.Context, metricflow_repo: Path) -> None:
     git_manager = _run_release_step_prechecks(context=context)
     state_file_path = _release_tool_state_file_path(current_directory=context.current_directory)
     release_tool_state = _load_release_tool_state(state_file_path=state_file_path)
+    _warn_if_step_previously_run(CLI_COMMAND_STEP_2, release_tool_state.step_2, console)
 
     if release_tool_state.step_1 is None:
         raise click.ClickException(f"Step 1 has not been completed. Run {CLI_COMMAND_STEP_1} first.")
@@ -481,6 +492,7 @@ def step_3(ctx: click.Context, metricflow_repo: Path) -> None:
     git_manager = _run_release_step_prechecks(context=context)
     state_file_path = _release_tool_state_file_path(current_directory=context.current_directory)
     release_tool_state = _load_release_tool_state(state_file_path=state_file_path)
+    _warn_if_step_previously_run(CLI_COMMAND_STEP_3, release_tool_state.step_3, console)
 
     if release_tool_state.step_1 is None:
         raise click.ClickException(f"Step 1 has not been completed. Run {CLI_COMMAND_STEP_1} first.")
@@ -536,6 +548,7 @@ def step_4(ctx: click.Context, metricflow_repo: Path, dbt_metricflow_version: st
     )
     state_file_path = _release_tool_state_file_path(current_directory=context.current_directory)
     release_tool_state = _load_release_tool_state(state_file_path=state_file_path)
+    _warn_if_step_previously_run(CLI_COMMAND_STEP_4, release_tool_state.step_4, console)
 
     if release_tool_state.step_3 is None:
         raise click.ClickException(f"Step 3 has not been completed. Run {CLI_COMMAND_STEP_3} first.")
@@ -587,6 +600,7 @@ def step_5(ctx: click.Context, metricflow_repo: Path) -> None:
     )
     state_file_path = _release_tool_state_file_path(current_directory=context.current_directory)
     release_tool_state = _load_release_tool_state(state_file_path=state_file_path)
+    _warn_if_step_previously_run(CLI_COMMAND_STEP_5, release_tool_state.step_5, console)
 
     if release_tool_state.step_4 is None:
         raise click.ClickException(f"Step 4 has not been completed. Run {CLI_COMMAND_STEP_4} first.")
@@ -630,6 +644,7 @@ def step_6(ctx: click.Context, metricflow_repo: Path) -> None:
     git_manager = _run_release_step_prechecks(context=context)
     state_file_path = _release_tool_state_file_path(current_directory=context.current_directory)
     release_tool_state = _load_release_tool_state(state_file_path=state_file_path)
+    _warn_if_step_previously_run(CLI_COMMAND_STEP_6, release_tool_state.step_6, console)
 
     if release_tool_state.step_4 is None:
         raise click.ClickException(f"Step 4 has not been completed. Run {CLI_COMMAND_STEP_4} first.")
@@ -674,6 +689,7 @@ def step_7(ctx: click.Context, metricflow_repo: Path) -> None:
     git_manager = _run_release_step_prechecks(context=context)
     state_file_path = _release_tool_state_file_path(current_directory=context.current_directory)
     release_tool_state = _load_release_tool_state(state_file_path=state_file_path)
+    _warn_if_step_previously_run(CLI_COMMAND_STEP_7, release_tool_state.step_7, console)
 
     if release_tool_state.step_1 is None:
         raise click.ClickException(f"Step 1 has not been completed. Run {CLI_COMMAND_STEP_1} first.")

--- a/scripts/release_tool/mf_release_tool.py
+++ b/scripts/release_tool/mf_release_tool.py
@@ -24,8 +24,8 @@ Ensure `fossa` and `changie` CLI commands are installed. e.g.
 Start the process with:
 
     hatch run dev-env:python -m scripts.release_tool.mf_release_tool \
-    step-1 \
     --metricflow-repo <separate repo checkout> \
+    step-1 \
     --metricflow-version 1.2.3
 
 Then run similar commands for steps 2-7 (only steps 1 and 4 require the version
@@ -362,6 +362,12 @@ def _run_release_step_prechecks(context: ReleaseToolContext) -> GitManager:
 
 @click.group()
 @click.option(
+    CLI_OPTION_METRICFLOW_REPO,
+    type=click.Path(exists=True, file_okay=False, dir_okay=True, path_type=Path),
+    required=True,
+    help="Path to the metricflow git repository.",
+)
+@click.option(
     CLI_OPTION_YES,
     CLI_OPTION_YES_SHORT,
     "confirm_all",
@@ -369,23 +375,17 @@ def _run_release_step_prechecks(context: ReleaseToolContext) -> GitManager:
     help="Answer yes to all confirmations.",
 )
 @click.pass_context
-def cli(ctx: click.Context, confirm_all: bool) -> None:
+def cli(ctx: click.Context, metricflow_repo: Path, confirm_all: bool) -> None:
     """Run MetricFlow release steps."""
     if ctx.obj is None:
-        ctx.obj = _default_release_tool_context(current_directory=Path.cwd()).copy(confirm_all=confirm_all)
+        ctx.obj = _default_release_tool_context(current_directory=metricflow_repo).copy(confirm_all=confirm_all)
         return
 
     release_tool_context = cast(ReleaseToolContext, ctx.obj)
-    ctx.obj = release_tool_context.copy(confirm_all=confirm_all)
+    ctx.obj = release_tool_context.copy(current_directory=metricflow_repo, confirm_all=confirm_all)
 
 
 @cli.command(CLI_COMMAND_STEP_1)
-@click.option(
-    CLI_OPTION_METRICFLOW_REPO,
-    type=click.Path(exists=True, file_okay=False, dir_okay=True, path_type=Path),
-    required=True,
-    help="Path to the metricflow git repository.",
-)
 @click.option(
     CLI_OPTION_METRICFLOW_VERSION,
     required=True,
@@ -393,11 +393,11 @@ def cli(ctx: click.Context, confirm_all: bool) -> None:
     help="Semantic version for the new `metricflow` release.",
 )
 @click.pass_context
-def step_1(ctx: click.Context, metricflow_repo: Path, metricflow_version: str) -> None:
+def step_1(ctx: click.Context, metricflow_version: str) -> None:
     """Prepare the first release pull-request branch."""
     console = _ClickReleaseConsole()
-    console.echo(f"MetricFlow repo directory: {metricflow_repo}")
-    context = _release_tool_context(ctx).copy(current_directory=metricflow_repo)
+    context = _release_tool_context(ctx)
+    console.echo(f"MetricFlow repo directory: {context.current_directory}")
     git_manager = _run_release_step_prechecks(context=context)
     _check_required_cli_commands(
         command_names=ReleaseStep1Runner.REQUIRED_CLI_COMMANDS,
@@ -432,18 +432,12 @@ def step_1(ctx: click.Context, metricflow_repo: Path, metricflow_version: str) -
 
 
 @cli.command(CLI_COMMAND_STEP_2)
-@click.option(
-    CLI_OPTION_METRICFLOW_REPO,
-    type=click.Path(exists=True, file_okay=False, dir_okay=True, path_type=Path),
-    required=True,
-    help="Path to the metricflow git repository.",
-)
 @click.pass_context
-def step_2(ctx: click.Context, metricflow_repo: Path) -> None:
+def step_2(ctx: click.Context) -> None:
     """Update the MetricFlow version for in-progress development."""
     console = _ClickReleaseConsole()
-    console.echo(f"MetricFlow repo directory: {metricflow_repo}")
-    context = _release_tool_context(ctx).copy(current_directory=metricflow_repo)
+    context = _release_tool_context(ctx)
+    console.echo(f"MetricFlow repo directory: {context.current_directory}")
     git_manager = _run_release_step_prechecks(context=context)
     state_file_path = _release_tool_state_file_path(current_directory=context.current_directory)
     release_tool_state = _load_release_tool_state(state_file_path=state_file_path)
@@ -477,18 +471,12 @@ def step_2(ctx: click.Context, metricflow_repo: Path) -> None:
 
 
 @cli.command(CLI_COMMAND_STEP_3)
-@click.option(
-    CLI_OPTION_METRICFLOW_REPO,
-    type=click.Path(exists=True, file_okay=False, dir_okay=True, path_type=Path),
-    required=True,
-    help="Path to the metricflow git repository.",
-)
 @click.pass_context
-def step_3(ctx: click.Context, metricflow_repo: Path) -> None:
+def step_3(ctx: click.Context) -> None:
     """Merge the release pull requests from steps 1 and 2."""
     console = _ClickReleaseConsole()
-    console.echo(f"MetricFlow repo directory: {metricflow_repo}")
-    context = _release_tool_context(ctx).copy(current_directory=metricflow_repo)
+    context = _release_tool_context(ctx)
+    console.echo(f"MetricFlow repo directory: {context.current_directory}")
     git_manager = _run_release_step_prechecks(context=context)
     state_file_path = _release_tool_state_file_path(current_directory=context.current_directory)
     release_tool_state = _load_release_tool_state(state_file_path=state_file_path)
@@ -523,12 +511,6 @@ def step_3(ctx: click.Context, metricflow_repo: Path) -> None:
 
 @cli.command(CLI_COMMAND_STEP_4)
 @click.option(
-    CLI_OPTION_METRICFLOW_REPO,
-    type=click.Path(exists=True, file_okay=False, dir_okay=True, path_type=Path),
-    required=True,
-    help="Path to the metricflow git repository.",
-)
-@click.option(
     CLI_OPTION_DBT_METRICFLOW_VERSION,
     "dbt_metricflow_version",
     required=True,
@@ -536,11 +518,11 @@ def step_3(ctx: click.Context, metricflow_repo: Path) -> None:
     help="Semantic version for the new `dbt-metricflow` release.",
 )
 @click.pass_context
-def step_4(ctx: click.Context, metricflow_repo: Path, dbt_metricflow_version: str) -> None:
+def step_4(ctx: click.Context, dbt_metricflow_version: str) -> None:
     """Update `dbt-metricflow` to depend on the released `metricflow` version."""
     console = _ClickReleaseConsole()
-    console.echo(f"MetricFlow repo directory: {metricflow_repo}")
-    context = _release_tool_context(ctx).copy(current_directory=metricflow_repo)
+    context = _release_tool_context(ctx)
+    console.echo(f"MetricFlow repo directory: {context.current_directory}")
     git_manager = _run_release_step_prechecks(context=context)
     _check_required_cli_commands(
         command_names=ReleaseStep4Runner.REQUIRED_CLI_COMMANDS,
@@ -581,18 +563,12 @@ def step_4(ctx: click.Context, metricflow_repo: Path, dbt_metricflow_version: st
 
 
 @cli.command(CLI_COMMAND_STEP_5)
-@click.option(
-    CLI_OPTION_METRICFLOW_REPO,
-    type=click.Path(exists=True, file_okay=False, dir_okay=True, path_type=Path),
-    required=True,
-    help="Path to the metricflow git repository.",
-)
 @click.pass_context
-def step_5(ctx: click.Context, metricflow_repo: Path) -> None:
+def step_5(ctx: click.Context) -> None:
     """Update the dbt-metricflow version for in-progress development."""
     console = _ClickReleaseConsole()
-    console.echo(f"MetricFlow repo directory: {metricflow_repo}")
-    context = _release_tool_context(ctx).copy(current_directory=metricflow_repo)
+    context = _release_tool_context(ctx)
+    console.echo(f"MetricFlow repo directory: {context.current_directory}")
     git_manager = _run_release_step_prechecks(context=context)
     _check_required_cli_commands(
         command_names=ReleaseStep5Runner.REQUIRED_CLI_COMMANDS,
@@ -629,18 +605,12 @@ def step_5(ctx: click.Context, metricflow_repo: Path) -> None:
 
 
 @cli.command(CLI_COMMAND_STEP_6)
-@click.option(
-    CLI_OPTION_METRICFLOW_REPO,
-    type=click.Path(exists=True, file_okay=False, dir_okay=True, path_type=Path),
-    required=True,
-    help="Path to the metricflow git repository.",
-)
 @click.pass_context
-def step_6(ctx: click.Context, metricflow_repo: Path) -> None:
+def step_6(ctx: click.Context) -> None:
     """Merge the dbt-metricflow release pull requests from steps 4 and 5."""
     console = _ClickReleaseConsole()
-    console.echo(f"MetricFlow repo directory: {metricflow_repo}")
-    context = _release_tool_context(ctx).copy(current_directory=metricflow_repo)
+    context = _release_tool_context(ctx)
+    console.echo(f"MetricFlow repo directory: {context.current_directory}")
     git_manager = _run_release_step_prechecks(context=context)
     state_file_path = _release_tool_state_file_path(current_directory=context.current_directory)
     release_tool_state = _load_release_tool_state(state_file_path=state_file_path)
@@ -674,18 +644,12 @@ def step_6(ctx: click.Context, metricflow_repo: Path) -> None:
 
 
 @cli.command(CLI_COMMAND_STEP_7)
-@click.option(
-    CLI_OPTION_METRICFLOW_REPO,
-    type=click.Path(exists=True, file_okay=False, dir_okay=True, path_type=Path),
-    required=True,
-    help="Path to the metricflow git repository.",
-)
 @click.pass_context
-def step_7(ctx: click.Context, metricflow_repo: Path) -> None:
+def step_7(ctx: click.Context) -> None:
     """Create the GitHub release note for the MetricFlow release."""
     console = _ClickReleaseConsole()
-    console.echo(f"MetricFlow repo directory: {metricflow_repo}")
-    context = _release_tool_context(ctx).copy(current_directory=metricflow_repo)
+    context = _release_tool_context(ctx)
+    console.echo(f"MetricFlow repo directory: {context.current_directory}")
     git_manager = _run_release_step_prechecks(context=context)
     state_file_path = _release_tool_state_file_path(current_directory=context.current_directory)
     release_tool_state = _load_release_tool_state(state_file_path=state_file_path)
@@ -718,18 +682,12 @@ def step_7(ctx: click.Context, metricflow_repo: Path) -> None:
 
 
 @cli.command(CLI_COMMAND_CLEAN)
-@click.option(
-    CLI_OPTION_METRICFLOW_REPO,
-    type=click.Path(exists=True, file_okay=False, dir_okay=True, path_type=Path),
-    required=True,
-    help="Path to the metricflow git repository.",
-)
 @click.pass_context
-def clean(ctx: click.Context, metricflow_repo: Path) -> None:
+def clean(ctx: click.Context) -> None:
     """Delete release branches and remove the state file."""
     console = _ClickReleaseConsole()
-    console.echo(f"MetricFlow repo directory: {metricflow_repo}")
-    context = _release_tool_context(ctx).copy(current_directory=metricflow_repo)
+    context = _release_tool_context(ctx)
+    console.echo(f"MetricFlow repo directory: {context.current_directory}")
     git_manager = context.git_manager_factory(context.current_directory)
     state_file_path = _release_tool_state_file_path(current_directory=context.current_directory)
 

--- a/scripts/release_tool/release_helper.py
+++ b/scripts/release_tool/release_helper.py
@@ -19,6 +19,7 @@ logger = logging.getLogger(__name__)
 _T = TypeVar("_T")
 
 _TRAILING_BANNER_SEPARATOR = "=" * 72
+_BANNER_TEXT_COLOR = "white"
 
 
 class ReleaseHelperConsole(ABC):
@@ -28,12 +29,17 @@ class ReleaseHelperConsole(ABC):
     """
 
     @abstractmethod
-    def echo(self, message: str) -> None:
+    def echo(self, message: str, color: str = "green") -> None:
         """Write a message to the user."""
 
     @abstractmethod
     def warning(self, message: str) -> None:
         """Write a warning message to the user."""
+
+    def banner(self, message: str) -> None:
+        """Write a trailing banner with consistent formatting."""
+        for banner_line in ("", _TRAILING_BANNER_SEPARATOR, *message.splitlines(), "", _TRAILING_BANNER_SEPARATOR):
+            self.echo(banner_line, color=_BANNER_TEXT_COLOR)
 
     @abstractmethod
     def confirm(self, message: str) -> None:
@@ -120,21 +126,15 @@ class ReleaseHelper:
 
     def echo_pull_request_review_banner(self, pr_link: str) -> None:
         """Echo a trailing banner with the pull request URL and a review reminder."""
-        self.console.echo("")
-        self.console.echo(_TRAILING_BANNER_SEPARATOR)
-        self.console.echo("Please have this pull request reviewed and approved before continuing:")
-        self.console.echo("")
-        self.console.echo(mf_indent(mf_hyperlink(pr_link)))
-        self.console.echo("")
-        self.console.echo(_TRAILING_BANNER_SEPARATOR)
+        self.console.banner(
+            "Please have this pull request reviewed and approved before continuing:\n\n"
+            f"{mf_indent(mf_hyperlink(pr_link))}"
+        )
 
     def echo_github_actions_workflow_approval_banner(self, workflow_file_name: str) -> None:
         """Echo a trailing banner with the workflow URL and an approval reminder."""
         workflow_url = f"https://github.com/{self.repository_name}/actions/workflows/{workflow_file_name}"
-        self.console.echo("")
-        self.console.echo(_TRAILING_BANNER_SEPARATOR)
-        self.console.echo("Please go to this workflow and approve it before continuing:")
-        self.console.echo("")
-        self.console.echo(mf_indent(mf_hyperlink(workflow_url)))
-        self.console.echo("")
-        self.console.echo(_TRAILING_BANNER_SEPARATOR)
+        self.console.banner(
+            "Please go to this workflow and approve it before continuing:\n\n"
+            f"{mf_indent(mf_hyperlink(workflow_url))}"
+        )

--- a/scripts/release_tool/release_helper.py
+++ b/scripts/release_tool/release_helper.py
@@ -32,6 +32,10 @@ class ReleaseHelperConsole(ABC):
         """Write a message to the user."""
 
     @abstractmethod
+    def warning(self, message: str) -> None:
+        """Write a warning message to the user."""
+
+    @abstractmethod
     def confirm(self, message: str) -> None:
         """Prompt the user to confirm a message."""
 

--- a/scripts/release_tool/release_pr_runner.py
+++ b/scripts/release_tool/release_pr_runner.py
@@ -132,7 +132,9 @@ class ReleasePrRunner:
     def _wait_for_user_review(self) -> None:
         """Prompt for a manual review pause before pushing."""
         if not self.release_helper.confirm_all:
-            self.release_helper.console.confirm("Make any edits to the commits now. Continue when ready?")
+            self.release_helper.console.confirm(
+                f"Make any edits to branch ({self.release_branch_name!r}) now. Continue when ready?"
+            )
 
     def _push_release_branch(self) -> None:
         """Force-push the release branch."""

--- a/scripts/release_tool/release_pr_runner.py
+++ b/scripts/release_tool/release_pr_runner.py
@@ -146,6 +146,11 @@ class ReleasePrRunner:
         create_pr_description = f"Create or update PR '{self.pr_title}' for {self.release_branch_name}"
         self.release_helper.confirm_state_changing_remote_action(description=create_pr_description)
         self.release_helper.console.echo(create_pr_description)
+        if self.existing_pr_number is not None:
+            self.release_helper.console.warning(
+                f"Warning: PR #{self.existing_pr_number} already exists according to the release state file. "
+                "Updating the existing PR instead of creating a new one."
+            )
         pr_number = self.github_client.create_or_update_pr(
             title=self.pr_title,
             body=self.pr_body,

--- a/scripts/release_tool/release_step_1.py
+++ b/scripts/release_tool/release_step_1.py
@@ -92,7 +92,6 @@ class ReleaseStep1Runner:
             release_helper=self.release_helper,
         ).run()
 
-        self.release_helper.echo_pull_request_review_banner(pr_link=pr_result.pr_link)
         return ReleaseStep1State(
             metricflow_package_version=self.version,
             branch_name=release_branch_name,

--- a/scripts/release_tool/release_step_2.py
+++ b/scripts/release_tool/release_step_2.py
@@ -103,7 +103,6 @@ class ReleaseStep2Runner:
             base_branch=step_1_branch_name,
             pull_base_branch=False,
         ).run()
-        self.release_helper.echo_pull_request_review_banner(pr_link=pr_result.pr_link)
         return ReleaseStep2State(
             metricflow_package_version=new_version,
             branch_name=step_2_branch_name,

--- a/scripts/release_tool/release_step_3.py
+++ b/scripts/release_tool/release_step_3.py
@@ -120,9 +120,6 @@ class ReleaseStep3Runner:
                 force=True,
             ),
         )
-        helper.echo_github_actions_workflow_approval_banner(
-            workflow_file_name=ReleaseHelper.CD_PUSH_METRICFLOW_TO_PYPI_WORKFLOW_FILE_NAME,
-        )
         return ReleaseStep3State(
             metricflow_release_tag_name=tag_name,
             metricflow_release_merge_commit_sha=step_1_merge_sha,

--- a/scripts/release_tool/release_step_4.py
+++ b/scripts/release_tool/release_step_4.py
@@ -102,7 +102,6 @@ class ReleaseStep4Runner:
             release_helper=self.release_helper,
         ).run()
 
-        self.release_helper.echo_pull_request_review_banner(pr_link=pr_result.pr_link)
         return ReleaseStep4State(
             metricflow_package_version=mf_version,
             dbt_metricflow_package_version=dbt_metricflow_version,

--- a/scripts/release_tool/release_step_5.py
+++ b/scripts/release_tool/release_step_5.py
@@ -102,7 +102,6 @@ class ReleaseStep5Runner:
             base_branch=step_4_branch_name,
             pull_base_branch=False,
         ).run()
-        self.release_helper.echo_pull_request_review_banner(pr_link=pr_result.pr_link)
         return ReleaseStep5State(
             metricflow_package_version=mf_version,
             dbt_metricflow_package_version=new_version,

--- a/scripts/release_tool/release_step_6.py
+++ b/scripts/release_tool/release_step_6.py
@@ -120,9 +120,6 @@ class ReleaseStep6Runner:
                 force=True,
             ),
         )
-        helper.echo_github_actions_workflow_approval_banner(
-            workflow_file_name=ReleaseHelper.CD_PUSH_DBT_METRICFLOW_TO_PYPI_WORKFLOW_FILE_NAME,
-        )
         return ReleaseStep6State(
             dbt_metricflow_release_tag_name=tag_name,
             dbt_metricflow_release_merge_commit_sha=step_4_merge_sha,

--- a/tests_metricflow/release_tools/release_tool_test_helpers.py
+++ b/tests_metricflow/release_tools/release_tool_test_helpers.py
@@ -697,7 +697,7 @@ def _release_tool_command(repo_path: Path, step_args: list[str], yes: bool = Tru
     command: list[str] = []
     if yes:
         command.append(CLI_OPTION_YES)
-    return [*command, step_args[0], CLI_OPTION_METRICFLOW_REPO, str(repo_path), *step_args[1:]]
+    return [*command, CLI_OPTION_METRICFLOW_REPO, str(repo_path), *step_args]
 
 
 class FakeSleep:


### PR DESCRIPTION
This PR updates the release tool with some refinements:
* Adds a warning if a PR already exists and will be updated.
* Adds a warning if a step was already run.
* Moves the `--metricflow-repo` argument to before the command to make running subsequent steps easier.
* Prints the banner message requiring user action as the last item shown.