### PR TITLE
Update DuckDB dev dependency to `>= 1.5`

### DIFF
--- a/.changes/unreleased/Dependencies-20260511-113110.yaml
+++ b/.changes/unreleased/Dependencies-20260511-113110.yaml
@@ -1,0 +1,6 @@
+kind: Dependencies
+body: Update DuckDB dev dependency to `>= 1.5`
+time: 2026-05-11T11:31:10.601663-07:00
+custom:
+    Author: plypaul
+    Issue: "2051"

--- a/dbt-metricflow/requirements-files/dev-env-requirements.txt
+++ b/dbt-metricflow/requirements-files/dev-env-requirements.txt
@@ -4,7 +4,4 @@ update-checker>=0.18.0, <0.19.0
 click>=8.1.6
 dbt-core>=1.10.4, <1.12.0
 dbt-duckdb>=1.8.0, <1.9.0
-# Excluding 1.2.1 due to window functions returning incorrect results:
-# https://github.com/duckdb/duckdb/issues/16617
-# Version 1.4.0 seems to have issues as well, so pinning to <1.4.0 until those are resolved.
-duckdb !=1.2.1, <1.4.0
+duckdb >=1.5, <1.6

--- a/requirements-files/dev-env-requirements.txt
+++ b/requirements-files/dev-env-requirements.txt
@@ -2,10 +2,7 @@
 sqlalchemy>=2.0.0, <2.1.0
 # DuckDB engine for DuckDB-backed, SqlAlchemy-based client
 duckdb-engine>=0.13.0, <0.14.0
-# Excluding duckdb 1.2.1 due to window functions returning incorrect results:
-# https://github.com/duckdb/duckdb/issues/16617
-# Version 1.4.0 seems to have issues as well, so pinning to <1.4.0 until those are resolved.
-duckdb !=1.2.1, <1.4.0
+duckdb >=1.5, <1.6
 graphviz>=0.18.2, <0.21
 tomli >=2.3.0, <3
 varname >=0.15.1, < 1

--- a/tests_metricflow/snapshots/test_internal_manifest.py/str/test_invalid_filter_sql__result.txt
+++ b/tests_metricflow/snapshots/test_internal_manifest.py/str/test_invalid_filter_sql__result.txt
@@ -27,7 +27,7 @@ query_56a97413:
     GROUP BY
       metric_time__day
   sql_exception:
-    (duckdb.duckdb.BinderException) Binder Error: Referenced column "invalid_column" not found in FROM clause!
+    (_duckdb.BinderException) Binder Error: Referenced column "invalid_column" not found in FROM clause!
     Candidate bindings: "metric_time__day"
 
     LINE 18: WHERE invalid_column > 1


### PR DESCRIPTION
This PR updates DuckDB dependency in the development environment to `>= 1.5` as the Python 3.14 wheels for some older versions are not available. Without the wheel, CI checks for Python 3.14 are slow as the package needs to be built locally. 