### PR TITLE
Allow multiple `--where` arguments in the CLI

### DIFF
--- a/.changes/unreleased/Features-20260511-102140.yaml
+++ b/.changes/unreleased/Features-20260511-102140.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Allow multiple `--where` arguments in the CLI
+time: 2026-05-11T10:21:40.772707-07:00
+custom:
+    Author: plypaul
+    Issue: "2050"

--- a/dbt-metricflow/dbt_metricflow/cli/main.py
+++ b/dbt-metricflow/dbt_metricflow/cli/main.py
@@ -181,7 +181,7 @@ def query(
     cfg: CLIConfiguration,
     metrics: Optional[Sequence[str]] = None,
     group_by: Optional[Sequence[str]] = None,
-    where: Optional[str] = None,
+    where: Sequence[str] = (),
     start_time: Optional[dt.datetime] = None,
     end_time: Optional[dt.datetime] = None,
     order: Optional[List[str]] = None,
@@ -216,7 +216,7 @@ def query(
         limit=limit,
         time_constraint_start=start_time,
         time_constraint_end=end_time,
-        where_constraints=[where] if where else None,
+        where_constraints=where or None,
         order_by_names=order,
     )
 

--- a/dbt-metricflow/dbt_metricflow/cli/utils.py
+++ b/dbt-metricflow/dbt_metricflow/cli/utils.py
@@ -46,7 +46,7 @@ def query_options(function: Callable) -> Callable:
     function = click.option(
         "--where",
         type=str,
-        default=None,
+        multiple=True,
         help=(
             "SQL-like where statement provided as a string and wrapped in quotes. "
             "All filter items must explicitly reference fields or dimensions "

--- a/dbt-metricflow/tests_dbt_metricflow/cli/test_cli.py
+++ b/dbt-metricflow/tests_dbt_metricflow/cli/test_cli.py
@@ -233,9 +233,6 @@ def test_saved_query_with_where(  # noqa: D103
     cli_test_configuration: MetricFlowTestConfiguration,
     cli_runner: IsolatedCliCommandRunner,
 ) -> None:
-    where_argument_value = (
-        "{{ Dimension('customer__customer_country') }}  = 'US' AND {{ TimeDimension('metric_time') }} <= '2022-03-12'"
-    )
     run_and_check_cli_command(
         request=request,
         cli_test_configuration=cli_test_configuration,
@@ -245,7 +242,9 @@ def test_saved_query_with_where(  # noqa: D103
             "--saved-query",
             "core_transaction_metrics",
             "--where",
-            where_argument_value,
+            "{{ Dimension('customer__customer_country') }}  = 'US'",
+            "--where",
+            "{{ TimeDimension('metric_time') }} <= '2022-03-12'",
             "--order",
             "metric_time__day,customer__customer_country,transactions,quick_buy_transactions",
         ],


### PR DESCRIPTION
This PR updates the CLI to allow multiple `--where` arguments. This provides a UX improvement and can be used to push different predicates to different levels.