### PR TITLE
Fix OSI ratio sub-metric names failing semantic manifest name validation

### DIFF
--- a/.changes/unreleased/Fixes-20260723-120000.yaml
+++ b/.changes/unreleased/Fixes-20260723-120000.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Name auto-generated OSI ratio sub-metrics without dunders so they pass semantic manifest name validation
+time: 2026-07-23T12:00:00.000000+09:00
+custom:
+    Author: ota2000
+    Issue: "2091"

--- a/metricflow/converters/osi_to_msi.py
+++ b/metricflow/converters/osi_to_msi.py
@@ -294,8 +294,8 @@ class OSIToMSIConverter:
         ratio_result = _try_parse_ratio(expr_str)
         if ratio_result is not None:
             num_expr, den_expr = ratio_result
-            num_name = f"{name}__numerator"
-            den_name = f"{name}__denominator"
+            num_name = f"{name}_numerator"
+            den_name = f"{name}_denominator"
             num_metrics = self._convert_metric(num_name, num_expr, None, datasets)
             den_metrics = self._convert_metric(den_name, den_expr, None, datasets)
             ratio_metric = PydanticMetric(

--- a/tests_metricflow_semantic_interfaces/osi/test_osi_to_msi.py
+++ b/tests_metricflow_semantic_interfaces/osi/test_osi_to_msi.py
@@ -250,8 +250,8 @@ class TestOSIToMSIMetricConversion:  # noqa: D101
         assert ratio.name == "arpu"
         assert ratio.type_params.numerator is not None
         assert ratio.type_params.denominator is not None
-        assert ratio.type_params.numerator.name == "arpu__numerator"
-        assert ratio.type_params.denominator.name == "arpu__denominator"
+        assert ratio.type_params.numerator.name == "arpu_numerator"
+        assert ratio.type_params.denominator.name == "arpu_denominator"
 
     def test_ratio_sub_metrics_are_simple(self) -> None:  # noqa: D102
         doc = _osi_doc(
@@ -263,7 +263,7 @@ class TestOSIToMSIMetricConversion:  # noqa: D101
         simple_metrics = [m for m in result.metrics if m.type == MetricType.SIMPLE]
         assert len(simple_metrics) == 2
         names = {m.name for m in simple_metrics}
-        assert names == {"ratio__numerator", "ratio__denominator"}
+        assert names == {"ratio_numerator", "ratio_denominator"}
 
     def test_complex_expression_falls_back_to_simple_with_raw_expr(self) -> None:  # noqa: D102
         doc = _osi_doc(


### PR DESCRIPTION
Resolves #2091

## Description

`OSIToMSIConverter` auto-generates sub-metrics for OSI ratio expressions (`(a) / (b)`) named `{name}__numerator` / `{name}__denominator`. `UniqueAndValidNameRule` rejects names containing dunders, so every OSI ratio metric failed dbt parse (`Semantic Manifest validation failed`) — the converter's output could never pass its own validation.

This changes the separator to a single underscore (`{name}_numerator` / `{name}_denominator`) and updates the affected test assertions.

## Verification

- `tests_metricflow_semantic_interfaces/osi/test_osi_to_msi.py`: 28 passed
- End-to-end with dbt-core 1.12.0 native OSI parsing: an OSI ratio metric that previously hard-failed parse now lands in the manifest as a `ratio` metric with `{name}_numerator` / `{name}_denominator` inputs (verified by patching the bundled metricflow 0.211.0 in a real project and re-running `dbt parse`)

## Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the CLA (will sign via cla-assistant if prompted)
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have added a changelog entry via changie