### PR TITLE
Change ID generation to use `threading.local` instead of `ContextVar`

### DIFF
--- a/metricflow_semantics/dag/sequential_id.py
+++ b/metricflow_semantics/dag/sequential_id.py
@@ -1,16 +1,12 @@
 from __future__ import annotations
 
 import logging
+import threading
 from contextlib import contextmanager
-from contextvars import ContextVar
-from functools import cached_property
-from typing import Generator, Mapping, Optional
+from typing import ClassVar, Generator
 
 from metricflow_semantics.dag.id_prefix import IdPrefix
-from metricflow_semantics.toolkit.collections.mapping_helpers import mf_items_to_dict, mf_mapping_to_items
 from metricflow_semantics.toolkit.dataclass_helpers import fast_frozen_dataclass
-from metricflow_semantics.toolkit.mf_logging.lazy_formattable import LazyFormat
-from metricflow_semantics.toolkit.mf_type_aliases import AnyLengthTuple, MappingItem
 from typing_extensions import override
 
 logger = logging.getLogger(__name__)
@@ -32,106 +28,42 @@ class SequentialId:
         return self.str_value
 
 
-@fast_frozen_dataclass()
-class _IdGenerationState:
-    """Keeps track of the next IDs to return for a given prefix.
+class _IdGenerationState(threading.local):
+    """Stores the mapping from the IdPrefix to the next index in a thread-local manner."""
 
-    Since this is used in a context variable, it can't be mutable or else mutations will be visible between contexts.
-    """
+    def __init__(self, default_start_value: int) -> None:
+        self.default_start_value = default_start_value
+        self.id_prefix_to_next_value: dict[IdPrefix, int] = {}
 
-    default_start_value: int
-    prefix_to_next_value_items: AnyLengthTuple[MappingItem[IdPrefix, int]]
+    def reset(self, default_start_value: int) -> None:
+        """Reset ID generation for the current thread."""
+        self.default_start_value = default_start_value
+        self.id_prefix_to_next_value = {}
 
-    @cached_property
-    def prefix_to_next_value(self) -> Mapping[IdPrefix, int]:
-        return mf_items_to_dict(self.prefix_to_next_value_items)
-
-    @staticmethod
-    def create(
-        default_start_value: int, prefix_to_next_value: Optional[Mapping[IdPrefix, int]] = None
-    ) -> _IdGenerationState:
-        return _IdGenerationState(
-            default_start_value=default_start_value,
-            prefix_to_next_value_items=mf_mapping_to_items(prefix_to_next_value or {}),
-        )
-
-
-class _IdGenerationStateStack:
-    """A stack that keeps track of the state of ID generation.
-
-    The stack allows the use of context managers to enter sections where ID generation starts at a configured value.
-    When entering the section, a new `_IdGenerationState` is pushed on to the stack, and the state at the top of the
-    stack is used to generate IDs. When exiting a section, the state is popped off so that ID generation resumes from
-    the previous values.
-
-    The bottom of the stack is the one at the lowest index in `_state_stack_items`, and the top of the stack is the highest.
-
-    The "current state" is the state at the top of the stack.
-    """
-
-    _state_stack_items: ContextVar[AnyLengthTuple[_IdGenerationState]] = ContextVar(
-        "_IdGenerationStateStack__state_stack_items"
-    )
-
-    @classmethod
-    def _get_stack_items(cls) -> AnyLengthTuple[_IdGenerationState]:
-        if cls._state_stack_items.get(None) is None:
-            cls._state_stack_items.set((_IdGenerationState.create(default_start_value=0),))
-        return cls._state_stack_items.get()
-
-    @classmethod
-    def push_state(cls, id_generation_state: _IdGenerationState) -> None:
-        cls._state_stack_items.set(cls._get_stack_items() + (id_generation_state,))
-
-    @classmethod
-    def pop_state(cls) -> None:
-        initial_items = cls._get_stack_items()
-        state_stack_size = len(initial_items)
-        if state_stack_size <= 1:
-            logger.error(
-                LazyFormat(
-                    "Attempted to pop the last element in the state stack. Since sequential ID generation may not "
-                    "be absolutely critical for resolving queries, logging this as an error but it should be "
-                    "investigated.",
-                    state_stack_size=state_stack_size,
-                ),
-                stack_info=True,
-            )
-            return
-
-        cls._state_stack_items.set(initial_items[:-1])
-
-    @classmethod
-    def get_current_state(cls) -> _IdGenerationState:
-        return cls._get_stack_items()[-1]
-
-    @classmethod
-    def replace_current_state(cls, updated_state: _IdGenerationState) -> None:
-        """Remove the current state and replace it the new state."""
-        cls._state_stack_items.set(cls._get_stack_items()[:-1] + (updated_state,))
+    def restore(self, default_start_value: int, id_prefix_to_next_value: dict[IdPrefix, int]) -> None:
+        """Restore ID generation state for the current thread."""
+        self.default_start_value = default_start_value
+        self.id_prefix_to_next_value = id_prefix_to_next_value
 
 
 class SequentialIdGenerator:
     """Generates sequential ID values based on a prefix."""
 
+    _id_generation_state: ClassVar[_IdGenerationState] = _IdGenerationState(0)
+
     @classmethod
     def create_next_id(cls, id_prefix: IdPrefix) -> SequentialId:  # noqa: D102
-        id_generation_state = _IdGenerationStateStack.get_current_state()
-        next_index = id_generation_state.prefix_to_next_value.get(id_prefix) or id_generation_state.default_start_value
-        updated_state = _IdGenerationState.create(
-            default_start_value=id_generation_state.default_start_value,
-            prefix_to_next_value={**id_generation_state.prefix_to_next_value, **{id_prefix: next_index + 1}},
-        )
-        _IdGenerationStateStack.replace_current_state(updated_state)
+        id_generation_state = cls._id_generation_state
+        id_prefix_to_next_value = id_generation_state.id_prefix_to_next_value
+        next_index = id_prefix_to_next_value.get(id_prefix, id_generation_state.default_start_value)
+        id_prefix_to_next_value[id_prefix] = next_index + 1
 
         return SequentialId(id_prefix=id_prefix, index=next_index)
 
     @classmethod
     def reset(cls, default_start_value: int = 0) -> None:
         """Resets the numbering of the generated IDs so that it starts at the given value."""
-        _IdGenerationStateStack.replace_current_state(
-            _IdGenerationState.create(default_start_value=default_start_value)
-        )
+        cls._id_generation_state.reset(default_start_value)
 
     @classmethod
     @contextmanager
@@ -140,6 +72,11 @@ class SequentialIdGenerator:
 
         On exit, resume ID numbering from prior to entering the context.
         """
-        _IdGenerationStateStack.push_state(_IdGenerationState.create(default_start_value=start_value))
-        yield None
-        _IdGenerationStateStack.pop_state()
+        id_generation_state = cls._id_generation_state
+        previous_default_start_value = id_generation_state.default_start_value
+        previous_id_prefix_to_next_value = id_generation_state.id_prefix_to_next_value
+        id_generation_state.reset(start_value)
+        try:
+            yield None
+        finally:
+            id_generation_state.restore(previous_default_start_value, previous_id_prefix_to_next_value)

--- a/metricflow_semantics/toolkit/dataclass_helpers.py
+++ b/metricflow_semantics/toolkit/dataclass_helpers.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import sys
 from dataclasses import dataclass
 from typing import Callable, Type, TypeVar
 
@@ -12,72 +11,40 @@ _T = TypeVar("_T")
 logger = logging.getLogger(__name__)
 
 
-if sys.version_info >= (3, 10):
+@dataclass_transform(kw_only_default=True, order_default=True, frozen_default=True)
+def fast_frozen_dataclass(order: bool = True) -> Callable[[Type[_T]], Type[_T]]:
+    """Decorator for creating an immutable dataclass that is faster than `@dataclass(frozen=True)`.
 
-    @dataclass_transform(kw_only_default=True, order_default=True, frozen_default=True)
-    def fast_frozen_dataclass(order: bool = True) -> Callable[[Type[_T]], Type[_T]]:
-        """Decorator for creating an immutable dataclass that is faster than `@dataclass(frozen=True)`.
+    * Calling `hash()` on a frozen dataclass always computes the hash from the fields.
+    * `hash()` performance can be improved by caching the hash value.
+    * A cached hash can help improve lookups times in sets / dicts.
+    * This uses a regular, mutable dataclass under the hood, with an update to the hash method.
+    * Since MF relies on `mypy`, this uses the `dataclass_transform` decorator to statically check that the code
+      does not make mutations.
+    * This also improve class instantiation times as there is a performance penalty with creating a frozen dataclass.
+    * All fields / recursive fields must be immutable.
+    * Includes default arguments for creating dataclasses.
 
-        * Calling `hash()` on a frozen dataclass always computes the hash from the fields.
-        * `hash()` performance can be improved by caching the hash value.
-        * A cached hash can help improve lookups times in sets / dicts.
-        * This uses a regular, mutable dataclass under the hood, with an update to the hash method.
-        * Since MF relies on `mypy`, this uses the `dataclass_transform` decorator to statically check that the code
-          does not make mutations.
-        * This also improve class instantiation times as there is a performance penalty with creating a frozen dataclass.
-        * All fields / recursive fields must be immutable.
-        * Includes default arguments for creating dataclasses.
+    """
 
-        """
+    def _make_dataclass_function(inner_cls: Type[_T]) -> Type[_T]:
+        # noinspection PyArgumentList
+        cls_to_return = dataclass(inner_cls, kw_only=True, order=order, unsafe_hash=True)  # type: ignore[call-overload]
+        cls_to_return.__mf_previous_hash_method = cls_to_return.__hash__
 
-        def _make_dataclass_function(inner_cls: Type[_T]) -> Type[_T]:
-            # noinspection PyArgumentList
-            cls_to_return = dataclass(  # type: ignore[call-overload]
-                inner_cls, kw_only=True, order=order, unsafe_hash=True
-            )
-            cls_to_return.__mf_previous_hash_method = cls_to_return.__hash__
-
-            def _new_hash_method(self) -> int:  # type: ignore[no-untyped-def]
-                # Since the object fields are immutable, not using a lock to reduce overhead.
-                cached_hash = self.__mf_cached_hash
-                if cached_hash is not None:
-                    return cached_hash
-
-                cached_hash = self.__mf_previous_hash_method()
-                self.__mf_cached_hash = cached_hash
+        def _new_hash_method(self) -> int:  # type: ignore[no-untyped-def]
+            # Since the object fields are immutable, not using a lock to reduce overhead.
+            cached_hash = self.__mf_cached_hash
+            if cached_hash is not None:
                 return cached_hash
 
-            cls_to_return.__mf_cached_hash = None
-            cls_to_return.__hash__ = _new_hash_method
+            cached_hash = self.__mf_previous_hash_method()
+            self.__mf_cached_hash = cached_hash
+            return cached_hash
 
-            return inner_cls
+        cls_to_return.__mf_cached_hash = None
+        cls_to_return.__hash__ = _new_hash_method
 
-        return _make_dataclass_function
+        return inner_cls
 
-else:
-
-    @dataclass_transform(order_default=True, frozen_default=True)
-    def fast_frozen_dataclass(order: bool = True) -> Callable[[Type[_T]], Type[_T]]:
-        """Similar to above but without `kw_args` as it was added in Python 3.10."""
-
-        def _make_dataclass_function(inner_cls: Type[_T]) -> Type[_T]:
-            # noinspection PyArgumentList
-            cls_to_return = dataclass(inner_cls, order=order, unsafe_hash=True)  # type: ignore[call-overload]
-            cls_to_return.__mf_previous_hash_method = cls_to_return.__hash__
-
-            def _new_hash_method(self) -> int:  # type: ignore[no-untyped-def]
-                # Since the object fields are immutable, not using a lock to reduce overhead.
-                cached_hash = self.__mf_cached_hash
-                if cached_hash is not None:
-                    return cached_hash
-
-                cached_hash = self.__mf_previous_hash_method()
-                self.__mf_cached_hash = cached_hash
-                return cached_hash
-
-            cls_to_return.__mf_cached_hash = None
-            cls_to_return.__hash__ = _new_hash_method
-
-            return inner_cls
-
-        return _make_dataclass_function
+    return _make_dataclass_function

--- a/tests_metricflow/performance/test_profiling_examples.py
+++ b/tests_metricflow/performance/test_profiling_examples.py
@@ -91,9 +91,7 @@ def mf_explain_saved_query(
                 logger.exception("Ignoring exception for the test")
 
     if performance_tracker is not None:
-        logger.info(
-            LazyFormat(lambda: "Profiled explain.\n" + mf_indent(performance_tracker.last_session_report.text_format()))
-        )
+        logger.info(LazyFormat("Profiled explain.", report=performance_tracker.last_session_report.text_format()))
 
     return explain_result
 

--- a/tests_metricflow_semantics/dag/test_sequential_id_generator.py
+++ b/tests_metricflow_semantics/dag/test_sequential_id_generator.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 import concurrent.futures
 import logging
 import time
@@ -33,25 +32,3 @@ def test_sequential_id_generator_in_threads() -> None:
         # This will raise the exception that was raised in the task.
         for future in futures:
             future.result()
-
-
-def test_sequential_id_generator_in_async_tasks() -> None:
-    """Test generating IDs in multiple async tasks."""
-    # Since other tests / fixtures could have generated IDs in the main thread, reset ID generation.
-
-    with SequentialIdGenerator.id_number_space(0):
-
-        async def _check_id_task(task_id: str, sleep_time: float) -> None:
-            for i in range(10):
-                generated_id = SequentialIdGenerator.create_next_id(DynamicIdPrefix(_ID_PREFIX))
-                logger.debug(LazyFormat("Generated ID", task_id=task_id, i=i, generated_id=generated_id.str_value))
-                assert generated_id.str_value == str(f"{_ID_PREFIX}_{i}")
-                await asyncio.sleep(sleep_time)
-
-        async def main() -> None:
-            await asyncio.gather(
-                _check_id_task("task_0", 0.001),
-                _check_id_task("task_1", 0.0015),
-            )
-
-        asyncio.run(main())


### PR DESCRIPTION
This PR updates ID generation to use `threading.local` instead of `ContextVar` as we didn't end up using async calls. The implementation using `ContextVar` had a significant performance impact in some cases (~10%).