### PR TITLE
Add option to use legacy column order

### DIFF
--- a/.changes/unreleased/Under the Hood-20260604-113633.yaml
+++ b/.changes/unreleased/Under the Hood-20260604-113633.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Add option to use legacy column order
+time: 2026-06-04T11:36:33.271783-07:00
+custom:
+    Author: plypaul
+    Issue: "2065"

--- a/metricflow/engine/metricflow_engine.py
+++ b/metricflow/engine/metricflow_engine.py
@@ -145,6 +145,7 @@ class MetricFlowQueryRequest:
     order_output_columns_by_input_order: The columns in the output are arranged in groups as described in
     `CreateSelectColumnsForInstances`. If this is set to True, the order of the columns in each group follows the order
     as described by inputs (e.g. `metric_names`).
+    legacy_output_column_order_default: Whether the legacy output column ordering should be used by default.
     """
 
     request_id: MetricFlowRequestId
@@ -165,6 +166,7 @@ class MetricFlowQueryRequest:
     dataflow_plan_optimizations: frozenset[DataflowPlanOptimization]
     query_type: MetricFlowQueryType
     order_output_columns_by_input_order: bool
+    legacy_output_column_order_default: bool
 
     @staticmethod
     def create(  # noqa: D102
@@ -186,6 +188,7 @@ class MetricFlowQueryRequest:
         min_max_only: bool = False,
         apply_group_by: bool = True,
         order_output_columns_by_input_order: bool = False,
+        legacy_output_column_order_default: bool = True,
     ) -> MetricFlowQueryRequest:
         return MetricFlowQueryRequest(
             request_id=MetricFlowRequestId(mf_rid=f"{mf_random_id()}") if request_id is None else request_id,
@@ -210,6 +213,7 @@ class MetricFlowQueryRequest:
             min_max_only=min_max_only,
             apply_group_by=apply_group_by,
             order_output_columns_by_input_order=order_output_columns_by_input_order,
+            legacy_output_column_order_default=legacy_output_column_order_default,
         )
 
     def with_request_id(self, request_id: MetricFlowRequestId) -> MetricFlowQueryRequest:  # noqa: D102
@@ -232,6 +236,7 @@ class MetricFlowQueryRequest:
             dataflow_plan_optimizations=self.dataflow_plan_optimizations,
             query_type=self.query_type,
             order_output_columns_by_input_order=self.order_output_columns_by_input_order,
+            legacy_output_column_order_default=self.legacy_output_column_order_default,
         )
 
 
@@ -639,8 +644,10 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
         # `TypeGroupedOrderer` during the rollout.
         elif DataflowPlanOptimization.PASSTHROUGH_METRIC_EVALUATION in mf_query_request.dataflow_plan_optimizations:
             output_column_orderer = TypeGroupedOrderer(query_spec.input_spec_order)
-        else:
+        elif mf_query_request.legacy_output_column_order_default:
             output_column_orderer = LegacyTypeGroupedOrderer()
+        else:
+            output_column_orderer = TypeGroupedOrderer(query_spec.input_spec_order)
 
         convert_to_execution_plan_result = _to_execution_plan_converter.convert_to_execution_plan(
             dataflow_plan=dataflow_plan,

--- a/metricflow/engine/metricflow_engine.py
+++ b/metricflow/engine/metricflow_engine.py
@@ -123,6 +123,22 @@ class MetricFlowQueryType(Enum):
     DIMENSION_VALUES = "dimension_values"
 
 
+class OutputColumnOrderMode(Enum):
+    """Describes the ordering of the columns in the output SQL.
+
+    See associated `OutputColumnOrderer` classes.
+    """
+
+    # Columns are grouped by the spec type, but columns in each group are in an arbitrary order that depends on
+    # how MF generates the SQL.
+    LEGACY_TYPE_GROUPED = "legacy"
+    # Columns are grouped by the spec type (e.g. time dimensions, entities, ...), but columns in each group are in
+    # the same order as the inputs.
+    TYPE_GROUPED = "type_grouped"
+    # Columns are in the order of the inputs.
+    INPUT_ORDER = "input_order"
+
+
 @dataclass(frozen=True)
 class MetricFlowQueryRequest:
     """Encapsulates the parameters for a metric query.
@@ -142,10 +158,7 @@ class MetricFlowQueryRequest:
     output_table: If specified, output the result data to this table instead of a result data_table.
     sql_optimization_level: The level of optimization for the generated SQL.
     query_type: Type of MetricFlow query.
-    order_output_columns_by_input_order: The columns in the output are arranged in groups as described in
-    `CreateSelectColumnsForInstances`. If this is set to True, the order of the columns in each group follows the order
-    as described by inputs (e.g. `metric_names`).
-    legacy_output_column_order_default: Whether the legacy output column ordering should be used by default.
+    output_column_order_mode: The ordering mode to use for columns in the output SQL.
     """
 
     request_id: MetricFlowRequestId
@@ -165,8 +178,7 @@ class MetricFlowQueryRequest:
     sql_optimization_level: SqlOptimizationLevel
     dataflow_plan_optimizations: frozenset[DataflowPlanOptimization]
     query_type: MetricFlowQueryType
-    order_output_columns_by_input_order: bool
-    legacy_output_column_order_default: bool
+    output_column_order_mode: OutputColumnOrderMode
 
     @staticmethod
     def create(  # noqa: D102
@@ -187,8 +199,7 @@ class MetricFlowQueryRequest:
         query_type: MetricFlowQueryType = MetricFlowQueryType.METRIC,
         min_max_only: bool = False,
         apply_group_by: bool = True,
-        order_output_columns_by_input_order: bool = False,
-        legacy_output_column_order_default: bool = True,
+        output_column_order_mode: Optional[OutputColumnOrderMode] = None,
     ) -> MetricFlowQueryRequest:
         return MetricFlowQueryRequest(
             request_id=MetricFlowRequestId(mf_rid=f"{mf_random_id()}") if request_id is None else request_id,
@@ -212,8 +223,9 @@ class MetricFlowQueryRequest:
             query_type=query_type,
             min_max_only=min_max_only,
             apply_group_by=apply_group_by,
-            order_output_columns_by_input_order=order_output_columns_by_input_order,
-            legacy_output_column_order_default=legacy_output_column_order_default,
+            output_column_order_mode=output_column_order_mode
+            if output_column_order_mode is not None
+            else OutputColumnOrderMode.LEGACY_TYPE_GROUPED,
         )
 
     def with_request_id(self, request_id: MetricFlowRequestId) -> MetricFlowQueryRequest:  # noqa: D102
@@ -235,8 +247,7 @@ class MetricFlowQueryRequest:
             sql_optimization_level=self.sql_optimization_level,
             dataflow_plan_optimizations=self.dataflow_plan_optimizations,
             query_type=self.query_type,
-            order_output_columns_by_input_order=self.order_output_columns_by_input_order,
-            legacy_output_column_order_default=self.legacy_output_column_order_default,
+            output_column_order_mode=self.output_column_order_mode,
         )
 
 
@@ -637,17 +648,15 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
             sql_optimization_level=mf_query_request.sql_optimization_level,
         )
 
-        output_column_orderer: OutputColumnOrderer
-        if mf_query_request.order_output_columns_by_input_order:
-            output_column_orderer = InputOrderPreservingOrderer(query_spec.input_spec_order)
-        # Since the passthrough optimization can change the output column order, use
-        # `TypeGroupedOrderer` during the rollout.
-        elif DataflowPlanOptimization.PASSTHROUGH_METRIC_EVALUATION in mf_query_request.dataflow_plan_optimizations:
+        output_column_order_mode = mf_query_request.output_column_order_mode
+        if output_column_order_mode is OutputColumnOrderMode.INPUT_ORDER:
+            output_column_orderer: OutputColumnOrderer = InputOrderPreservingOrderer(query_spec.input_spec_order)
+        elif output_column_order_mode is OutputColumnOrderMode.TYPE_GROUPED:
             output_column_orderer = TypeGroupedOrderer(query_spec.input_spec_order)
-        elif mf_query_request.legacy_output_column_order_default:
+        elif output_column_order_mode is OutputColumnOrderMode.LEGACY_TYPE_GROUPED:
             output_column_orderer = LegacyTypeGroupedOrderer()
         else:
-            output_column_orderer = TypeGroupedOrderer(query_spec.input_spec_order)
+            assert_values_exhausted(output_column_order_mode)
 
         convert_to_execution_plan_result = _to_execution_plan_converter.convert_to_execution_plan(
             dataflow_plan=dataflow_plan,

--- a/metricflow/plan_conversion/to_sql_plan/output_column_orderer.py
+++ b/metricflow/plan_conversion/to_sql_plan/output_column_orderer.py
@@ -66,14 +66,18 @@ class TypeGroupedOrderer(OutputColumnOrderer):
     def order_columns(
         self, spec_to_columns_mapping: Mapping[InstanceSpec, Sequence[SqlSelectColumn]]
     ) -> Sequence[SqlSelectColumn]:
-        specs_in_order = TypeGroupedOrderer._OrderByTypeTransform(self._input_spec_order).transform(
-            InstanceSpecSet.create_from_specs(spec_to_columns_mapping)
-        )
-        select_columns: list[SqlSelectColumn] = []
-        for spec in specs_in_order:
-            select_columns.extend(spec_to_columns_mapping[spec])
+        try:
+            specs_in_order = TypeGroupedOrderer._OrderByTypeTransform(self._input_spec_order).transform(
+                InstanceSpecSet.create_from_specs(spec_to_columns_mapping)
+            )
+            select_columns: list[SqlSelectColumn] = []
+            for spec in specs_in_order:
+                select_columns.extend(spec_to_columns_mapping[spec])
 
-        return select_columns
+            return select_columns
+        except Exception:
+            logger.exception("Error resolving output column order falling back to legacy order")
+            return LegacyTypeGroupedOrderer().order_columns(spec_to_columns_mapping)
 
     class _OrderByTypeTransform(InstanceSpecSetTransform):
         def __init__(self, input_spec_order: InputSpecOrder) -> None:  # noqa: D107
@@ -128,14 +132,15 @@ class InputOrderPreservingOrderer(OutputColumnOrderer):
         for spec in self._input_spec_order.group_by_item_specs + self._input_spec_order.metric_specs:
             select_columns = spec_to_columns_mapping.get(spec)
             if select_columns is None:
-                raise RuntimeError(
+                logger.error(
                     LazyFormat(
                         "Spec missing from select column mapping. Check generation of `input_spec_order`"
-                        " and `spec_to_columns_mapping`.",
+                        " and `spec_to_columns_mapping`. Falling back to legacy column order.",
                         missing_spec=spec,
                         input_spec_order=self._input_spec_order,
                     )
                 )
+                return LegacyTypeGroupedOrderer().order_columns(spec_to_columns_mapping)
             results.extend(select_columns)
 
         return results

--- a/tests_metricflow/integration/query_output/test_output_column_order.py
+++ b/tests_metricflow/integration/query_output/test_output_column_order.py
@@ -6,7 +6,7 @@ import pytest
 from metricflow_semantics.test_helpers.config_helpers import MetricFlowTestConfiguration
 from metricflow_semantics.toolkit.mf_type_aliases import AnyLengthTuple
 
-from metricflow.engine.metricflow_engine import MetricFlowQueryRequest, MetricFlowQueryResult
+from metricflow.engine.metricflow_engine import MetricFlowQueryRequest, MetricFlowQueryResult, OutputColumnOrderMode
 from metricflow.protocols.sql_client import SqlClient
 from metricflow.sql.optimizer.optimization_levels import SqlOptimizationLevel
 from tests_metricflow.integration.conftest import IntegrationTestHelpers
@@ -20,14 +20,14 @@ def test_output_column_order(
     sql_client: SqlClient,
     it_helpers: IntegrationTestHelpers,
 ) -> None:
-    """Test the order of output columns when `order_output_columns_by_input_order=True`."""
+    """Test output columns when `OutputColumnOrderMode.INPUT_ORDER` is used."""
     metric_names: AnyLengthTuple[str] = ("bookings", "listings")
     group_by_names: AnyLengthTuple[str] = ("metric_time__day", "listing", "listing__country_latest")
     query_result: MetricFlowQueryResult = it_helpers.mf_engine.query(
         MetricFlowQueryRequest.create(
             metric_names=metric_names,
             group_by_names=group_by_names,
-            order_output_columns_by_input_order=True,
+            output_column_order_mode=OutputColumnOrderMode.INPUT_ORDER,
         )
     )
     assert query_result.result_df is not None
@@ -56,7 +56,7 @@ def test_output_column_order(
             MetricFlowQueryRequest.create(
                 metric_names=reversed_metric_names,
                 group_by_names=reversed_group_by_names,
-                order_output_columns_by_input_order=True,
+                output_column_order_mode=OutputColumnOrderMode.INPUT_ORDER,
                 sql_optimization_level=optimization_level,
             )
         )

--- a/tests_metricflow/integration/test_configured_cases.py
+++ b/tests_metricflow/integration/test_configured_cases.py
@@ -31,7 +31,7 @@ from metricflow_semantics.time.time_spine_source import TimeSpineSource
 from metricflow_semantics.toolkit.mf_logging.lazy_formattable import LazyFormat
 
 from metricflow.dataflow.optimizer.dataflow_optimizer_factory import DataflowPlanOptimization
-from metricflow.engine.metricflow_engine import MetricFlowQueryRequest
+from metricflow.engine.metricflow_engine import MetricFlowQueryRequest, OutputColumnOrderMode
 from metricflow.protocols.sql_client import SqlClient
 from metricflow_semantic_interfaces.enum_extension import assert_values_exhausted
 from metricflow_semantic_interfaces.implementations.elements.measure import PydanticMeasureAggregationParameters
@@ -374,7 +374,7 @@ def _test_case(
             order_by_names=case.order_bys,
             min_max_only=case.min_max_only,
             apply_group_by=case.apply_group_by,
-            order_output_columns_by_input_order=True,
+            output_column_order_mode=OutputColumnOrderMode.INPUT_ORDER,
             dataflow_plan_optimizations=dataflow_optimizers,
         )
     )

--- a/tests_metricflow/snapshots/test_external_manifest.py/str/test_explain_all_saved_queries_from_external_manifest__result.txt
+++ b/tests_metricflow/snapshots/test_external_manifest.py/str/test_explain_all_saved_queries_from_external_manifest__result.txt
@@ -3,27 +3,89 @@ test_filename: test_external_manifest.py
 docstring:
   Test generated SQL for all saved queries in a JSON-serialized manifest.
 ---
-query_0b295dd4:
+query_30d37a87:
   status: PASS
   explain_sql:
-    -- Constrain Output with WHERE
-    -- Select: ['__bookings', '__instant_bookings', 'listing__capacity_latest', 'metric_time__day']
+    -- Join Standard Outputs
+    -- Select: ['listing__capacity_latest', 'metric_time__month']
+    -- Select: ['listing__capacity_latest', 'metric_time__month']
+    -- Write to DataTable
+    SELECT
+      DATE_TRUNC('month', time_spine_src_10006.ds) AS metric_time__month
+      , subq_0.listing__capacity_latest AS listing__capacity_latest
+    FROM (
+      -- Read Elements From Semantic Model 'listings_latest'
+      SELECT
+        '1' AS listing__capacity_latest
+      FROM simple_semantic_manifest.dummy_table listings_latest_src_10000
+    ) subq_0
+    CROSS JOIN
+      simple_semantic_manifest.time_spine time_spine_src_10006
+    GROUP BY
+      DATE_TRUNC('month', time_spine_src_10006.ds)
+      , subq_0.listing__capacity_latest
+
+query_95e50fcd:
+  status: PASS
+  explain_sql:
+    -- Join Self Over Time Range
+    -- Select: ['__revenue', 'metric_time__day']
+    -- Select: ['__revenue', 'metric_time__day']
     -- Aggregate Inputs for Simple Metrics
+    -- Compute Metrics via Expressions
     -- Compute Metrics via Expressions
     -- Write to DataTable
     SELECT
-      metric_time__day
-      , listing__capacity_latest
-      , SUM(bookings) AS bookings
-      , SUM(instant_bookings) AS instant_bookings
+      subq_3.ds AS metric_time__day
+      , SUM(subq_1.__revenue) AS trailing_2_months_revenue
+    FROM simple_semantic_manifest.time_spine subq_3
+    INNER JOIN (
+      -- Read Elements From Semantic Model 'revenue'
+      -- Metric Time Dimension 'ds'
+      SELECT
+        DATE_TRUNC('day', CAST('2020-01-01' AS TIMESTAMP)) AS metric_time__day
+        , 1 AS __revenue
+      FROM simple_semantic_manifest.dummy_table revenue_src_10000
+    ) subq_1
+    ON
+      (
+        subq_1.metric_time__day <= subq_3.ds
+      ) AND (
+        subq_1.metric_time__day > subq_3.ds - INTERVAL 2 month
+      )
+    GROUP BY
+      subq_3.ds
+
+query_96742aac:
+  status: PASS
+  explain_sql:
+    -- Combine Aggregated Outputs
+    -- Order By ['metric_time__day', 'listing__capacity_latest', 'bookings', 'views'] Limit 10
+    -- Write to DataTable
+    WITH sma_10014_cte AS (
+      -- Read Elements From Semantic Model 'listings_latest'
+      -- Metric Time Dimension 'ds'
+      SELECT
+        1 AS listing
+        , '1' AS capacity_latest
+      FROM simple_semantic_manifest.dummy_table listings_latest_src_10000
+    )
+
+    SELECT
+      COALESCE(subq_9.metric_time__day, subq_18.metric_time__day) AS metric_time__day
+      , COALESCE(subq_9.listing__capacity_latest, subq_18.listing__capacity_latest) AS listing__capacity_latest
+      , MAX(subq_9.bookings) AS bookings
+      , MAX(subq_18.views) AS views
     FROM (
       -- Join Standard Outputs
-      -- Select: ['__bookings', '__instant_bookings', 'listing__capacity_latest', 'metric_time__day']
+      -- Select: ['__bookings', 'listing__capacity_latest', 'metric_time__day']
+      -- Select: ['__bookings', 'listing__capacity_latest', 'metric_time__day']
+      -- Aggregate Inputs for Simple Metrics
+      -- Compute Metrics via Expressions
       SELECT
         subq_1.metric_time__day AS metric_time__day
-        , subq_4.capacity_latest AS listing__capacity_latest
-        , subq_1.__bookings AS bookings
-        , subq_1.__instant_bookings AS instant_bookings
+        , sma_10014_cte.capacity_latest AS listing__capacity_latest
+        , SUM(subq_1.__bookings) AS bookings
       FROM (
         -- Read Elements From Semantic Model 'bookings_source'
         -- Metric Time Dimension 'ds'
@@ -31,27 +93,56 @@ query_0b295dd4:
           DATE_TRUNC('day', CAST('2020-01-01' AS TIMESTAMP)) AS metric_time__day
           , 1 AS listing
           , 1 AS __bookings
-          , 1 AS __instant_bookings
         FROM simple_semantic_manifest.dummy_table bookings_source_src_10000
       ) subq_1
-      LEFT OUTER JOIN (
-        -- Read Elements From Semantic Model 'listings_latest'
-        -- Metric Time Dimension 'ds'
-        -- Select: ['capacity_latest', 'listing']
-        SELECT
-          1 AS listing
-          , '1' AS capacity_latest
-        FROM simple_semantic_manifest.dummy_table listings_latest_src_10000
-      ) subq_4
+      LEFT OUTER JOIN
+        sma_10014_cte
       ON
-        subq_1.listing = subq_4.listing
-    ) subq_6
-    WHERE (listing__capacity_latest IS NOT NULL)
+        subq_1.listing = sma_10014_cte.listing
+      GROUP BY
+        subq_1.metric_time__day
+        , sma_10014_cte.capacity_latest
+    ) subq_9
+    FULL OUTER JOIN (
+      -- Join Standard Outputs
+      -- Select: ['__views', 'listing__capacity_latest', 'metric_time__day']
+      -- Select: ['__views', 'listing__capacity_latest', 'metric_time__day']
+      -- Aggregate Inputs for Simple Metrics
+      -- Compute Metrics via Expressions
+      SELECT
+        subq_11.metric_time__day AS metric_time__day
+        , sma_10014_cte.capacity_latest AS listing__capacity_latest
+        , SUM(subq_11.__views) AS views
+      FROM (
+        -- Read Elements From Semantic Model 'views_source'
+        -- Metric Time Dimension 'ds'
+        SELECT
+          DATE_TRUNC('day', CAST('2020-01-01' AS TIMESTAMP)) AS metric_time__day
+          , 1 AS listing
+          , 1 AS __views
+        FROM simple_semantic_manifest.dummy_table views_source_src_10000
+      ) subq_11
+      LEFT OUTER JOIN
+        sma_10014_cte
+      ON
+        subq_11.listing = sma_10014_cte.listing
+      GROUP BY
+        subq_11.metric_time__day
+        , sma_10014_cte.capacity_latest
+    ) subq_18
+    ON
+      (
+        subq_9.listing__capacity_latest = subq_18.listing__capacity_latest
+      ) AND (
+        subq_9.metric_time__day = subq_18.metric_time__day
+      )
     GROUP BY
-      metric_time__day
-      , listing__capacity_latest
+      COALESCE(subq_9.metric_time__day, subq_18.metric_time__day)
+      , COALESCE(subq_9.listing__capacity_latest, subq_18.listing__capacity_latest)
+    ORDER BY metric_time__day DESC, listing__capacity_latest, bookings DESC, views
+    LIMIT 10
 
-query_1ee34d0e:
+query_a4f2514d:
   status: PASS
   explain_sql:
     -- Combine Aggregated Outputs
@@ -173,36 +264,27 @@ query_1ee34d0e:
     GROUP BY
       COALESCE(cm_3_cte.listing__capacity_latest, cm_4_cte.listing__capacity_latest, subq_23.listing__capacity_latest)
 
-query_25c402a1:
+query_d6ee91c5:
   status: PASS
   explain_sql:
-    -- Combine Aggregated Outputs
-    -- Order By ['metric_time__day', 'listing__capacity_latest', 'bookings', 'views'] Limit 10
+    -- Constrain Output with WHERE
+    -- Select: ['__bookings', '__instant_bookings', 'listing__capacity_latest', 'metric_time__day']
+    -- Aggregate Inputs for Simple Metrics
+    -- Compute Metrics via Expressions
     -- Write to DataTable
-    WITH sma_10014_cte AS (
-      -- Read Elements From Semantic Model 'listings_latest'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        1 AS listing
-        , '1' AS capacity_latest
-      FROM simple_semantic_manifest.dummy_table listings_latest_src_10000
-    )
-
     SELECT
-      COALESCE(subq_9.metric_time__day, subq_18.metric_time__day) AS metric_time__day
-      , COALESCE(subq_9.listing__capacity_latest, subq_18.listing__capacity_latest) AS listing__capacity_latest
-      , MAX(subq_9.bookings) AS bookings
-      , MAX(subq_18.views) AS views
+      metric_time__day
+      , listing__capacity_latest
+      , SUM(bookings) AS bookings
+      , SUM(instant_bookings) AS instant_bookings
     FROM (
       -- Join Standard Outputs
-      -- Select: ['__bookings', 'listing__capacity_latest', 'metric_time__day']
-      -- Select: ['__bookings', 'listing__capacity_latest', 'metric_time__day']
-      -- Aggregate Inputs for Simple Metrics
-      -- Compute Metrics via Expressions
+      -- Select: ['__bookings', '__instant_bookings', 'listing__capacity_latest', 'metric_time__day']
       SELECT
         subq_1.metric_time__day AS metric_time__day
-        , sma_10014_cte.capacity_latest AS listing__capacity_latest
-        , SUM(subq_1.__bookings) AS bookings
+        , subq_4.capacity_latest AS listing__capacity_latest
+        , subq_1.__bookings AS bookings
+        , subq_1.__instant_bookings AS instant_bookings
       FROM (
         -- Read Elements From Semantic Model 'bookings_source'
         -- Metric Time Dimension 'ds'
@@ -210,104 +292,22 @@ query_25c402a1:
           DATE_TRUNC('day', CAST('2020-01-01' AS TIMESTAMP)) AS metric_time__day
           , 1 AS listing
           , 1 AS __bookings
+          , 1 AS __instant_bookings
         FROM simple_semantic_manifest.dummy_table bookings_source_src_10000
       ) subq_1
-      LEFT OUTER JOIN
-        sma_10014_cte
-      ON
-        subq_1.listing = sma_10014_cte.listing
-      GROUP BY
-        subq_1.metric_time__day
-        , sma_10014_cte.capacity_latest
-    ) subq_9
-    FULL OUTER JOIN (
-      -- Join Standard Outputs
-      -- Select: ['__views', 'listing__capacity_latest', 'metric_time__day']
-      -- Select: ['__views', 'listing__capacity_latest', 'metric_time__day']
-      -- Aggregate Inputs for Simple Metrics
-      -- Compute Metrics via Expressions
-      SELECT
-        subq_11.metric_time__day AS metric_time__day
-        , sma_10014_cte.capacity_latest AS listing__capacity_latest
-        , SUM(subq_11.__views) AS views
-      FROM (
-        -- Read Elements From Semantic Model 'views_source'
+      LEFT OUTER JOIN (
+        -- Read Elements From Semantic Model 'listings_latest'
         -- Metric Time Dimension 'ds'
+        -- Select: ['capacity_latest', 'listing']
         SELECT
-          DATE_TRUNC('day', CAST('2020-01-01' AS TIMESTAMP)) AS metric_time__day
-          , 1 AS listing
-          , 1 AS __views
-        FROM simple_semantic_manifest.dummy_table views_source_src_10000
-      ) subq_11
-      LEFT OUTER JOIN
-        sma_10014_cte
+          1 AS listing
+          , '1' AS capacity_latest
+        FROM simple_semantic_manifest.dummy_table listings_latest_src_10000
+      ) subq_4
       ON
-        subq_11.listing = sma_10014_cte.listing
-      GROUP BY
-        subq_11.metric_time__day
-        , sma_10014_cte.capacity_latest
-    ) subq_18
-    ON
-      (
-        subq_9.listing__capacity_latest = subq_18.listing__capacity_latest
-      ) AND (
-        subq_9.metric_time__day = subq_18.metric_time__day
-      )
+        subq_1.listing = subq_4.listing
+    ) subq_6
+    WHERE (listing__capacity_latest IS NOT NULL)
     GROUP BY
-      COALESCE(subq_9.metric_time__day, subq_18.metric_time__day)
-      , COALESCE(subq_9.listing__capacity_latest, subq_18.listing__capacity_latest)
-    ORDER BY metric_time__day DESC, listing__capacity_latest, bookings DESC, views
-    LIMIT 10
-
-query_788497ac:
-  status: PASS
-  explain_sql:
-    -- Join Self Over Time Range
-    -- Select: ['__revenue', 'metric_time__day']
-    -- Select: ['__revenue', 'metric_time__day']
-    -- Aggregate Inputs for Simple Metrics
-    -- Compute Metrics via Expressions
-    -- Compute Metrics via Expressions
-    -- Write to DataTable
-    SELECT
-      subq_3.ds AS metric_time__day
-      , SUM(subq_1.__revenue) AS trailing_2_months_revenue
-    FROM simple_semantic_manifest.time_spine subq_3
-    INNER JOIN (
-      -- Read Elements From Semantic Model 'revenue'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATE_TRUNC('day', CAST('2020-01-01' AS TIMESTAMP)) AS metric_time__day
-        , 1 AS __revenue
-      FROM simple_semantic_manifest.dummy_table revenue_src_10000
-    ) subq_1
-    ON
-      (
-        subq_1.metric_time__day <= subq_3.ds
-      ) AND (
-        subq_1.metric_time__day > subq_3.ds - INTERVAL 2 month
-      )
-    GROUP BY
-      subq_3.ds
-
-query_d4073379:
-  status: PASS
-  explain_sql:
-    -- Join Standard Outputs
-    -- Select: ['listing__capacity_latest', 'metric_time__month']
-    -- Select: ['listing__capacity_latest', 'metric_time__month']
-    -- Write to DataTable
-    SELECT
-      DATE_TRUNC('month', time_spine_src_10006.ds) AS metric_time__month
-      , subq_0.listing__capacity_latest AS listing__capacity_latest
-    FROM (
-      -- Read Elements From Semantic Model 'listings_latest'
-      SELECT
-        '1' AS listing__capacity_latest
-      FROM simple_semantic_manifest.dummy_table listings_latest_src_10000
-    ) subq_0
-    CROSS JOIN
-      simple_semantic_manifest.time_spine time_spine_src_10006
-    GROUP BY
-      DATE_TRUNC('month', time_spine_src_10006.ds)
-      , subq_0.listing__capacity_latest
+      metric_time__day
+      , listing__capacity_latest

--- a/tests_metricflow/snapshots/test_external_manifest.py/str/test_explain_all_saved_queries_from_external_manifest__result.txt
+++ b/tests_metricflow/snapshots/test_external_manifest.py/str/test_explain_all_saved_queries_from_external_manifest__result.txt
@@ -3,60 +3,55 @@ test_filename: test_external_manifest.py
 docstring:
   Test generated SQL for all saved queries in a JSON-serialized manifest.
 ---
-query_30d37a87:
+query_95e26474:
   status: PASS
   explain_sql:
-    -- Join Standard Outputs
-    -- Select: ['listing__capacity_latest', 'metric_time__month']
-    -- Select: ['listing__capacity_latest', 'metric_time__month']
-    -- Write to DataTable
-    SELECT
-      DATE_TRUNC('month', time_spine_src_10006.ds) AS metric_time__month
-      , subq_0.listing__capacity_latest AS listing__capacity_latest
-    FROM (
-      -- Read Elements From Semantic Model 'listings_latest'
-      SELECT
-        '1' AS listing__capacity_latest
-      FROM simple_semantic_manifest.dummy_table listings_latest_src_10000
-    ) subq_0
-    CROSS JOIN
-      simple_semantic_manifest.time_spine time_spine_src_10006
-    GROUP BY
-      DATE_TRUNC('month', time_spine_src_10006.ds)
-      , subq_0.listing__capacity_latest
-
-query_95e50fcd:
-  status: PASS
-  explain_sql:
-    -- Join Self Over Time Range
-    -- Select: ['__revenue', 'metric_time__day']
-    -- Select: ['__revenue', 'metric_time__day']
+    -- Constrain Output with WHERE
+    -- Select: ['__bookings', '__instant_bookings', 'listing__capacity_latest', 'metric_time__day']
     -- Aggregate Inputs for Simple Metrics
     -- Compute Metrics via Expressions
-    -- Compute Metrics via Expressions
     -- Write to DataTable
     SELECT
-      subq_3.ds AS metric_time__day
-      , SUM(subq_1.__revenue) AS trailing_2_months_revenue
-    FROM simple_semantic_manifest.time_spine subq_3
-    INNER JOIN (
-      -- Read Elements From Semantic Model 'revenue'
-      -- Metric Time Dimension 'ds'
+      metric_time__day
+      , listing__capacity_latest
+      , SUM(bookings) AS bookings
+      , SUM(instant_bookings) AS instant_bookings
+    FROM (
+      -- Join Standard Outputs
+      -- Select: ['__bookings', '__instant_bookings', 'listing__capacity_latest', 'metric_time__day']
       SELECT
-        DATE_TRUNC('day', CAST('2020-01-01' AS TIMESTAMP)) AS metric_time__day
-        , 1 AS __revenue
-      FROM simple_semantic_manifest.dummy_table revenue_src_10000
-    ) subq_1
-    ON
-      (
-        subq_1.metric_time__day <= subq_3.ds
-      ) AND (
-        subq_1.metric_time__day > subq_3.ds - INTERVAL 2 month
-      )
+        subq_1.metric_time__day AS metric_time__day
+        , subq_4.capacity_latest AS listing__capacity_latest
+        , subq_1.__bookings AS bookings
+        , subq_1.__instant_bookings AS instant_bookings
+      FROM (
+        -- Read Elements From Semantic Model 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        SELECT
+          DATE_TRUNC('day', CAST('2020-01-01' AS TIMESTAMP)) AS metric_time__day
+          , 1 AS listing
+          , 1 AS __bookings
+          , 1 AS __instant_bookings
+        FROM simple_semantic_manifest.dummy_table bookings_source_src_10000
+      ) subq_1
+      LEFT OUTER JOIN (
+        -- Read Elements From Semantic Model 'listings_latest'
+        -- Metric Time Dimension 'ds'
+        -- Select: ['capacity_latest', 'listing']
+        SELECT
+          1 AS listing
+          , '1' AS capacity_latest
+        FROM simple_semantic_manifest.dummy_table listings_latest_src_10000
+      ) subq_4
+      ON
+        subq_1.listing = subq_4.listing
+    ) subq_6
+    WHERE (listing__capacity_latest IS NOT NULL)
     GROUP BY
-      subq_3.ds
+      metric_time__day
+      , listing__capacity_latest
 
-query_96742aac:
+query_ab068517:
   status: PASS
   explain_sql:
     -- Combine Aggregated Outputs
@@ -142,7 +137,29 @@ query_96742aac:
     ORDER BY metric_time__day DESC, listing__capacity_latest, bookings DESC, views
     LIMIT 10
 
-query_a4f2514d:
+query_b9044f9f:
+  status: PASS
+  explain_sql:
+    -- Join Standard Outputs
+    -- Select: ['listing__capacity_latest', 'metric_time__month']
+    -- Select: ['listing__capacity_latest', 'metric_time__month']
+    -- Write to DataTable
+    SELECT
+      DATE_TRUNC('month', time_spine_src_10006.ds) AS metric_time__month
+      , subq_0.listing__capacity_latest AS listing__capacity_latest
+    FROM (
+      -- Read Elements From Semantic Model 'listings_latest'
+      SELECT
+        '1' AS listing__capacity_latest
+      FROM simple_semantic_manifest.dummy_table listings_latest_src_10000
+    ) subq_0
+    CROSS JOIN
+      simple_semantic_manifest.time_spine time_spine_src_10006
+    GROUP BY
+      DATE_TRUNC('month', time_spine_src_10006.ds)
+      , subq_0.listing__capacity_latest
+
+query_d7540401:
   status: PASS
   explain_sql:
     -- Combine Aggregated Outputs
@@ -264,50 +281,33 @@ query_a4f2514d:
     GROUP BY
       COALESCE(cm_3_cte.listing__capacity_latest, cm_4_cte.listing__capacity_latest, subq_23.listing__capacity_latest)
 
-query_d6ee91c5:
+query_e6b38834:
   status: PASS
   explain_sql:
-    -- Constrain Output with WHERE
-    -- Select: ['__bookings', '__instant_bookings', 'listing__capacity_latest', 'metric_time__day']
+    -- Join Self Over Time Range
+    -- Select: ['__revenue', 'metric_time__day']
+    -- Select: ['__revenue', 'metric_time__day']
     -- Aggregate Inputs for Simple Metrics
+    -- Compute Metrics via Expressions
     -- Compute Metrics via Expressions
     -- Write to DataTable
     SELECT
-      metric_time__day
-      , listing__capacity_latest
-      , SUM(bookings) AS bookings
-      , SUM(instant_bookings) AS instant_bookings
-    FROM (
-      -- Join Standard Outputs
-      -- Select: ['__bookings', '__instant_bookings', 'listing__capacity_latest', 'metric_time__day']
+      subq_3.ds AS metric_time__day
+      , SUM(subq_1.__revenue) AS trailing_2_months_revenue
+    FROM simple_semantic_manifest.time_spine subq_3
+    INNER JOIN (
+      -- Read Elements From Semantic Model 'revenue'
+      -- Metric Time Dimension 'ds'
       SELECT
-        subq_1.metric_time__day AS metric_time__day
-        , subq_4.capacity_latest AS listing__capacity_latest
-        , subq_1.__bookings AS bookings
-        , subq_1.__instant_bookings AS instant_bookings
-      FROM (
-        -- Read Elements From Semantic Model 'bookings_source'
-        -- Metric Time Dimension 'ds'
-        SELECT
-          DATE_TRUNC('day', CAST('2020-01-01' AS TIMESTAMP)) AS metric_time__day
-          , 1 AS listing
-          , 1 AS __bookings
-          , 1 AS __instant_bookings
-        FROM simple_semantic_manifest.dummy_table bookings_source_src_10000
-      ) subq_1
-      LEFT OUTER JOIN (
-        -- Read Elements From Semantic Model 'listings_latest'
-        -- Metric Time Dimension 'ds'
-        -- Select: ['capacity_latest', 'listing']
-        SELECT
-          1 AS listing
-          , '1' AS capacity_latest
-        FROM simple_semantic_manifest.dummy_table listings_latest_src_10000
-      ) subq_4
-      ON
-        subq_1.listing = subq_4.listing
-    ) subq_6
-    WHERE (listing__capacity_latest IS NOT NULL)
+        DATE_TRUNC('day', CAST('2020-01-01' AS TIMESTAMP)) AS metric_time__day
+        , 1 AS __revenue
+      FROM simple_semantic_manifest.dummy_table revenue_src_10000
+    ) subq_1
+    ON
+      (
+        subq_1.metric_time__day <= subq_3.ds
+      ) AND (
+        subq_1.metric_time__day > subq_3.ds - INTERVAL 2 month
+      )
     GROUP BY
-      metric_time__day
-      , listing__capacity_latest
+      subq_3.ds

--- a/tests_metricflow/snapshots/test_internal_manifest.py/str/test_explain_all_saved_queries__result.txt
+++ b/tests_metricflow/snapshots/test_internal_manifest.py/str/test_explain_all_saved_queries__result.txt
@@ -3,27 +3,78 @@ test_filename: test_internal_manifest.py
 docstring:
   Test SQL generated for all saved queries in the manifest.
 ---
-query_0b295dd4:
+query_30d37a87:
   status: PASS
   explain_sql:
-    -- Constrain Output with WHERE
-    -- Select: ['__bookings', '__instant_bookings', 'listing__capacity_latest', 'metric_time__day']
+    -- Join Standard Outputs
+    -- Select: ['listing__capacity_latest', 'metric_time__month']
+    -- Select: ['listing__capacity_latest', 'metric_time__month']
+    -- Write to DataTable
+    SELECT
+      DATE_TRUNC('month', time_spine_src_10006.ds) AS metric_time__month
+      , listings_latest_src_10000.capacity AS listing__capacity_latest
+    FROM default_schema.dim_listings_latest listings_latest_src_10000
+    CROSS JOIN
+      default_schema.mf_time_spine time_spine_src_10006
+    GROUP BY
+      DATE_TRUNC('month', time_spine_src_10006.ds)
+      , listings_latest_src_10000.capacity
+
+query_95e50fcd:
+  status: PASS
+  explain_sql:
+    -- Join Self Over Time Range
+    -- Select: ['__revenue', 'metric_time__day']
+    -- Select: ['__revenue', 'metric_time__day']
     -- Aggregate Inputs for Simple Metrics
+    -- Compute Metrics via Expressions
     -- Compute Metrics via Expressions
     -- Write to DataTable
     SELECT
-      metric_time__day
-      , listing__capacity_latest
-      , SUM(bookings) AS bookings
-      , SUM(instant_bookings) AS instant_bookings
+      subq_3.ds AS metric_time__day
+      , SUM(revenue_src_10000.revenue) AS trailing_2_months_revenue
+    FROM default_schema.mf_time_spine subq_3
+    INNER JOIN
+      default_schema.fct_revenue revenue_src_10000
+    ON
+      (
+        DATE_TRUNC('day', revenue_src_10000.created_at) <= subq_3.ds
+      ) AND (
+        DATE_TRUNC('day', revenue_src_10000.created_at) > subq_3.ds - INTERVAL 2 month
+      )
+    GROUP BY
+      subq_3.ds
+
+query_96742aac:
+  status: PASS
+  explain_sql:
+    -- Combine Aggregated Outputs
+    -- Order By ['metric_time__day', 'listing__capacity_latest', 'bookings', 'views'] Limit 10
+    -- Write to DataTable
+    WITH sma_10014_cte AS (
+      -- Read Elements From Semantic Model 'listings_latest'
+      -- Metric Time Dimension 'ds'
+      SELECT
+        listing_id AS listing
+        , capacity AS capacity_latest
+      FROM default_schema.dim_listings_latest listings_latest_src_10000
+    )
+
+    SELECT
+      COALESCE(subq_9.metric_time__day, subq_18.metric_time__day) AS metric_time__day
+      , COALESCE(subq_9.listing__capacity_latest, subq_18.listing__capacity_latest) AS listing__capacity_latest
+      , MAX(subq_9.bookings) AS bookings
+      , MAX(subq_18.views) AS views
     FROM (
       -- Join Standard Outputs
-      -- Select: ['__bookings', '__instant_bookings', 'listing__capacity_latest', 'metric_time__day']
+      -- Select: ['__bookings', 'listing__capacity_latest', 'metric_time__day']
+      -- Select: ['__bookings', 'listing__capacity_latest', 'metric_time__day']
+      -- Aggregate Inputs for Simple Metrics
+      -- Compute Metrics via Expressions
       SELECT
         subq_1.metric_time__day AS metric_time__day
-        , listings_latest_src_10000.capacity AS listing__capacity_latest
-        , subq_1.__bookings AS bookings
-        , subq_1.__instant_bookings AS instant_bookings
+        , sma_10014_cte.capacity_latest AS listing__capacity_latest
+        , SUM(subq_1.__bookings) AS bookings
       FROM (
         -- Read Elements From Semantic Model 'bookings_source'
         -- Metric Time Dimension 'ds'
@@ -31,20 +82,56 @@ query_0b295dd4:
           DATE_TRUNC('day', ds) AS metric_time__day
           , listing_id AS listing
           , 1 AS __bookings
-          , CASE WHEN is_instant THEN 1 ELSE 0 END AS __instant_bookings
         FROM default_schema.fct_bookings bookings_source_src_10000
       ) subq_1
       LEFT OUTER JOIN
-        default_schema.dim_listings_latest listings_latest_src_10000
+        sma_10014_cte
       ON
-        subq_1.listing = listings_latest_src_10000.listing_id
-    ) subq_6
-    WHERE listing__capacity_latest > 3
+        subq_1.listing = sma_10014_cte.listing
+      GROUP BY
+        subq_1.metric_time__day
+        , sma_10014_cte.capacity_latest
+    ) subq_9
+    FULL OUTER JOIN (
+      -- Join Standard Outputs
+      -- Select: ['__views', 'listing__capacity_latest', 'metric_time__day']
+      -- Select: ['__views', 'listing__capacity_latest', 'metric_time__day']
+      -- Aggregate Inputs for Simple Metrics
+      -- Compute Metrics via Expressions
+      SELECT
+        subq_11.metric_time__day AS metric_time__day
+        , sma_10014_cte.capacity_latest AS listing__capacity_latest
+        , SUM(subq_11.__views) AS views
+      FROM (
+        -- Read Elements From Semantic Model 'views_source'
+        -- Metric Time Dimension 'ds'
+        SELECT
+          DATE_TRUNC('day', ds) AS metric_time__day
+          , listing_id AS listing
+          , 1 AS __views
+        FROM default_schema.fct_views views_source_src_10000
+      ) subq_11
+      LEFT OUTER JOIN
+        sma_10014_cte
+      ON
+        subq_11.listing = sma_10014_cte.listing
+      GROUP BY
+        subq_11.metric_time__day
+        , sma_10014_cte.capacity_latest
+    ) subq_18
+    ON
+      (
+        subq_9.listing__capacity_latest = subq_18.listing__capacity_latest
+      ) AND (
+        subq_9.metric_time__day = subq_18.metric_time__day
+      )
     GROUP BY
-      metric_time__day
-      , listing__capacity_latest
+      COALESCE(subq_9.metric_time__day, subq_18.metric_time__day)
+      , COALESCE(subq_9.listing__capacity_latest, subq_18.listing__capacity_latest)
+    ORDER BY metric_time__day DESC, listing__capacity_latest, bookings DESC, views
+    LIMIT 10
 
-query_1ee34d0e:
+query_a4f2514d:
   status: PASS
   explain_sql:
     -- Combine Aggregated Outputs
@@ -158,36 +245,27 @@ query_1ee34d0e:
     GROUP BY
       COALESCE(cm_3_cte.listing__capacity_latest, cm_4_cte.listing__capacity_latest, subq_23.listing__capacity_latest)
 
-query_25c402a1:
+query_d6ee91c5:
   status: PASS
   explain_sql:
-    -- Combine Aggregated Outputs
-    -- Order By ['metric_time__day', 'listing__capacity_latest', 'bookings', 'views'] Limit 10
+    -- Constrain Output with WHERE
+    -- Select: ['__bookings', '__instant_bookings', 'listing__capacity_latest', 'metric_time__day']
+    -- Aggregate Inputs for Simple Metrics
+    -- Compute Metrics via Expressions
     -- Write to DataTable
-    WITH sma_10014_cte AS (
-      -- Read Elements From Semantic Model 'listings_latest'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        listing_id AS listing
-        , capacity AS capacity_latest
-      FROM default_schema.dim_listings_latest listings_latest_src_10000
-    )
-
     SELECT
-      COALESCE(subq_9.metric_time__day, subq_18.metric_time__day) AS metric_time__day
-      , COALESCE(subq_9.listing__capacity_latest, subq_18.listing__capacity_latest) AS listing__capacity_latest
-      , MAX(subq_9.bookings) AS bookings
-      , MAX(subq_18.views) AS views
+      metric_time__day
+      , listing__capacity_latest
+      , SUM(bookings) AS bookings
+      , SUM(instant_bookings) AS instant_bookings
     FROM (
       -- Join Standard Outputs
-      -- Select: ['__bookings', 'listing__capacity_latest', 'metric_time__day']
-      -- Select: ['__bookings', 'listing__capacity_latest', 'metric_time__day']
-      -- Aggregate Inputs for Simple Metrics
-      -- Compute Metrics via Expressions
+      -- Select: ['__bookings', '__instant_bookings', 'listing__capacity_latest', 'metric_time__day']
       SELECT
         subq_1.metric_time__day AS metric_time__day
-        , sma_10014_cte.capacity_latest AS listing__capacity_latest
-        , SUM(subq_1.__bookings) AS bookings
+        , listings_latest_src_10000.capacity AS listing__capacity_latest
+        , subq_1.__bookings AS bookings
+        , subq_1.__instant_bookings AS instant_bookings
       FROM (
         -- Read Elements From Semantic Model 'bookings_source'
         -- Metric Time Dimension 'ds'
@@ -195,93 +273,15 @@ query_25c402a1:
           DATE_TRUNC('day', ds) AS metric_time__day
           , listing_id AS listing
           , 1 AS __bookings
+          , CASE WHEN is_instant THEN 1 ELSE 0 END AS __instant_bookings
         FROM default_schema.fct_bookings bookings_source_src_10000
       ) subq_1
       LEFT OUTER JOIN
-        sma_10014_cte
+        default_schema.dim_listings_latest listings_latest_src_10000
       ON
-        subq_1.listing = sma_10014_cte.listing
-      GROUP BY
-        subq_1.metric_time__day
-        , sma_10014_cte.capacity_latest
-    ) subq_9
-    FULL OUTER JOIN (
-      -- Join Standard Outputs
-      -- Select: ['__views', 'listing__capacity_latest', 'metric_time__day']
-      -- Select: ['__views', 'listing__capacity_latest', 'metric_time__day']
-      -- Aggregate Inputs for Simple Metrics
-      -- Compute Metrics via Expressions
-      SELECT
-        subq_11.metric_time__day AS metric_time__day
-        , sma_10014_cte.capacity_latest AS listing__capacity_latest
-        , SUM(subq_11.__views) AS views
-      FROM (
-        -- Read Elements From Semantic Model 'views_source'
-        -- Metric Time Dimension 'ds'
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , listing_id AS listing
-          , 1 AS __views
-        FROM default_schema.fct_views views_source_src_10000
-      ) subq_11
-      LEFT OUTER JOIN
-        sma_10014_cte
-      ON
-        subq_11.listing = sma_10014_cte.listing
-      GROUP BY
-        subq_11.metric_time__day
-        , sma_10014_cte.capacity_latest
-    ) subq_18
-    ON
-      (
-        subq_9.listing__capacity_latest = subq_18.listing__capacity_latest
-      ) AND (
-        subq_9.metric_time__day = subq_18.metric_time__day
-      )
+        subq_1.listing = listings_latest_src_10000.listing_id
+    ) subq_6
+    WHERE listing__capacity_latest > 3
     GROUP BY
-      COALESCE(subq_9.metric_time__day, subq_18.metric_time__day)
-      , COALESCE(subq_9.listing__capacity_latest, subq_18.listing__capacity_latest)
-    ORDER BY metric_time__day DESC, listing__capacity_latest, bookings DESC, views
-    LIMIT 10
-
-query_788497ac:
-  status: PASS
-  explain_sql:
-    -- Join Self Over Time Range
-    -- Select: ['__revenue', 'metric_time__day']
-    -- Select: ['__revenue', 'metric_time__day']
-    -- Aggregate Inputs for Simple Metrics
-    -- Compute Metrics via Expressions
-    -- Compute Metrics via Expressions
-    -- Write to DataTable
-    SELECT
-      subq_3.ds AS metric_time__day
-      , SUM(revenue_src_10000.revenue) AS trailing_2_months_revenue
-    FROM default_schema.mf_time_spine subq_3
-    INNER JOIN
-      default_schema.fct_revenue revenue_src_10000
-    ON
-      (
-        DATE_TRUNC('day', revenue_src_10000.created_at) <= subq_3.ds
-      ) AND (
-        DATE_TRUNC('day', revenue_src_10000.created_at) > subq_3.ds - INTERVAL 2 month
-      )
-    GROUP BY
-      subq_3.ds
-
-query_d4073379:
-  status: PASS
-  explain_sql:
-    -- Join Standard Outputs
-    -- Select: ['listing__capacity_latest', 'metric_time__month']
-    -- Select: ['listing__capacity_latest', 'metric_time__month']
-    -- Write to DataTable
-    SELECT
-      DATE_TRUNC('month', time_spine_src_10006.ds) AS metric_time__month
-      , listings_latest_src_10000.capacity AS listing__capacity_latest
-    FROM default_schema.dim_listings_latest listings_latest_src_10000
-    CROSS JOIN
-      default_schema.mf_time_spine time_spine_src_10006
-    GROUP BY
-      DATE_TRUNC('month', time_spine_src_10006.ds)
-      , listings_latest_src_10000.capacity
+      metric_time__day
+      , listing__capacity_latest

--- a/tests_metricflow/snapshots/test_internal_manifest.py/str/test_explain_all_saved_queries__result.txt
+++ b/tests_metricflow/snapshots/test_internal_manifest.py/str/test_explain_all_saved_queries__result.txt
@@ -3,49 +3,48 @@ test_filename: test_internal_manifest.py
 docstring:
   Test SQL generated for all saved queries in the manifest.
 ---
-query_30d37a87:
+query_95e26474:
   status: PASS
   explain_sql:
-    -- Join Standard Outputs
-    -- Select: ['listing__capacity_latest', 'metric_time__month']
-    -- Select: ['listing__capacity_latest', 'metric_time__month']
-    -- Write to DataTable
-    SELECT
-      DATE_TRUNC('month', time_spine_src_10006.ds) AS metric_time__month
-      , listings_latest_src_10000.capacity AS listing__capacity_latest
-    FROM default_schema.dim_listings_latest listings_latest_src_10000
-    CROSS JOIN
-      default_schema.mf_time_spine time_spine_src_10006
-    GROUP BY
-      DATE_TRUNC('month', time_spine_src_10006.ds)
-      , listings_latest_src_10000.capacity
-
-query_95e50fcd:
-  status: PASS
-  explain_sql:
-    -- Join Self Over Time Range
-    -- Select: ['__revenue', 'metric_time__day']
-    -- Select: ['__revenue', 'metric_time__day']
+    -- Constrain Output with WHERE
+    -- Select: ['__bookings', '__instant_bookings', 'listing__capacity_latest', 'metric_time__day']
     -- Aggregate Inputs for Simple Metrics
     -- Compute Metrics via Expressions
-    -- Compute Metrics via Expressions
     -- Write to DataTable
     SELECT
-      subq_3.ds AS metric_time__day
-      , SUM(revenue_src_10000.revenue) AS trailing_2_months_revenue
-    FROM default_schema.mf_time_spine subq_3
-    INNER JOIN
-      default_schema.fct_revenue revenue_src_10000
-    ON
-      (
-        DATE_TRUNC('day', revenue_src_10000.created_at) <= subq_3.ds
-      ) AND (
-        DATE_TRUNC('day', revenue_src_10000.created_at) > subq_3.ds - INTERVAL 2 month
-      )
+      metric_time__day
+      , listing__capacity_latest
+      , SUM(bookings) AS bookings
+      , SUM(instant_bookings) AS instant_bookings
+    FROM (
+      -- Join Standard Outputs
+      -- Select: ['__bookings', '__instant_bookings', 'listing__capacity_latest', 'metric_time__day']
+      SELECT
+        subq_1.metric_time__day AS metric_time__day
+        , listings_latest_src_10000.capacity AS listing__capacity_latest
+        , subq_1.__bookings AS bookings
+        , subq_1.__instant_bookings AS instant_bookings
+      FROM (
+        -- Read Elements From Semantic Model 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        SELECT
+          DATE_TRUNC('day', ds) AS metric_time__day
+          , listing_id AS listing
+          , 1 AS __bookings
+          , CASE WHEN is_instant THEN 1 ELSE 0 END AS __instant_bookings
+        FROM default_schema.fct_bookings bookings_source_src_10000
+      ) subq_1
+      LEFT OUTER JOIN
+        default_schema.dim_listings_latest listings_latest_src_10000
+      ON
+        subq_1.listing = listings_latest_src_10000.listing_id
+    ) subq_6
+    WHERE listing__capacity_latest > 3
     GROUP BY
-      subq_3.ds
+      metric_time__day
+      , listing__capacity_latest
 
-query_96742aac:
+query_ab068517:
   status: PASS
   explain_sql:
     -- Combine Aggregated Outputs
@@ -131,7 +130,24 @@ query_96742aac:
     ORDER BY metric_time__day DESC, listing__capacity_latest, bookings DESC, views
     LIMIT 10
 
-query_a4f2514d:
+query_b9044f9f:
+  status: PASS
+  explain_sql:
+    -- Join Standard Outputs
+    -- Select: ['listing__capacity_latest', 'metric_time__month']
+    -- Select: ['listing__capacity_latest', 'metric_time__month']
+    -- Write to DataTable
+    SELECT
+      DATE_TRUNC('month', time_spine_src_10006.ds) AS metric_time__month
+      , listings_latest_src_10000.capacity AS listing__capacity_latest
+    FROM default_schema.dim_listings_latest listings_latest_src_10000
+    CROSS JOIN
+      default_schema.mf_time_spine time_spine_src_10006
+    GROUP BY
+      DATE_TRUNC('month', time_spine_src_10006.ds)
+      , listings_latest_src_10000.capacity
+
+query_d7540401:
   status: PASS
   explain_sql:
     -- Combine Aggregated Outputs
@@ -245,43 +261,27 @@ query_a4f2514d:
     GROUP BY
       COALESCE(cm_3_cte.listing__capacity_latest, cm_4_cte.listing__capacity_latest, subq_23.listing__capacity_latest)
 
-query_d6ee91c5:
+query_e6b38834:
   status: PASS
   explain_sql:
-    -- Constrain Output with WHERE
-    -- Select: ['__bookings', '__instant_bookings', 'listing__capacity_latest', 'metric_time__day']
+    -- Join Self Over Time Range
+    -- Select: ['__revenue', 'metric_time__day']
+    -- Select: ['__revenue', 'metric_time__day']
     -- Aggregate Inputs for Simple Metrics
+    -- Compute Metrics via Expressions
     -- Compute Metrics via Expressions
     -- Write to DataTable
     SELECT
-      metric_time__day
-      , listing__capacity_latest
-      , SUM(bookings) AS bookings
-      , SUM(instant_bookings) AS instant_bookings
-    FROM (
-      -- Join Standard Outputs
-      -- Select: ['__bookings', '__instant_bookings', 'listing__capacity_latest', 'metric_time__day']
-      SELECT
-        subq_1.metric_time__day AS metric_time__day
-        , listings_latest_src_10000.capacity AS listing__capacity_latest
-        , subq_1.__bookings AS bookings
-        , subq_1.__instant_bookings AS instant_bookings
-      FROM (
-        -- Read Elements From Semantic Model 'bookings_source'
-        -- Metric Time Dimension 'ds'
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , listing_id AS listing
-          , 1 AS __bookings
-          , CASE WHEN is_instant THEN 1 ELSE 0 END AS __instant_bookings
-        FROM default_schema.fct_bookings bookings_source_src_10000
-      ) subq_1
-      LEFT OUTER JOIN
-        default_schema.dim_listings_latest listings_latest_src_10000
-      ON
-        subq_1.listing = listings_latest_src_10000.listing_id
-    ) subq_6
-    WHERE listing__capacity_latest > 3
+      subq_3.ds AS metric_time__day
+      , SUM(revenue_src_10000.revenue) AS trailing_2_months_revenue
+    FROM default_schema.mf_time_spine subq_3
+    INNER JOIN
+      default_schema.fct_revenue revenue_src_10000
+    ON
+      (
+        DATE_TRUNC('day', revenue_src_10000.created_at) <= subq_3.ds
+      ) AND (
+        DATE_TRUNC('day', revenue_src_10000.created_at) > subq_3.ds - INTERVAL 2 month
+      )
     GROUP BY
-      metric_time__day
-      , listing__capacity_latest
+      subq_3.ds

--- a/tests_metricflow/snapshots/test_internal_manifest.py/str/test_invalid_filter_sql__result.txt
+++ b/tests_metricflow/snapshots/test_internal_manifest.py/str/test_invalid_filter_sql__result.txt
@@ -3,7 +3,7 @@ test_filename: test_internal_manifest.py
 docstring:
   Test that invalid SQL in a filter is detected.
 ---
-query_56a97413:
+query_742bc81c:
   status: SQL_EXCEPTION
   explain_sql:
     -- Constrain Output with WHERE

--- a/tests_metricflow/snapshots/test_internal_manifest.py/str/test_invalid_filter_sql__result.txt
+++ b/tests_metricflow/snapshots/test_internal_manifest.py/str/test_invalid_filter_sql__result.txt
@@ -3,7 +3,7 @@ test_filename: test_internal_manifest.py
 docstring:
   Test that invalid SQL in a filter is detected.
 ---
-query_742bc81c:
+query_7415c13c:
   status: SQL_EXCEPTION
   explain_sql:
     -- Constrain Output with WHERE

--- a/tests_metricflow/snapshots/test_internal_manifest.py/str/test_invalid_metric__result.txt
+++ b/tests_metricflow/snapshots/test_internal_manifest.py/str/test_invalid_metric__result.txt
@@ -3,7 +3,7 @@ test_filename: test_internal_manifest.py
 docstring:
   Test that an invalid metric is detected.
 ---
-query_8f3ebb7d:
+query_e0e62a72:
   status: MF_EXCEPTION
   mf_exception:
     Got error(s) during query resolution.

--- a/tests_metricflow/snapshots/test_internal_manifest.py/str/test_invalid_metric__result.txt
+++ b/tests_metricflow/snapshots/test_internal_manifest.py/str/test_invalid_metric__result.txt
@@ -3,7 +3,7 @@ test_filename: test_internal_manifest.py
 docstring:
   Test that an invalid metric is detected.
 ---
-query_79239747:
+query_8f3ebb7d:
   status: MF_EXCEPTION
   mf_exception:
     Got error(s) during query resolution.


### PR DESCRIPTION
To aid rollout, this PR adds an option to the query request to control whether the legacy column orderer should be used.