### PR TITLE
Use timezone-aware objects instead of `datetime.utcnow()`

### DIFF
--- a/metricflow/engine/time_source.py
+++ b/metricflow/engine/time_source.py
@@ -9,4 +9,4 @@ class ServerTimeSource(TimeSource):
     """A time source that represents the current datetime in UTC."""
 
     def get_time(self) -> dt.datetime:  # noqa: D102
-        return dt.datetime.utcnow()
+        return dt.datetime.now(dt.timezone.utc)


### PR DESCRIPTION
This PR replaces `datetime.utcnow()` to `datetime.now(timezone.utc)` as the former was deprecated in Python 3.12.