### PR TITLE
Add BIGQUERY and MAQL to OSIDialect

### DIFF
--- a/.changes/unreleased/Features-20260723-130000.yaml
+++ b/.changes/unreleased/Features-20260723-130000.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Add BIGQUERY and MAQL to OSIDialect, matching the OSI core spec dialect enum
+time: 2026-07-23T13:00:00.000000+09:00
+custom:
+    Author: ota2000
+    Issue: "2094"

--- a/metricflow/converters/models.py
+++ b/metricflow/converters/models.py
@@ -15,6 +15,8 @@ class OSIDialect(str, Enum):
     MDX = "MDX"
     TABLEAU = "TABLEAU"
     DATABRICKS = "DATABRICKS"
+    MAQL = "MAQL"
+    BIGQUERY = "BIGQUERY"
 
 
 class OSIAIContextObject(FrozenBaseModel):


### PR DESCRIPTION
Resolves #2094

## Description

The OSI core spec dialect enum is `["ANSI_SQL", "SNOWFLAKE", "MDX", "TABLEAU", "DATABRICKS", "MAQL", "BIGQUERY"]` (apache/ossie `core-spec/osi-schema.json`). `OSIDialect` only has the first five, so OSI documents carrying `BIGQUERY` / `MAQL` expressions fail pydantic validation — with dbt-core 1.12 native OSI parsing that is a hard `dbt parse` failure.

Adding the two members is sufficient to unblock those documents: `_get_expression` already falls back to the first available dialect when the preferred one is absent, so e.g. a BigQuery-only expression is picked up under the default `ANSI_SQL` preference.

## Verification

- `tests_metricflow_semantic_interfaces/osi/`: 94 passed

## Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the CLA
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have added a changelog entry via changie