### PR TITLE
DI-4819: swap x86_64-apple-darwin leg to MACOS_RUNNER_INTEL

### DIFF
--- a/.github/workflows/cd-build-sidecar-binaries.yaml
+++ b/.github/workflows/cd-build-sidecar-binaries.yaml
@@ -19,14 +19,21 @@ jobs:
         include:
           - runner: macos-14
             target-triple: aarch64-apple-darwin
-          # macos-13 (x86_64-apple-darwin) is disabled: GitHub's hosted Intel Mac runner
-          # pool is scarce/deprecating, and this leg has sat in `queued` with no runner
-          # assigned for 2+ hours in testing. Since `publish` below needs the whole `build`
-          # matrix to complete, a hung leg here blocks release artifacts for every other
-          # (working) platform. Re-enable once DI-4819 (Depot access for metricflow) lands
-          # and this leg is switched to a Depot-hosted runner, as fs/dbt-core v2 already do.
-          # - runner: macos-13
-          #   target-triple: x86_64-apple-darwin
+          # DI-4819: was macos-13 (GitHub's free-tier Intel Mac pool), which sat in
+          # `queued` with no runner assigned for 2+ hours in testing -- a hung leg here
+          # would block `publish` (needs: build) for every other platform. Depot -- fs's
+          # and dbt-core v2's route for aarch64-apple-darwin -- turned out not to be a fix:
+          # Depot's macOS runners are Apple Silicon only (confirmed via Depot's docs), and
+          # Nuitka can't cross-compile the way fs/dbt-core's Rust CLI builds do, since it
+          # embeds native CPython plus precompiled per-arch wheels (pydantic-core, duckdb).
+          # `vars.MACOS_RUNNER_INTEL` is fs's actual genuine-Intel-hardware path (used for
+          # its ADBC/DuckDB driver native builds, which have the same can't-cross-compile
+          # constraint) -- a GitHub-hosted paid "larger runner" (macos-15-intel), not Depot.
+          # Untested whether this variable is visible to metricflow yet (it may be scoped
+          # to fs's repo only); if this leg hangs the same way macos-13 did, that's the
+          # signal it isn't, and getting it added is an org-admin ask, not a YAML fix.
+          - runner: ${{ vars.MACOS_RUNNER_INTEL }}
+            target-triple: x86_64-apple-darwin
           - runner: ubuntu-22.04
             target-triple: x86_64-unknown-linux-gnu
           - runner: ubuntu-24.04-arm


### PR DESCRIPTION
## Summary

Follow-up to #2079. The `macos-13` leg of `cd-build-sidecar-binaries.yaml` was disabled there (GitHub's free-tier hosted Intel Mac pool queues indefinitely). This swaps it to `vars.MACOS_RUNNER_INTEL` (`macos-15-intel`).

## Why this variable, not Depot

Depot (dbt-core v2's route for aarch64-apple-darwin) doesn't work here: Depot's own docs confirm its macOS runners are Apple Silicon (M2/M4) only, and Nuitka can't cross-compile the way dbt-core's Rust CLI builds do. This is because the Nuitka builds embeds native CPython plus precompiled per-arch wheels (pydantic-core, duckdb), so it needs to actually run on Intel hardware to produce an Intel binary. However there is still a path forward. Some of the drivers core v2 uses for adapters are go based, and go also don't have cross compilation. For these builds it turns out we target macos-15-intel, which is now what we do.

## Validated

`MACOS_RUNNER_INTEL` has been added as a variable on this repo. Confirmed in two stages:

- A one-step, no-compile check scheduled and ran in 5s on genuine `x86_64` hardware (`Darwin ... RELEASE_X86_64 x86_64`, macOS 15.7.7) -- no queueing, unlike `macos-13`.
- The full matrix then ran end-to-end via a temporary draft-PR validation trigger (since removed): all 5 legs passed, including `Compile & Validate mf_entry (x86_64-apple-darwin)` in 23m6s on `macos-15-intel`.

## Caveat

GitHub has announced it's retiring Intel macOS support entirely after the macOS 15 runner image goes away (~Fall 2027) -- this is a real fix but not a permanent one.

Refs DI-4819