### PR TITLE
Improve invalid state file handling in the release tool

### DIFF
--- a/.changes/unreleased/Under the Hood-20260720-095904.yaml
+++ b/.changes/unreleased/Under the Hood-20260720-095904.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Improve invalid state file handling in the release tool
+time: 2026-07-20T09:59:04.221869-07:00
+custom:
+    Author: plypaul
+    Issue: "2088"

--- a/metricflow_semantics/toolkit/performance_helpers.py
+++ b/metricflow_semantics/toolkit/performance_helpers.py
@@ -100,8 +100,8 @@ class ExecutionTimer(ContextManager["ExecutionTimer"]):
                 if self._duration_warning_threshold is not None and total_duration > self._duration_warning_threshold:
                     logger.warning(
                         LazyFormat(
-                            lambda: f"{self._render_execution_timer_description(description)!r} is slow with a duration "
-                            f"of {pretty_total_duration}"
+                            lambda: f"{str(self._render_execution_timer_description(description))!r}"
+                            f" is slow with a duration of {pretty_total_duration}"
                         ),
                         extra=self._context_state.extra,
                     )

--- a/scripts/release_tool/mf_release_tool.py
+++ b/scripts/release_tool/mf_release_tool.py
@@ -49,6 +49,7 @@ from pathlib import Path
 from typing import cast
 
 import click
+from metricflow_semantics.toolkit.mf_logging.lazy_formattable import LazyFormat
 from packaging.version import InvalidVersion, Version
 
 from msi_pydantic_shim import BaseModel
@@ -340,7 +341,12 @@ def _load_release_tool_state(state_file_path: Path) -> ReleaseToolState:
     """Load and return the release-tool state, raising if the file is missing."""
     if not state_file_path.exists():
         raise click.ClickException(f"Release tool state file not found at {state_file_path}.")
-    return ReleaseToolState.parse_raw(state_file_path.read_text())
+    try:
+        return ReleaseToolState.parse_raw(state_file_path.read_text())
+    except Exception as e:
+        raise LoadStateFileException(
+            LazyFormat("Unable to load release tool state", state_file_path=state_file_path)
+        ) from e
 
 
 def _warn_if_step_previously_run(step_name: str, step_state: object | None, console: ReleaseHelperConsole) -> None:
@@ -701,8 +707,17 @@ def clean(ctx: click.Context) -> None:
     git_manager = context.git_manager_factory(context.current_directory)
     state_file_path = _release_tool_state_file_path(current_directory=context.current_directory)
 
-    if state_file_path.exists():
+    release_tool_state: ReleaseToolState | None = None
+    try:
         release_tool_state = _load_release_tool_state(state_file_path=state_file_path)
+    except LoadStateFileException:
+        click.echo(
+            LazyFormat(
+                "Unable to load state file so not deleting branches used in release", state_file_path=state_file_path
+            )
+        )
+
+    if release_tool_state:
         branch_names: list[str] = []
         if release_tool_state.step_1 is not None:
             branch_names.append(release_tool_state.step_1.branch_name)
@@ -726,6 +741,12 @@ def clean(ctx: click.Context) -> None:
         state_file_path.unlink()
     else:
         console.echo(f"State file {state_file_path} does not exist, nothing to delete")
+
+
+class LoadStateFileException(Exception):
+    """Exception raised when there's an error loading the state file."""
+
+    pass
 
 
 if __name__ == "__main__":

--- a/scripts/release_tool/mf_release_tool.py
+++ b/scripts/release_tool/mf_release_tool.py
@@ -708,14 +708,13 @@ def clean(ctx: click.Context) -> None:
     state_file_path = _release_tool_state_file_path(current_directory=context.current_directory)
 
     release_tool_state: ReleaseToolState | None = None
-    try:
-        release_tool_state = _load_release_tool_state(state_file_path=state_file_path)
-    except LoadStateFileException:
-        click.echo(
-            LazyFormat(
-                "Unable to load state file so not deleting branches used in release", state_file_path=state_file_path
-            )
-        )
+    if state_file_path.exists():
+        try:
+            release_tool_state = _load_release_tool_state(state_file_path=state_file_path)
+        except LoadStateFileException as e:
+            raise click.ClickException(
+                f"Unable to load release tool state at {state_file_path}. Please fix the file or remove it."
+            ) from e
 
     if release_tool_state:
         branch_names: list[str] = []

--- a/tests_metricflow/release_tools/test_clean.py
+++ b/tests_metricflow/release_tools/test_clean.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from _pytest.fixtures import FixtureRequest
+from click.testing import CliRunner
+from metricflow_semantics.test_helpers.config_helpers import MetricFlowTestConfiguration
+from metricflow_semantics.test_helpers.snapshot_helpers import assert_str_snapshot_equal
+
+from scripts.release_tool.mf_release_tool import (
+    CLI_COMMAND_CLEAN,
+    RELEASE_TOOL_STATE_FILE_PATH,
+    ReleaseToolContext,
+    cli,
+)
+from tests_metricflow.release_tools.release_tool_test_helpers import (
+    RELEASE_TOOL_TEST_ENVIRONMENT,
+    FakeCliCommandRunner,
+    FakeGitHubClient,
+    FakeGitHubClientFactory,
+    FakeGitManager,
+    FakeGitManagerFactory,
+    FakeSleep,
+    _make_metricflow_repo,
+    _release_tool_command,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _release_tool_context(repo_path: Path, git_manager: FakeGitManager) -> ReleaseToolContext:
+    """Create a release-tool context backed by test fakes."""
+    fake_git_manager_factory = FakeGitManagerFactory(git_manager=git_manager)
+    return ReleaseToolContext(
+        environment=RELEASE_TOOL_TEST_ENVIRONMENT,
+        current_directory=repo_path,
+        confirm_all=False,
+        git_manager_factory=fake_git_manager_factory.create_manager,
+        github_client_factory=FakeGitHubClientFactory(github_client=FakeGitHubClient()).create_client,
+        is_cli_command_available=("fossa", "changie").__contains__,
+        cli_command_runner=FakeCliCommandRunner(),
+        sleep=FakeSleep().sleep,
+    )
+
+
+def _normalize_output(output: str, tmp_path: Path) -> str:
+    """Return command output with temp paths normalized for snapshots."""
+    return output.replace(str(tmp_path), "<TMP>")
+
+
+def test_clean_with_missing_state_file(
+    request: FixtureRequest,
+    mf_test_configuration: MetricFlowTestConfiguration,
+    tmp_path: Path,
+) -> None:
+    """Check running `clean` with a missing state file."""
+    git_manager = FakeGitManager()
+    repo_path = _make_metricflow_repo(tmp_path)
+
+    result = CliRunner().invoke(
+        cli,
+        _release_tool_command(repo_path, [CLI_COMMAND_CLEAN], yes=True),
+        obj=_release_tool_context(repo_path=repo_path, git_manager=git_manager),
+    )
+
+    assert result.exit_code == 0, result.output
+    assert_str_snapshot_equal(
+        request=request,
+        snapshot_configuration=mf_test_configuration,
+        snapshot_str=_normalize_output(output=result.output, tmp_path=tmp_path),
+        expectation_description="Includes a message for a missing state file.",
+    )
+
+
+def test_clean_with_invalid_state_file(
+    request: FixtureRequest,
+    mf_test_configuration: MetricFlowTestConfiguration,
+    tmp_path: Path,
+) -> None:
+    """Check running `clean` with an invalid state file."""
+    git_manager = FakeGitManager()
+    repo_path = _make_metricflow_repo(tmp_path)
+    state_file_path = repo_path / RELEASE_TOOL_STATE_FILE_PATH
+    state_file_path.parent.mkdir(parents=True, exist_ok=True)
+    state_file_path.write_text("<Invalid JSON>")
+
+    result = CliRunner().invoke(
+        cli,
+        _release_tool_command(repo_path, [CLI_COMMAND_CLEAN], yes=True),
+        obj=_release_tool_context(repo_path=repo_path, git_manager=git_manager),
+    )
+
+    assert result.exit_code == 1, result.output
+    assert_str_snapshot_equal(
+        request=request,
+        snapshot_configuration=mf_test_configuration,
+        snapshot_str=_normalize_output(output=result.output, tmp_path=tmp_path),
+        expectation_description="Includes a message for an invalid state file.",
+    )

--- a/tests_metricflow/snapshots/test_clean.py/str/test_clean_with_invalid_state_file__result.txt
+++ b/tests_metricflow/snapshots/test_clean.py/str/test_clean_with_invalid_state_file__result.txt
@@ -1,0 +1,9 @@
+test_name: test_clean_with_invalid_state_file
+test_filename: test_clean.py
+docstring:
+  Check running `clean` with an invalid state file.
+expectation_description:
+  Includes a message for an invalid state file.
+---
+MetricFlow repo directory: <TMP>/metricflow
+Error: Unable to load release tool state at <TMP>/metricflow/git_ignored/mf_release_tool_state.json. Please fix the file or remove it.

--- a/tests_metricflow/snapshots/test_clean.py/str/test_clean_with_missing_state_file__result.txt
+++ b/tests_metricflow/snapshots/test_clean.py/str/test_clean_with_missing_state_file__result.txt
@@ -1,0 +1,9 @@
+test_name: test_clean_with_missing_state_file
+test_filename: test_clean.py
+docstring:
+  Check running `clean` with a missing state file.
+expectation_description:
+  Includes a message for a missing state file.
+---
+MetricFlow repo directory: <TMP>/metricflow
+State file <TMP>/metricflow/git_ignored/mf_release_tool_state.json does not exist, nothing to delete


### PR DESCRIPTION
For the release tool, this PR improves handling when the state file is invalid by logging the path to the state file and allowing the `clean` operation to delete it.