### PR TITLE
Add parentheses around user-supplied filter strings

### DIFF
--- a/.changes/unreleased/Fixes-20260604-093306.yaml
+++ b/.changes/unreleased/Fixes-20260604-093306.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Add parentheses around user-supplied filter strings
+time: 2026-06-04T09:33:06.88408-07:00
+custom:
+    Author: plypaul
+    Issue: "2066"

--- a/metricflow/plan_conversion/to_sql_plan/dataflow_to_subquery.py
+++ b/metricflow/plan_conversion/to_sql_plan/dataflow_to_subquery.py
@@ -1016,6 +1016,10 @@ class DataflowNodeToSqlSubqueryVisitor(DataflowPlanNodeVisitor[SqlDataSet]):
                     column_association.column_name for column_association in column_associations_in_where_sql
                 ),
                 bind_parameter_set=filter_spec.bind_parameters,
+                # Where-filter SQL is raw text, so require parenthesis to avoid operator precedence issues when combined
+                # with other expressions.
+                # e.g. `(booking__ds__day = '2020-01-01' OR booking__ds__day = '2020-01-02) AND ...`
+                requires_parenthesis=True,
             )
 
         # Odd type-check inspection with just `tuple(filter_key_to_string_expression.values())`

--- a/tests_metricflow/plan_conversion/test_dataflow_to_sql_plan.py
+++ b/tests_metricflow/plan_conversion/test_dataflow_to_sql_plan.py
@@ -191,18 +191,21 @@ def test_filter_with_where_constraint_node(
         entity_links=(),
         time_granularity=ExpandedTimeGranularity.from_time_granularity(TimeGranularity.DAY),
     )
+    is_instant_spec = DimensionSpec(element_name="is_instant", entity_links=())
     selector_node = SelectorNode.create(
         parent_node=source_node,
         include_specs=InstanceSpecSet(
-            simple_metric_input_specs=(simple_metric_input_spec,), time_dimension_specs=(ds_spec,)
+            simple_metric_input_specs=(simple_metric_input_spec,),
+            dimension_specs=(is_instant_spec,),
+            time_dimension_specs=(ds_spec,),
         ),
-    )  # need to include ds_spec because where constraint operates on ds
+    )
     time_grain = ExpandedTimeGranularity.from_time_granularity(TimeGranularity.DAY)
     where_constraint_node = WhereFilterNode.create(
         parent_node=selector_node,
         filter_specs=(
             WhereFilterSpec(
-                where_sql="booking__ds__day = '2020-01-01'",
+                where_sql="booking__ds__day = '2020-01-01' OR booking__ds__day = '2020-01-02'",
                 bind_parameters=SqlBindParameterSet(),
                 element_set=GroupByItemSet(
                     annotated_specs=(
@@ -211,6 +214,25 @@ def test_filter_with_where_constraint_node(
                             element_name="ds",
                             entity_links=(EntityReference(element_name="booking"),),
                             time_grain=time_grain,
+                            date_part=None,
+                            metric_subquery_entity_links=None,
+                            properties=(),
+                            origin_model_ids=(),
+                            derived_from_semantic_models=(),
+                        ),
+                    ),
+                ),
+            ),
+            WhereFilterSpec(
+                where_sql="booking__is_instant",
+                bind_parameters=SqlBindParameterSet(),
+                element_set=GroupByItemSet(
+                    annotated_specs=(
+                        AnnotatedSpec.create(
+                            element_type=LinkableElementType.DIMENSION,
+                            element_name="is_instant",
+                            entity_links=(EntityReference(element_name="booking"),),
+                            time_grain=None,
                             date_part=None,
                             metric_subquery_entity_links=None,
                             properties=(),

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/DuckDB/test_filter_with_where_constraint_node__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/DuckDB/test_filter_with_where_constraint_node__plan0.sql
@@ -7,11 +7,13 @@ sql_engine: DuckDB
 -- Constrain Output with WHERE
 SELECT
   subq_1.bookings AS __bookings
+  , subq_1.is_instant
   , subq_1.ds__day
 FROM (
-  -- Select: ['__bookings', 'ds__day']
+  -- Select: ['__bookings', 'is_instant', 'ds__day']
   SELECT
     subq_0.ds__day
+    , subq_0.is_instant
     , subq_0.__bookings AS bookings
   FROM (
     -- Read Elements From Semantic Model 'bookings_source'
@@ -116,4 +118,8 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
   ) subq_0
 ) subq_1
-WHERE booking__ds__day = '2020-01-01'
+WHERE (
+  booking__ds__day = '2020-01-01' OR booking__ds__day = '2020-01-02'
+) AND (
+  booking__is_instant
+)

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/DuckDB/test_filter_with_where_constraint_node__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/DuckDB/test_filter_with_where_constraint_node__plan0_optimized.sql
@@ -7,13 +7,19 @@ sql_engine: DuckDB
 -- Constrain Output with WHERE
 SELECT
   bookings AS __bookings
+  , is_instant
   , ds__day
 FROM (
   -- Read Elements From Semantic Model 'bookings_source'
-  -- Select: ['__bookings', 'ds__day']
+  -- Select: ['__bookings', 'is_instant', 'ds__day']
   SELECT
     DATE_TRUNC('day', ds) AS ds__day
+    , is_instant
     , 1 AS bookings
   FROM ***************************.fct_bookings bookings_source_src_28000
 ) subq_3
-WHERE booking__ds__day = '2020-01-01'
+WHERE (
+  booking__ds__day = '2020-01-01' OR booking__ds__day = '2020-01-02'
+) AND (
+  booking__is_instant
+)

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/test_filter_with_where_constraint_node__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlPlan/test_filter_with_where_constraint_node__plan0.xml
@@ -7,16 +7,18 @@ docstring:
     <SqlSelectStatementNode>
         <!-- description = 'Constrain Output with WHERE' -->
         <!-- node_id = NodeId(id_str='ss_5') -->
-        <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_2), column_alias='__bookings') -->
-        <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_3), column_alias='ds__day') -->
+        <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_3), column_alias='__bookings') -->
+        <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_4), column_alias='is_instant') -->
+        <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_5), column_alias='ds__day') -->
         <!-- from_source = SqlSelectStatementNode(node_id=ss_2) -->
-        <!-- where = SqlStringExpression(node_id=str_0 sql_expr=booking__ds__day = '2020-01-01') -->
+        <!-- where = SqlLogicalExpression(node_id=lo_0) -->
         <!-- distinct = False -->
         <SqlSelectStatementNode>
-            <!-- description = "Select: ['__bookings', 'ds__day']" -->
+            <!-- description = "Select: ['__bookings', 'is_instant', 'ds__day']" -->
             <!-- node_id = NodeId(id_str='ss_2') -->
-            <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_1), column_alias='ds__day') -->
-            <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_0), column_alias='bookings') -->
+            <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_2), column_alias='ds__day') -->
+            <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_1), column_alias='is_instant') -->
+            <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_0), column_alias='bookings') -->
             <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
             <!-- where = None -->
             <!-- distinct = False -->


### PR DESCRIPTION
Resolves https://github.com/dbt-labs/metricflow/issues/2066

This PR updates the rendering of user-supplied SQL in filter expressions to include parentheses to address operator precedence issues when multiple filters are provided.

This fixes problematic rendering from:

```
WHERE booking__ds__day = '2020-01-01' OR booking__ds__day = '2020-01-02'
  AND booking__is_instant
```

to:

```
WHERE (
  booking__ds__day = '2020-01-01' OR booking__ds__day = '2020-01-02'
) AND (
  booking__is_instant
)
```