### PR TITLE
Validate ratio/cumulative metrics reference input metrics that exist

### DIFF
--- a/.changes/unreleased/Fixes-20260618-000100.yaml
+++ b/.changes/unreleased/Fixes-20260618-000100.yaml
@@ -1,0 +1,9 @@
+kind: Fixes
+body: Validate that ratio (`numerator` / `denominator`) and cumulative (`cumulative_type_params.metric`)
+    metrics reference input metrics that exist in the manifest. Previously only derived metrics were
+    checked, so undefined references on these metric types passed validation and failed later during
+    semantic-graph construction.
+time: 2026-06-18T00:01:00.000000-07:00
+custom:
+    Author: WilliamDee
+    Issue: "2073"

--- a/metricflow_semantic_interfaces/validations/metrics.py
+++ b/metricflow_semantic_interfaces/validations/metrics.py
@@ -246,6 +246,29 @@ class DerivedMetricRule(SemanticManifestValidationRule[SemanticManifestT], Gener
         return issues
 
     @staticmethod
+    def _input_metrics_to_check_for_existence(metric: Metric) -> Sequence[MetricInput]:
+        """Return the input metrics whose existence should be validated against the manifest.
+
+        Covers derived (`type_params.metrics`), ratio (`numerator` / `denominator`), and cumulative
+        (`cumulative_type_params.metric`) input metric references. Conversion metrics are validated separately
+        in `ConversionMetricRule`, so they're excluded here to avoid emitting duplicate issues.
+        """
+        type_params = metric.type_params
+        if metric.type == MetricType.DERIVED:
+            return type_params.metrics or []
+        if metric.type == MetricType.RATIO:
+            return [
+                input_metric
+                for input_metric in (type_params.numerator, type_params.denominator)
+                if input_metric is not None
+            ]
+        if metric.type == MetricType.CUMULATIVE:
+            cumulative_type_params = type_params.cumulative_type_params
+            input_metric = cumulative_type_params.metric if cumulative_type_params is not None else None
+            return [input_metric] if input_metric is not None else []
+        return []
+
+    @staticmethod
     @validate_safely(whats_being_done="checking that the input metrics exist")
     def _validate_input_metrics_exist(semantic_manifest: SemanticManifest) -> Sequence[ValidationIssue]:
         issues: List[ValidationIssue] = []
@@ -256,24 +279,23 @@ class DerivedMetricRule(SemanticManifestValidationRule[SemanticManifestT], Gener
                 file_context=FileContext.from_metadata(metadata=metric.metadata),
                 metric=MetricModelReference(metric_name=metric.name),
             )
-            if metric.type == MetricType.DERIVED:
-                if not metric.type_params.metrics:
+            if metric.type == MetricType.DERIVED and not metric.type_params.metrics:
+                issues.append(
+                    ValidationError(
+                        context=metric_context,
+                        message=f"No input metrics found for derived metric '{metric.name}'. "
+                        "Please add metrics to type_params.metrics.",
+                    )
+                )
+            for input_metric in DerivedMetricRule._input_metrics_to_check_for_existence(metric):
+                if input_metric.name not in all_metrics:
                     issues.append(
                         ValidationError(
                             context=metric_context,
-                            message=f"No input metrics found for derived metric '{metric.name}'. "
-                            "Please add metrics to type_params.metrics.",
+                            message=f"For metric: {metric.name}, input metric: '{input_metric.name}' does not "
+                            "exist as a configured metric in the model.",
                         )
                     )
-                for input_metric in metric.type_params.metrics or []:
-                    if input_metric.name not in all_metrics:
-                        issues.append(
-                            ValidationError(
-                                context=metric_context,
-                                message=f"For metric: {metric.name}, input metric: '{input_metric.name}' does not "
-                                "exist as a configured metric in the model.",
-                            )
-                        )
         return issues
 
     @staticmethod

--- a/tests_metricflow_semantic_interfaces/validations/test_metrics.py
+++ b/tests_metricflow_semantic_interfaces/validations/test_metrics.py
@@ -1103,6 +1103,70 @@ def test_derived_metric() -> None:  # noqa: D103
     check_error_in_issues(error_substrings=expected_substrings, issues=build_issues)
 
 
+def test_input_metrics_exist_for_ratio_and_cumulative_metrics() -> None:
+    """Ratio and cumulative metrics referencing an undefined input metric are flagged during validation.
+
+    Previously `_validate_input_metrics_exist` only covered derived metrics, so these references could slip
+    through validation and fail later (with an opaque error) during semantic-graph construction.
+    """
+    measure_name = "foo"
+    model_validator = SemanticManifestValidator[PydanticSemanticManifest]([DerivedMetricRule()])
+    validation_results = model_validator.validate_semantic_manifest(
+        PydanticSemanticManifest(
+            semantic_models=[
+                semantic_model_with_guaranteed_meta(
+                    name="sum_measure",
+                    measures=[
+                        PydanticMeasure(name=measure_name, agg=AggregationType.SUM, agg_time_dimension="ds"),
+                    ],
+                    dimensions=[
+                        PydanticDimension(
+                            name="ds",
+                            type=DimensionType.TIME,
+                            type_params=PydanticDimensionTypeParams(time_granularity=TimeGranularity.DAY),
+                        ),
+                    ],
+                ),
+            ],
+            metrics=[
+                metric_with_guaranteed_meta(
+                    name="existing_metric",
+                    type=MetricType.SIMPLE,
+                    type_params=PydanticMetricTypeParams(measure=PydanticMetricInputMeasure(name=measure_name)),
+                ),
+                metric_with_guaranteed_meta(
+                    name="ratio_with_missing_denominator",
+                    type=MetricType.RATIO,
+                    type_params=PydanticMetricTypeParams(
+                        numerator=PydanticMetricInput(name="existing_metric"),
+                        denominator=PydanticMetricInput(name="missing_denominator"),
+                    ),
+                ),
+                metric_with_guaranteed_meta(
+                    name="cumulative_with_missing_input",
+                    type=MetricType.CUMULATIVE,
+                    type_params=PydanticMetricTypeParams(
+                        cumulative_type_params=PydanticCumulativeTypeParams(
+                            metric=PydanticMetricInput(name="missing_cumulative_input"),
+                            period_agg=PeriodAggregation.FIRST,
+                        ),
+                    ),
+                ),
+            ],
+            project_configuration=EXAMPLE_PROJECT_CONFIGURATION,
+        )
+    )
+    build_issues = validation_results.all_issues
+    assert len(build_issues) == 2
+    check_error_in_issues(
+        error_substrings=[
+            "input metric: 'missing_denominator' does not exist as a configured metric",
+            "input metric: 'missing_cumulative_input' does not exist as a configured metric",
+        ],
+        issues=build_issues,
+    )
+
+
 def test_cumulative_metrics() -> None:  # noqa: D103
     measure_name = "foo"
     model_validator = SemanticManifestValidator[PydanticSemanticManifest]([CumulativeMetricRule()])


### PR DESCRIPTION
# Why

Input-metric existence was only validated for `DERIVED` metrics. **Ratio** (`numerator` / `denominator`) and **cumulative** (`cumulative_type_params.metric`) metrics that reference a non-existent metric slipped through validation entirely, then failed later during semantic-graph construction with an opaque error (`ManifestObjectLookup.get_metric` raising `KeyError: <LazyFormat object at 0x…>`). (Conversion metrics already validate their inputs in `ConversionMetricRule`.)

# What

`DerivedMetricRule._validate_input_metrics_exist` now also checks ratio and cumulative input metric references, so manifests with dangling references are rejected up front with a clear message instead of detonating during graph construction. A small `_input_metrics_to_check_for_existence` helper centralizes which input metrics each metric type exposes; conversion is intentionally left to its existing rule to avoid duplicate issues.

The validation lives in the vendored `metricflow_semantic_interfaces` package.

Drafted by Claude Opus 4.8 under the direction of @WilliamDee
