### PR TITLE
Update `dbt-core` to `>=1.11, <1.13`

### DIFF
--- a/.changes/unreleased/Dependencies-20260727-132111.yaml
+++ b/.changes/unreleased/Dependencies-20260727-132111.yaml
@@ -1,0 +1,6 @@
+kind: Dependencies
+body: Update `dbt-core` to `>=1.11, <1.13`
+time: 2026-07-27T13:21:11.695751-07:00
+custom:
+    Author: plypaul
+    Issue: "2105"

--- a/dbt-metricflow/requirements-files/requirements-cli.txt
+++ b/dbt-metricflow/requirements-files/requirements-cli.txt
@@ -1,5 +1,5 @@
 # Internal dependencies
-dbt-core>=1.10.4, <1.12.0
+dbt-core>=1.11, <1.13
 
 # CLI-related
 Jinja2>=3.1.6, <3.7.0


### PR DESCRIPTION
This PR updates the `dbt-core` dependency in `dbt-metricflow` to `>=1.11, <1.13`.