### PR TITLE
Exclude test_helper files from hatch build & distribution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,18 @@ Documentation = "https://docs.getdbt.com/docs/build/about-metricflow"
 "Source Code" = "https://github.com/dbt-labs/metricflow"
 
 
+# test_helpers is only used by tests_metricflow/, which isn't published (see
+# addopts below and the sdist/wheel packages list) -- nothing importable from
+# the published package touches it. Excluding it shrinks the distribution and
+# avoids shipping the symlinked fixtures under semantic_manifest_yamls/, which
+# break building this sdist on Windows (hatchling's os.stat() on the
+# tar-extracted symlinks raises WinError 123).
+[tool.hatch.build]
+exclude = [
+  "metricflow_semantics/test_helpers",
+  "metricflow_semantic_interfaces/test_helpers",
+]
+
 # There are files that hatch will always include as well (e.g. the LICENSE file).
 # See hatch build docs for more details.
 [tool.hatch.build.targets.sdist]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,12 +74,8 @@ Documentation = "https://docs.getdbt.com/docs/build/about-metricflow"
 "Source Code" = "https://github.com/dbt-labs/metricflow"
 
 
-# test_helpers is only used by tests_metricflow/, which isn't published (see
-# addopts below and the sdist/wheel packages list) -- nothing importable from
-# the published package touches it. Excluding it shrinks the distribution and
-# avoids shipping the symlinked fixtures under semantic_manifest_yamls/, which
-# break building this sdist on Windows (hatchling's os.stat() on the
-# tar-extracted symlinks raises WinError 123).
+# The test_helpers directories are only used by tests_metricflow/,
+# which isn't packaged and distributed.
 [tool.hatch.build]
 exclude = [
   "metricflow_semantics/test_helpers",


### PR DESCRIPTION
Nothing in the published package imports metricflow_semantics/test_helpers or `metricflow_semantic_interfaces/test_helpers` -- they're only used by `tests_metricflow/`, which isn't published to PyPI.

Some of these files are symlinks under `semantic_manifest_yamls/`, and building this sdist on Windows fails because hatchling's os.stat() call while walking the package tree can't handle the tar-extracted symlinks (WinError 123, "invalid filename syntax").

Verified locally that both the sdist and wheel build cleanly, contain no test_helpers content or symlinks, and that a fresh install (both from the wheel and by building the sdist with --no-binary) still imports correctly.

Closes: #2089 