### PR TITLE
Add retries to `test_format_report_to_text_table`

### DIFF
--- a/.changes/unreleased/Under the Hood-20260508-103822.yaml
+++ b/.changes/unreleased/Under the Hood-20260508-103822.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Add retries to `test_format_report_to_text_table`
+time: 2026-05-08T10:38:22.589085-07:00
+custom:
+    Author: plypaul
+    Issue: "2047"

--- a/tests_metricflow_semantics/helpers/performance/test_report_formatter.py
+++ b/tests_metricflow_semantics/helpers/performance/test_report_formatter.py
@@ -8,8 +8,11 @@ from metricflow_semantics.test_helpers.config_helpers import MetricFlowTestConfi
 from metricflow_semantics.test_helpers.performance.profiling import PerformanceTracker
 from metricflow_semantics.test_helpers.performance.report_formatter import TableTextFormatter
 from metricflow_semantics.test_helpers.snapshot_helpers import assert_str_snapshot_equal
+from metricflow_semantics.toolkit.mf_logging.lazy_formattable import LazyFormat
 
 logger = logging.getLogger(__name__)
+
+_TEST_MAX_ATTEMPT_COUNT = 3
 
 
 def test_format_report_to_text_table(
@@ -23,12 +26,26 @@ def test_format_report_to_text_table(
             _recurse_n_times(depth=depth - 1)
         return
 
-    performance_tracker = PerformanceTracker()
-    with performance_tracker.session("Profile `_recurse_n_times(2)`"):
-        _recurse_n_times(2)
+    for attempt_index in range(_TEST_MAX_ATTEMPT_COUNT):
+        performance_tracker = PerformanceTracker()
+        with performance_tracker.session("Profile `_recurse_n_times(2)`"):
+            _recurse_n_times(2)
 
-    text_table = performance_tracker.last_session_report.text_format(TableTextFormatter(row_limit=1))
-    # Replace line numbers that come after a `:` with `*`.
-    text_table = re.sub(pattern=r":(\d+)", repl=lambda match: ":" + "*" * len(match.group(1)), string=text_table)
+        text_table = performance_tracker.last_session_report.text_format(TableTextFormatter(row_limit=1))
+        # Replace line numbers that come after a `:` with `*`.
+        text_table = re.sub(pattern=r":(\d+)", repl=lambda match: ":" + "*" * len(match.group(1)), string=text_table)
 
-    assert_str_snapshot_equal(request=request, snapshot_configuration=mf_test_configuration, snapshot_str=text_table)
+        try:
+            assert_str_snapshot_equal(
+                request=request, snapshot_configuration=mf_test_configuration, snapshot_str=text_table
+            )
+            return
+        except Exception as e:
+            if attempt_index == _TEST_MAX_ATTEMPT_COUNT - 1:
+                raise
+            logger.warning(
+                LazyFormat(
+                    "Got a snapshot error. Retrying as slight variations in runtime will cause snapshot differences.",
+                    exc_info=e,
+                )
+            )


### PR DESCRIPTION
This PR adds retries to `test_format_report_to_text_table` as it can be flaky due to different runtimes.