### PR TITLE
Restore `dbt-metricflow` dependency changes in release flow

### DIFF
--- a/scripts/release_tool/release_step_2.py
+++ b/scripts/release_tool/release_step_2.py
@@ -25,7 +25,7 @@ class ReleaseStep2State(BaseModel):
     # Development version branch name.
     branch_name: str
     # Commit SHA for the version update.
-    commit_sha: str
+    version_update_commit_sha: str
     # Development version pull request number.
     pr_number: int
     # Development version pull request link.
@@ -106,7 +106,7 @@ class ReleaseStep2Runner:
         return ReleaseStep2State(
             metricflow_package_version=new_version,
             branch_name=step_2_branch_name,
-            commit_sha=pr_result.commit_shas[0],
+            version_update_commit_sha=pr_result.commit_shas[0],
             pr_number=pr_result.pr_number,
             pr_link=pr_result.pr_link,
         )

--- a/scripts/release_tool/release_step_3.py
+++ b/scripts/release_tool/release_step_3.py
@@ -67,7 +67,7 @@ class ReleaseStep3Runner:
         step_1_pr = self.step_1_state.pr_number
         step_2_pr = self.step_2_state.pr_number
         step_2_branch = self.step_2_state.branch_name
-        step_2_commit_sha = self.step_2_state.commit_sha
+        step_2_commit_sha = self.step_2_state.version_update_commit_sha
         helper = self.release_helper
         git = helper.git_manager
         tag_name = f"{ReleaseHelper.METRICFLOW_RELEASE_TAG_PREFIX}{self.step_1_state.metricflow_package_version}"

--- a/scripts/release_tool/release_step_5.py
+++ b/scripts/release_tool/release_step_5.py
@@ -29,7 +29,7 @@ class ReleaseStep5State(BaseModel):
     # Development version branch name.
     branch_name: str
     # Commit SHA for the version update.
-    commit_sha: str
+    version_update_commit_sha: str
     # Commit SHA for setting dbt-metricflow's metricflow dependency back to the local monorepo package.
     local_metricflow_requirement_commit_sha: str
     # Development version pull request number.
@@ -44,7 +44,7 @@ class ReleaseStep5State(BaseModel):
 
     def commit_shas_for_branch_refresh(self) -> tuple[str, ...]:
         """Return the step-5 commit SHAs that should be replayed when refreshing the branch."""
-        return (self.commit_sha, self.local_metricflow_requirement_commit_sha)
+        return (self.version_update_commit_sha, self.local_metricflow_requirement_commit_sha)
 
 
 @dataclass(frozen=True)
@@ -128,7 +128,7 @@ class ReleaseStep5Runner:
             metricflow_package_version=mf_version,
             dbt_metricflow_package_version=new_version,
             branch_name=step_5_branch_name,
-            commit_sha=pr_result.commit_shas[0],
+            version_update_commit_sha=pr_result.commit_shas[0],
             local_metricflow_requirement_commit_sha=pr_result.commit_shas[1],
             pr_number=pr_result.pr_number,
             pr_link=pr_result.pr_link,

--- a/scripts/release_tool/release_step_5.py
+++ b/scripts/release_tool/release_step_5.py
@@ -6,11 +6,13 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import ClassVar
 
+import click
+
 from msi_pydantic_shim import BaseModel
 from scripts.release_tool.github_client import GitHubClient
 from scripts.release_tool.package_version import PackageVersionUpdate
 from scripts.release_tool.release_helper import ReleaseHelper
-from scripts.release_tool.release_pr_runner import ReleasePrRunner
+from scripts.release_tool.release_pr_runner import ReleasePrCommitTask, ReleasePrRunner
 from scripts.release_tool.release_step_2 import ReleaseStep2Runner
 from scripts.release_tool.release_step_4 import ReleaseStep4Runner, ReleaseStep4State
 
@@ -28,6 +30,8 @@ class ReleaseStep5State(BaseModel):
     branch_name: str
     # Commit SHA for the version update.
     commit_sha: str
+    # Commit SHA for setting dbt-metricflow's metricflow dependency back to the local monorepo package.
+    local_metricflow_requirement_commit_sha: str
     # Development version pull request number.
     pr_number: int
     # Development version pull request link.
@@ -37,6 +41,10 @@ class ReleaseStep5State(BaseModel):
         """Pydantic configuration."""
 
         allow_mutation = False
+
+    def commit_shas_for_branch_refresh(self) -> tuple[str, ...]:
+        """Return the step-5 commit SHAs that should be replayed when refreshing the branch."""
+        return (self.commit_sha, self.local_metricflow_requirement_commit_sha)
 
 
 @dataclass(frozen=True)
@@ -48,14 +56,23 @@ class ReleaseStep5Runner:
     * Creating the local step-5 branch from the step-4 branch
     * Updating the `dbt-metricflow` package version to the next dev version
     * Validating that only `dbt-metricflow/dbt_metricflow/__about__.py` changed
-    * Committing and force-pushing the version update
+    * Committing the version update
+    * Setting the `dbt-metricflow` package's `metricflow` requirement to use
+      the local monorepo package
+    * Committing the requirements update and force-pushing the branch
     * Creating or updating a PR against the step-4 branch
     """
 
     # File path that the `dbt-metricflow` version update is allowed to modify.
     ALLOWED_DBT_ABOUT_FILE_PATH: ClassVar[str] = ReleaseStep4Runner.ALLOWED_DBT_ABOUT_FILE_PATH
+    # Path to the dbt-metricflow requirements file that depends on the `metricflow` package.
+    REQUIREMENTS_FILE_PATH: ClassVar[str] = ReleaseStep4Runner.REQUIREMENTS_FILE_PATH
     # Name of the package updated in step 5.
     PACKAGE_NAME: ClassVar[str] = "dbt-metricflow"
+    # Requirement line used by dbt-metricflow development branches to depend on the local monorepo metricflow package.
+    LOCAL_METRICFLOW_REQUIREMENT_LINE: ClassVar[str] = "metricflow @ {root:parent:uri}"
+    # Commit message used when setting the local metricflow requirement.
+    LOCAL_METRICFLOW_REQUIREMENT_COMMIT_MESSAGE: ClassVar[str] = "Set local `metricflow` requirement"
     # CLI commands that must be available on PATH for step 5.
     REQUIRED_CLI_COMMANDS: ClassVar[tuple[str, ...]] = ("hatch",)
     # State saved from step 4.
@@ -94,7 +111,12 @@ class ReleaseStep5Runner:
             existing_pr_number=self.existing_state.pr_number if self.existing_state is not None else None,
             tasks=(
                 package_version_update.as_release_pr_commit_task(
-                    commit_message=pr_title,
+                    commit_message=self._development_version_pr_title(version=new_version),
+                ),
+                ReleasePrCommitTask(
+                    action=self._set_local_metricflow_requirement,
+                    validate=self._check_requirements_only_changes,
+                    commit_message=ReleaseStep5Runner.LOCAL_METRICFLOW_REQUIREMENT_COMMIT_MESSAGE,
                 ),
             ),
             github_client=self.github_client,
@@ -107,9 +129,39 @@ class ReleaseStep5Runner:
             dbt_metricflow_package_version=new_version,
             branch_name=step_5_branch_name,
             commit_sha=pr_result.commit_shas[0],
+            local_metricflow_requirement_commit_sha=pr_result.commit_shas[1],
             pr_number=pr_result.pr_number,
             pr_link=pr_result.pr_link,
         )
+
+    def _set_local_metricflow_requirement(self) -> None:
+        """Set the local metricflow requirement for post-release dbt-metricflow development."""
+        self.release_helper.run(
+            description=(
+                f"Update {ReleaseStep5Runner.REQUIREMENTS_FILE_PATH} to use "
+                f"`{ReleaseStep5Runner.LOCAL_METRICFLOW_REQUIREMENT_LINE}`"
+            ),
+            action=lambda: self._write_requirements_file(
+                requirement_line=ReleaseStep5Runner.LOCAL_METRICFLOW_REQUIREMENT_LINE
+            ),
+        )
+
+    def _write_requirements_file(self, requirement_line: str) -> None:
+        """Write the `metricflow` requirement to the dbt-metricflow requirements file."""
+        requirements_path = self.release_helper.current_directory / ReleaseStep5Runner.REQUIREMENTS_FILE_PATH
+        requirements_path.write_text(f"{requirement_line}\n")
+
+    def _check_requirements_only_changes(self) -> None:
+        """Raise if setting the local requirement changed files outside the metricflow requirement file."""
+        changed_file_paths = self.release_helper.git_manager.changed_file_paths()
+        unexpected_file_paths = [
+            file_path for file_path in changed_file_paths if file_path != ReleaseStep5Runner.REQUIREMENTS_FILE_PATH
+        ]
+        if unexpected_file_paths:
+            raise click.ClickException(
+                f"Setting the local requirement may only change {ReleaseStep5Runner.REQUIREMENTS_FILE_PATH}. "
+                f"Unexpected changed paths: {', '.join(unexpected_file_paths)}"
+            )
 
     def _dbt_metricflow_root(self) -> Path:
         """Return the dbt-metricflow hatch project directory."""

--- a/scripts/release_tool/release_step_6.py
+++ b/scripts/release_tool/release_step_6.py
@@ -41,7 +41,7 @@ class ReleaseStep6Runner:
     * Polling until both the step-4 and step-5 PRs are ready to merge
     * Merging the step-4 PR
     * Switching to main, pulling, then recreating the step-5 branch from main
-      and cherry-picking the step-5 commit onto it
+      and cherry-picking the step-5 commits onto it
     * Force-pushing the step-5 branch
     * Polling until the step-5 PR is ready to merge, then merging it
     * Creating or updating a lightweight ``dbt-metricflow/v$VERSION`` tag
@@ -66,7 +66,7 @@ class ReleaseStep6Runner:
         step_4_pr = self.step_4_state.pr_number
         step_5_pr = self.step_5_state.pr_number
         step_5_branch = self.step_5_state.branch_name
-        step_5_commit_sha = self.step_5_state.commit_sha
+        step_5_commit_shas = self.step_5_state.commit_shas_for_branch_refresh()
         dbt_metricflow_version = self.step_4_state.dbt_metricflow_package_version
         helper = self.release_helper
         git = helper.git_manager
@@ -97,10 +97,11 @@ class ReleaseStep6Runner:
             def _create_branch_and_cherry_pick() -> None:
                 git.create_branch(step_5_branch)
                 git.switch_branch(step_5_branch)
-                git.cherry_pick(step_5_commit_sha)
+                for commit_sha in step_5_commit_shas:
+                    git.cherry_pick(commit_sha)
 
             helper.run(
-                description=f"Create branch {step_5_branch} and cherry-pick {step_5_commit_sha}",
+                description=f"Create branch {step_5_branch} and cherry-pick step-5 commits",
                 action=_create_branch_and_cherry_pick,
             )
             helper.run_confirmed_remote_action(

--- a/tests_metricflow/release_tools/release_tool_test_helpers.py
+++ b/tests_metricflow/release_tools/release_tool_test_helpers.py
@@ -690,6 +690,9 @@ def _make_metricflow_repo(tmp_path: Path) -> Path:
     dbt_metricflow_path.joinpath("pyproject.toml").write_text(
         '[tool.hatch.version]\npath = "dbt_metricflow/__about__.py"\n'
     )
+    dbt_requirements_path = dbt_metricflow_path / "requirements-files"
+    dbt_requirements_path.mkdir()
+    dbt_requirements_path.joinpath("requirements-metricflow.txt").write_text("metricflow==1.2.3\n")
     return repo_path
 
 

--- a/tests_metricflow/release_tools/test_step_3.py
+++ b/tests_metricflow/release_tools/test_step_3.py
@@ -54,7 +54,7 @@ def _write_step_1_and_step_2_state(
     step_2 = ReleaseStep2State(
         metricflow_package_version=dev_version,
         branch_name=f"{username}/release_pr/{version}/step_2",
-        commit_sha="fake-step-2-commit-sha",
+        version_update_commit_sha="fake-step-2-commit-sha",
         pr_number=step_2_pr_number,
         pr_link=f"{GITHUB_REPOSITORY_HTML_BASE_URL}/pull/{step_2_pr_number}",
     )

--- a/tests_metricflow/release_tools/test_step_5.py
+++ b/tests_metricflow/release_tools/test_step_5.py
@@ -70,7 +70,12 @@ def test_step_5_all_operations_match_snapshot(
     """Snapshot of the fake-operation log and final state file for ``step-5`` with ``--yes``."""
     operation_log = FakeOperations()
     git_manager = FakeGitManager(
-        changed_file_paths=(_STEP_4_DBT_ABOUT_FILE_PATH,),
+        changed_file_paths_sequence=(
+            (_STEP_4_DBT_ABOUT_FILE_PATH,),
+            (_STEP_4_DBT_ABOUT_FILE_PATH,),
+            ("dbt-metricflow/requirements-files/requirements-metricflow.txt",),
+            ("dbt-metricflow/requirements-files/requirements-metricflow.txt",),
+        ),
         operation_log=operation_log,
     )
     cli_command_runner = FakeCliCommandRunner(operation_log=operation_log)

--- a/tests_metricflow/release_tools/test_step_6.py
+++ b/tests_metricflow/release_tools/test_step_6.py
@@ -66,6 +66,7 @@ def _write_step_1_and_step_4_and_step_5_state(
         dbt_metricflow_package_version=dbt_dev_version,
         branch_name=f"{username}/release_pr/{version}/step_5",
         commit_sha="fake-step-5-commit-sha",
+        local_metricflow_requirement_commit_sha="fake-step-5-requirement-commit-sha",
         pr_number=step_5_pr_number,
         pr_link=f"{GITHUB_REPOSITORY_HTML_BASE_URL}/pull/{step_5_pr_number}",
     )

--- a/tests_metricflow/release_tools/test_step_6.py
+++ b/tests_metricflow/release_tools/test_step_6.py
@@ -65,7 +65,7 @@ def _write_step_1_and_step_4_and_step_5_state(
         metricflow_package_version=version,
         dbt_metricflow_package_version=dbt_dev_version,
         branch_name=f"{username}/release_pr/{version}/step_5",
-        commit_sha="fake-step-5-commit-sha",
+        version_update_commit_sha="fake-step-5-commit-sha",
         local_metricflow_requirement_commit_sha="fake-step-5-requirement-commit-sha",
         pr_number=step_5_pr_number,
         pr_link=f"{GITHUB_REPOSITORY_HTML_BASE_URL}/pull/{step_5_pr_number}",

--- a/tests_metricflow/release_tools/test_step_7.py
+++ b/tests_metricflow/release_tools/test_step_7.py
@@ -55,7 +55,7 @@ def _write_step_1_step_2_and_step_3_state(
     step_2 = ReleaseStep2State(
         metricflow_package_version=dev_version,
         branch_name=f"{username}/release_pr/{version}/step_2",
-        commit_sha="fake-step-2-commit-sha",
+        version_update_commit_sha="fake-step-2-commit-sha",
         pr_number=step_2_pr_number,
         pr_link=f"{GITHUB_REPOSITORY_HTML_BASE_URL}/pull/{step_2_pr_number}",
     )

--- a/tests_metricflow/snapshots/test_step_2.py/FakeRunSnapshot/test_step_2_all_operations_match_snapshot__result.txt
+++ b/tests_metricflow/snapshots/test_step_2.py/FakeRunSnapshot/test_step_2_all_operations_match_snapshot__result.txt
@@ -43,7 +43,7 @@ FakeRunSnapshot(
        '    "step_2": {\n'
        '        "metricflow_package_version": "1.3.0.dev0",\n'
        '        "branch_name": "metricflow-user/release_pr/1.2.3/step_2",\n'
-       '        "commit_sha": "commit-sha",\n'
+       '        "version_update_commit_sha": "commit-sha",\n'
        '        "pr_number": 456,\n'
        '        "pr_link": "https://github.com/dbt-labs/metricflow/pull/456"\n'
        '    },\n'

--- a/tests_metricflow/snapshots/test_step_3.py/FakeRunSnapshot/test_step_3_all_operations_match_snapshot__result.txt
+++ b/tests_metricflow/snapshots/test_step_3.py/FakeRunSnapshot/test_step_3_all_operations_match_snapshot__result.txt
@@ -41,7 +41,7 @@ FakeRunSnapshot(
        '    "step_2": {\n'
        '        "metricflow_package_version": "1.3.0.dev0",\n'
        '        "branch_name": "metricflow-user/release_pr/1.2.3/step_2",\n'
-       '        "commit_sha": "fake-step-2-commit-sha",\n'
+       '        "version_update_commit_sha": "fake-step-2-commit-sha",\n'
        '        "pr_number": 200,\n'
        '        "pr_link": "https://github.com/dbt-labs/metricflow/pull/200"\n'
        '    },\n'

--- a/tests_metricflow/snapshots/test_step_4.py/FakeRunSnapshot/test_step_4_all_operations_match_snapshot__result.txt
+++ b/tests_metricflow/snapshots/test_step_4.py/FakeRunSnapshot/test_step_4_all_operations_match_snapshot__result.txt
@@ -53,7 +53,7 @@ FakeRunSnapshot(
        '    "step_2": {\n'
        '        "metricflow_package_version": "1.3.0.dev0",\n'
        '        "branch_name": "metricflow-user/release_pr/1.2.3/step_2",\n'
-       '        "commit_sha": "fake-step-2-commit-sha",\n'
+       '        "version_update_commit_sha": "fake-step-2-commit-sha",\n'
        '        "pr_number": 200,\n'
        '        "pr_link": "https://github.com/dbt-labs/metricflow/pull/200"\n'
        '    },\n'

--- a/tests_metricflow/snapshots/test_step_5.py/FakeRunSnapshot/test_step_5_all_operations_match_snapshot__result.txt
+++ b/tests_metricflow/snapshots/test_step_5.py/FakeRunSnapshot/test_step_5_all_operations_match_snapshot__result.txt
@@ -22,6 +22,10 @@ FakeRunSnapshot(
     FakeCliCommand(command=('make', 'lint'), current_directory='<TMP>/metricflow'),
     FakeGitOperation(name='add_all_changes'),
     FakeGitOperation(name='add_commit', message='Update `dbt-metricflow` version to 0.13.0.dev0'),
+    FakeGitOperation(name='add_all_changes'),
+    FakeCliCommand(command=('make', 'lint'), current_directory='<TMP>/metricflow'),
+    FakeGitOperation(name='add_all_changes'),
+    FakeGitOperation(name='add_commit', message='Set local `metricflow` requirement'),
     FakeGitOperation(name='push_branch', branch_name='metricflow-user/release_pr/1.2.3/step_5'),
     FakeGitHubPullRequest(
       source='create_or_update_create',
@@ -57,7 +61,8 @@ FakeRunSnapshot(
        '        "metricflow_package_version": "1.2.3",\n'
        '        "dbt_metricflow_package_version": "0.13.0.dev0",\n'
        '        "branch_name": "metricflow-user/release_pr/1.2.3/step_5",\n'
-       '        "commit_sha": "commit-sha",\n'
+       '        "version_update_commit_sha": "commit-sha",\n'
+       '        "local_metricflow_requirement_commit_sha": "commit-sha",\n'
        '        "pr_number": 901,\n'
        '        "pr_link": "https://github.com/dbt-labs/metricflow/pull/901"\n'
        '    },\n'

--- a/tests_metricflow/snapshots/test_step_6.py/FakeRunSnapshot/test_step_6_all_operations_match_snapshot__result.txt
+++ b/tests_metricflow/snapshots/test_step_6.py/FakeRunSnapshot/test_step_6_all_operations_match_snapshot__result.txt
@@ -52,7 +52,7 @@ FakeRunSnapshot(
        '        "metricflow_package_version": "1.2.3",\n'
        '        "dbt_metricflow_package_version": "0.13.0.dev0",\n'
        '        "branch_name": "metricflow-user/release_pr/1.2.3/step_5",\n'
-       '        "commit_sha": "fake-step-5-commit-sha",\n'
+       '        "version_update_commit_sha": "fake-step-5-commit-sha",\n'
        '        "local_metricflow_requirement_commit_sha": "fake-step-5-requirement-commit-sha",\n'
        '        "pr_number": 400,\n'
        '        "pr_link": "https://github.com/dbt-labs/metricflow/pull/400"\n'

--- a/tests_metricflow/snapshots/test_step_6.py/FakeRunSnapshot/test_step_6_all_operations_match_snapshot__result.txt
+++ b/tests_metricflow/snapshots/test_step_6.py/FakeRunSnapshot/test_step_6_all_operations_match_snapshot__result.txt
@@ -23,6 +23,7 @@ FakeRunSnapshot(
     FakeGitOperation(name='create_branch', branch_name='metricflow-user/release_pr/1.2.3/step_5'),
     FakeGitOperation(name='switch_branch', branch_name='metricflow-user/release_pr/1.2.3/step_5'),
     FakeGitOperation(name='cherry_pick', commit_sha='fake-step-5-commit-sha'),
+    FakeGitOperation(name='cherry_pick', commit_sha='fake-step-5-requirement-commit-sha'),
     FakeGitOperation(name='push_branch', branch_name='metricflow-user/release_pr/1.2.3/step_5'),
     FakeGitHubIsMerged(pr_number=400, result=False),
     FakeGitHubMergeableState(pr_number=400),
@@ -52,6 +53,7 @@ FakeRunSnapshot(
        '        "dbt_metricflow_package_version": "0.13.0.dev0",\n'
        '        "branch_name": "metricflow-user/release_pr/1.2.3/step_5",\n'
        '        "commit_sha": "fake-step-5-commit-sha",\n'
+       '        "local_metricflow_requirement_commit_sha": "fake-step-5-requirement-commit-sha",\n'
        '        "pr_number": 400,\n'
        '        "pr_link": "https://github.com/dbt-labs/metricflow/pull/400"\n'
        '    },\n'

--- a/tests_metricflow/snapshots/test_step_7.py/FakeRunSnapshot/test_step_7_all_operations_match_snapshot__result.txt
+++ b/tests_metricflow/snapshots/test_step_7.py/FakeRunSnapshot/test_step_7_all_operations_match_snapshot__result.txt
@@ -28,7 +28,7 @@ FakeRunSnapshot(
        '    "step_2": {\n'
        '        "metricflow_package_version": "1.3.0.dev0",\n'
        '        "branch_name": "metricflow-user/release_pr/1.2.3/step_2",\n'
-       '        "commit_sha": "fake-step-2-commit-sha",\n'
+       '        "version_update_commit_sha": "fake-step-2-commit-sha",\n'
        '        "pr_number": 200,\n'
        '        "pr_link": "https://github.com/dbt-labs/metricflow/pull/200"\n'
        '    },\n'


### PR DESCRIPTION
During development, the `dbt-metricflow` package is configured to depend on the `metricflow` package in the repo i.e. (`metricflow @ {root:parent:uri}`. In step 4 of the release, the dependency is changed to a published version of `metricflow`. To restore the dependency for development, this PR updates step 5 to add a commit to revert the change.