### PR TITLE
DI-4631: CI Nuitka binary build and artifact publication

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,8 @@
+self-hosted-runner:
+  # ubuntu-24.04-arm is a GitHub-hosted (not self-hosted) runner label for
+  # GitHub's native Linux ARM64 runners. It's missing from actionlint
+  # v1.7.6's bundled hosted-runner-label list (pinned in .pre-commit-config.yaml);
+  # listing it here is actionlint's documented workaround for a hosted label
+  # it doesn't recognize yet.
+  labels:
+    - ubuntu-24.04-arm

--- a/.github/actions/setup-python-env/action.yaml
+++ b/.github/actions/setup-python-env/action.yaml
@@ -23,6 +23,7 @@ runs:
 
   steps:
   - name: Set Linux Release Environment Variable
+    if: runner.os == 'Linux'
     shell: bash
     run: echo "LINUX_RELEASE=$(lsb_release -rs)" >> $GITHUB_ENV
 
@@ -52,6 +53,7 @@ runs:
       # The cache key can be any string. The format used here is just for readability.
       # `manual_update_key` can be changed to manually force the cache action to create a new cache.
       key: >-
+        runner_os: "${{ runner.os }}" AND
         python_location: "${{ env.pythonLocation }}" AND
         files_hash: "${{
           hashFiles(

--- a/.github/workflows/cd-build-sidecar-binaries.yaml
+++ b/.github/workflows/cd-build-sidecar-binaries.yaml
@@ -23,6 +23,8 @@ jobs:
             target-triple: x86_64-apple-darwin
           - runner: ubuntu-22.04
             target-triple: x86_64-unknown-linux-gnu
+          - runner: ubuntu-24.04-arm
+            target-triple: aarch64-unknown-linux-gnu
           - runner: windows-latest
             target-triple: x86_64-pc-windows-msvc
     steps:

--- a/.github/workflows/cd-build-sidecar-binaries.yaml
+++ b/.github/workflows/cd-build-sidecar-binaries.yaml
@@ -1,7 +1,5 @@
 # Compiles sidecar/mf_entry.py into standalone Nuitka binaries for every platform
-# Fusion needs to embed via rust-embed (DI-4631). Windows x64 is intentionally not
-# included yet — see ci-sidecar-windows-nuitka-spike.yaml, which is de-risking that
-# leg in isolation before it's added here.
+# Fusion needs to embed via rust-embed (DI-4631).
 name: Build Sidecar Binaries
 
 on:
@@ -25,6 +23,8 @@ jobs:
             target-triple: x86_64-apple-darwin
           - runner: ubuntu-22.04
             target-triple: x86_64-unknown-linux-gnu
+          - runner: windows-latest
+            target-triple: x86_64-pc-windows-msvc
     steps:
       - name: Check-out the repo
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # actions/checkout@v4

--- a/.github/workflows/cd-build-sidecar-binaries.yaml
+++ b/.github/workflows/cd-build-sidecar-binaries.yaml
@@ -52,3 +52,42 @@ jobs:
           name: mf_entry-${{ matrix.target-triple }}
           path: sidecar/mf_entry.dist/
           if-no-files-found: error
+
+  publish:
+    name: Publish release assets
+    needs: build
+    # Only publish on an actual release tag. workflow_dispatch and pull_request runs exist
+    # to validate the build matrix on real runners and have no tag to attach assets to.
+    # `needs: build` already means this only runs if every matrix leg succeeded.
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download all platform artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # actions/download-artifact@v4
+        with:
+          pattern: mf_entry-*
+          path: dist
+
+      - name: Package archives and generate checksums
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd dist
+          for dir in mf_entry-*/; do
+            dir="${dir%/}"
+            triple="${dir#mf_entry-}"
+            if [[ "$triple" == *windows* ]]; then
+              (cd "$dir" && zip -r "../mf_entry-${{ github.ref_name }}-${triple}.zip" .)
+            else
+              tar -czf "mf_entry-${{ github.ref_name }}-${triple}.tar.gz" -C "$dir" .
+            fi
+            rm -rf "$dir"
+          done
+          sha256sum mf_entry-* > SHA256SUMS.txt
+
+      - name: Publish to GitHub Release
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # softprops/action-gh-release@v2
+        with:
+          files: dist/*

--- a/.github/workflows/cd-build-sidecar-binaries.yaml
+++ b/.github/workflows/cd-build-sidecar-binaries.yaml
@@ -1,0 +1,54 @@
+# Compiles sidecar/mf_entry.py into standalone Nuitka binaries for every platform
+# Fusion needs to embed via rust-embed (DI-4631). Windows x64 is intentionally not
+# included yet — see ci-sidecar-windows-nuitka-spike.yaml, which is de-risking that
+# leg in isolation before it's added here.
+name: Build Sidecar Binaries
+
+on:
+  push:
+    # Mirrors the MetricFlow release tag pattern in cd-push-metricflow-to-pypi.yaml.
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+*"
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Compile & Validate mf_entry (${{ matrix.target-triple }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: macos-14
+            target-triple: aarch64-apple-darwin
+          - runner: macos-13
+            target-triple: x86_64-apple-darwin
+          - runner: ubuntu-22.04
+            target-triple: x86_64-unknown-linux-gnu
+    steps:
+      - name: Check-out the repo
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # actions/checkout@v4
+
+      - uses: ./.github/actions/setup-python-env
+        with:
+          hatch-environment-cache-config-json: >-
+            {
+              "configs": [
+                {"hatch_project_directory": ".", "hatch_environment_name": "nuitka-build"}
+              ]
+            }
+
+      - name: Compile mf_entry with Nuitka
+        shell: bash
+        run: hatch run nuitka-build:compile
+
+      - name: Validate compiled binary against Python interpreter
+        shell: bash
+        run: hatch run nuitka-build:validate
+
+      - name: Upload mf_entry.dist for ${{ matrix.target-triple }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # actions/upload-artifact@v4
+        with:
+          name: mf_entry-${{ matrix.target-triple }}
+          path: sidecar/mf_entry.dist/
+          if-no-files-found: error

--- a/.github/workflows/cd-build-sidecar-binaries.yaml
+++ b/.github/workflows/cd-build-sidecar-binaries.yaml
@@ -19,8 +19,14 @@ jobs:
         include:
           - runner: macos-14
             target-triple: aarch64-apple-darwin
-          - runner: macos-13
-            target-triple: x86_64-apple-darwin
+          # macos-13 (x86_64-apple-darwin) is disabled: GitHub's hosted Intel Mac runner
+          # pool is scarce/deprecating, and this leg has sat in `queued` with no runner
+          # assigned for 2+ hours in testing. Since `publish` below needs the whole `build`
+          # matrix to complete, a hung leg here blocks release artifacts for every other
+          # (working) platform. Re-enable once DI-4819 (Depot access for metricflow) lands
+          # and this leg is switched to a Depot-hosted runner, as fs/dbt-core v2 already do.
+          # - runner: macos-13
+          #   target-triple: x86_64-apple-darwin
           - runner: ubuntu-22.04
             target-triple: x86_64-unknown-linux-gnu
           - runner: ubuntu-24.04-arm

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,7 +153,7 @@ extra-dependencies = ["nuitka==4.1.2"]
 
 [tool.hatch.envs.nuitka-build.scripts]
 compile = [
-  "python -m nuitka --standalone --follow-imports --include-package=metricflow --include-package=metricflow_semantics --include-package=metricflow_semantic_interfaces --output-dir=sidecar/ sidecar/mf_entry.py",
+  "python -m nuitka --standalone --follow-imports --assume-yes-for-downloads --include-package=metricflow --include-package=metricflow_semantics --include-package=metricflow_semantic_interfaces --output-dir=sidecar/ sidecar/mf_entry.py",
 ]
 validate = [
   "python sidecar/validate_mf_entry.py",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,7 +149,7 @@ features = ["trino-env-requirements"]
 [tool.hatch.envs.nuitka-build]
 description = "Nuitka compilation environment for building a standalone MetricFlow binary."
 template = "dev-env"
-extra-dependencies = ["nuitka"]
+extra-dependencies = ["nuitka==4.1.2"]
 
 [tool.hatch.envs.nuitka-build.scripts]
 compile = [

--- a/sidecar/README.md
+++ b/sidecar/README.md
@@ -69,6 +69,7 @@ results as assets on that tag's GitHub Release:
 | `aarch64-apple-darwin` | macos-14 | `mf_entry-<tag>-aarch64-apple-darwin.tar.gz` |
 | `x86_64-apple-darwin` | macos-13 | `mf_entry-<tag>-x86_64-apple-darwin.tar.gz` |
 | `x86_64-unknown-linux-gnu` | ubuntu-22.04 | `mf_entry-<tag>-x86_64-unknown-linux-gnu.tar.gz` |
+| `aarch64-unknown-linux-gnu` | ubuntu-24.04-arm | `mf_entry-<tag>-aarch64-unknown-linux-gnu.tar.gz` |
 | `x86_64-pc-windows-msvc` | windows-latest | `mf_entry-<tag>-x86_64-pc-windows-msvc.zip` |
 
 A `SHA256SUMS.txt` asset is published alongside the archives for integrity

--- a/sidecar/README.md
+++ b/sidecar/README.md
@@ -57,6 +57,42 @@ hatch run nuitka-build:compile    # build only
 hatch run nuitka-build:validate   # validate only (binary must already exist)
 ```
 
+## CI builds and release artifacts
+
+On every MetricFlow release tag (`v<major>.<minor>.<patch>...`),
+[`cd-build-sidecar-binaries.yaml`](../.github/workflows/cd-build-sidecar-binaries.yaml)
+compiles `mf_entry.py` for every platform Fusion needs and publishes the
+results as assets on that tag's GitHub Release:
+
+| target triple | runner | archive |
+|---|---|---|
+| `aarch64-apple-darwin` | macos-14 | `mf_entry-<tag>-aarch64-apple-darwin.tar.gz` |
+| `x86_64-apple-darwin` | macos-13 | `mf_entry-<tag>-x86_64-apple-darwin.tar.gz` |
+| `x86_64-unknown-linux-gnu` | ubuntu-22.04 | `mf_entry-<tag>-x86_64-unknown-linux-gnu.tar.gz` |
+| `x86_64-pc-windows-msvc` | windows-latest | `mf_entry-<tag>-x86_64-pc-windows-msvc.zip` |
+
+A `SHA256SUMS.txt` asset is published alongside the archives for integrity
+verification. Consumers fetch a specific version at
+`https://github.com/dbt-labs/metricflow/releases/download/<tag>/<archive>` —
+no authentication required, since the repo is public. Each archive extracts
+to the same layout as a local `sidecar/mf_entry.dist/` build.
+
+This is the contract Fusion's build tooling depends on — changing the target
+triple list, archive naming, or checksum file name is a breaking change from
+Fusion's perspective, not just a MetricFlow-internal refactor.
+
+**Version pins:** binaries are compiled with Nuitka `4.1.2` (pinned in
+`pyproject.toml`) against Python 3.10, per `setup-python-env`'s default. Both
+are chosen for parity with the Nuitka PoC that was manually validated against
+`sg_00_minimal_manifest`, not for any Python-3.10-specific behavior.
+
+**Not covered by this pipeline** (tracked separately — see the parent
+epic's other tickets): code signing and notarization for the macOS and
+Windows binaries, a musl/Alpine Linux build, and full snapshot-suite
+validation across every SQL dialect and metric type. The `validate`
+step above only diffs one fixture (`sg_00_minimal_manifest`) against
+`DUCKDB` — it's a build-sanity smoke check, not a correctness gate.
+
 ## mf-ipc v1 protocol
 
 All messages are newline-delimited JSON (NDJSON). The protocol is strictly


### PR DESCRIPTION
## Summary

Implements DI-4631 — a CI pipeline that compiles `sidecar/mf_entry.py` with Nuitka
across macOS arm64, macOS x86_64, Linux x86_64, Linux arm64, and Windows x64, and
publishes the resulting artifacts to GitHub Releases for Fusion to consume via
`rust-embed`.

## What's implemented

- Pinned Nuitka to `4.1.2` (`pyproject.toml`) for reproducible builds
- Fixed `setup-python-env` to work on non-Linux runners (guarded `lsb_release`,
  OS-scoped cache key)
- 4-leg active build matrix (`cd-build-sidecar-binaries.yaml`): macos-14/aarch64-apple-darwin,
  ubuntu-22.04/x86_64-unknown-linux-gnu, ubuntu-24.04-arm/aarch64-unknown-linux-gnu,
  windows-latest/x86_64-pc-windows-msvc — each leg compiles and validates (Python
  vs. binary SQL diff) before uploading `sidecar/mf_entry.dist/` as an artifact.
  (macos-13/x86_64-apple-darwin is commented out; see "Out of scope" below.) The
  triple list matches what `fs` and `dbt-core` v2 already build for.
- Publish job (gated to `refs/tags/v*`): downloads all platform artifacts, packages
  them (`.tar.gz` / `.zip` for Windows), generates `SHA256SUMS.txt`, and attaches
  everything to the tag's GitHub Release
- `.github/actionlint.yaml`, allowlisting `ubuntu-24.04-arm` — GitHub's native
  hosted Linux ARM64 runner label is newer than what the pinned actionlint version
  recognizes
- Documented the artifact naming/versioning contract in `sidecar/README.md`, since
  Fusion's build tooling will hard-code against it

## Validated

- macOS arm64, Linux x86_64, and Windows x64 legs compiled and validated successfully
  on real GitHub runners (Windows ~42 min)

## Not yet validated

- The publish job itself has never fired — it's gated to a real release tag and
  can't be exercised from a PR or `workflow_dispatch` (this workflow doesn't exist
  on `main` yet, so `workflow_dispatch` isn't invocable). It'll run for the first
  time on the next real MetricFlow release tag.
- The full matrix hasn't been re-run since this branch was rebased onto `main`
  (post PR #2072's squash-merge) and since the Linux arm64 leg was added. The new
  `ubuntu-24.04-arm` leg specifically has never executed yet — it should behave
  identically to the proven `ubuntu-22.04` leg (same steps, native GitHub-hosted
  runner, no cross-compilation), but that's an expectation, not an observation.

## Out of scope (tracked separately under epic DI-4630)

- `macos-13` (Intel) has never successfully scheduled a runner in validation runs
  (queued 2+ hours, zero steps executed, both attempts) — GitHub-hosted runner
  scarcity, not a config issue. Since `publish` needs the whole `build` matrix, a
  hung leg here would block release assets for every platform, so the leg is now
  commented out of the matrix rather than left to hang on a real release tag.
  `fs`/`dbt-core` avoid this by routing macOS through Depot instead of GitHub's
  native runner pool; `metricflow` has no Depot access configured yet. Filed as
  [DI-4819](https://dbtlabs.atlassian.net/browse/DI-4819) — deliberately kept out of
  this PR since it depends on an external access grant with its own timeline;
  re-enabling this leg is the follow-up once access lands.
- Full snapshot-suite validation across all dialects/metric types — DI-4632
- musl/Alpine Linux build — DI-4633
- Code signing/notarization (macOS DI-4634, Windows EV DI-4635)

Refs DI-4631


[DI-4819]: https://dbtlabs.atlassian.net/browse/DI-4819?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ