### PR TITLE
Isolate mypy cache between metricflow / dbt-metricflow

### DIFF
--- a/.changes/unreleased/Fixes-20260508-103751.yaml
+++ b/.changes/unreleased/Fixes-20260508-103751.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Isolate mypy cache between metricflow / dbt-metricflow
+time: 2026-05-08T10:37:51.18161-07:00
+custom:
+    Author: plypaul
+    Issue: "2046"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,8 @@ repos:
         # dbt-metricflow requires dbt-core, which is not installed in the main metricflow dev environment.
         # We typecheck dbt-metricflow separately via direct invocation inside the `make lint` command
         exclude: "^dbt-metricflow/"
-        args: [--show-error-codes]
+        # Keep mypy's incremental cache isolated to this Hatch environment's dependency set.
+        args: [--show-error-codes, --cache-dir=.mypy_cache/root_dev_env]
         verbose: true
         # "system" means that the current environment will be used to run the hook, not the environment installed by
         # pre-commit. This is set for mypy to use the specified package dependencies in Hatch (assuming pre-commit is

--- a/dbt-metricflow/.pre-commit-config.yaml
+++ b/dbt-metricflow/.pre-commit-config.yaml
@@ -35,7 +35,8 @@ repos:
     rev: v1.3.0
     hooks:
       - id: mypy
-        args: [--show-error-codes]
+        # Keep mypy's incremental cache isolated to this Hatch environment's dependency set.
+        args: [--show-error-codes, --cache-dir=.mypy_cache/dbt_metricflow_dev_env]
         verbose: true
         # "system" means that the current environment will be used to run the hook, not the environment installed by
         # pre-commit. This is set for mypy to use the specified package dependencies in Hatch (assuming pre-commit is


### PR DESCRIPTION
This PR updates the mypy configuration so that different cache directories are used between metricflow and dbt-metricflow. The resolves some mypy-related cache errors that would occasionally appear due to the different requirements in the two packages.