### PR TITLE
Limit result cache in group-by item resolver

### DIFF
--- a/.changes/unreleased/Under the Hood-20260624-103945.yaml
+++ b/.changes/unreleased/Under the Hood-20260624-103945.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Limit result cache in group-by item resolver
+time: 2026-06-24T10:39:45.936593-07:00
+custom:
+    Author: plypaul
+    Issue: "2075"

--- a/metricflow_semantics/semantic_graph/attribute_resolution/sg_linkable_spec_resolver.py
+++ b/metricflow_semantics/semantic_graph/attribute_resolution/sg_linkable_spec_resolver.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from collections import defaultdict
-from typing import Iterable, Optional
+from typing import Final, Iterable, Optional
 
 from metricflow_semantics.errors.error_classes import MetricFlowInternalError, UnknownMetricError
 from metricflow_semantics.model.semantics.element_filter import GroupByItemSetFilter
@@ -37,7 +37,7 @@ from metricflow_semantics.semantic_graph.trie_resolver.group_by_metric_resolver 
     GroupByMetricTrieResolver,
 )
 from metricflow_semantics.semantic_graph.trie_resolver.simple_resolver import SimpleTrieResolver
-from metricflow_semantics.toolkit.cache.result_cache import ResultCache
+from metricflow_semantics.toolkit.cache.weighted_lru_result_cache import WeightedLruResultCache
 from metricflow_semantics.toolkit.collections.ordered_set import FrozenOrderedSet, MutableOrderedSet
 from metricflow_semantics.toolkit.dataclass_helpers import fast_frozen_dataclass
 from metricflow_semantics.toolkit.mf_graph.graph_labeling import MetricFlowGraphLabel
@@ -54,11 +54,15 @@ logger = logging.getLogger(__name__)
 class SemanticGraphGroupByItemSetResolver(GroupByItemSetResolver):
     """An implementation of `GroupByItemSetResolver` using the semantic graph."""
 
+    # Weight is an approximate count of cached group-by item specs.
+    _DEFAULT_RESULT_CACHE_WEIGHT_LIMIT: Final[int] = 100_000
+
     def __init__(  # noqa: D107
         self,
         semantic_graph: SemanticGraph,
         manifest_object_lookup: ManifestObjectLookup,
         path_finder: MetricFlowPathfinder[SemanticGraphNode, SemanticGraphEdge, AttributeRecipeWriterPath],
+        result_cache_weight_limit: Optional[int] = None,
     ) -> None:
         self._semantic_graph = semantic_graph
         self._pathfinder = path_finder
@@ -70,12 +74,25 @@ class SemanticGraphGroupByItemSetResolver(GroupByItemSetResolver):
         self._metric_time_node_set = FrozenOrderedSet(
             (self._semantic_graph.node_with_label(MetricTimeLabel.get_instance()),)
         )
+        resolved_result_cache_weight_limit = (
+            self._DEFAULT_RESULT_CACHE_WEIGHT_LIMIT if result_cache_weight_limit is None else result_cache_weight_limit
+        )
 
-        self._result_cache_for_distinct_values: ResultCache[
+        self._result_cache_for_distinct_values: WeightedLruResultCache[
             tuple[Optional[GroupByItemSetFilter]], BaseGroupByItemSet
-        ] = ResultCache()
+        ] = WeightedLruResultCache(weight_limit=resolved_result_cache_weight_limit)
 
-        self._result_cache_for_common_set: ResultCache[_CommonSetCacheKey, BaseGroupByItemSet] = ResultCache()
+        self._result_cache_for_common_set: WeightedLruResultCache[
+            _CommonSetCacheKey, BaseGroupByItemSet
+        ] = WeightedLruResultCache(weight_limit=resolved_result_cache_weight_limit)
+
+    @staticmethod
+    def _result_cache_weight(group_by_item_set: BaseGroupByItemSet) -> int:
+        """Return the cache weight for a group-by item set.
+
+        Weight is 1 (key object) + 1 (value object) + count of group-by items.
+        """
+        return 2 + len(group_by_item_set.annotated_specs)
 
     @override
     def get_set_for_distinct_values_query(
@@ -122,9 +139,10 @@ class SemanticGraphGroupByItemSetResolver(GroupByItemSetResolver):
 
         tries_to_union.append(filtered_metric_time_trie)
         result_trie = MutableDunderNameTrie.union_merge_common(tries_to_union)
+        result = GroupByItemSet.create_from_trie(result_trie)
 
         return self._result_cache_for_distinct_values.set_and_get(
-            cache_key, GroupByItemSet.create_from_trie(result_trie)
+            cache_key, result, weight=self._result_cache_weight(result)
         )
 
     @override
@@ -189,15 +207,17 @@ class SemanticGraphGroupByItemSetResolver(GroupByItemSetResolver):
 
         if joins_disallowed:
             simple_trie = self._simple_resolver_limit_one_model.resolve_trie(source_nodes, set_filter).dunder_name_trie
+            result = GroupByItemSet.create_from_trie(simple_trie)
             return self._result_cache_for_common_set.set_and_get(
-                cache_key, GroupByItemSet.create_from_trie(simple_trie)
+                cache_key, result, weight=self._result_cache_weight(result)
             )
 
         simple_trie = self._simple_resolver.resolve_trie(source_nodes, set_filter).dunder_name_trie
         group_by_metric_trie = self._group_by_metric_resolver.resolve_trie(source_nodes, set_filter).dunder_name_trie
 
+        result = GroupByItemSet.create_from_trie(simple_trie, group_by_metric_trie)
         return self._result_cache_for_common_set.set_and_get(
-            cache_key, GroupByItemSet.create_from_trie(simple_trie, group_by_metric_trie)
+            cache_key, result, weight=self._result_cache_weight(result)
         )
 
 

--- a/metricflow_semantics/toolkit/cache/weighted_lru_result_cache.py
+++ b/metricflow_semantics/toolkit/cache/weighted_lru_result_cache.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Generic, Optional
+
+from metricflow_semantics.toolkit.cache.result_cache import ResultCacheKeyT, ValueT
+from metricflow_semantics.toolkit.dataclass_helpers import fast_frozen_dataclass
+from metricflow_semantics.toolkit.mf_logging.lazy_formattable import LazyFormat
+
+logger = logging.getLogger(__name__)
+
+
+@fast_frozen_dataclass()
+class WeightedLruResultCacheEntry(Generic[ValueT]):
+    """Container for a cache result and its eviction weight."""
+
+    value: ValueT
+    weight: int
+
+
+class WeightedLruResultCache(Generic[ResultCacheKeyT, ValueT]):
+    """A result cache that evicts least-recently-used entries to stay under a total weight limit."""
+
+    def __init__(self, weight_limit: int) -> None:  # noqa: D107
+        if weight_limit < 0:
+            raise ValueError(LazyFormat("Weight limit should be >= 0", weight_limit=weight_limit))
+
+        self._weight_limit = weight_limit
+        self._current_weight = 0
+        self._cache_dict: dict[ResultCacheKeyT, WeightedLruResultCacheEntry[ValueT]] = {}
+        self._lock = threading.Lock()
+
+    def get(self, key: ResultCacheKeyT) -> Optional[WeightedLruResultCacheEntry[ValueT]]:
+        """Returns the cache entry for a given key."""
+        with self._lock:
+            cache_entry = self._cache_dict.get(key)
+            if cache_entry is None:
+                return None
+
+            del self._cache_dict[key]
+            self._cache_dict[key] = cache_entry
+            return cache_entry
+
+    def set_and_get(self, key: ResultCacheKeyT, value: ValueT, weight: int) -> ValueT:
+        """Set the result for the given key and return the same result.
+
+        If the total weight of the entries in the cache exceeds the threshold, the least recently used items are evicted
+        to make room for the new item.
+        """
+        if weight < 0:
+            raise ValueError(LazyFormat("Cache entry weight should be >= 0", weight=weight))
+
+        with self._lock:
+            previous_cache_entry = self._cache_dict.pop(key, None)
+            if previous_cache_entry is not None:
+                self._current_weight -= previous_cache_entry.weight
+
+            new_cache_entry = WeightedLruResultCacheEntry(value=value, weight=weight)
+            if new_cache_entry.weight > self._weight_limit:
+                return value
+
+            while self._current_weight + new_cache_entry.weight > self._weight_limit:
+                lru_key = next(iter(self._cache_dict))
+                lru_cache_entry = self._cache_dict.pop(lru_key)
+                self._current_weight -= lru_cache_entry.weight
+
+            self._cache_dict[key] = new_cache_entry
+            self._current_weight += new_cache_entry.weight
+
+        return value

--- a/tests_metricflow_semantics/toolkit/cache/test_weighted_lru_result_cache.py
+++ b/tests_metricflow_semantics/toolkit/cache/test_weighted_lru_result_cache.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import logging
+
+import pytest
+from metricflow_semantics.toolkit.cache.weighted_lru_result_cache import WeightedLruResultCache
+from metricflow_semantics.toolkit.mf_type_aliases import ValueT
+
+logger = logging.getLogger(__name__)
+
+
+def _assert_cached_value(
+    cache: WeightedLruResultCache[str, ValueT],
+    key: str,
+    expected_value: ValueT,
+    expected_weight: int,
+) -> None:
+    cache_entry = cache.get(key)
+
+    assert cache_entry is not None
+    assert cache_entry.value == expected_value
+    assert cache_entry.weight == expected_weight
+
+
+def test_set_and_get_caches_entry() -> None:
+    """The cache entry can be retrieved after the value is set."""
+    cache = WeightedLruResultCache[str, object](weight_limit=1)
+    value = object()
+
+    assert cache.set_and_get("key", value, weight=1) is value
+
+    _assert_cached_value(cache, "key", value, expected_weight=1)
+
+
+def test_lru_eviction() -> None:
+    """The LRU entry is selected by access order while eviction capacity uses the entry weight."""
+    cache = WeightedLruResultCache[str, str](weight_limit=5)
+
+    cache.set_and_get("key_0", "value_0", weight=3)
+    cache.set_and_get("key_1", "value_1", weight=1)
+
+    _assert_cached_value(cache, "key_0", "value_0", expected_weight=3)
+
+    cache.set_and_get("key_2", "value_2", weight=2)
+
+    assert cache.get("key_1") is None
+    _assert_cached_value(cache, "key_0", "value_0", expected_weight=3)
+    _assert_cached_value(cache, "key_2", "value_2", expected_weight=2)
+
+
+def test_oversized_entry_is_not_cached() -> None:
+    """An entry larger than the cache weight limit is returned but not stored."""
+    cache = WeightedLruResultCache[str, str](weight_limit=1)
+
+    assert cache.set_and_get("key", "value", weight=2) == "value"
+
+    assert cache.get("key") is None
+
+
+def test_negative_entry_weight_raises_error() -> None:
+    """Entry weight must be non-negative."""
+    cache = WeightedLruResultCache[str, str](weight_limit=1)
+
+    with pytest.raises(ValueError, match="Cache entry weight should be >= 0"):
+        cache.set_and_get("key", "value", weight=-1)
+
+
+def test_negative_weight_limit_raises_error() -> None:
+    """Cache weight limit must be non-negative."""
+    with pytest.raises(ValueError, match="Weight limit should be >= 0"):
+        WeightedLruResultCache[str, str](weight_limit=-1)


### PR DESCRIPTION
Currently, the group-by item resolver caches all results for group-by items for a given set of metrics. If `MetricFlowEngine.list_dimensions` is called with many different metrics, then the cache can grow to a large size and use a significant amount of memory.

To limit growth, this PR changes the cache to associate a weight with each cache entry and to evict LRU items to keep the total weight below a configured limit.

A follow up PR will allow for configuration of the cache in engine initialization.