### PR TITLE
Release `dbt-metricflow` 0.13.0 with `metricflow` 0.211.0

### DIFF
--- a/dbt-metricflow/dbt_metricflow/__about__.py
+++ b/dbt-metricflow/dbt_metricflow/__about__.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-__version__ = "0.13.0.dev0"
+__version__ = "0.13.0"

--- a/dbt-metricflow/requirements-files/requirements-metricflow.txt
+++ b/dbt-metricflow/requirements-files/requirements-metricflow.txt
@@ -1,1 +1,1 @@
-metricflow @ {root:parent:uri}
+metricflow==0.211.0


### PR DESCRIPTION
Release `dbt-metricflow` 0.13.0 with updated dependency `metricflow==0.211.0`.

Release PR: https://github.com/dbt-labs/metricflow/pull/2044