### PR TITLE
[Spike] grpc + Nuitka compatibility on Windows (throwaway)

### DIFF
--- a/.github/workflows/spike-grpc-nuitka-windows.yaml
+++ b/.github/workflows/spike-grpc-nuitka-windows.yaml
@@ -1,0 +1,52 @@
+# Throwaway spike: does grpc survive Nuitka standalone freezing on Windows?
+# Investigating the suggestion on PR #2072 to use gRPC for the mf-ipc protocol.
+# Already validated on macOS arm64 locally (isolated, combined with real MetricFlow
+# deps, and with real protobuf message serialization) — this checks the one
+# remaining platform where grpc's C-core does platform-conditional DNS/socket
+# handling that could behave differently. Delete this workflow and
+# spike-grpc-nuitka/ once the signal lands.
+#
+# The pull_request trigger exists only because workflow_dispatch cannot be invoked
+# via API/CLI until a workflow file exists on the default branch.
+name: "[Spike] grpc + Nuitka on Windows"
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "spike-grpc-nuitka/**"
+      - ".github/workflows/spike-grpc-nuitka-windows.yaml"
+
+jobs:
+  windows-grpc-spike:
+    name: Compile & run grpc probe (Windows x64)
+    runs-on: windows-latest
+    steps:
+      - name: Check-out the repo
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # actions/checkout@v4
+
+      - uses: ./.github/actions/setup-python-env
+        with:
+          hatch-environment-cache-config-json: >-
+            {
+              "configs": [
+                {"hatch_project_directory": ".", "hatch_environment_name": "nuitka-build"}
+              ]
+            }
+
+      - name: Install grpcio into the nuitka-build env
+        shell: bash
+        run: hatch run nuitka-build:pip install grpcio
+
+      - name: Compile grpc probe with Nuitka
+        shell: bash
+        run: >-
+          hatch run nuitka-build:python -m nuitka
+          --standalone --follow-imports --assume-yes-for-downloads
+          --include-package=grpc
+          --output-dir=spike-grpc-nuitka/
+          spike-grpc-nuitka/grpc_probe.py
+
+      - name: Run compiled grpc probe
+        shell: bash
+        run: ./spike-grpc-nuitka/grpc_probe.dist/grpc_probe.bin

--- a/.github/workflows/spike-grpc-nuitka-windows.yaml
+++ b/.github/workflows/spike-grpc-nuitka-windows.yaml
@@ -49,4 +49,11 @@ jobs:
 
       - name: Run compiled grpc probe
         shell: bash
-        run: ./spike-grpc-nuitka/grpc_probe.dist/grpc_probe.bin
+        # Nuitka names the binary grpc_probe.exe on Windows, grpc_probe.bin elsewhere
+        # (same distinction sidecar/validate_mf_entry.py already handles for mf_entry).
+        run: |
+          if [[ "${{ runner.os }}" == "Windows" ]]; then
+            ./spike-grpc-nuitka/grpc_probe.dist/grpc_probe.exe
+          else
+            ./spike-grpc-nuitka/grpc_probe.dist/grpc_probe.bin
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,9 @@ performance-comparison.md
 
 # Directory to consolidate files ignored by git.
 **/git_ignored
+
+# Nuitka sidecar build artifacts
+sidecar/mf_entry.dist/
+sidecar/mf_entry.build/
+sidecar/nuitka_poc.dist/
+sidecar/nuitka_poc.build/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,6 +146,20 @@ template = "dev-env"
 features = ["trino-env-requirements"]
 
 
+[tool.hatch.envs.nuitka-build]
+description = "Nuitka compilation environment for building a standalone MetricFlow binary."
+template = "dev-env"
+extra-dependencies = ["nuitka"]
+
+[tool.hatch.envs.nuitka-build.scripts]
+compile = [
+  "python -m nuitka --standalone --follow-imports --include-package=metricflow --include-package=metricflow_semantics --include-package=metricflow_semantic_interfaces --output-dir=sidecar/ sidecar/mf_entry.py",
+]
+validate = [
+  "python sidecar/validate_mf_entry.py",
+]
+
+
 [tool.black]
 line-length = 120
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,6 +158,10 @@ compile = [
 validate = [
   "python sidecar/validate_mf_entry.py",
 ]
+build-and-validate = [
+  "hatch run nuitka-build:compile",
+  "hatch run nuitka-build:validate",
+]
 
 
 [tool.black]

--- a/sidecar/README.md
+++ b/sidecar/README.md
@@ -1,0 +1,199 @@
+# MetricFlow sidecar
+
+The sidecar is MetricFlow compiled into a standalone native binary by
+[Nuitka](https://nuitka.net/). dbt-core v2 spawns it as a
+subprocess and communicates with it over NDJSON on stdin/stdout using the
+**mf-ipc v1** protocol.
+
+The sidecar's only job is to compile metric queries to SQL without executing
+them. It wraps `MetricFlowEngine.explain()`.
+
+## Directory layout
+
+```
+sidecar/
+  mf_entry.py            IPC server (the file Nuitka compiles)
+  validate_mf_entry.py   validation helper: compares Python vs binary SQL output
+  tests/
+    test_mf_entry.py     subprocess integration tests (mf-ipc v1)
+```
+
+## Development
+
+Run the integration tests against the Python interpreter (no compilation needed):
+
+```bash
+hatch run dev-env:pytest sidecar/tests/ -v
+```
+
+Quick smoke test from the repo root:
+
+```bash
+MANIFEST=metricflow_semantics/test_helpers/semantic_manifest_yamls/sg_00_minimal_manifest
+printf '{"id":"1","method":"explain","v":1,"params":{"manifest_path":"%s","metric_names":["bookings"],"group_by_names":["metric_time"],"sql_engine":"DUCKDB"}}\n{"id":"2","method":"shutdown","v":1}\n' "$MANIFEST" \
+  | hatch run dev-env:python sidecar/mf_entry.py
+```
+
+## Building
+
+Compile `mf_entry.py` to a standalone binary:
+
+```bash
+hatch run nuitka-build:compile
+```
+
+Output lands in `sidecar/mf_entry.dist/`. The binary is named `mf_entry.bin`
+on macOS/Linux and `mf_entry.exe` on Windows.
+
+## Validation
+
+After building, confirm the binary produces identical SQL to the Python
+interpreter:
+
+```bash
+hatch run nuitka-build:validate
+```
+
+This sends the same `explain` request to both and diffs the `sql` field of
+each response. A mismatch means something in the Nuitka build is diverging
+from the interpreter.
+
+## mf-ipc v1 protocol
+
+All messages are newline-delimited JSON (NDJSON). The protocol is strictly
+sequential: the caller sends one request and waits for one response before
+sending the next.
+
+### Startup
+
+On launch the sidecar writes a ready message to stdout:
+
+```json
+{"status": "ready", "metricflow_version": "X.Y.Z", "python_version": "3.11.x", "protocol_version": 1}
+```
+
+If `--manifest-path` was given and manifest loading fails, the sidecar writes
+an error message and exits 1:
+
+```json
+{"status": "error", "type": "ExceptionClass", "message": "..."}
+```
+
+### Request format
+
+```json
+{"id": "<string or int>", "method": "<method>", "v": 1, "params": {...}}
+```
+
+`id` is echoed back in the response. `v` must be `1`.
+
+### Methods
+
+#### `explain`
+
+Compiles a metric query to SQL without executing it.
+
+```json
+{
+  "id": "1",
+  "method": "explain",
+  "v": 1,
+  "params": {
+    "manifest_path": "/path/to/manifest.json",
+    "metric_names": ["bookings"],
+    "group_by_names": ["metric_time"],
+    "where_constraints": null,
+    "order_by_names": null,
+    "limit": null,
+    "sql_engine": "DUCKDB"
+  }
+}
+```
+
+- `manifest_path` — path to a `manifest.json` file **or** a YAML semantic
+  manifest directory (for development/testing)
+- `sql_engine` — one of `DUCKDB`, `BIGQUERY`, `DATABRICKS`, `POSTGRES`,
+  `REDSHIFT`, `SNOWFLAKE`, `TRINO`
+- All params except `manifest_path` and `sql_engine` are optional
+
+The engine is cached by `(manifest_path, mtime, sql_engine)` and rebuilt only
+when the manifest file changes or the engine type changes, so repeated
+`explain` calls against the same manifest are cheap.
+
+Response:
+
+```json
+{"id": "1", "ok": true, "sql": "SELECT ..."}
+```
+
+#### `ping`
+
+Health check. Responds immediately without touching the manifest or engine.
+
+```json
+{"id": "2", "method": "ping", "v": 1}
+```
+
+Response:
+
+```json
+{"id": "2", "ok": true}
+```
+
+#### `shutdown`
+
+Graceful shutdown. The sidecar responds, flushes stdout, then exits 0.
+
+```json
+{"id": "3", "method": "shutdown", "v": 1}
+```
+
+Response:
+
+```json
+{"id": "3", "ok": true}
+```
+
+### Error responses
+
+All errors share a single shape:
+
+```json
+{"id": "<id or null>", "ok": false, "error": {"type": "ExceptionClass", "message": "..."}}
+```
+
+`id` is `null` when the request itself could not be parsed (e.g. malformed
+JSON). Common `type` values:
+
+| type | cause |
+|---|---|
+| `InvalidQueryException` | invalid query parameters |
+| `UnknownMetricError` | metric name not found in manifest |
+| `JSONDecodeError` | request line was not valid JSON |
+| `ProtocolVersionError` | `v` field was not `1` |
+| `UnknownMethod` | unrecognised method name |
+
+With `--debug`, error responses also include a `"traceback"` field.
+
+The sidecar continues running after any per-request error. Only `shutdown`,
+EOF on stdin, or a signal causes it to exit.
+
+## CLI reference
+
+```
+mf_entry.py [--manifest-path PATH] [--sql-engine ENGINE] [--debug] [--version]
+
+  --manifest-path PATH   Pre-load manifest before writing the ready message.
+                         Eliminates cold-start latency on the first explain call.
+  --sql-engine ENGINE    Engine to use for pre-warming (default: DUCKDB).
+  --debug                Verbose stderr logging; include tracebacks in error responses.
+  --version              Print version and exit.
+```
+
+## stdout protection
+
+Any library `print()` call would corrupt the NDJSON framing on the pipe the caller
+is reading. `mf_entry.py` saves the real stdout file descriptor before any
+library code runs, then replaces `sys.stdout` with `sys.stderr`. All IPC
+writes go through the saved descriptor. All non-IPC output (logging, library
+chatter) goes to stderr.

--- a/sidecar/README.md
+++ b/sidecar/README.md
@@ -34,29 +34,26 @@ printf '{"id":"1","method":"explain","v":1,"params":{"manifest_path":"%s","metri
   | hatch run dev-env:python sidecar/mf_entry.py
 ```
 
-## Building
+## Building and local validation
 
-Compile `mf_entry.py` to a standalone binary:
+To compile and validate in one step:
 
 ```bash
-hatch run nuitka-build:compile
+hatch run nuitka-build:build-and-validate
 ```
 
 Output lands in `sidecar/mf_entry.dist/`. The binary is named `mf_entry.bin`
-on macOS/Linux and `mf_entry.exe` on Windows.
+on macOS/Linux and `mf_entry.exe` on Windows. The validation step sends the
+same `explain` request to both the Python interpreter and the compiled binary
+and diffs the `sql` field — a mismatch means the Nuitka build is diverging
+from the interpreter.
 
-## Validation
-
-After building, confirm the binary produces identical SQL to the Python
-interpreter:
+The two steps can also be run separately:
 
 ```bash
-hatch run nuitka-build:validate
+hatch run nuitka-build:compile    # build only
+hatch run nuitka-build:validate   # validate only (binary must already exist)
 ```
-
-This sends the same `explain` request to both and diffs the `sql` field of
-each response. A mismatch means something in the Nuitka build is diverging
-from the interpreter.
 
 ## mf-ipc v1 protocol
 

--- a/sidecar/mf_entry.py
+++ b/sidecar/mf_entry.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""mf_entry.py — MetricFlow IPC entry point for the Nuitka sidecar.
+
+Compiled by Nuitka into a standalone binary for use as a general sidecar
+as a subprocess. Communicates via NDJSON over stdin/stdout (mf-ipc v1).
+
+Protocol v1:
+  ready:    {"status":"ready","metricflow_version":"X","python_version":"X","protocol_version":1}
+  explain:  {"id":"...","method":"explain","v":1,"params":{
+                "manifest_path":"...","metric_names":[...],"group_by_names":[...],
+                "where_constraints":null,"order_by_names":null,"limit":null,"sql_engine":"DUCKDB"
+            }} → {"id":"...","ok":true,"sql":"..."}
+  ping:     {"id":"...","method":"ping","v":1} → {"id":"...","ok":true}
+  shutdown: {"id":"...","method":"shutdown","v":1} → {"id":"...","ok":true}
+  error:    {"id":"...","ok":false,"error":{"type":"ExceptionClass","message":"..."}}
+
+manifest_path may be a YAML directory (dev/testing) or a manifest.json file (production).
+sql_engine must be a SqlEngine enum name: DUCKDB, BIGQUERY, DATABRICKS, POSTGRES, REDSHIFT,
+SNOWFLAKE, or TRINO.
+"""
+from __future__ import annotations
+
+import argparse
+import importlib.metadata
+import json
+import logging
+import os
+import signal
+import sys
+import traceback as _traceback
+import types
+from pathlib import Path
+from typing import IO
+
+from metricflow_semantics.model.semantic_manifest_lookup import SemanticManifestLookup
+from metricflow_semantics.sql.sql_bind_parameters import SqlBindParameterSet
+from metricflow_semantics.test_helpers.manifest_helpers import (
+    mf_load_manifest_from_json_file,
+    mf_load_manifest_from_yaml_directory,
+)
+
+from metricflow.data_table.mf_table import MetricFlowDataTable
+from metricflow.engine.metricflow_engine import MetricFlowEngine, MetricFlowQueryRequest
+from metricflow.protocols.sql_client import SqlEngine
+from metricflow.sql.render.big_query import BigQuerySqlPlanRenderer
+from metricflow.sql.render.databricks import DatabricksSqlPlanRenderer
+from metricflow.sql.render.duckdb_renderer import DuckDbSqlPlanRenderer
+from metricflow.sql.render.postgres import PostgresSQLSqlPlanRenderer
+from metricflow.sql.render.redshift import RedshiftSqlPlanRenderer
+from metricflow.sql.render.snowflake import SnowflakeSqlPlanRenderer
+from metricflow.sql.render.sql_plan_renderer import SqlPlanRenderer
+from metricflow.sql.render.trino import TrinoSqlPlanRenderer
+from metricflow_semantic_interfaces.implementations.semantic_manifest import PydanticSemanticManifest
+
+try:
+    _MF_VERSION = importlib.metadata.version("metricflow")
+except Exception:
+    _MF_VERSION = "unknown"
+
+_ipc: IO[str] = sys.stdout  # replaced by main() before first write
+_debug: bool = False
+_cached: tuple[str, float, SqlEngine, MetricFlowEngine] | None = None
+
+
+class _SqlClientStub:
+    """Minimal SqlClient satisfying the Protocol for explain() only.
+
+    explain() compiles SQL but never executes it. MetricFlowEngine needs
+    sql_engine_type (for feature-gating) and sql_plan_renderer (for dialect SQL).
+    All execution methods raise to make accidental execution obvious.
+    """
+
+    def __init__(self, engine: SqlEngine) -> None:
+        self._engine = engine
+        self._renderer = _renderer_for(engine)
+
+    @property
+    def sql_engine_type(self) -> SqlEngine:
+        return self._engine
+
+    @property
+    def sql_plan_renderer(self) -> SqlPlanRenderer:
+        return self._renderer
+
+    def query(
+        self, stmt: str, sql_bind_parameter_set: SqlBindParameterSet = SqlBindParameterSet()
+    ) -> MetricFlowDataTable:
+        raise NotImplementedError("IPC stub does not execute SQL")
+
+    def execute(self, stmt: str, sql_bind_parameter_set: SqlBindParameterSet = SqlBindParameterSet()) -> None:
+        raise NotImplementedError("IPC stub does not execute SQL")
+
+    def dry_run(self, stmt: str, sql_bind_parameter_set: SqlBindParameterSet = SqlBindParameterSet()) -> None:
+        raise NotImplementedError("IPC stub does not execute SQL")
+
+    def close(self) -> None:
+        pass
+
+    def render_bind_parameter_key(self, k: str) -> str:
+        return f":{k}"
+
+
+def _renderer_for(engine: SqlEngine) -> SqlPlanRenderer:
+    match engine:
+        case SqlEngine.DUCKDB:
+            return DuckDbSqlPlanRenderer()
+        case SqlEngine.BIGQUERY:
+            return BigQuerySqlPlanRenderer()
+        case SqlEngine.DATABRICKS:
+            return DatabricksSqlPlanRenderer()
+        case SqlEngine.POSTGRES:
+            return PostgresSQLSqlPlanRenderer()
+        case SqlEngine.REDSHIFT:
+            return RedshiftSqlPlanRenderer()
+        case SqlEngine.SNOWFLAKE:
+            return SnowflakeSqlPlanRenderer()
+        case SqlEngine.TRINO:
+            return TrinoSqlPlanRenderer()
+        case _:
+            raise ValueError(f"No renderer for engine: {engine!r}")
+
+
+def _load_manifest(path: str) -> PydanticSemanticManifest:
+    p = Path(path)
+    if p.is_dir():
+        return mf_load_manifest_from_yaml_directory(p, {"source_schema": "production"})
+    return mf_load_manifest_from_json_file(p)
+
+
+def _get_engine(manifest_path: str, sql_engine: SqlEngine) -> MetricFlowEngine:
+    global _cached
+    mtime = os.path.getmtime(manifest_path)
+    if _cached and _cached[:3] == (manifest_path, mtime, sql_engine):
+        return _cached[3]
+    manifest = _load_manifest(manifest_path)
+    lookup = SemanticManifestLookup(manifest)
+    engine = MetricFlowEngine(lookup, _SqlClientStub(sql_engine))  # type: ignore[arg-type]
+    _cached = (manifest_path, mtime, sql_engine, engine)
+    return engine
+
+
+def _write(obj: dict) -> None:
+    try:
+        _ipc.write(json.dumps(obj) + "\n")
+        _ipc.flush()
+    except BrokenPipeError:
+        logging.warning("IPC pipe broken; exiting")
+        sys.exit(0)
+
+
+def _err(req_id: str | int | None, exc: Exception) -> dict:
+    error: dict[str, str] = {"type": type(exc).__name__, "message": str(exc)}
+    if _debug:
+        error["traceback"] = _traceback.format_exc()
+    return {"id": req_id, "ok": False, "error": error}
+
+
+def _handle_explain(req_id: str | int | None, params: dict) -> dict:
+    try:
+        manifest_path = params["manifest_path"]
+        sql_engine = SqlEngine[params.get("sql_engine", "DUCKDB")]
+        engine = _get_engine(manifest_path, sql_engine)
+        request = MetricFlowQueryRequest.create(
+            metric_names=params.get("metric_names"),
+            group_by_names=params.get("group_by_names"),
+            where_constraints=params.get("where_constraints"),
+            order_by_names=params.get("order_by_names"),
+            limit=params.get("limit"),
+        )
+        result = engine.explain(request)
+        return {"id": req_id, "ok": True, "sql": result.sql_statement.sql}
+    except Exception as e:
+        return _err(req_id, e)
+
+
+def _dispatch(req: dict) -> dict:
+    req_id = req.get("id")
+    method = req.get("method")
+    v = req.get("v", 1)
+    if v != 1:
+        return {
+            "id": req_id,
+            "ok": False,
+            "error": {"type": "ProtocolVersionError", "message": f"Expected v=1, got v={v!r}"},
+        }
+    if method == "ping":
+        return {"id": req_id, "ok": True}
+    if method == "shutdown":
+        return {"id": req_id, "ok": True}
+    if method == "explain":
+        return _handle_explain(req_id, req.get("params") or {})
+    return {
+        "id": req_id,
+        "ok": False,
+        "error": {
+            "type": "UnknownMethod",
+            "message": f"Unknown method: {method!r}. Supported: explain, ping, shutdown",
+        },
+    }
+
+
+def main(argv: list[str]) -> int:  # noqa: D103
+    global _ipc, _debug
+
+    parser = argparse.ArgumentParser(description="MetricFlow IPC entry point (mf-ipc v1)")
+    parser.add_argument("--manifest-path", help="Pre-load manifest before sending the ready message")
+    parser.add_argument("--sql-engine", default="DUCKDB", help="SQL engine for pre-warming (default: DUCKDB)")
+    parser.add_argument("--debug", action="store_true", help="Verbose logging and tracebacks in error responses")
+    parser.add_argument("--version", action="store_true", help="Print version and exit")
+    args = parser.parse_args(argv)
+
+    if args.version:
+        sys.stdout.write(f"mf_entry {_MF_VERSION} (mf-ipc v1)\n")
+        return 0
+
+    _debug = args.debug
+
+    # Protect the IPC channel: save real stdout, redirect print()/logging to stderr.
+    # Any library that calls print() will write to stderr rather than corrupting the
+    # NDJSON framing on the pipe the caller is reading.
+    _ipc = sys.stdout
+    sys.stdout = sys.stderr
+
+    logging.basicConfig(
+        stream=sys.stderr,
+        level=logging.DEBUG if _debug else logging.WARNING,
+        format="%(asctime)s %(levelname)s %(message)s",
+    )
+
+    def _exit_clean(signum: int, frame: types.FrameType | None) -> None:
+        _ipc.flush()
+        sys.exit(0)
+
+    signal.signal(signal.SIGTERM, _exit_clean)
+    signal.signal(signal.SIGINT, _exit_clean)
+
+    if args.manifest_path:
+        try:
+            _get_engine(args.manifest_path, SqlEngine[args.sql_engine])
+        except Exception as e:
+            _ipc.write(json.dumps({"status": "error", "type": type(e).__name__, "message": str(e)}) + "\n")
+            _ipc.flush()
+            return 1
+
+    _write(
+        {
+            "status": "ready",
+            "metricflow_version": _MF_VERSION,
+            "python_version": sys.version.split()[0],
+            "protocol_version": 1,
+        }
+    )
+
+    try:
+        for line in sys.stdin:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                req = json.loads(line)
+            except json.JSONDecodeError as e:
+                _write({"id": None, "ok": False, "error": {"type": "JSONDecodeError", "message": str(e)}})
+                continue
+            resp = _dispatch(req)
+            _write(resp)
+            if req.get("method") == "shutdown":
+                break
+    except Exception:
+        logging.exception("Uncaught error in IPC loop")
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/sidecar/tests/test_mf_entry.py
+++ b/sidecar/tests/test_mf_entry.py
@@ -1,0 +1,161 @@
+"""Subprocess integration tests for sidecar/mf_entry.py (mf-ipc v1).
+
+Each test communicates with a real mf_entry.py process over stdin/stdout,
+mirroring exactly how dbt-core v2 uses the sidecar.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).parent.parent.parent
+_MF_ENTRY = _REPO_ROOT / "poc" / "mf_entry.py"
+_MANIFEST_DIR = (
+    _REPO_ROOT / "metricflow_semantics" / "test_helpers" / "semantic_manifest_yamls" / "sg_00_minimal_manifest"
+)
+
+
+def _send(proc: subprocess.Popen, req: dict) -> dict:  # type: ignore[type-arg]
+    assert proc.stdin is not None and proc.stdout is not None
+    proc.stdin.write(json.dumps(req) + "\n")
+    proc.stdin.flush()
+    return json.loads(proc.stdout.readline())
+
+
+@pytest.fixture(scope="module")
+def sidecar() -> Iterator[subprocess.Popen[str]]:
+    """Spawns mf_entry.py pre-warmed with the test manifest; shared across the module."""
+    proc = subprocess.Popen(
+        [sys.executable, str(_MF_ENTRY), "--manifest-path", str(_MANIFEST_DIR)],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    ready = json.loads(proc.stdout.readline())  # type: ignore[union-attr]
+    assert ready["status"] == "ready", f"Expected ready, got: {ready}"
+    yield proc
+    try:
+        proc.stdin.write(json.dumps({"id": "teardown", "method": "shutdown", "v": 1}) + "\n")  # type: ignore[union-attr]
+        proc.stdin.flush()  # type: ignore[union-attr]
+        proc.wait(timeout=10)
+    except Exception:
+        proc.kill()
+
+
+def test_ready_message_fields(sidecar: subprocess.Popen) -> None:  # type: ignore[type-arg]
+    """Ready message must include version and protocol fields; process must be alive."""
+    assert sidecar.poll() is None  # still running
+
+
+def test_ping(sidecar: subprocess.Popen) -> None:  # type: ignore[type-arg]
+    """Ping returns ok:true with the matching request id."""
+    resp = _send(sidecar, {"id": "ping-1", "method": "ping", "v": 1})
+    assert resp == {"id": "ping-1", "ok": True}
+
+
+def test_explain_returns_sql(sidecar: subprocess.Popen) -> None:  # type: ignore[type-arg]
+    """Explain returns ok:true with a non-empty SQL string containing the metric name."""
+    resp = _send(
+        sidecar,
+        {
+            "id": "explain-1",
+            "method": "explain",
+            "v": 1,
+            "params": {
+                "manifest_path": str(_MANIFEST_DIR),
+                "metric_names": ["bookings"],
+                "group_by_names": ["metric_time"],
+                "sql_engine": "DUCKDB",
+            },
+        },
+    )
+    assert resp["id"] == "explain-1"
+    assert resp["ok"] is True
+    assert "SELECT" in resp["sql"]
+    assert "bookings" in resp["sql"].lower()
+
+
+def test_explain_invalid_metric_returns_structured_error(sidecar: subprocess.Popen) -> None:  # type: ignore[type-arg]
+    """Explain with an unknown metric name returns ok:false with InvalidQueryException."""
+    resp = _send(
+        sidecar,
+        {
+            "id": "explain-2",
+            "method": "explain",
+            "v": 1,
+            "params": {
+                "manifest_path": str(_MANIFEST_DIR),
+                "metric_names": ["nonexistent_metric"],
+                "sql_engine": "DUCKDB",
+            },
+        },
+    )
+    assert resp["id"] == "explain-2"
+    assert resp["ok"] is False
+    assert resp["error"]["type"] == "InvalidQueryException"
+    assert "nonexistent_metric" in resp["error"]["message"]
+
+
+def test_unknown_method(sidecar: subprocess.Popen) -> None:  # type: ignore[type-arg]
+    """An unrecognised method name returns ok:false with UnknownMethod."""
+    resp = _send(sidecar, {"id": "unk-1", "method": "does_not_exist", "v": 1})
+    assert resp["id"] == "unk-1"
+    assert resp["ok"] is False
+    assert resp["error"]["type"] == "UnknownMethod"
+    assert "explain" in resp["error"]["message"]
+
+
+def test_wrong_protocol_version(sidecar: subprocess.Popen) -> None:  # type: ignore[type-arg]
+    """A request with v!=1 returns ok:false with ProtocolVersionError."""
+    resp = _send(sidecar, {"id": "ver-1", "method": "ping", "v": 99})
+    assert resp["id"] == "ver-1"
+    assert resp["ok"] is False
+    assert resp["error"]["type"] == "ProtocolVersionError"
+
+
+def test_malformed_json(sidecar: subprocess.Popen) -> None:  # type: ignore[type-arg]
+    """A non-JSON line returns ok:false with id:null and JSONDecodeError."""
+    assert sidecar.stdin is not None and sidecar.stdout is not None
+    sidecar.stdin.write("not valid json\n")
+    sidecar.stdin.flush()
+    resp = json.loads(sidecar.stdout.readline())
+    assert resp["id"] is None
+    assert resp["ok"] is False
+    assert resp["error"]["type"] == "JSONDecodeError"
+
+
+def test_shutdown_exits_zero() -> None:
+    """Shutdown response is ok:true and process exits with code 0."""
+    proc = subprocess.Popen(
+        [sys.executable, str(_MF_ENTRY)],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    assert proc.stdout is not None and proc.stdin is not None
+    json.loads(proc.stdout.readline())  # consume ready
+    resp = _send(proc, {"id": "shut-1", "method": "shutdown", "v": 1})
+    assert resp == {"id": "shut-1", "ok": True}
+    proc.wait(timeout=5)
+    assert proc.returncode == 0
+
+
+def test_eof_exits_zero() -> None:
+    """Closing stdin (EOF) causes the process to exit cleanly with code 0."""
+    proc = subprocess.Popen(
+        [sys.executable, str(_MF_ENTRY)],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    assert proc.stdout is not None and proc.stdin is not None
+    json.loads(proc.stdout.readline())  # consume ready
+    proc.stdin.close()
+    proc.wait(timeout=5)
+    assert proc.returncode == 0

--- a/sidecar/validate_mf_entry.py
+++ b/sidecar/validate_mf_entry.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Validate that the Nuitka binary produces identical SQL to the Python interpreter.
+
+Sends the same explain request to both and diffs the SQL field of the response.
+Run via: hatch run nuitka-build:validate
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+_MANIFEST = "metricflow_semantics/test_helpers/semantic_manifest_yamls/sg_00_minimal_manifest"
+_INPUT = (
+    json.dumps(
+        {
+            "id": "1",
+            "method": "explain",
+            "v": 1,
+            "params": {
+                "manifest_path": _MANIFEST,
+                "metric_names": ["bookings"],
+                "group_by_names": ["metric_time"],
+                "sql_engine": "DUCKDB",
+            },
+        }
+    )
+    + "\n"
+    + json.dumps({"id": "2", "method": "shutdown", "v": 1})
+    + "\n"
+)
+
+_BIN = Path("sidecar/mf_entry.dist") / ("mf_entry.bin" if sys.platform != "win32" else "mf_entry.exe")
+
+
+def get_sql(cmd: list[str]) -> str:
+    """Run cmd, send IPC requests via stdin, return the SQL from the explain response."""
+    result = subprocess.run(cmd, input=_INPUT, capture_output=True, text=True)
+    lines = [line for line in result.stdout.splitlines() if line.strip()]
+    if len(lines) < 2:
+        raise RuntimeError(f"Unexpected output from {cmd}:\nstdout: {result.stdout}\nstderr: {result.stderr}")
+    resp = json.loads(lines[1])
+    if not resp.get("ok"):
+        raise RuntimeError(f"explain failed: {resp}")
+    return str(resp["sql"])
+
+
+if __name__ == "__main__":
+    if not _BIN.exists():
+        print(f"ERROR: binary not found at {_BIN} — run 'hatch run nuitka-build:compile' first", file=sys.stderr)
+        sys.exit(1)
+
+    print("Generating reference SQL with Python interpreter...")
+    py_sql = get_sql([sys.executable, "sidecar/mf_entry.py"])
+
+    print(f"Generating SQL with Nuitka binary ({_BIN})...")
+    bin_sql = get_sql([str(_BIN)])
+
+    if py_sql != bin_sql:
+        print("FAIL: SQL mismatch", file=sys.stderr)
+        print(f"\nPython output:\n{py_sql}", file=sys.stderr)
+        print(f"\nBinary output:\n{bin_sql}", file=sys.stderr)
+        sys.exit(1)
+
+    print("OK: Python and Nuitka binary produce identical SQL")

--- a/spike-grpc-nuitka/grpc_probe.py
+++ b/spike-grpc-nuitka/grpc_probe.py
@@ -1,0 +1,51 @@
+"""Throwaway spike probe: does grpc survive Nuitka standalone freezing on Windows?
+
+Not production code. Exists only to get a CI signal on real Windows runners for
+the risk raised in PR #2072 (Paul's suggestion to use gRPC for the mf-ipc
+protocol). Already validated on macOS arm64 locally, including combined with
+real MetricFlow deps and real protobuf message serialization — this is the
+one remaining untested platform. Delete this directory once that signal lands.
+"""
+from __future__ import annotations
+
+from concurrent import futures
+
+import grpc  # type: ignore[import-not-found]
+
+
+def _echo(request: bytes, context: grpc.ServicerContext) -> bytes:
+    return request
+
+
+class _EchoHandler(grpc.GenericRpcHandler):
+    def service(self, handler_call_details: grpc.HandlerCallDetails) -> grpc.RpcMethodHandler:
+        return grpc.unary_unary_rpc_method_handler(
+            _echo,
+            request_deserializer=lambda x: x,
+            response_serializer=lambda x: x,
+        )
+
+
+def main() -> None:
+    """Run a real grpc server/client RPC round trip and assert the response matches."""
+    print(f"grpc version: {grpc.__version__}")
+
+    server = grpc.server(futures.ThreadPoolExecutor(max_workers=2))
+    server.add_generic_rpc_handlers((_EchoHandler(),))
+    port = server.add_insecure_port("127.0.0.1:0")
+    server.start()
+    print(f"server listening on 127.0.0.1:{port}")
+
+    channel = grpc.insecure_channel(f"127.0.0.1:{port}")
+    stub = channel.unary_unary("/probe/Echo")
+    response = stub(b"hello from windows spike")
+    assert response == b"hello from windows spike", f"unexpected response: {response!r}"
+    print(f"RPC round-trip OK: {response!r}")
+
+    channel.close()
+    server.stop(None).wait(timeout=5)
+    print("OK")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Throwaway spike, not a real feature PR. Investigating the suggestion on #2072
to use gRPC for the mf-ipc protocol instead of NDJSON.

Already validated locally on macOS arm64:
- grpc alone survives Nuitka standalone freezing (including its `roots.pem`
  data file, handled automatically by Nuitka's `data-files` plugin)
- grpc compiles and runs correctly alongside real MetricFlow deps
  (pydantic-core, duckdb) in the same binary, no C-extension conflicts
- real protobuf message serialization works through a live RPC

This PR exists only to exercise the same probe on a real Windows runner via
the `pull_request` trigger (`workflow_dispatch` can't be invoked until the
workflow exists on the default branch). Will close without merging once the
signal lands — see `spike-grpc-nuitka/grpc_probe.py`.