### PR TITLE
feat(ipc): Create a binary for sidecars using Nuitka

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,9 @@ performance-comparison.md
 
 # Directory to consolidate files ignored by git.
 **/git_ignored
+
+# Nuitka sidecar build artifacts
+sidecar/mf_entry.dist/
+sidecar/mf_entry.build/
+sidecar/nuitka_poc.dist/
+sidecar/nuitka_poc.build/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,6 +146,20 @@ template = "dev-env"
 features = ["trino-env-requirements"]
 
 
+[tool.hatch.envs.nuitka-build]
+description = "Nuitka compilation environment for building a standalone MetricFlow binary."
+template = "dev-env"
+extra-dependencies = ["nuitka"]
+
+[tool.hatch.envs.nuitka-build.scripts]
+compile = [
+  "python -m nuitka --standalone --follow-imports --include-package=metricflow --include-package=metricflow_semantics --include-package=metricflow_semantic_interfaces --output-dir=sidecar/ sidecar/mf_entry.py",
+]
+validate = [
+  "python sidecar/validate_mf_entry.py",
+]
+
+
 [tool.black]
 line-length = 120
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,6 +158,10 @@ compile = [
 validate = [
   "python sidecar/validate_mf_entry.py",
 ]
+build-and-validate = [
+  "hatch run nuitka-build:compile",
+  "hatch run nuitka-build:validate",
+]
 
 
 [tool.black]

--- a/sidecar/README.md
+++ b/sidecar/README.md
@@ -1,0 +1,199 @@
+# MetricFlow sidecar
+
+The sidecar is MetricFlow compiled into a standalone native binary by
+[Nuitka](https://nuitka.net/). dbt-core v2 spawns it as a
+subprocess and communicates with it over NDJSON on stdin/stdout using the
+**mf-ipc v1** protocol.
+
+The sidecar's only job is to compile metric queries to SQL without executing
+them. It wraps `MetricFlowEngine.explain()`.
+
+## Directory layout
+
+```
+sidecar/
+  mf_entry.py            IPC server (the file Nuitka compiles)
+  validate_mf_entry.py   validation helper: compares Python vs binary SQL output
+  tests/
+    test_mf_entry.py     subprocess integration tests (mf-ipc v1)
+```
+
+## Development
+
+Run the integration tests against the Python interpreter (no compilation needed):
+
+```bash
+hatch run dev-env:pytest sidecar/tests/ -v
+```
+
+Quick smoke test from the repo root:
+
+```bash
+MANIFEST=metricflow_semantics/test_helpers/semantic_manifest_yamls/sg_00_minimal_manifest
+printf '{"id":"1","method":"explain","v":1,"params":{"manifest_path":"%s","metric_names":["bookings"],"group_by_names":["metric_time"],"sql_engine":"DUCKDB"}}\n{"id":"2","method":"shutdown","v":1}\n' "$MANIFEST" \
+  | hatch run dev-env:python sidecar/mf_entry.py
+```
+
+## Building
+
+Compile `mf_entry.py` to a standalone binary:
+
+```bash
+hatch run nuitka-build:compile
+```
+
+Output lands in `sidecar/mf_entry.dist/`. The binary is named `mf_entry.bin`
+on macOS/Linux and `mf_entry.exe` on Windows.
+
+## Validation
+
+After building, confirm the binary produces identical SQL to the Python
+interpreter:
+
+```bash
+hatch run nuitka-build:validate
+```
+
+This sends the same `explain` request to both and diffs the `sql` field of
+each response. A mismatch means something in the Nuitka build is diverging
+from the interpreter.
+
+## mf-ipc v1 protocol
+
+All messages are newline-delimited JSON (NDJSON). The protocol is strictly
+sequential: the caller sends one request and waits for one response before
+sending the next.
+
+### Startup
+
+On launch the sidecar writes a ready message to stdout:
+
+```json
+{"status": "ready", "metricflow_version": "X.Y.Z", "python_version": "3.11.x", "protocol_version": 1}
+```
+
+If `--manifest-path` was given and manifest loading fails, the sidecar writes
+an error message and exits 1:
+
+```json
+{"status": "error", "type": "ExceptionClass", "message": "..."}
+```
+
+### Request format
+
+```json
+{"id": "<string or int>", "method": "<method>", "v": 1, "params": {...}}
+```
+
+`id` is echoed back in the response. `v` must be `1`.
+
+### Methods
+
+#### `explain`
+
+Compiles a metric query to SQL without executing it.
+
+```json
+{
+  "id": "1",
+  "method": "explain",
+  "v": 1,
+  "params": {
+    "manifest_path": "/path/to/manifest.json",
+    "metric_names": ["bookings"],
+    "group_by_names": ["metric_time"],
+    "where_constraints": null,
+    "order_by_names": null,
+    "limit": null,
+    "sql_engine": "DUCKDB"
+  }
+}
+```
+
+- `manifest_path` — path to a `manifest.json` file **or** a YAML semantic
+  manifest directory (for development/testing)
+- `sql_engine` — one of `DUCKDB`, `BIGQUERY`, `DATABRICKS`, `POSTGRES`,
+  `REDSHIFT`, `SNOWFLAKE`, `TRINO`
+- All params except `manifest_path` and `sql_engine` are optional
+
+The engine is cached by `(manifest_path, mtime, sql_engine)` and rebuilt only
+when the manifest file changes or the engine type changes, so repeated
+`explain` calls against the same manifest are cheap.
+
+Response:
+
+```json
+{"id": "1", "ok": true, "sql": "SELECT ..."}
+```
+
+#### `ping`
+
+Health check. Responds immediately without touching the manifest or engine.
+
+```json
+{"id": "2", "method": "ping", "v": 1}
+```
+
+Response:
+
+```json
+{"id": "2", "ok": true}
+```
+
+#### `shutdown`
+
+Graceful shutdown. The sidecar responds, flushes stdout, then exits 0.
+
+```json
+{"id": "3", "method": "shutdown", "v": 1}
+```
+
+Response:
+
+```json
+{"id": "3", "ok": true}
+```
+
+### Error responses
+
+All errors share a single shape:
+
+```json
+{"id": "<id or null>", "ok": false, "error": {"type": "ExceptionClass", "message": "..."}}
+```
+
+`id` is `null` when the request itself could not be parsed (e.g. malformed
+JSON). Common `type` values:
+
+| type | cause |
+|---|---|
+| `InvalidQueryException` | invalid query parameters |
+| `UnknownMetricError` | metric name not found in manifest |
+| `JSONDecodeError` | request line was not valid JSON |
+| `ProtocolVersionError` | `v` field was not `1` |
+| `UnknownMethod` | unrecognised method name |
+
+With `--debug`, error responses also include a `"traceback"` field.
+
+The sidecar continues running after any per-request error. Only `shutdown`,
+EOF on stdin, or a signal causes it to exit.
+
+## CLI reference
+
+```
+mf_entry.py [--manifest-path PATH] [--sql-engine ENGINE] [--debug] [--version]
+
+  --manifest-path PATH   Pre-load manifest before writing the ready message.
+                         Eliminates cold-start latency on the first explain call.
+  --sql-engine ENGINE    Engine to use for pre-warming (default: DUCKDB).
+  --debug                Verbose stderr logging; include tracebacks in error responses.
+  --version              Print version and exit.
+```
+
+## stdout protection
+
+Any library `print()` call would corrupt the NDJSON framing on the pipe the caller
+is reading. `mf_entry.py` saves the real stdout file descriptor before any
+library code runs, then replaces `sys.stdout` with `sys.stderr`. All IPC
+writes go through the saved descriptor. All non-IPC output (logging, library
+chatter) goes to stderr.

--- a/sidecar/README.md
+++ b/sidecar/README.md
@@ -168,15 +168,15 @@ All errors share a single shape:
 {"id": "<id or null>", "ok": false, "error": {"type": "ExceptionClass", "message": "..."}}
 ```
 
-`id` is `null` when the request itself could not be parsed (e.g. malformed
-JSON). Common `type` values:
+`id` is `null` when the request itself could not be parsed or validated
+(e.g. malformed JSON, or a missing/invalid field). Common `type` values:
 
 | type | cause |
 |---|---|
 | `InvalidQueryException` | invalid query parameters |
 | `UnknownMetricError` | metric name not found in manifest |
-| `JSONDecodeError` | request line was not valid JSON |
-| `ProtocolVersionError` | `v` field was not `1` |
+| `ValidationError` | request line was not valid JSON, or didn't match the expected shape |
+| `ProtocolVersionError` | `protocol_version` field was not `1` |
 | `UnknownMethod` | unrecognised method name |
 
 With `--debug`, error responses also include a `"traceback"` field.

--- a/sidecar/README.md
+++ b/sidecar/README.md
@@ -32,7 +32,7 @@ Quick smoke test from the repo root:
 
 ```bash
 MANIFEST=metricflow_semantics/test_helpers/semantic_manifest_yamls/sg_00_minimal_manifest
-printf '{"id":"1","method":"explain","v":1,"params":{"manifest_path":"%s","metric_names":["bookings"],"group_by_names":["metric_time"],"sql_engine":"DUCKDB"}}\n{"id":"2","method":"shutdown","v":1}\n' "$MANIFEST" \
+printf '{"id":"1","method":"explain","protocol_version":1,"params":{"manifest_path":"%s","metric_names":["bookings"],"group_by_names":["metric_time"],"sql_engine":"DUCKDB"}}\n{"id":"2","method":"shutdown","protocol_version":1}\n' "$MANIFEST" \
   | hatch run dev-env:python sidecar/mf_entry.py
 ```
 
@@ -88,10 +88,10 @@ an error message and exits 1:
 ### Request format
 
 ```json
-{"id": "<string or int>", "method": "<method>", "v": 1, "params": {...}}
+{"id": "<string or int>", "method": "<method>", "protocol_version": 1, "params": {...}}
 ```
 
-`id` is echoed back in the response. `v` must be `1`.
+`id` is echoed back in the response. `protocol_version` must be `1`.
 
 ### Methods
 
@@ -103,7 +103,7 @@ Compiles a metric query to SQL without executing it.
 {
   "id": "1",
   "method": "explain",
-  "v": 1,
+  "protocol_version": 1,
   "params": {
     "manifest_path": "/path/to/manifest.json",
     "metric_names": ["bookings"],
@@ -137,7 +137,7 @@ Response:
 Health check. Responds immediately without touching the manifest or engine.
 
 ```json
-{"id": "2", "method": "ping", "v": 1}
+{"id": "2", "method": "ping", "protocol_version": 1}
 ```
 
 Response:
@@ -151,7 +151,7 @@ Response:
 Graceful shutdown. The sidecar responds, flushes stdout, then exits 0.
 
 ```json
-{"id": "3", "method": "shutdown", "v": 1}
+{"id": "3", "method": "shutdown", "protocol_version": 1}
 ```
 
 Response:

--- a/sidecar/README.md
+++ b/sidecar/README.md
@@ -13,9 +13,11 @@ them. It wraps `MetricFlowEngine.explain()`.
 ```
 sidecar/
   mf_entry.py            IPC server (the file Nuitka compiles)
+  mf_ipc_protocol.py     pydantic models for every message shape below
   validate_mf_entry.py   validation helper: compares Python vs binary SQL output
   tests/
-    test_mf_entry.py     subprocess integration tests (mf-ipc v1)
+    test_mf_entry.py         subprocess integration tests (mf-ipc v1)
+    test_mf_ipc_protocol.py  direct unit tests for the pydantic models
 ```
 
 ## Development
@@ -60,6 +62,13 @@ hatch run nuitka-build:validate   # validate only (binary must already exist)
 All messages are newline-delimited JSON (NDJSON). The protocol is strictly
 sequential: the caller sends one request and waits for one response before
 sending the next.
+
+Every message shape documented below has a corresponding pydantic model in
+`mf_ipc_protocol.py`, which `mf_entry.py` validates requests against and
+builds responses from. This is a minimal, MetricFlow-internal typing layer —
+there's no shared schema artifact or codegen for the Rust side yet. Adopting
+a structured cross-repo contract (gRPC/protobuf, or a JSON Schema shared with
+Fusion) is tracked separately in DI-4709.
 
 ### Startup
 

--- a/sidecar/README.md
+++ b/sidecar/README.md
@@ -34,29 +34,26 @@ printf '{"id":"1","method":"explain","v":1,"params":{"manifest_path":"%s","metri
   | hatch run dev-env:python sidecar/mf_entry.py
 ```
 
-## Building
+## Building and local validation
 
-Compile `mf_entry.py` to a standalone binary:
+To compile and validate in one step:
 
 ```bash
-hatch run nuitka-build:compile
+hatch run nuitka-build:build-and-validate
 ```
 
 Output lands in `sidecar/mf_entry.dist/`. The binary is named `mf_entry.bin`
-on macOS/Linux and `mf_entry.exe` on Windows.
+on macOS/Linux and `mf_entry.exe` on Windows. The validation step sends the
+same `explain` request to both the Python interpreter and the compiled binary
+and diffs the `sql` field — a mismatch means the Nuitka build is diverging
+from the interpreter.
 
-## Validation
-
-After building, confirm the binary produces identical SQL to the Python
-interpreter:
+The two steps can also be run separately:
 
 ```bash
-hatch run nuitka-build:validate
+hatch run nuitka-build:compile    # build only
+hatch run nuitka-build:validate   # validate only (binary must already exist)
 ```
-
-This sends the same `explain` request to both and diffs the `sql` field of
-each response. A mismatch means something in the Nuitka build is diverging
-from the interpreter.
 
 ## mf-ipc v1 protocol
 

--- a/sidecar/mf_entry.py
+++ b/sidecar/mf_entry.py
@@ -30,7 +30,7 @@ import sys
 import traceback as _traceback
 import types
 from pathlib import Path
-from typing import IO
+from typing import IO, Literal
 
 from metricflow_semantics.model.semantic_manifest_lookup import SemanticManifestLookup
 from metricflow_semantics.sql.sql_bind_parameters import SqlBindParameterSet
@@ -212,7 +212,7 @@ def _dispatch(req: object) -> ExplainResponse | OkResponse | ErrorResponse:
     )
 
 
-def main(argv: list[str]) -> int:  # noqa: D103
+def main(argv: list[str]) -> Literal[0, 1]:  # noqa: D103
     global _ipc, _debug
 
     parser = argparse.ArgumentParser(description="MetricFlow IPC entry point (mf-ipc v1)")

--- a/sidecar/mf_entry.py
+++ b/sidecar/mf_entry.py
@@ -22,7 +22,6 @@ from __future__ import annotations
 
 import argparse
 import importlib.metadata
-import json
 import logging
 import os
 import signal
@@ -188,15 +187,6 @@ def _handle_explain(req_id: RequestId, raw_params: dict) -> ExplainResponse | Er
         return _err(req_id, e)
 
 
-def _parse_envelope(req: object) -> RequestEnvelope | ErrorResponse:
-    """Validate a decoded JSON value into a RequestEnvelope, or a structured error."""
-    try:
-        return RequestEnvelope.model_validate(req)
-    except ValidationError as e:
-        fallback_id = req.get("id") if isinstance(req, dict) else None
-        return _err(fallback_id, e)
-
-
 def _dispatch(envelope: RequestEnvelope) -> ExplainResponse | OkResponse | ErrorResponse:
     """Route a validated envelope to its method handler.
 
@@ -280,16 +270,9 @@ def main(argv: list[str]) -> Literal[0, 1]:  # noqa: D103
             if not line:
                 continue
             try:
-                # Parsed as raw JSON, then separately validated into a RequestEnvelope,
-                # so malformed JSON (JSONDecodeError) and schema-invalid JSON
-                # (ValidationError) remain distinguishable error types for the caller.
-                req = json.loads(line)
-            except json.JSONDecodeError as e:
-                _write(ErrorResponse(id=None, error=ErrorDetail(type="JSONDecodeError", message=str(e))))
-                continue
-            envelope = _parse_envelope(req)
-            if isinstance(envelope, ErrorResponse):
-                _write(envelope)
+                envelope = RequestEnvelope.model_validate_json(line)
+            except ValidationError as e:
+                _write(_err(None, e))
                 continue
             if envelope.method == Method.SHUTDOWN:
                 _write(OkResponse(id=envelope.id))

--- a/sidecar/mf_entry.py
+++ b/sidecar/mf_entry.py
@@ -38,6 +38,18 @@ from metricflow_semantics.test_helpers.manifest_helpers import (
     mf_load_manifest_from_json_file,
     mf_load_manifest_from_yaml_directory,
 )
+from mf_ipc_protocol import (
+    ErrorDetail,
+    ErrorResponse,
+    ExplainParams,
+    ExplainResponse,
+    OkResponse,
+    ReadyMessage,
+    RequestEnvelope,
+    RequestId,
+    StartupErrorMessage,
+)
+from pydantic import BaseModel, ValidationError
 
 from metricflow.data_table.mf_table import MetricFlowDataTable
 from metricflow.engine.metricflow_engine import MetricFlowEngine, MetricFlowQueryRequest
@@ -139,64 +151,65 @@ def _get_engine(manifest_path: str, sql_engine: SqlEngine) -> MetricFlowEngine:
     return engine
 
 
-def _write(obj: dict) -> None:
+def _write(msg: BaseModel) -> None:
     try:
-        _ipc.write(json.dumps(obj) + "\n")
+        _ipc.write(msg.model_dump_json() + "\n")
         _ipc.flush()
     except BrokenPipeError:
         logging.warning("IPC pipe broken; exiting")
         sys.exit(0)
 
 
-def _err(req_id: str | int | None, exc: Exception) -> dict:
-    error: dict[str, str] = {"type": type(exc).__name__, "message": str(exc)}
+def _err(req_id: RequestId, exc: Exception) -> ErrorResponse:
+    error = ErrorDetail(type=type(exc).__name__, message=str(exc))
     if _debug:
-        error["traceback"] = _traceback.format_exc()
-    return {"id": req_id, "ok": False, "error": error}
+        error.traceback = _traceback.format_exc()
+    return ErrorResponse(id=req_id, error=error)
 
 
-def _handle_explain(req_id: str | int | None, params: dict) -> dict:
+def _handle_explain(req_id: RequestId, raw_params: dict) -> ExplainResponse | ErrorResponse:
     try:
-        manifest_path = params["manifest_path"]
-        sql_engine = SqlEngine[params.get("sql_engine", "DUCKDB")]
-        engine = _get_engine(manifest_path, sql_engine)
+        params = ExplainParams.model_validate(raw_params)
+        sql_engine = SqlEngine[params.sql_engine]
+        engine = _get_engine(params.manifest_path, sql_engine)
         request = MetricFlowQueryRequest.create(
-            metric_names=params.get("metric_names"),
-            group_by_names=params.get("group_by_names"),
-            where_constraints=params.get("where_constraints"),
-            order_by_names=params.get("order_by_names"),
-            limit=params.get("limit"),
+            metric_names=params.metric_names,
+            group_by_names=params.group_by_names,
+            where_constraints=params.where_constraints,
+            order_by_names=params.order_by_names,
+            limit=params.limit,
         )
         result = engine.explain(request)
-        return {"id": req_id, "ok": True, "sql": result.sql_statement.sql}
+        return ExplainResponse(id=req_id, sql=result.sql_statement.sql)
     except Exception as e:
         return _err(req_id, e)
 
 
-def _dispatch(req: dict) -> dict:
-    req_id = req.get("id")
-    method = req.get("method")
-    v = req.get("v", 1)
-    if v != 1:
-        return {
-            "id": req_id,
-            "ok": False,
-            "error": {"type": "ProtocolVersionError", "message": f"Expected v=1, got v={v!r}"},
-        }
-    if method == "ping":
-        return {"id": req_id, "ok": True}
-    if method == "shutdown":
-        return {"id": req_id, "ok": True}
-    if method == "explain":
-        return _handle_explain(req_id, req.get("params") or {})
-    return {
-        "id": req_id,
-        "ok": False,
-        "error": {
-            "type": "UnknownMethod",
-            "message": f"Unknown method: {method!r}. Supported: explain, ping, shutdown",
-        },
-    }
+def _dispatch(req: object) -> ExplainResponse | OkResponse | ErrorResponse:
+    try:
+        envelope = RequestEnvelope.model_validate(req)
+    except ValidationError as e:
+        fallback_id = req.get("id") if isinstance(req, dict) else None
+        return _err(fallback_id, e)
+
+    if envelope.v != 1:
+        return ErrorResponse(
+            id=envelope.id,
+            error=ErrorDetail(type="ProtocolVersionError", message=f"Expected v=1, got v={envelope.v!r}"),
+        )
+    if envelope.method == "ping":
+        return OkResponse(id=envelope.id)
+    if envelope.method == "shutdown":
+        return OkResponse(id=envelope.id)
+    if envelope.method == "explain":
+        return _handle_explain(envelope.id, envelope.params or {})
+    return ErrorResponse(
+        id=envelope.id,
+        error=ErrorDetail(
+            type="UnknownMethod",
+            message=f"Unknown method: {envelope.method!r}. Supported: explain, ping, shutdown",
+        ),
+    )
 
 
 def main(argv: list[str]) -> int:  # noqa: D103
@@ -238,17 +251,14 @@ def main(argv: list[str]) -> int:  # noqa: D103
         try:
             _get_engine(args.manifest_path, SqlEngine[args.sql_engine])
         except Exception as e:
-            _ipc.write(json.dumps({"status": "error", "type": type(e).__name__, "message": str(e)}) + "\n")
-            _ipc.flush()
+            _write(StartupErrorMessage(type=type(e).__name__, message=str(e)))
             return 1
 
     _write(
-        {
-            "status": "ready",
-            "metricflow_version": _MF_VERSION,
-            "python_version": sys.version.split()[0],
-            "protocol_version": 1,
-        }
+        ReadyMessage(
+            metricflow_version=_MF_VERSION,
+            python_version=sys.version.split()[0],
+        )
     )
 
     try:
@@ -259,11 +269,11 @@ def main(argv: list[str]) -> int:  # noqa: D103
             try:
                 req = json.loads(line)
             except json.JSONDecodeError as e:
-                _write({"id": None, "ok": False, "error": {"type": "JSONDecodeError", "message": str(e)}})
+                _write(ErrorResponse(id=None, error=ErrorDetail(type="JSONDecodeError", message=str(e))))
                 continue
             resp = _dispatch(req)
             _write(resp)
-            if req.get("method") == "shutdown":
+            if isinstance(req, dict) and req.get("method") == "shutdown":
                 break
     except Exception:
         logging.exception("Uncaught error in IPC loop")

--- a/sidecar/mf_entry.py
+++ b/sidecar/mf_entry.py
@@ -6,12 +6,12 @@ as a subprocess. Communicates via NDJSON over stdin/stdout (mf-ipc v1).
 
 Protocol v1:
   ready:    {"status":"ready","metricflow_version":"X","python_version":"X","protocol_version":1}
-  explain:  {"id":"...","method":"explain","v":1,"params":{
+  explain:  {"id":"...","method":"explain","protocol_version":1,"params":{
                 "manifest_path":"...","metric_names":[...],"group_by_names":[...],
                 "where_constraints":null,"order_by_names":null,"limit":null,"sql_engine":"DUCKDB"
             }} → {"id":"...","ok":true,"sql":"..."}
-  ping:     {"id":"...","method":"ping","v":1} → {"id":"...","ok":true}
-  shutdown: {"id":"...","method":"shutdown","v":1} → {"id":"...","ok":true}
+  ping:     {"id":"...","method":"ping","protocol_version":1} → {"id":"...","ok":true}
+  shutdown: {"id":"...","method":"shutdown","protocol_version":1} → {"id":"...","ok":true}
   error:    {"id":"...","ok":false,"error":{"type":"ExceptionClass","message":"..."}}
 
 manifest_path may be a YAML directory (dev/testing) or a manifest.json file (production).
@@ -43,6 +43,7 @@ from mf_ipc_protocol import (
     ErrorResponse,
     ExplainParams,
     ExplainResponse,
+    Method,
     OkResponse,
     ReadyMessage,
     RequestEnvelope,
@@ -161,9 +162,11 @@ def _write(msg: BaseModel) -> None:
 
 
 def _err(req_id: RequestId, exc: Exception) -> ErrorResponse:
-    error = ErrorDetail(type=type(exc).__name__, message=str(exc))
-    if _debug:
-        error.traceback = _traceback.format_exc()
+    error = ErrorDetail(
+        type=type(exc).__name__,
+        message=str(exc),
+        traceback=_traceback.format_exc() if _debug else None,
+    )
     return ErrorResponse(id=req_id, error=error)
 
 
@@ -185,29 +188,39 @@ def _handle_explain(req_id: RequestId, raw_params: dict) -> ExplainResponse | Er
         return _err(req_id, e)
 
 
-def _dispatch(req: object) -> ExplainResponse | OkResponse | ErrorResponse:
+def _parse_envelope(req: object) -> RequestEnvelope | ErrorResponse:
+    """Validate a decoded JSON value into a RequestEnvelope, or a structured error."""
     try:
-        envelope = RequestEnvelope.model_validate(req)
+        return RequestEnvelope.model_validate(req)
     except ValidationError as e:
         fallback_id = req.get("id") if isinstance(req, dict) else None
         return _err(fallback_id, e)
 
-    if envelope.v != 1:
+
+def _dispatch(envelope: RequestEnvelope) -> ExplainResponse | OkResponse | ErrorResponse:
+    """Route a validated envelope to its method handler.
+
+    `shutdown` is handled by the caller (main's IPC loop), not here: it needs
+    to break the read loop, which is a loop-control concern rather than a
+    per-method response to compute.
+    """
+    if envelope.protocol_version != 1:
         return ErrorResponse(
             id=envelope.id,
-            error=ErrorDetail(type="ProtocolVersionError", message=f"Expected v=1, got v={envelope.v!r}"),
+            error=ErrorDetail(
+                type="ProtocolVersionError",
+                message=f"Expected protocol_version=1, got protocol_version={envelope.protocol_version!r}",
+            ),
         )
-    if envelope.method == "ping":
+    if envelope.method == Method.PING:
         return OkResponse(id=envelope.id)
-    if envelope.method == "shutdown":
-        return OkResponse(id=envelope.id)
-    if envelope.method == "explain":
+    if envelope.method == Method.EXPLAIN:
         return _handle_explain(envelope.id, envelope.params or {})
     return ErrorResponse(
         id=envelope.id,
         error=ErrorDetail(
             type="UnknownMethod",
-            message=f"Unknown method: {envelope.method!r}. Supported: explain, ping, shutdown",
+            message=f"Unknown method: {envelope.method!r}. Supported: {', '.join(m.value for m in Method)}",
         ),
     )
 
@@ -267,14 +280,21 @@ def main(argv: list[str]) -> Literal[0, 1]:  # noqa: D103
             if not line:
                 continue
             try:
+                # Parsed as raw JSON, then separately validated into a RequestEnvelope,
+                # so malformed JSON (JSONDecodeError) and schema-invalid JSON
+                # (ValidationError) remain distinguishable error types for the caller.
                 req = json.loads(line)
             except json.JSONDecodeError as e:
                 _write(ErrorResponse(id=None, error=ErrorDetail(type="JSONDecodeError", message=str(e))))
                 continue
-            resp = _dispatch(req)
-            _write(resp)
-            if isinstance(req, dict) and req.get("method") == "shutdown":
+            envelope = _parse_envelope(req)
+            if isinstance(envelope, ErrorResponse):
+                _write(envelope)
+                continue
+            if envelope.method == Method.SHUTDOWN:
+                _write(OkResponse(id=envelope.id))
                 break
+            _write(_dispatch(envelope))
     except Exception:
         logging.exception("Uncaught error in IPC loop")
         return 1

--- a/sidecar/mf_entry.py
+++ b/sidecar/mf_entry.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""mf_entry.py — MetricFlow IPC entry point for the Nuitka sidecar.
+
+Compiled by Nuitka into a standalone binary for use as a general sidecar
+as a subprocess. Communicates via NDJSON over stdin/stdout (mf-ipc v1).
+
+Protocol v1:
+  ready:    {"status":"ready","metricflow_version":"X","python_version":"X","protocol_version":1}
+  explain:  {"id":"...","method":"explain","v":1,"params":{
+                "manifest_path":"...","metric_names":[...],"group_by_names":[...],
+                "where_constraints":null,"order_by_names":null,"limit":null,"sql_engine":"DUCKDB"
+            }} → {"id":"...","ok":true,"sql":"..."}
+  ping:     {"id":"...","method":"ping","v":1} → {"id":"...","ok":true}
+  shutdown: {"id":"...","method":"shutdown","v":1} → {"id":"...","ok":true}
+  error:    {"id":"...","ok":false,"error":{"type":"ExceptionClass","message":"..."}}
+
+manifest_path may be a YAML directory (dev/testing) or a manifest.json file (production).
+sql_engine must be a SqlEngine enum name: DUCKDB, BIGQUERY, DATABRICKS, POSTGRES, REDSHIFT,
+SNOWFLAKE, or TRINO.
+"""
+from __future__ import annotations
+
+import argparse
+import importlib.metadata
+import json
+import logging
+import os
+import signal
+import sys
+import traceback as _traceback
+import types
+from pathlib import Path
+from typing import IO
+
+from metricflow_semantics.model.semantic_manifest_lookup import SemanticManifestLookup
+from metricflow_semantics.sql.sql_bind_parameters import SqlBindParameterSet
+from metricflow_semantics.test_helpers.manifest_helpers import (
+    mf_load_manifest_from_json_file,
+    mf_load_manifest_from_yaml_directory,
+)
+
+from metricflow.data_table.mf_table import MetricFlowDataTable
+from metricflow.engine.metricflow_engine import MetricFlowEngine, MetricFlowQueryRequest
+from metricflow.protocols.sql_client import SqlEngine
+from metricflow.sql.render.big_query import BigQuerySqlPlanRenderer
+from metricflow.sql.render.databricks import DatabricksSqlPlanRenderer
+from metricflow.sql.render.duckdb_renderer import DuckDbSqlPlanRenderer
+from metricflow.sql.render.postgres import PostgresSQLSqlPlanRenderer
+from metricflow.sql.render.redshift import RedshiftSqlPlanRenderer
+from metricflow.sql.render.snowflake import SnowflakeSqlPlanRenderer
+from metricflow.sql.render.sql_plan_renderer import SqlPlanRenderer
+from metricflow.sql.render.trino import TrinoSqlPlanRenderer
+from metricflow_semantic_interfaces.implementations.semantic_manifest import PydanticSemanticManifest
+
+try:
+    _MF_VERSION = importlib.metadata.version("metricflow")
+except Exception:
+    _MF_VERSION = "unknown"
+
+_ipc: IO[str] = sys.stdout  # replaced by main() before first write
+_debug: bool = False
+_cached: tuple[str, float, SqlEngine, MetricFlowEngine] | None = None
+
+
+class _SqlClientStub:
+    """Minimal SqlClient satisfying the Protocol for explain() only.
+
+    explain() compiles SQL but never executes it. MetricFlowEngine needs
+    sql_engine_type (for feature-gating) and sql_plan_renderer (for dialect SQL).
+    All execution methods raise to make accidental execution obvious.
+    """
+
+    def __init__(self, engine: SqlEngine) -> None:
+        self._engine = engine
+        self._renderer = _renderer_for(engine)
+
+    @property
+    def sql_engine_type(self) -> SqlEngine:
+        return self._engine
+
+    @property
+    def sql_plan_renderer(self) -> SqlPlanRenderer:
+        return self._renderer
+
+    def query(
+        self, stmt: str, sql_bind_parameter_set: SqlBindParameterSet = SqlBindParameterSet()
+    ) -> MetricFlowDataTable:
+        raise NotImplementedError("IPC stub does not execute SQL")
+
+    def execute(self, stmt: str, sql_bind_parameter_set: SqlBindParameterSet = SqlBindParameterSet()) -> None:
+        raise NotImplementedError("IPC stub does not execute SQL")
+
+    def dry_run(self, stmt: str, sql_bind_parameter_set: SqlBindParameterSet = SqlBindParameterSet()) -> None:
+        raise NotImplementedError("IPC stub does not execute SQL")
+
+    def close(self) -> None:
+        pass
+
+    def render_bind_parameter_key(self, k: str) -> str:
+        return f":{k}"
+
+
+def _renderer_for(engine: SqlEngine) -> SqlPlanRenderer:
+    match engine:
+        case SqlEngine.DUCKDB:
+            return DuckDbSqlPlanRenderer()
+        case SqlEngine.BIGQUERY:
+            return BigQuerySqlPlanRenderer()
+        case SqlEngine.DATABRICKS:
+            return DatabricksSqlPlanRenderer()
+        case SqlEngine.POSTGRES:
+            return PostgresSQLSqlPlanRenderer()
+        case SqlEngine.REDSHIFT:
+            return RedshiftSqlPlanRenderer()
+        case SqlEngine.SNOWFLAKE:
+            return SnowflakeSqlPlanRenderer()
+        case SqlEngine.TRINO:
+            return TrinoSqlPlanRenderer()
+        case _:
+            raise ValueError(f"No renderer for engine: {engine!r}")
+
+
+def _load_manifest(path: str) -> PydanticSemanticManifest:
+    p = Path(path)
+    if p.is_dir():
+        return mf_load_manifest_from_yaml_directory(p, {"source_schema": "production"})
+    return mf_load_manifest_from_json_file(p)
+
+
+def _get_engine(manifest_path: str, sql_engine: SqlEngine) -> MetricFlowEngine:
+    global _cached
+    mtime = os.path.getmtime(manifest_path)
+    if _cached and _cached[:3] == (manifest_path, mtime, sql_engine):
+        return _cached[3]
+    manifest = _load_manifest(manifest_path)
+    lookup = SemanticManifestLookup(manifest)
+    engine = MetricFlowEngine(lookup, _SqlClientStub(sql_engine))  # type: ignore[arg-type]
+    _cached = (manifest_path, mtime, sql_engine, engine)
+    return engine
+
+
+def _write(obj: dict) -> None:
+    try:
+        _ipc.write(json.dumps(obj) + "\n")
+        _ipc.flush()
+    except BrokenPipeError:
+        logging.warning("IPC pipe broken; exiting")
+        sys.exit(0)
+
+
+def _err(req_id: str | int | None, exc: Exception) -> dict:
+    error: dict[str, str] = {"type": type(exc).__name__, "message": str(exc)}
+    if _debug:
+        error["traceback"] = _traceback.format_exc()
+    return {"id": req_id, "ok": False, "error": error}
+
+
+def _handle_explain(req_id: str | int | None, params: dict) -> dict:
+    try:
+        manifest_path = params["manifest_path"]
+        sql_engine = SqlEngine[params.get("sql_engine", "DUCKDB")]
+        engine = _get_engine(manifest_path, sql_engine)
+        request = MetricFlowQueryRequest.create(
+            metric_names=params.get("metric_names"),
+            group_by_names=params.get("group_by_names"),
+            where_constraints=params.get("where_constraints"),
+            order_by_names=params.get("order_by_names"),
+            limit=params.get("limit"),
+        )
+        result = engine.explain(request)
+        return {"id": req_id, "ok": True, "sql": result.sql_statement.sql}
+    except Exception as e:
+        return _err(req_id, e)
+
+
+def _dispatch(req: dict) -> dict:
+    req_id = req.get("id")
+    method = req.get("method")
+    v = req.get("v", 1)
+    if v != 1:
+        return {
+            "id": req_id,
+            "ok": False,
+            "error": {"type": "ProtocolVersionError", "message": f"Expected v=1, got v={v!r}"},
+        }
+    if method == "ping":
+        return {"id": req_id, "ok": True}
+    if method == "shutdown":
+        return {"id": req_id, "ok": True}
+    if method == "explain":
+        return _handle_explain(req_id, req.get("params") or {})
+    return {
+        "id": req_id,
+        "ok": False,
+        "error": {
+            "type": "UnknownMethod",
+            "message": f"Unknown method: {method!r}. Supported: explain, ping, shutdown",
+        },
+    }
+
+
+def main(argv: list[str]) -> int:  # noqa: D103
+    global _ipc, _debug
+
+    parser = argparse.ArgumentParser(description="MetricFlow IPC entry point (mf-ipc v1)")
+    parser.add_argument("--manifest-path", help="Pre-load manifest before sending the ready message")
+    parser.add_argument("--sql-engine", default="DUCKDB", help="SQL engine for pre-warming (default: DUCKDB)")
+    parser.add_argument("--debug", action="store_true", help="Verbose logging and tracebacks in error responses")
+    parser.add_argument("--version", action="store_true", help="Print version and exit")
+    args = parser.parse_args(argv)
+
+    if args.version:
+        sys.stdout.write(f"mf_entry {_MF_VERSION} (mf-ipc v1)\n")
+        return 0
+
+    _debug = args.debug
+
+    # Protect the IPC channel: save real stdout, redirect print()/logging to stderr.
+    # Any library that calls print() will write to stderr rather than corrupting the
+    # NDJSON framing on the pipe the caller is reading.
+    _ipc = sys.stdout
+    sys.stdout = sys.stderr
+
+    logging.basicConfig(
+        stream=sys.stderr,
+        level=logging.DEBUG if _debug else logging.WARNING,
+        format="%(asctime)s %(levelname)s %(message)s",
+    )
+
+    def _exit_clean(signum: int, frame: types.FrameType | None) -> None:
+        _ipc.flush()
+        sys.exit(0)
+
+    signal.signal(signal.SIGTERM, _exit_clean)
+    signal.signal(signal.SIGINT, _exit_clean)
+
+    if args.manifest_path:
+        try:
+            _get_engine(args.manifest_path, SqlEngine[args.sql_engine])
+        except Exception as e:
+            _ipc.write(json.dumps({"status": "error", "type": type(e).__name__, "message": str(e)}) + "\n")
+            _ipc.flush()
+            return 1
+
+    _write(
+        {
+            "status": "ready",
+            "metricflow_version": _MF_VERSION,
+            "python_version": sys.version.split()[0],
+            "protocol_version": 1,
+        }
+    )
+
+    try:
+        for line in sys.stdin:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                req = json.loads(line)
+            except json.JSONDecodeError as e:
+                _write({"id": None, "ok": False, "error": {"type": "JSONDecodeError", "message": str(e)}})
+                continue
+            resp = _dispatch(req)
+            _write(resp)
+            if req.get("method") == "shutdown":
+                break
+    except Exception:
+        logging.exception("Uncaught error in IPC loop")
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/sidecar/mf_ipc_protocol.py
+++ b/sidecar/mf_ipc_protocol.py
@@ -1,0 +1,102 @@
+"""Pydantic models for the mf-ipc v1 wire protocol.
+
+These give the IPC boundary between Fusion and the MetricFlow sidecar request/
+response validation and a single typed source of truth for the message
+shapes documented in sidecar/README.md — without changing the wire format
+itself. Messages are still NDJSON dicts; these models parse and construct
+them.
+
+This is intentionally minimal: it does not introduce a schema artifact,
+codegen, or cross-repo drift protection. That heavier structured-contract
+work (evaluating gRPC/protobuf, or a JSON Schema shared with Fusion) is
+tracked separately in DI-4709.
+"""
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel
+
+RequestId = str | int | None
+
+
+class ReadyMessage(BaseModel):
+    """Startup handshake, written once before any request is read from stdin."""
+
+    status: Literal["ready"] = "ready"
+    metricflow_version: str
+    python_version: str
+    protocol_version: Literal[1] = 1
+
+
+class StartupErrorMessage(BaseModel):
+    """Written instead of ReadyMessage if --manifest-path pre-loading fails."""
+
+    status: Literal["error"] = "error"
+    type: str
+    message: str
+
+
+class RequestEnvelope(BaseModel):
+    """Generic shape every request must have, validated before method dispatch.
+
+    `method` and `v` are intentionally left unconstrained (not Literal) here:
+    an unknown method or a protocol version other than 1 is a valid, expected
+    input that must reach _dispatch's own UnknownMethod / ProtocolVersionError
+    handling, not fail at the envelope-parsing stage.
+    """
+
+    id: RequestId = None
+    method: str | None = None
+    v: int = 1
+    params: dict | None = None
+
+
+class ExplainParams(BaseModel):
+    """Params for the `explain` method.
+
+    sql_engine is intentionally a plain string, not the SqlEngine enum:
+    mf_entry.py looks it up by enum *member name* (SqlEngine["DUCKDB"]), not
+    by enum value (SqlEngine.DUCKDB.value == "DuckDB"). Typing this field as
+    SqlEngine directly would make pydantic validate against enum values
+    instead, silently changing which strings are accepted over the wire.
+    """
+
+    manifest_path: str
+    metric_names: list[str] | None = None
+    group_by_names: list[str] | None = None
+    where_constraints: list[str] | None = None
+    order_by_names: list[str] | None = None
+    limit: int | None = None
+    sql_engine: str = "DUCKDB"
+
+
+class ErrorDetail(BaseModel):
+    """The `error` payload of an ErrorResponse."""
+
+    type: str
+    message: str
+    traceback: str | None = None
+
+
+class ErrorResponse(BaseModel):
+    """Response shape for any request that fails, regardless of method."""
+
+    id: RequestId
+    ok: Literal[False] = False
+    error: ErrorDetail
+
+
+class OkResponse(BaseModel):
+    """Response for `ping` / `shutdown` — ok:true with no extra payload."""
+
+    id: RequestId
+    ok: Literal[True] = True
+
+
+class ExplainResponse(BaseModel):
+    """Successful response for the `explain` method."""
+
+    id: RequestId
+    ok: Literal[True] = True
+    sql: str

--- a/sidecar/mf_ipc_protocol.py
+++ b/sidecar/mf_ipc_protocol.py
@@ -13,14 +13,34 @@ tracked separately in DI-4709.
 """
 from __future__ import annotations
 
+from enum import Enum
 from typing import Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 RequestId = str | int | None
 
 
-class ReadyMessage(BaseModel):
+class Method(str, Enum):
+    """Method names recognized by _dispatch.
+
+    RequestEnvelope.method stays a plain `str | None` (not this enum): an
+    unrecognized method is a valid, expected input that must reach
+    _dispatch's own UnknownMethod handling, not fail at parse time.
+    """
+
+    EXPLAIN = "explain"
+    PING = "ping"
+    SHUTDOWN = "shutdown"
+
+
+class _FrozenModel(BaseModel):
+    """Base for all mf-ipc messages: parsed or built once, then only read."""
+
+    model_config = ConfigDict(frozen=True)
+
+
+class ReadyMessage(_FrozenModel):
     """Startup handshake, written once before any request is read from stdin."""
 
     status: Literal["ready"] = "ready"
@@ -29,7 +49,7 @@ class ReadyMessage(BaseModel):
     protocol_version: Literal[1] = 1
 
 
-class StartupErrorMessage(BaseModel):
+class StartupErrorMessage(_FrozenModel):
     """Written instead of ReadyMessage if --manifest-path pre-loading fails."""
 
     status: Literal["error"] = "error"
@@ -37,22 +57,28 @@ class StartupErrorMessage(BaseModel):
     message: str
 
 
-class RequestEnvelope(BaseModel):
+class RequestEnvelope(_FrozenModel):
     """Generic shape every request must have, validated before method dispatch.
 
-    `method` and `v` are intentionally left unconstrained (not Literal) here:
-    an unknown method or a protocol version other than 1 is a valid, expected
-    input that must reach _dispatch's own UnknownMethod / ProtocolVersionError
-    handling, not fail at the envelope-parsing stage.
+    `id` is required: the IPC loop writes exactly one response per request
+    line, so there is no fire-and-forget "notification" case that would
+    justify defaulting it. A request missing `id` fails validation here and
+    surfaces to the caller as a structured error (itself with id=None, since
+    there's no id to echo back) rather than silently proceeding.
+
+    `method` and `protocol_version` are intentionally left unconstrained (not
+    Literal) here: an unknown method or a protocol version other than 1 is a
+    valid, expected input that must reach _dispatch's own UnknownMethod /
+    ProtocolVersionError handling, not fail at the envelope-parsing stage.
     """
 
-    id: RequestId = None
+    id: RequestId
     method: str | None = None
-    v: int = 1
+    protocol_version: int = 1
     params: dict | None = None
 
 
-class ExplainParams(BaseModel):
+class ExplainParams(_FrozenModel):
     """Params for the `explain` method.
 
     sql_engine is intentionally a plain string, not the SqlEngine enum:
@@ -63,15 +89,15 @@ class ExplainParams(BaseModel):
     """
 
     manifest_path: str
-    metric_names: list[str] | None = None
-    group_by_names: list[str] | None = None
-    where_constraints: list[str] | None = None
-    order_by_names: list[str] | None = None
+    metric_names: tuple[str, ...] | None = None
+    group_by_names: tuple[str, ...] | None = None
+    where_constraints: tuple[str, ...] | None = None
+    order_by_names: tuple[str, ...] | None = None
     limit: int | None = None
     sql_engine: str = "DUCKDB"
 
 
-class ErrorDetail(BaseModel):
+class ErrorDetail(_FrozenModel):
     """The `error` payload of an ErrorResponse."""
 
     type: str
@@ -79,7 +105,7 @@ class ErrorDetail(BaseModel):
     traceback: str | None = None
 
 
-class ErrorResponse(BaseModel):
+class ErrorResponse(_FrozenModel):
     """Response shape for any request that fails, regardless of method."""
 
     id: RequestId
@@ -87,14 +113,14 @@ class ErrorResponse(BaseModel):
     error: ErrorDetail
 
 
-class OkResponse(BaseModel):
+class OkResponse(_FrozenModel):
     """Response for `ping` / `shutdown` — ok:true with no extra payload."""
 
     id: RequestId
     ok: Literal[True] = True
 
 
-class ExplainResponse(BaseModel):
+class ExplainResponse(_FrozenModel):
     """Successful response for the `explain` method."""
 
     id: RequestId

--- a/sidecar/mf_ipc_protocol.py
+++ b/sidecar/mf_ipc_protocol.py
@@ -19,6 +19,14 @@ from typing import Literal
 from pydantic import BaseModel, ConfigDict
 
 RequestId = str | int | None
+"""The `id` carried on a response, or a fallback used while building one.
+
+None specifically means "no request to attribute this response to": either
+the incoming line wasn't valid JSON at all, or it failed RequestEnvelope
+validation (including a missing `id`). It is never produced by echoing a
+validated request's own id, because RequestEnvelope.id itself excludes None
+— see RequestEnvelope's docstring.
+"""
 
 
 class Method(str, Enum):
@@ -60,9 +68,11 @@ class StartupErrorMessage(_FrozenModel):
 class RequestEnvelope(_FrozenModel):
     """Generic shape every request must have, validated before method dispatch.
 
-    `id` is required: the IPC loop writes exactly one response per request
-    line, so there is no fire-and-forget "notification" case that would
-    justify defaulting it. A request missing `id` fails validation here and
+    `id` is required and typed `str | int` (not RequestId): the IPC loop
+    writes exactly one response per request line, so there is no
+    fire-and-forget "notification" case that would justify a default, and
+    excluding None means an explicit `"id": null` is rejected the same way
+    as an absent `id` key. Either way, the request fails validation here and
     surfaces to the caller as a structured error (itself with id=None, since
     there's no id to echo back) rather than silently proceeding.
 
@@ -72,7 +82,7 @@ class RequestEnvelope(_FrozenModel):
     ProtocolVersionError handling, not fail at the envelope-parsing stage.
     """
 
-    id: RequestId
+    id: str | int
     method: str | None = None
     protocol_version: int = 1
     params: dict | None = None

--- a/sidecar/tests/test_mf_entry.py
+++ b/sidecar/tests/test_mf_entry.py
@@ -123,14 +123,14 @@ def test_null_id_returns_structured_error(sidecar: subprocess.Popen) -> None:  #
 
 
 def test_malformed_json(sidecar: subprocess.Popen) -> None:  # type: ignore[type-arg]
-    """A non-JSON line returns ok:false with id:null and JSONDecodeError."""
+    """A non-JSON line returns ok:false with id:null and ValidationError."""
     assert sidecar.stdin is not None and sidecar.stdout is not None
     sidecar.stdin.write("not valid json\n")
     sidecar.stdin.flush()
     resp = json.loads(sidecar.stdout.readline())
     assert resp["id"] is None
     assert resp["ok"] is False
-    assert resp["error"]["type"] == "JSONDecodeError"
+    assert resp["error"]["type"] == "ValidationError"
 
 
 def test_shutdown_exits_zero() -> None:

--- a/sidecar/tests/test_mf_entry.py
+++ b/sidecar/tests/test_mf_entry.py
@@ -11,18 +11,24 @@ import sys
 from collections.abc import Iterator
 from pathlib import Path
 
+import mf_entry
 import pytest
+from metricflow_semantics.test_helpers.semantic_manifest_yamls.sg_00_minimal_manifest import SG_00_MINIMAL_MANIFEST
+from mf_ipc_protocol import ExplainParams, Method, RequestEnvelope
 
-_REPO_ROOT = Path(__file__).parent.parent.parent
-_MF_ENTRY = _REPO_ROOT / "sidecar" / "mf_entry.py"
-_MANIFEST_DIR = (
-    _REPO_ROOT / "metricflow_semantics" / "test_helpers" / "semantic_manifest_yamls" / "sg_00_minimal_manifest"
-)
+_MF_ENTRY = Path(mf_entry.__file__)
+_MANIFEST_DIR = SG_00_MINIMAL_MANIFEST.directory
 
 
-def _send(proc: subprocess.Popen, req: dict) -> dict:  # type: ignore[type-arg]
+def _send(proc: subprocess.Popen, req: RequestEnvelope | dict) -> dict:  # type: ignore[type-arg]
+    """Send a request and return the decoded response.
+
+    Accepts a raw dict (in addition to RequestEnvelope) so tests can send
+    envelopes that wouldn't validate, e.g. one missing the now-required id.
+    """
     assert proc.stdin is not None and proc.stdout is not None
-    proc.stdin.write(json.dumps(req) + "\n")
+    body = req.model_dump_json() if isinstance(req, RequestEnvelope) else json.dumps(req)
+    proc.stdin.write(body + "\n")
     proc.stdin.flush()
     return json.loads(proc.stdout.readline())
 
@@ -41,8 +47,7 @@ def sidecar() -> Iterator[subprocess.Popen[str]]:
     assert ready["status"] == "ready", f"Expected ready, got: {ready}"
     yield proc
     try:
-        proc.stdin.write(json.dumps({"id": "teardown", "method": "shutdown", "v": 1}) + "\n")  # type: ignore[union-attr]
-        proc.stdin.flush()  # type: ignore[union-attr]
+        _send(proc, RequestEnvelope(id="teardown", method=Method.SHUTDOWN.value))
         proc.wait(timeout=10)
     except Exception:
         proc.kill()
@@ -55,26 +60,19 @@ def test_ready_message_fields(sidecar: subprocess.Popen) -> None:  # type: ignor
 
 def test_ping(sidecar: subprocess.Popen) -> None:  # type: ignore[type-arg]
     """Ping returns ok:true with the matching request id."""
-    resp = _send(sidecar, {"id": "ping-1", "method": "ping", "v": 1})
+    resp = _send(sidecar, RequestEnvelope(id="ping-1", method=Method.PING.value))
     assert resp == {"id": "ping-1", "ok": True}
 
 
 def test_explain_returns_sql(sidecar: subprocess.Popen) -> None:  # type: ignore[type-arg]
     """Explain returns ok:true with a non-empty SQL string containing the metric name."""
-    resp = _send(
-        sidecar,
-        {
-            "id": "explain-1",
-            "method": "explain",
-            "v": 1,
-            "params": {
-                "manifest_path": str(_MANIFEST_DIR),
-                "metric_names": ["bookings"],
-                "group_by_names": ["metric_time"],
-                "sql_engine": "DUCKDB",
-            },
-        },
+    params = ExplainParams(
+        manifest_path=str(_MANIFEST_DIR),
+        metric_names=["bookings"],
+        group_by_names=["metric_time"],
+        sql_engine="DUCKDB",
     )
+    resp = _send(sidecar, RequestEnvelope(id="explain-1", method=Method.EXPLAIN.value, params=params.model_dump()))
     assert resp["id"] == "explain-1"
     assert resp["ok"] is True
     assert "SELECT" in resp["sql"]
@@ -83,19 +81,8 @@ def test_explain_returns_sql(sidecar: subprocess.Popen) -> None:  # type: ignore
 
 def test_explain_invalid_metric_returns_structured_error(sidecar: subprocess.Popen) -> None:  # type: ignore[type-arg]
     """Explain with an unknown metric name returns ok:false with InvalidQueryException."""
-    resp = _send(
-        sidecar,
-        {
-            "id": "explain-2",
-            "method": "explain",
-            "v": 1,
-            "params": {
-                "manifest_path": str(_MANIFEST_DIR),
-                "metric_names": ["nonexistent_metric"],
-                "sql_engine": "DUCKDB",
-            },
-        },
-    )
+    params = ExplainParams(manifest_path=str(_MANIFEST_DIR), metric_names=["nonexistent_metric"], sql_engine="DUCKDB")
+    resp = _send(sidecar, RequestEnvelope(id="explain-2", method=Method.EXPLAIN.value, params=params.model_dump()))
     assert resp["id"] == "explain-2"
     assert resp["ok"] is False
     assert resp["error"]["type"] == "InvalidQueryException"
@@ -104,7 +91,7 @@ def test_explain_invalid_metric_returns_structured_error(sidecar: subprocess.Pop
 
 def test_unknown_method(sidecar: subprocess.Popen) -> None:  # type: ignore[type-arg]
     """An unrecognised method name returns ok:false with UnknownMethod."""
-    resp = _send(sidecar, {"id": "unk-1", "method": "does_not_exist", "v": 1})
+    resp = _send(sidecar, RequestEnvelope(id="unk-1", method="does_not_exist"))
     assert resp["id"] == "unk-1"
     assert resp["ok"] is False
     assert resp["error"]["type"] == "UnknownMethod"
@@ -112,11 +99,19 @@ def test_unknown_method(sidecar: subprocess.Popen) -> None:  # type: ignore[type
 
 
 def test_wrong_protocol_version(sidecar: subprocess.Popen) -> None:  # type: ignore[type-arg]
-    """A request with v!=1 returns ok:false with ProtocolVersionError."""
-    resp = _send(sidecar, {"id": "ver-1", "method": "ping", "v": 99})
+    """A request with protocol_version!=1 returns ok:false with ProtocolVersionError."""
+    resp = _send(sidecar, RequestEnvelope(id="ver-1", method=Method.PING.value, protocol_version=99))
     assert resp["id"] == "ver-1"
     assert resp["ok"] is False
     assert resp["error"]["type"] == "ProtocolVersionError"
+
+
+def test_missing_id_returns_structured_error(sidecar: subprocess.Popen) -> None:  # type: ignore[type-arg]
+    """A request without an id fails RequestEnvelope validation; the error id falls back to None."""
+    resp = _send(sidecar, {"method": Method.PING.value, "protocol_version": 1})
+    assert resp["id"] is None
+    assert resp["ok"] is False
+    assert "id" in resp["error"]["message"]
 
 
 def test_malformed_json(sidecar: subprocess.Popen) -> None:  # type: ignore[type-arg]
@@ -140,7 +135,7 @@ def test_shutdown_exits_zero() -> None:
     )
     assert proc.stdout is not None and proc.stdin is not None
     json.loads(proc.stdout.readline())  # consume ready
-    resp = _send(proc, {"id": "shut-1", "method": "shutdown", "v": 1})
+    resp = _send(proc, RequestEnvelope(id="shut-1", method=Method.SHUTDOWN.value))
     assert resp == {"id": "shut-1", "ok": True}
     proc.wait(timeout=5)
     assert proc.returncode == 0

--- a/sidecar/tests/test_mf_entry.py
+++ b/sidecar/tests/test_mf_entry.py
@@ -114,6 +114,14 @@ def test_missing_id_returns_structured_error(sidecar: subprocess.Popen) -> None:
     assert "id" in resp["error"]["message"]
 
 
+def test_null_id_returns_structured_error(sidecar: subprocess.Popen) -> None:  # type: ignore[type-arg]
+    """A request with an explicit null id fails RequestEnvelope validation the same as a missing one."""
+    resp = _send(sidecar, {"id": None, "method": Method.PING.value, "protocol_version": 1})
+    assert resp["id"] is None
+    assert resp["ok"] is False
+    assert "id" in resp["error"]["message"]
+
+
 def test_malformed_json(sidecar: subprocess.Popen) -> None:  # type: ignore[type-arg]
     """A non-JSON line returns ok:false with id:null and JSONDecodeError."""
     assert sidecar.stdin is not None and sidecar.stdout is not None

--- a/sidecar/tests/test_mf_entry.py
+++ b/sidecar/tests/test_mf_entry.py
@@ -1,0 +1,161 @@
+"""Subprocess integration tests for sidecar/mf_entry.py (mf-ipc v1).
+
+Each test communicates with a real mf_entry.py process over stdin/stdout,
+mirroring exactly how dbt-core v2 uses the sidecar.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).parent.parent.parent
+_MF_ENTRY = _REPO_ROOT / "poc" / "mf_entry.py"
+_MANIFEST_DIR = (
+    _REPO_ROOT / "metricflow_semantics" / "test_helpers" / "semantic_manifest_yamls" / "sg_00_minimal_manifest"
+)
+
+
+def _send(proc: subprocess.Popen, req: dict) -> dict:  # type: ignore[type-arg]
+    assert proc.stdin is not None and proc.stdout is not None
+    proc.stdin.write(json.dumps(req) + "\n")
+    proc.stdin.flush()
+    return json.loads(proc.stdout.readline())
+
+
+@pytest.fixture(scope="module")
+def sidecar() -> Iterator[subprocess.Popen[str]]:
+    """Spawns mf_entry.py pre-warmed with the test manifest; shared across the module."""
+    proc = subprocess.Popen(
+        [sys.executable, str(_MF_ENTRY), "--manifest-path", str(_MANIFEST_DIR)],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    ready = json.loads(proc.stdout.readline())  # type: ignore[union-attr]
+    assert ready["status"] == "ready", f"Expected ready, got: {ready}"
+    yield proc
+    try:
+        proc.stdin.write(json.dumps({"id": "teardown", "method": "shutdown", "v": 1}) + "\n")  # type: ignore[union-attr]
+        proc.stdin.flush()  # type: ignore[union-attr]
+        proc.wait(timeout=10)
+    except Exception:
+        proc.kill()
+
+
+def test_ready_message_fields(sidecar: subprocess.Popen) -> None:  # type: ignore[type-arg]
+    """Ready message must include version and protocol fields; process must be alive."""
+    assert sidecar.poll() is None  # still running
+
+
+def test_ping(sidecar: subprocess.Popen) -> None:  # type: ignore[type-arg]
+    """Ping returns ok:true with the matching request id."""
+    resp = _send(sidecar, {"id": "ping-1", "method": "ping", "v": 1})
+    assert resp == {"id": "ping-1", "ok": True}
+
+
+def test_explain_returns_sql(sidecar: subprocess.Popen) -> None:  # type: ignore[type-arg]
+    """Explain returns ok:true with a non-empty SQL string containing the metric name."""
+    resp = _send(
+        sidecar,
+        {
+            "id": "explain-1",
+            "method": "explain",
+            "v": 1,
+            "params": {
+                "manifest_path": str(_MANIFEST_DIR),
+                "metric_names": ["bookings"],
+                "group_by_names": ["metric_time"],
+                "sql_engine": "DUCKDB",
+            },
+        },
+    )
+    assert resp["id"] == "explain-1"
+    assert resp["ok"] is True
+    assert "SELECT" in resp["sql"]
+    assert "bookings" in resp["sql"].lower()
+
+
+def test_explain_invalid_metric_returns_structured_error(sidecar: subprocess.Popen) -> None:  # type: ignore[type-arg]
+    """Explain with an unknown metric name returns ok:false with InvalidQueryException."""
+    resp = _send(
+        sidecar,
+        {
+            "id": "explain-2",
+            "method": "explain",
+            "v": 1,
+            "params": {
+                "manifest_path": str(_MANIFEST_DIR),
+                "metric_names": ["nonexistent_metric"],
+                "sql_engine": "DUCKDB",
+            },
+        },
+    )
+    assert resp["id"] == "explain-2"
+    assert resp["ok"] is False
+    assert resp["error"]["type"] == "InvalidQueryException"
+    assert "nonexistent_metric" in resp["error"]["message"]
+
+
+def test_unknown_method(sidecar: subprocess.Popen) -> None:  # type: ignore[type-arg]
+    """An unrecognised method name returns ok:false with UnknownMethod."""
+    resp = _send(sidecar, {"id": "unk-1", "method": "does_not_exist", "v": 1})
+    assert resp["id"] == "unk-1"
+    assert resp["ok"] is False
+    assert resp["error"]["type"] == "UnknownMethod"
+    assert "explain" in resp["error"]["message"]
+
+
+def test_wrong_protocol_version(sidecar: subprocess.Popen) -> None:  # type: ignore[type-arg]
+    """A request with v!=1 returns ok:false with ProtocolVersionError."""
+    resp = _send(sidecar, {"id": "ver-1", "method": "ping", "v": 99})
+    assert resp["id"] == "ver-1"
+    assert resp["ok"] is False
+    assert resp["error"]["type"] == "ProtocolVersionError"
+
+
+def test_malformed_json(sidecar: subprocess.Popen) -> None:  # type: ignore[type-arg]
+    """A non-JSON line returns ok:false with id:null and JSONDecodeError."""
+    assert sidecar.stdin is not None and sidecar.stdout is not None
+    sidecar.stdin.write("not valid json\n")
+    sidecar.stdin.flush()
+    resp = json.loads(sidecar.stdout.readline())
+    assert resp["id"] is None
+    assert resp["ok"] is False
+    assert resp["error"]["type"] == "JSONDecodeError"
+
+
+def test_shutdown_exits_zero() -> None:
+    """Shutdown response is ok:true and process exits with code 0."""
+    proc = subprocess.Popen(
+        [sys.executable, str(_MF_ENTRY)],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    assert proc.stdout is not None and proc.stdin is not None
+    json.loads(proc.stdout.readline())  # consume ready
+    resp = _send(proc, {"id": "shut-1", "method": "shutdown", "v": 1})
+    assert resp == {"id": "shut-1", "ok": True}
+    proc.wait(timeout=5)
+    assert proc.returncode == 0
+
+
+def test_eof_exits_zero() -> None:
+    """Closing stdin (EOF) causes the process to exit cleanly with code 0."""
+    proc = subprocess.Popen(
+        [sys.executable, str(_MF_ENTRY)],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    assert proc.stdout is not None and proc.stdin is not None
+    json.loads(proc.stdout.readline())  # consume ready
+    proc.stdin.close()
+    proc.wait(timeout=5)
+    assert proc.returncode == 0

--- a/sidecar/tests/test_mf_entry.py
+++ b/sidecar/tests/test_mf_entry.py
@@ -14,7 +14,7 @@ from pathlib import Path
 import pytest
 
 _REPO_ROOT = Path(__file__).parent.parent.parent
-_MF_ENTRY = _REPO_ROOT / "poc" / "mf_entry.py"
+_MF_ENTRY = _REPO_ROOT / "sidecar" / "mf_entry.py"
 _MANIFEST_DIR = (
     _REPO_ROOT / "metricflow_semantics" / "test_helpers" / "semantic_manifest_yamls" / "sg_00_minimal_manifest"
 )

--- a/sidecar/tests/test_mf_ipc_protocol.py
+++ b/sidecar/tests/test_mf_ipc_protocol.py
@@ -42,6 +42,12 @@ def test_request_envelope_requires_id() -> None:
         RequestEnvelope.model_validate({})
 
 
+def test_request_envelope_rejects_null_id() -> None:
+    """The id field is typed str | int (not RequestId): an explicit null must be rejected, not just an absent key."""
+    with pytest.raises(ValidationError, match="id"):
+        RequestEnvelope.model_validate({"id": None})
+
+
 def test_request_envelope_defaults() -> None:
     """Given only id, method/params default to None and protocol_version defaults to 1."""
     envelope = RequestEnvelope.model_validate({"id": "1"})

--- a/sidecar/tests/test_mf_ipc_protocol.py
+++ b/sidecar/tests/test_mf_ipc_protocol.py
@@ -1,0 +1,96 @@
+"""Direct unit tests for sidecar/mf_ipc_protocol.py's pydantic models.
+
+Complements sidecar/tests/test_mf_entry.py's subprocess integration tests by
+testing the message shapes directly, without spawning a process for each case.
+"""
+from __future__ import annotations
+
+import pytest
+from mf_ipc_protocol import (
+    ErrorDetail,
+    ErrorResponse,
+    ExplainParams,
+    ExplainResponse,
+    OkResponse,
+    ReadyMessage,
+    RequestEnvelope,
+    StartupErrorMessage,
+)
+from pydantic import BaseModel, ValidationError
+
+
+def test_explain_params_requires_manifest_path() -> None:
+    """manifest_path has no default; omitting it must raise a field-level ValidationError."""
+    with pytest.raises(ValidationError, match="manifest_path"):
+        ExplainParams.model_validate({})
+
+
+def test_explain_params_defaults() -> None:
+    """All fields except manifest_path are optional, with sql_engine defaulting to DUCKDB."""
+    params = ExplainParams.model_validate({"manifest_path": "/some/path"})
+    assert params.sql_engine == "DUCKDB"
+    assert params.metric_names is None
+    assert params.group_by_names is None
+    assert params.where_constraints is None
+    assert params.order_by_names is None
+    assert params.limit is None
+
+
+def test_request_envelope_defaults() -> None:
+    """An empty request body still parses, with id/method/params defaulting to None and v to 1."""
+    envelope = RequestEnvelope.model_validate({})
+    assert envelope.id is None
+    assert envelope.method is None
+    assert envelope.v == 1
+    assert envelope.params is None
+
+
+def test_request_envelope_accepts_unknown_method_and_version() -> None:
+    """Unconstrained so _dispatch's own UnknownMethod/ProtocolVersionError logic can run."""
+    envelope = RequestEnvelope.model_validate({"method": "does_not_exist", "v": 99})
+    assert envelope.method == "does_not_exist"
+    assert envelope.v == 99
+
+
+def test_request_envelope_rejects_non_mapping_input() -> None:
+    """A JSON array (or any non-mapping) must raise ValidationError, not crash _dispatch."""
+    with pytest.raises(ValidationError):
+        RequestEnvelope.model_validate([1, 2, 3])
+
+
+@pytest.mark.parametrize("model_cls", [RequestEnvelope, ExplainParams])
+def test_extra_fields_are_ignored_not_rejected(model_cls: type[BaseModel]) -> None:
+    """An older MetricFlow shouldn't reject a newer Fusion's request over an unknown field."""
+    payload = {"manifest_path": "/some/path", "some_future_field": "value"}
+    model_cls.model_validate(payload)  # must not raise
+
+
+def test_ready_message_round_trips_through_json() -> None:
+    """ReadyMessage survives a model_dump_json -> model_validate_json round trip unchanged."""
+    msg = ReadyMessage(metricflow_version="0.1.0", python_version="3.11.0")
+    restored = ReadyMessage.model_validate_json(msg.model_dump_json())
+    assert restored == msg
+    assert restored.status == "ready"
+    assert restored.protocol_version == 1
+
+
+def test_startup_error_message_shape() -> None:
+    """StartupErrorMessage dumps to the exact shape documented in sidecar/README.md."""
+    msg = StartupErrorMessage(type="ValueError", message="bad manifest")
+    assert msg.model_dump() == {"status": "error", "type": "ValueError", "message": "bad manifest"}
+
+
+def test_error_response_shape() -> None:
+    """ErrorResponse dumps to the exact shape documented in sidecar/README.md."""
+    resp = ErrorResponse(id="1", error=ErrorDetail(type="UnknownMethod", message="nope"))
+    assert resp.model_dump() == {
+        "id": "1",
+        "ok": False,
+        "error": {"type": "UnknownMethod", "message": "nope", "traceback": None},
+    }
+
+
+def test_ok_and_explain_response_ok_field_is_fixed() -> None:
+    """Ok is always True on these two response types, regardless of construction order."""
+    assert OkResponse(id="1").ok is True
+    assert ExplainResponse(id="1", sql="SELECT 1").ok is True

--- a/sidecar/tests/test_mf_ipc_protocol.py
+++ b/sidecar/tests/test_mf_ipc_protocol.py
@@ -36,20 +36,26 @@ def test_explain_params_defaults() -> None:
     assert params.limit is None
 
 
+def test_request_envelope_requires_id() -> None:
+    """The id field has no default; omitting it must raise a field-level ValidationError."""
+    with pytest.raises(ValidationError, match="id"):
+        RequestEnvelope.model_validate({})
+
+
 def test_request_envelope_defaults() -> None:
-    """An empty request body still parses, with id/method/params defaulting to None and v to 1."""
-    envelope = RequestEnvelope.model_validate({})
-    assert envelope.id is None
+    """Given only id, method/params default to None and protocol_version defaults to 1."""
+    envelope = RequestEnvelope.model_validate({"id": "1"})
+    assert envelope.id == "1"
     assert envelope.method is None
-    assert envelope.v == 1
+    assert envelope.protocol_version == 1
     assert envelope.params is None
 
 
 def test_request_envelope_accepts_unknown_method_and_version() -> None:
     """Unconstrained so _dispatch's own UnknownMethod/ProtocolVersionError logic can run."""
-    envelope = RequestEnvelope.model_validate({"method": "does_not_exist", "v": 99})
+    envelope = RequestEnvelope.model_validate({"id": "1", "method": "does_not_exist", "protocol_version": 99})
     assert envelope.method == "does_not_exist"
-    assert envelope.v == 99
+    assert envelope.protocol_version == 99
 
 
 def test_request_envelope_rejects_non_mapping_input() -> None:
@@ -61,7 +67,7 @@ def test_request_envelope_rejects_non_mapping_input() -> None:
 @pytest.mark.parametrize("model_cls", [RequestEnvelope, ExplainParams])
 def test_extra_fields_are_ignored_not_rejected(model_cls: type[BaseModel]) -> None:
     """An older MetricFlow shouldn't reject a newer Fusion's request over an unknown field."""
-    payload = {"manifest_path": "/some/path", "some_future_field": "value"}
+    payload = {"id": "1", "manifest_path": "/some/path", "some_future_field": "value"}
     model_cls.model_validate(payload)  # must not raise
 
 

--- a/sidecar/validate_mf_entry.py
+++ b/sidecar/validate_mf_entry.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Validate that the Nuitka binary produces identical SQL to the Python interpreter.
+
+Sends the same explain request to both and diffs the SQL field of the response.
+Run via: hatch run nuitka-build:validate
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+_MANIFEST = "metricflow_semantics/test_helpers/semantic_manifest_yamls/sg_00_minimal_manifest"
+_INPUT = (
+    json.dumps(
+        {
+            "id": "1",
+            "method": "explain",
+            "v": 1,
+            "params": {
+                "manifest_path": _MANIFEST,
+                "metric_names": ["bookings"],
+                "group_by_names": ["metric_time"],
+                "sql_engine": "DUCKDB",
+            },
+        }
+    )
+    + "\n"
+    + json.dumps({"id": "2", "method": "shutdown", "v": 1})
+    + "\n"
+)
+
+_BIN = Path("sidecar/mf_entry.dist") / ("mf_entry.bin" if sys.platform != "win32" else "mf_entry.exe")
+
+
+def get_sql(cmd: list[str]) -> str:
+    """Run cmd, send IPC requests via stdin, return the SQL from the explain response."""
+    result = subprocess.run(cmd, input=_INPUT, capture_output=True, text=True)
+    lines = [line for line in result.stdout.splitlines() if line.strip()]
+    if len(lines) < 2:
+        raise RuntimeError(f"Unexpected output from {cmd}:\nstdout: {result.stdout}\nstderr: {result.stderr}")
+    resp = json.loads(lines[1])
+    if not resp.get("ok"):
+        raise RuntimeError(f"explain failed: {resp}")
+    return str(resp["sql"])
+
+
+if __name__ == "__main__":
+    if not _BIN.exists():
+        print(f"ERROR: binary not found at {_BIN} — run 'hatch run nuitka-build:compile' first", file=sys.stderr)
+        sys.exit(1)
+
+    print("Generating reference SQL with Python interpreter...")
+    py_sql = get_sql([sys.executable, "sidecar/mf_entry.py"])
+
+    print(f"Generating SQL with Nuitka binary ({_BIN})...")
+    bin_sql = get_sql([str(_BIN)])
+
+    if py_sql != bin_sql:
+        print("FAIL: SQL mismatch", file=sys.stderr)
+        print(f"\nPython output:\n{py_sql}", file=sys.stderr)
+        print(f"\nBinary output:\n{bin_sql}", file=sys.stderr)
+        sys.exit(1)
+
+    print("OK: Python and Nuitka binary produce identical SQL")

--- a/sidecar/validate_mf_entry.py
+++ b/sidecar/validate_mf_entry.py
@@ -17,7 +17,7 @@ _INPUT = (
         {
             "id": "1",
             "method": "explain",
-            "v": 1,
+            "protocol_version": 1,
             "params": {
                 "manifest_path": _MANIFEST,
                 "metric_names": ["bookings"],
@@ -27,7 +27,7 @@ _INPUT = (
         }
     )
     + "\n"
-    + json.dumps({"id": "2", "method": "shutdown", "v": 1})
+    + json.dumps({"id": "2", "method": "shutdown", "protocol_version": 1})
     + "\n"
 )
 


### PR DESCRIPTION
## Summary

This PR adds `sidecar/mf_entry.py`, the production inter-process communication (IPC) entry point that other applications can spawn as a subprocess and communicate with over stdin/stdout to compile metric queries to SQL. It implements the mf-ipc v1 protocol, wrapping `MetricFlowEngine.explain()` across all seven supported SQL engines.

The server is designed to run as a long-lived process. Engines are cached by `(manifest_path, mtime, sql_engine)` so repeated `explain` calls against the same manifest are cheap, with automatic invalidation when the manifest file changes. `sys.stdout` is replaced with `sys.stderr` at startup (before any library code runs) so incidental `print()` calls from MetricFlow internals can't corrupt the JSON framing when reading from pipes.

Nine subprocess integration tests cover the full protocol surface: ping, explain (happy path and error cases), unknown method, protocol version mismatch, malformed JSON, shutdown, and EOF. The test fixture spawns a real `mf_entry.py` process over stdin/stdout, no mocking of the IPC layer or MetricFlowEngine is required. The `sidecar/validate_mf_entry.py` script is a local validation helper that sends the same `explain` request to both the Python interpreter and the compiled Nuitka binary and diffs the SQL output; it's the basis for the CI validation gate that will land in a follow-on PR.

## How to try it yourself

**Run the integration tests (no compilation needed):**
```bash
hatch run dev-env:pytest sidecar/tests/test_mf_entry.py -v
```

**Interactive smoke test:**
```bash
# Ping
echo '{"id":"1","method":"ping","v":1}' | hatch run dev-env:python sidecar/mf_entry.py

# Explain (bookings metric)
MANIFEST=metricflow_semantics/test_helpers/semantic_manifest_yamls/sg_00_minimal_manifest
printf '{"id":"2","method":"explain","v":1,"params":{"manifest_path":"%s","metric_names":["bookings"],"group_by_names":["metric_time"],"sql_engine":"DUCKDB"}}\n' "$MANIFEST" \
  | hatch run dev-env:python sidecar/mf_entry.py
```

**Compile and validate the Nuitka binary** (takes ~10 min on first run):
```bash
hatch run nuitka-build:build-and-validate
```

## Protocol (mf-ipc v1)

```
ready:    {"status":"ready","metricflow_version":"X","python_version":"X","protocol_version":1}
explain:  {"id":"...","method":"explain","v":1,"params":{"manifest_path":"...","metric_names":[...],"group_by_names":[...],"sql_engine":"DUCKDB"}} → {"id":"...","ok":true,"sql":"..."}
ping:     {"id":"...","method":"ping","v":1} → {"id":"...","ok":true}
shutdown: {"id":"...","method":"shutdown","v":1} → {"id":"...","ok":true}
error:    {"id":"...","ok":false,"error":{"type":"ExceptionClass","message":"..."}}
```

`manifest_path` may be a YAML directory (dev/testing) or a `manifest.json` file (production). `sql_engine` must match a `SqlEngine` enum name: `DUCKDB`, `BIGQUERY`, `DATABRICKS`, `POSTGRES`, `REDSHIFT`, `SNOWFLAKE`, or `TRINO`.