### PR TITLE
Update error handling for invalid percentile configuration

### DIFF
--- a/.changes/unreleased/Under the Hood-20260625-152050.yaml
+++ b/.changes/unreleased/Under the Hood-20260625-152050.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Update error handling for invalid percentile configuration
+time: 2026-06-25T15:20:50.419765-07:00
+custom:
+    Author: plypaul
+    Issue: "2076"

--- a/metricflow/dataflow/nodes/semi_additive_join.py
+++ b/metricflow/dataflow/nodes/semi_additive_join.py
@@ -5,13 +5,13 @@ from typing import Optional, Sequence
 
 from metricflow_semantics.dag.id_prefix import IdPrefix, StaticIdPrefix
 from metricflow_semantics.dag.mf_dag import DisplayedProperty
+from metricflow_semantics.specs.non_additive_dimension_spec import NonAdditiveWindowChoiceType
 from metricflow_semantics.specs.time_dimension_spec import TimeDimensionSpec
 from metricflow_semantics.toolkit.visitor import VisitorOutputT
 
 from metricflow.dataflow.dataflow_plan import DataflowPlanNode
 from metricflow.dataflow.dataflow_plan_visitor import DataflowPlanNodeVisitor
 from metricflow_semantic_interfaces.references import EntityReference
-from metricflow_semantic_interfaces.type_enums import AggregationType
 
 
 @dataclass(frozen=True, eq=False)
@@ -72,7 +72,7 @@ class SemiAdditiveJoinNode(DataflowPlanNode):
 
     entity_references: Sequence[EntityReference]
     time_dimension_spec: TimeDimensionSpec
-    agg_by_function: AggregationType
+    agg_by_function: NonAdditiveWindowChoiceType
     queried_time_dimension_spec: Optional[TimeDimensionSpec]
 
     def __post_init__(self) -> None:  # noqa: D105
@@ -84,7 +84,7 @@ class SemiAdditiveJoinNode(DataflowPlanNode):
         parent_node: DataflowPlanNode,
         entity_references: Sequence[EntityReference],
         time_dimension_spec: TimeDimensionSpec,
-        agg_by_function: AggregationType,
+        agg_by_function: NonAdditiveWindowChoiceType,
         queried_time_dimension_spec: Optional[TimeDimensionSpec] = None,
     ) -> SemiAdditiveJoinNode:
         return SemiAdditiveJoinNode(

--- a/metricflow/plan_conversion/instance_set_transforms/aggregated_simple_metric_input.py
+++ b/metricflow/plan_conversion/instance_set_transforms/aggregated_simple_metric_input.py
@@ -3,15 +3,23 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import List, Tuple
 
+from metricflow_semantics.errors.error_classes import InvalidManifestException
 from metricflow_semantics.instances import InstanceSet, InstanceSetTransform, SimpleMetricInputInstance
 from metricflow_semantics.semantic_graph.lookups.manifest_object_lookup import ManifestObjectLookup
 from metricflow_semantics.specs.column_assoc import ColumnAssociationResolver
 from metricflow_semantics.specs.simple_metric_input_spec import SimpleMetricInputSpec
-from metricflow_semantics.sql.sql_exprs import SqlColumnReference, SqlColumnReferenceExpression, SqlFunctionExpression
+from metricflow_semantics.sql.sql_exprs import (
+    SqlColumnReference,
+    SqlColumnReferenceExpression,
+    SqlFunctionExpression,
+    SqlPercentileExpressionArgument,
+)
+from metricflow_semantics.toolkit.mf_logging.lazy_formattable import LazyFormat
 
 from metricflow.plan_conversion.instance_set_transforms.select_columns import CreateSelectColumnsForInstances
 from metricflow.plan_conversion.select_column_gen import SelectColumnSet
 from metricflow.sql.sql_plan import SqlSelectColumn
+from metricflow_semantic_interfaces.type_enums import AggregationType
 
 
 @dataclass(frozen=True)
@@ -73,11 +81,32 @@ class CreateAggregatedSimpleMetricInputsTransform(InstanceSetTransform[CreateAgg
         )
 
         # Figure out the aggregation function for the simple metric.
-        aggregation_expression = SqlFunctionExpression.build_expression_from_aggregation_type(
-            aggregation_type=simple_metric_input.agg,
-            sql_column_expression=read_expression,
-            agg_params=simple_metric_input.agg_params,
-        )
+        aggregation_type = simple_metric_input.agg
+
+        if aggregation_type is AggregationType.PERCENTILE:
+            agg_params = simple_metric_input.agg_params
+            if agg_params is None or agg_params.percentile is None:
+                raise InvalidManifestException(
+                    LazyFormat(
+                        "Percentile value not set for a simple metric configured with a percentile aggregation."
+                        " This indicates an error in the manifest and should have been caught in validation.",
+                        simple_metric_name=simple_metric_input.name,
+                    )
+                )
+
+            aggregation_expression = SqlFunctionExpression.build_expression_for_percentile_aggregation(
+                percentile_args=SqlPercentileExpressionArgument.create(
+                    percentile=agg_params.percentile,
+                    approximate=agg_params.use_approximate_percentile,
+                    discrete=agg_params.use_discrete_percentile,
+                ),
+                sql_column_expression=read_expression,
+            )
+        else:
+            aggregation_expression = SqlFunctionExpression.build_expression_for_non_percentile_aggregation(
+                aggregation_type=aggregation_type,
+                sql_column_expression=read_expression,
+            )
 
         # Get the output column name for the simple-metric input.
 

--- a/metricflow/plan_conversion/instance_set_transforms/instance_converters.py
+++ b/metricflow/plan_conversion/instance_set_transforms/instance_converters.py
@@ -556,7 +556,7 @@ class CreateSelectColumnForCombineOutputNode(InstanceSetTransform[SelectColumnSe
                 column_name=column_name,
             )
         )
-        select_expression: SqlExpressionNode = SqlFunctionExpression.build_expression_from_aggregation_type(
+        select_expression: SqlExpressionNode = SqlFunctionExpression.build_expression_for_non_percentile_aggregation(
             aggregation_type=AggregationType.MAX, sql_column_expression=column_reference_expression
         )
         if fill_nulls_with is not None:

--- a/metricflow/plan_conversion/to_sql_plan/dataflow_to_subquery.py
+++ b/metricflow/plan_conversion/to_sql_plan/dataflow_to_subquery.py
@@ -31,6 +31,7 @@ from metricflow_semantics.specs.spec_set import InstanceSpecSet
 from metricflow_semantics.specs.where_filter.where_filter_spec import WhereFilterSpec
 from metricflow_semantics.sql.sql_bind_parameters import SqlBindParameterSet
 from metricflow_semantics.sql.sql_exprs import (
+    NonPercentileAggregationType,
     SqlAddTimeExpression,
     SqlAggregateFunctionExpression,
     SqlArithmeticExpression,
@@ -1311,7 +1312,7 @@ class DataflowNodeToSqlSubqueryVisitor(DataflowPlanNodeVisitor[SqlDataSet]):
             node.time_dimension_spec.with_aggregation_state(AggregationState.COMPLETE),
         ).column_name
         time_dimension_select_column = SqlSelectColumn(
-            expr=SqlFunctionExpression.build_expression_from_aggregation_type(
+            expr=SqlFunctionExpression.build_expression_for_non_percentile_aggregation(
                 aggregation_type=node.agg_by_function,
                 sql_column_expression=SqlColumnReferenceExpression.create(
                     SqlColumnReference(
@@ -1681,12 +1682,13 @@ class DataflowNodeToSqlSubqueryVisitor(DataflowPlanNodeVisitor[SqlDataSet]):
 
         select_columns: List[SqlSelectColumn] = []
         metadata_instances: List[MetadataInstance] = []
-        for agg_type in (AggregationType.MIN, AggregationType.MAX):
+        agg_types: Tuple[NonPercentileAggregationType, ...] = (AggregationType.MIN, AggregationType.MAX)
+        for agg_type in agg_types:
             metadata_spec = MetadataSpec(element_name=parent_column_alias, agg_type=agg_type)
             output_column_association = self._column_association_resolver.resolve_spec(metadata_spec)
             select_columns.append(
                 SqlSelectColumn(
-                    expr=SqlFunctionExpression.build_expression_from_aggregation_type(
+                    expr=SqlFunctionExpression.build_expression_for_non_percentile_aggregation(
                         aggregation_type=agg_type,
                         sql_column_expression=SqlColumnReferenceExpression.create(
                             SqlColumnReference(table_alias=parent_table_alias, column_name=parent_column_alias)

--- a/metricflow_semantics/specs/non_additive_dimension_spec.py
+++ b/metricflow_semantics/specs/non_additive_dimension_spec.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Optional, Sequence, Tuple
+from typing import TYPE_CHECKING, Literal, Optional, Sequence, Tuple
 
+from metricflow_semantics.errors.error_classes import InvalidManifestException
 from metricflow_semantics.model.semantics.simple_metric_input import SimpleMetricInput
 from metricflow_semantics.naming.linkable_spec_name import DUNDER
 from metricflow_semantics.specs.entity_spec import EntitySpec
@@ -22,6 +23,8 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__file__)
 
+NonAdditiveWindowChoiceType = Literal[AggregationType.MIN, AggregationType.MAX]
+
 
 @dataclass(frozen=True)
 class NonAdditiveDimensionSpec(SerializableDataclass):
@@ -32,7 +35,7 @@ class NonAdditiveDimensionSpec(SerializableDataclass):
     """
 
     name: str
-    window_choice: AggregationType
+    window_choice: NonAdditiveWindowChoiceType
     window_groupings: Tuple[str, ...] = ()
 
     @staticmethod
@@ -42,9 +45,21 @@ class NonAdditiveDimensionSpec(SerializableDataclass):
         if simple_metric_input.non_additive_dimension is None:
             return None
 
+        window_choice = simple_metric_input.non_additive_dimension.window_choice
+        if not (window_choice is AggregationType.MIN or window_choice is AggregationType.MAX):
+            raise InvalidManifestException(
+                LazyFormat(
+                    "Non-additive dimension uses an unsupported window choice. Only min or max are supported."
+                    " This indicates an error in the manifest and should have been caught in validation.",
+                    simple_metric_name=simple_metric_input.name,
+                    non_additive_dimension_name=simple_metric_input.non_additive_dimension.name,
+                    window_choice=window_choice.value,
+                )
+            )
+
         return NonAdditiveDimensionSpec(
             name=simple_metric_input.non_additive_dimension.name,
-            window_choice=simple_metric_input.non_additive_dimension.window_choice,
+            window_choice=window_choice,
             window_groupings=tuple(sorted(simple_metric_input.non_additive_dimension.window_groupings)),
         )
 

--- a/metricflow_semantics/sql/sql_exprs.py
+++ b/metricflow_semantics/sql/sql_exprs.py
@@ -6,11 +6,10 @@ import itertools
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import Enum
-from typing import Dict, Generic, List, Mapping, Optional, Sequence, Tuple
+from typing import ClassVar, Dict, Generic, List, Literal, Mapping, Optional, Sequence, Tuple
 
 from metricflow_semantics.dag.id_prefix import IdPrefix, StaticIdPrefix
 from metricflow_semantics.dag.mf_dag import DagNode, DisplayedProperty
-from metricflow_semantics.model.semantics.simple_metric_input import SimpleMetricInputAggregation
 from metricflow_semantics.sql.sql_bind_parameters import SqlBindParameterSet
 from metricflow_semantics.toolkit.merger import Mergeable
 from metricflow_semantics.toolkit.mf_logging.pretty_formatter import PrettyFormatContext
@@ -18,7 +17,6 @@ from metricflow_semantics.toolkit.visitor import Visitable, VisitorOutputT
 from typing_extensions import override
 
 from metricflow_semantic_interfaces.enum_extension import assert_values_exhausted
-from metricflow_semantic_interfaces.protocols.measure import MeasureAggregationParameters
 from metricflow_semantic_interfaces.type_enums.aggregation_type import AggregationType
 from metricflow_semantic_interfaces.type_enums.date_part import DatePart
 from metricflow_semantic_interfaces.type_enums.period_agg import PeriodAggregation
@@ -792,6 +790,18 @@ class SqlFunction(Enum):
             assert_values_exhausted(aggregation_type)
 
 
+NonPercentileAggregationType = Literal[
+    AggregationType.SUM,
+    AggregationType.MIN,
+    AggregationType.MAX,
+    AggregationType.COUNT_DISTINCT,
+    AggregationType.SUM_BOOLEAN,
+    AggregationType.AVERAGE,
+    AggregationType.MEDIAN,
+    AggregationType.COUNT,
+]
+
+
 @dataclass(frozen=True, eq=False)
 class SqlFunctionExpression(SqlExpressionNode):
     """Denotes a function expression in SQL."""
@@ -803,19 +813,20 @@ class SqlFunctionExpression(SqlExpressionNode):
         pass
 
     @staticmethod
-    def build_expression_from_aggregation_type(
-        aggregation_type: AggregationType,
+    def build_expression_for_non_percentile_aggregation(
+        aggregation_type: NonPercentileAggregationType,
         sql_column_expression: SqlColumnReferenceExpression,
-        agg_params: Optional[SimpleMetricInputAggregation] = None,
     ) -> SqlFunctionExpression:
-        """Returns sql function expression depending on aggregation type."""
-        if aggregation_type is AggregationType.PERCENTILE:
-            assert agg_params is not None, "Agg_params is none, which should have been caught in validation"
-            return SqlPercentileExpression.create(
-                sql_column_expression, SqlPercentileExpressionArgument.from_aggregation_parameters(agg_params)
-            )
-        else:
-            return SqlAggregateFunctionExpression.from_aggregation_type(aggregation_type, sql_column_expression)
+        """Build a SQL expression for an aggregation that does not require percentile-specific syntax."""
+        return SqlAggregateFunctionExpression.from_aggregation_type(aggregation_type, sql_column_expression)
+
+    @staticmethod
+    def build_expression_for_percentile_aggregation(
+        percentile_args: SqlPercentileExpressionArgument,
+        sql_column_expression: SqlColumnReferenceExpression,
+    ) -> SqlFunctionExpression:
+        """Build a SQL expression for a percentile aggregation."""
+        return SqlPercentileExpression.create(sql_column_expression, percentile_args)
 
 
 @dataclass(frozen=True, eq=False)
@@ -926,28 +937,21 @@ class SqlPercentileExpressionArgument:
     percentile: float
     function_type: SqlPercentileFunctionType
 
+    _PERCENTILE_FLAGS_TO_FUNCTION_TYPE: ClassVar[
+        Mapping[Tuple[UseDiscretePercentile, UseApproximatePercentile], SqlPercentileFunctionType]
+    ] = {
+        (False, False): SqlPercentileFunctionType.CONTINUOUS,
+        (True, False): SqlPercentileFunctionType.DISCRETE,
+        (False, True): SqlPercentileFunctionType.APPROXIMATE_CONTINUOUS,
+        (True, True): SqlPercentileFunctionType.APPROXIMATE_DISCRETE,
+    }
+
     @staticmethod
-    def from_aggregation_parameters(agg_params: MeasureAggregationParameters) -> SqlPercentileExpressionArgument:
-        """Given the simple-metric input parameters, returns a SqlPercentileExpressionArgument with the corresponding percentile args."""
-        if not agg_params.percentile:
-            raise RuntimeError("Percentile value is none - this should have been caught during model parsing.")
-
-        flags_to_function_type: Mapping[
-            Tuple[UseDiscretePercentile, UseApproximatePercentile], SqlPercentileFunctionType
-        ] = {
-            (False, False): SqlPercentileFunctionType.CONTINUOUS,
-            (True, False): SqlPercentileFunctionType.DISCRETE,
-            (False, True): SqlPercentileFunctionType.APPROXIMATE_CONTINUOUS,
-            (True, True): SqlPercentileFunctionType.APPROXIMATE_DISCRETE,
-        }
-
-        percentile_function_type = flags_to_function_type[
-            (agg_params.use_discrete_percentile, agg_params.use_approximate_percentile)
-        ]
-
+    def create(percentile: float, discrete: bool, approximate: bool) -> SqlPercentileExpressionArgument:
+        """Create a SQL percentile argument from percentile settings."""
         return SqlPercentileExpressionArgument(
-            agg_params.percentile,
-            percentile_function_type,
+            percentile,
+            SqlPercentileExpressionArgument._PERCENTILE_FLAGS_TO_FUNCTION_TYPE[(discrete, approximate)],
         )
 
 

--- a/tests_metricflow/integration/test_configured_cases.py
+++ b/tests_metricflow/integration/test_configured_cases.py
@@ -34,7 +34,6 @@ from metricflow.dataflow.optimizer.dataflow_optimizer_factory import DataflowPla
 from metricflow.engine.metricflow_engine import MetricFlowQueryRequest, OutputColumnOrderMode
 from metricflow.protocols.sql_client import SqlClient
 from metricflow_semantic_interfaces.enum_extension import assert_values_exhausted
-from metricflow_semantic_interfaces.implementations.elements.measure import PydanticMeasureAggregationParameters
 from metricflow_semantic_interfaces.type_enums.date_part import DatePart
 from metricflow_semantic_interfaces.type_enums.time_granularity import TimeGranularity
 from tests_metricflow.fixtures.manifest_fixtures import MetricFlowEngineTestFixture, SemanticManifestSetup
@@ -145,12 +144,10 @@ class CheckQueryHelpers:
         self, expr: str, percentile: float, use_discrete_percentile: bool, use_approximate_percentile: bool
     ) -> str:
         """Return the percentile call that can be used for computing a percentile aggregation."""
-        percentile_args = SqlPercentileExpressionArgument.from_aggregation_parameters(
-            PydanticMeasureAggregationParameters(
-                percentile=percentile,
-                use_discrete_percentile=use_discrete_percentile,
-                use_approximate_percentile=use_approximate_percentile,
-            )
+        percentile_args = SqlPercentileExpressionArgument.create(
+            percentile=percentile,
+            discrete=use_discrete_percentile,
+            approximate=use_approximate_percentile,
         )
 
         renderable_expr = SqlPercentileExpression.create(


### PR DESCRIPTION
This PR updates error handling to raise an `InvalidManifestException` when a simple metric is configured with a percentile aggregation but no percentile value, such as 0.99, is specified. Normally, this is caught during manifest validation, but the updated exception improves handling for cases where the engine is provided a non-validated manifest.

Some type and method refactoring was needed to raise the exception at the appropriate call site.