### PR TITLE
DI-4871: decouple sidecar release versioning from MetricFlow release tags

### DIFF
--- a/.changes/unreleased/Under the Hood-20260730-164420.yaml
+++ b/.changes/unreleased/Under the Hood-20260730-164420.yaml
@@ -1,0 +1,8 @@
+kind: Under the Hood
+body: Add CI pipeline to compile MetricFlow into standalone Nuitka binaries for macOS,
+  Linux, and Windows, and publish them as versioned GitHub Release artifacts for embedding
+  in dbt-core v2 (Fusion)
+time: 2026-07-30T16:44:20.063502-05:00
+custom:
+  Author: QMalcolm
+  Issue: "2106"

--- a/.github/workflows/cd-build-sidecar-binaries.yaml
+++ b/.github/workflows/cd-build-sidecar-binaries.yaml
@@ -6,15 +6,15 @@ on:
   push:
     tags:
       # DI-4871: every sidecar binary release -- including the one cut alongside a new
-      # MetricFlow version -- goes through the mf-entry-bin/v<mf_version>+<timestamp>.<sha8>
+      # MetricFlow version -- goes through the mf-stdio-sidecar/v<mf_version>+<timestamp>.<sha8>
       # namespace. release_step_3.py automatically pushes one of these tags alongside
       # MetricFlow's own `v<version>` tag on every release, so this is the sole trigger for
       # this workflow; the bare `v*` tag's only remaining job is triggering
-      # cd-push-metricflow-to-pypi.yaml. (Triggering on both `v*` and `mf-entry-bin/v*`
+      # cd-push-metricflow-to-pypi.yaml. (Triggering on both `v*` and `mf-stdio-sidecar/v*`
       # would double-build and double-publish for every release, once per tag.) Ad hoc
       # sidecar-only releases are pushed the same way via the ad hoc-release Action's
       # re-dispatch.
-      - "mf-entry-bin/v[0-9]+.[0-9]+.[0-9]+*"
+      - "mf-stdio-sidecar/v[0-9]+.[0-9]+.[0-9]+*"
   workflow_dispatch:
 
 jobs:
@@ -102,10 +102,10 @@ jobs:
     name: Publish release assets
     needs: build
     # Only publish on an actual release tag -- either MetricFlow's own `v*` tags or the
-    # sidecar-only `mf-entry-bin/v*` namespace (DI-4871). workflow_dispatch and pull_request
+    # sidecar-only `mf-stdio-sidecar/v*` namespace (DI-4871). workflow_dispatch and pull_request
     # runs exist to validate the build matrix on real runners and have no tag to attach
     # assets to. `needs: build` already means this only runs if every matrix leg succeeded.
-    if: startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/mf-entry-bin/v')
+    if: startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/mf-stdio-sidecar/v')
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/cd-build-sidecar-binaries.yaml
+++ b/.github/workflows/cd-build-sidecar-binaries.yaml
@@ -5,12 +5,14 @@ name: Build Sidecar Binaries
 on:
   push:
     tags:
-      # Mirrors the MetricFlow release tag pattern in cd-push-metricflow-to-pypi.yaml.
-      - "v[0-9]+.[0-9]+.[0-9]+*"
-      # DI-4871: sidecar-only releases (no corresponding MetricFlow version bump), e.g.
-      # sidecar/v0.208.0+2. Pushed either by release_step_3.py's automated `+1` baseline
-      # (a real user token, so this push trigger fires normally) or by hand for an `+n`
-      # tag created outside the ad hoc-release Action's re-dispatch path.
+      # DI-4871: every sidecar binary release -- including the baseline build for a new
+      # MetricFlow version -- goes through the sidecar/v<mf_version>+<counter> namespace.
+      # release_step_3.py automatically pushes a `+1` tag alongside MetricFlow's own
+      # `v<version>` tag on every release, so this is the sole trigger for this workflow;
+      # the bare `v*` tag's only remaining job is triggering
+      # cd-push-metricflow-to-pypi.yaml. (Triggering on both `v*` and `sidecar/v*` would
+      # double-build and double-publish for every release, once per tag.) `+2`, `+3`,
+      # etc. are pushed by hand or via the ad hoc-release Action's re-dispatch.
       - "sidecar/v[0-9]+.[0-9]+.[0-9]+*"
   workflow_dispatch:
 

--- a/.github/workflows/cd-build-sidecar-binaries.yaml
+++ b/.github/workflows/cd-build-sidecar-binaries.yaml
@@ -73,6 +73,28 @@ jobs:
           path: sidecar/mf_entry.dist/
           if-no-files-found: error
 
+      # DI-4871: build-info.json records the Nuitka/Python versions actually used, rather
+      # than re-stating pyproject.toml's pin (which could drift from what really ran).
+      # These values don't vary by platform (single pinned Nuitka version, and
+      # setup-python-env's python-version input is the same for every matrix leg), so
+      # they only need capturing once -- arbitrarily, on this leg -- rather than on all 5.
+      - name: Record build tool versions for build-info.json
+        if: matrix.target-triple == 'x86_64-unknown-linux-gnu'
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p build-metadata
+          hatch run nuitka-build:python -m nuitka --version | head -n1 > build-metadata/nuitka-version.txt
+          hatch run nuitka-build:python --version > build-metadata/python-version.txt
+
+      - name: Upload build tool version metadata
+        if: matrix.target-triple == 'x86_64-unknown-linux-gnu'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # actions/upload-artifact@v4
+        with:
+          name: build-metadata
+          path: build-metadata/
+          if-no-files-found: error
+
   publish:
     name: Publish release assets
     needs: build
@@ -90,6 +112,12 @@ jobs:
         with:
           pattern: mf_entry-*
           path: dist
+
+      - name: Download build tool version metadata
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # actions/download-artifact@v4
+        with:
+          name: build-metadata
+          path: build-metadata
 
       - name: Package archives and generate checksums
         shell: bash
@@ -114,6 +142,41 @@ jobs:
             rm -rf "$dir"
           done
           sha256sum mf_entry-* > SHA256SUMS.txt
+
+      - name: Generate build-info.json
+        shell: bash
+        env:
+          COMMIT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          tag="${{ github.ref_name }}"
+          tag="${tag#sidecar/}"
+          # Everything from the first `+` on is the ad hoc counter, not part of the
+          # embedded MetricFlow version (a baseline `+1`/real-release tag has no `+` at
+          # all, so this is a harmless no-op in that case).
+          mf_version="${tag%%+*}"
+          mf_version="${mf_version#v}"
+          NUITKA_VERSION="$(cat build-metadata/nuitka-version.txt)" \
+          PYTHON_VERSION="$(cat build-metadata/python-version.txt)" \
+          SIDECAR_TAG="$tag" \
+          METRICFLOW_VERSION="$mf_version" \
+          python3 - <<'PY' > dist/build-info.json
+          import json
+          import os
+
+          print(
+              json.dumps(
+                  {
+                      "sidecar_tag": os.environ["SIDECAR_TAG"],
+                      "metricflow_version": os.environ["METRICFLOW_VERSION"],
+                      "commit": os.environ["COMMIT_SHA"],
+                      "nuitka_version": os.environ["NUITKA_VERSION"].strip(),
+                      "python_version": os.environ["PYTHON_VERSION"].strip(),
+                  },
+                  indent=2,
+              )
+          )
+          PY
 
       - name: Publish to GitHub Release
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # softprops/action-gh-release@v2

--- a/.github/workflows/cd-build-sidecar-binaries.yaml
+++ b/.github/workflows/cd-build-sidecar-binaries.yaml
@@ -119,3 +119,7 @@ jobs:
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # softprops/action-gh-release@v2
         with:
           files: dist/*
+          # DI-4871: default is `true`, which silently overwrites assets on a re-push of
+          # an existing tag. An accidental re-push (mistyped/reused ad hoc counter, or a
+          # force-moved tag) should fail loudly instead of clobbering a published release.
+          overwrite_files: false

--- a/.github/workflows/cd-build-sidecar-binaries.yaml
+++ b/.github/workflows/cd-build-sidecar-binaries.yaml
@@ -4,9 +4,14 @@ name: Build Sidecar Binaries
 
 on:
   push:
-    # Mirrors the MetricFlow release tag pattern in cd-push-metricflow-to-pypi.yaml.
     tags:
+      # Mirrors the MetricFlow release tag pattern in cd-push-metricflow-to-pypi.yaml.
       - "v[0-9]+.[0-9]+.[0-9]+*"
+      # DI-4871: sidecar-only releases (no corresponding MetricFlow version bump), e.g.
+      # sidecar/v0.208.0+2. Pushed either by release_step_3.py's automated `+1` baseline
+      # (a real user token, so this push trigger fires normally) or by hand for an `+n`
+      # tag created outside the ad hoc-release Action's re-dispatch path.
+      - "sidecar/v[0-9]+.[0-9]+.[0-9]+*"
   workflow_dispatch:
 
 jobs:
@@ -71,10 +76,11 @@ jobs:
   publish:
     name: Publish release assets
     needs: build
-    # Only publish on an actual release tag. workflow_dispatch and pull_request runs exist
-    # to validate the build matrix on real runners and have no tag to attach assets to.
-    # `needs: build` already means this only runs if every matrix leg succeeded.
-    if: startsWith(github.ref, 'refs/tags/v')
+    # Only publish on an actual release tag -- either MetricFlow's own `v*` tags or the
+    # sidecar-only `sidecar/v*` namespace (DI-4871). workflow_dispatch and pull_request
+    # runs exist to validate the build matrix on real runners and have no tag to attach
+    # assets to. `needs: build` already means this only runs if every matrix leg succeeded.
+    if: startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/sidecar/v')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -90,13 +96,20 @@ jobs:
         run: |
           set -euo pipefail
           cd dist
+          # DI-4871: sidecar/v<mf_version>+<counter> tags are slash-namespaced (to avoid
+          # colliding with cd-push-metricflow-to-pypi.yaml's `v*` trigger glob), but
+          # `github.ref_name` keeps the slash -- interpolating it as-is would have
+          # tar/zip try to write into a nonexistent `sidecar/` subdirectory. Strip the
+          # namespace for the asset filename only; the tag itself stays slash-namespaced.
+          tag="${{ github.ref_name }}"
+          tag="${tag#sidecar/}"
           for dir in mf_entry-*/; do
             dir="${dir%/}"
             triple="${dir#mf_entry-}"
             if [[ "$triple" == *windows* ]]; then
-              (cd "$dir" && zip -r "../mf_entry-${{ github.ref_name }}-${triple}.zip" .)
+              (cd "$dir" && zip -r "../mf_entry-${tag}-${triple}.zip" .)
             else
-              tar -czf "mf_entry-${{ github.ref_name }}-${triple}.tar.gz" -C "$dir" .
+              tar -czf "mf_entry-${tag}-${triple}.tar.gz" -C "$dir" .
             fi
             rm -rf "$dir"
           done

--- a/.github/workflows/cd-build-sidecar-binaries.yaml
+++ b/.github/workflows/cd-build-sidecar-binaries.yaml
@@ -109,6 +109,9 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Check-out the repo
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # actions/checkout@v4
+
       - name: Download all platform artifacts
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # actions/download-artifact@v4
         with:
@@ -123,62 +126,19 @@ jobs:
 
       - name: Package archives and generate checksums
         shell: bash
-        run: |
-          set -euo pipefail
-          cd dist
-          # DI-4871: sidecar/v<mf_version>+<counter> tags are slash-namespaced (to avoid
-          # colliding with cd-push-metricflow-to-pypi.yaml's `v*` trigger glob), but
-          # `github.ref_name` keeps the slash -- interpolating it as-is would have
-          # tar/zip try to write into a nonexistent `sidecar/` subdirectory. Strip the
-          # namespace for the asset filename only; the tag itself stays slash-namespaced.
-          tag="${{ github.ref_name }}"
-          tag="${tag#sidecar/}"
-          for dir in mf_entry-*/; do
-            dir="${dir%/}"
-            triple="${dir#mf_entry-}"
-            if [[ "$triple" == *windows* ]]; then
-              (cd "$dir" && zip -r "../mf_entry-${tag}-${triple}.zip" .)
-            else
-              tar -czf "mf_entry-${tag}-${triple}.tar.gz" -C "$dir" .
-            fi
-            rm -rf "$dir"
-          done
-          sha256sum mf_entry-* > SHA256SUMS.txt
+        # DI-4871: stdlib-only script (scripts/sidecar_release/), no hatch env needed --
+        # runnable locally against a real `sidecar/mf_entry.dist/` build the same way.
+        run: python3 -m scripts.sidecar_release.package_archives --dist-dir dist --tag "${{ github.ref_name }}"
 
       - name: Generate build-info.json
         shell: bash
-        env:
-          COMMIT_SHA: ${{ github.sha }}
         run: |
-          set -euo pipefail
-          tag="${{ github.ref_name }}"
-          tag="${tag#sidecar/}"
-          # Everything from the first `+` on is the ad hoc counter, not part of the
-          # embedded MetricFlow version (a baseline `+1`/real-release tag has no `+` at
-          # all, so this is a harmless no-op in that case).
-          mf_version="${tag%%+*}"
-          mf_version="${mf_version#v}"
-          NUITKA_VERSION="$(cat build-metadata/nuitka-version.txt)" \
-          PYTHON_VERSION="$(cat build-metadata/python-version.txt)" \
-          SIDECAR_TAG="$tag" \
-          METRICFLOW_VERSION="$mf_version" \
-          python3 - <<'PY' > dist/build-info.json
-          import json
-          import os
-
-          print(
-              json.dumps(
-                  {
-                      "sidecar_tag": os.environ["SIDECAR_TAG"],
-                      "metricflow_version": os.environ["METRICFLOW_VERSION"],
-                      "commit": os.environ["COMMIT_SHA"],
-                      "nuitka_version": os.environ["NUITKA_VERSION"].strip(),
-                      "python_version": os.environ["PYTHON_VERSION"].strip(),
-                  },
-                  indent=2,
-              )
-          )
-          PY
+          python3 -m scripts.sidecar_release.generate_build_info \
+            --tag "${{ github.ref_name }}" \
+            --commit "${{ github.sha }}" \
+            --nuitka-version-file build-metadata/nuitka-version.txt \
+            --python-version-file build-metadata/python-version.txt \
+            --output dist/build-info.json
 
       - name: Publish to GitHub Release
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # softprops/action-gh-release@v2

--- a/.github/workflows/cd-build-sidecar-binaries.yaml
+++ b/.github/workflows/cd-build-sidecar-binaries.yaml
@@ -5,15 +5,16 @@ name: Build Sidecar Binaries
 on:
   push:
     tags:
-      # DI-4871: every sidecar binary release -- including the baseline build for a new
-      # MetricFlow version -- goes through the sidecar/v<mf_version>+<counter> namespace.
-      # release_step_3.py automatically pushes a `+1` tag alongside MetricFlow's own
-      # `v<version>` tag on every release, so this is the sole trigger for this workflow;
-      # the bare `v*` tag's only remaining job is triggering
-      # cd-push-metricflow-to-pypi.yaml. (Triggering on both `v*` and `sidecar/v*` would
-      # double-build and double-publish for every release, once per tag.) `+2`, `+3`,
-      # etc. are pushed by hand or via the ad hoc-release Action's re-dispatch.
-      - "sidecar/v[0-9]+.[0-9]+.[0-9]+*"
+      # DI-4871: every sidecar binary release -- including the one cut alongside a new
+      # MetricFlow version -- goes through the mf-entry-bin/v<mf_version>+<timestamp>.<sha8>
+      # namespace. release_step_3.py automatically pushes one of these tags alongside
+      # MetricFlow's own `v<version>` tag on every release, so this is the sole trigger for
+      # this workflow; the bare `v*` tag's only remaining job is triggering
+      # cd-push-metricflow-to-pypi.yaml. (Triggering on both `v*` and `mf-entry-bin/v*`
+      # would double-build and double-publish for every release, once per tag.) Ad hoc
+      # sidecar-only releases are pushed the same way via the ad hoc-release Action's
+      # re-dispatch.
+      - "mf-entry-bin/v[0-9]+.[0-9]+.[0-9]+*"
   workflow_dispatch:
 
 jobs:
@@ -101,10 +102,10 @@ jobs:
     name: Publish release assets
     needs: build
     # Only publish on an actual release tag -- either MetricFlow's own `v*` tags or the
-    # sidecar-only `sidecar/v*` namespace (DI-4871). workflow_dispatch and pull_request
+    # sidecar-only `mf-entry-bin/v*` namespace (DI-4871). workflow_dispatch and pull_request
     # runs exist to validate the build matrix on real runners and have no tag to attach
     # assets to. `needs: build` already means this only runs if every matrix leg succeeded.
-    if: startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/sidecar/v')
+    if: startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/mf-entry-bin/v')
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/cd-cut-adhoc-sidecar-release.yaml
+++ b/.github/workflows/cd-cut-adhoc-sidecar-release.yaml
@@ -1,8 +1,9 @@
-# Cuts an ad hoc sidecar-only release (DI-4871): a new sidecar/v<mf_version>+<counter>
-# tag for a change to sidecar/mf_entry.py or mf_ipc_protocol.py that doesn't correspond to
-# a new MetricFlow version. The `+1` baseline for each MetricFlow version is cut
-# automatically by scripts/release_tool/release_step_3.py instead -- this workflow is only
-# for `+2`, `+3`, etc.
+# Cuts an ad hoc sidecar-only release (DI-4871): a new
+# mf-entry-bin/v<mf_version>+<timestamp>.<sha8> tag for a change to sidecar/mf_entry.py or
+# mf_ipc_protocol.py that doesn't correspond to a new MetricFlow version. The tag cut
+# alongside each MetricFlow release is instead pushed automatically by
+# scripts/release_tool/release_step_3.py -- this workflow is only for sidecar-only changes
+# in between releases.
 name: Cut Ad Hoc Sidecar Release
 
 on:
@@ -31,35 +32,16 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
-      - name: Resolve MetricFlow version, compute next counter, and push the tag
+      - name: Cut the local release tag
         id: tag
         shell: bash
-        run: |
-          set -euo pipefail
-          # The nearest real MetricFlow release tag reachable from this commit -- not
-          # metricflow/__about__.py's __version__, which is a `.devN` string between
-          # releases. `--tags` is required since release tags are lightweight, not
-          # annotated. DI-4871 explicitly does not guard against metricflow/,
-          # metricflow_semantics/, or metricflow_semantic_interfaces/ having changed
-          # since that release -- build-info.json's recorded commit is the source of
-          # truth if that's ever in question.
-          mf_version="$(git describe --tags --abbrev=0 --match 'v[0-9]*.[0-9]*.[0-9]*' HEAD)"
-          mf_version="${mf_version#v}"
+        # DI-4871: stdlib-only script (scripts/sidecar_release/), no hatch env needed --
+        # run it locally with --dry-run to preview the tag a real dispatch would cut.
+        run: python3 -m scripts.sidecar_release.cut_adhoc_release
 
-          highest_counter=0
-          for existing_tag in $(git tag -l "sidecar/v${mf_version}+*"); do
-            counter="${existing_tag##*+}"
-            if [[ "$counter" =~ ^[0-9]+$ ]] && (( counter > highest_counter )); then
-              highest_counter="$counter"
-            fi
-          done
-          new_tag="sidecar/v${mf_version}+$((highest_counter + 1))"
-
-          echo "Cutting ${new_tag} at $(git rev-parse HEAD)"
-          git tag "$new_tag"
-          git push origin "refs/tags/${new_tag}"
-
-          echo "tag=${new_tag}" >> "$GITHUB_OUTPUT"
+      - name: Push the release tag
+        shell: bash
+        run: git push origin "refs/tags/${{ steps.tag.outputs.tag }}"
 
       - name: Trigger the sidecar build+publish workflow for the new tag
         env:
@@ -69,7 +51,7 @@ jobs:
           # A tag pushed with this workflow's own GITHUB_TOKEN does not trigger another
           # workflow's `on: push: tags:` (GitHub's built-in same-token recursion guard),
           # so cd-build-sidecar-binaries.yaml must be dispatched explicitly rather than
-          # relying on the push trigger it uses for the automated `+1` baseline tag.
+          # relying on the push trigger it uses for the automated release_step_3.py tag.
           gh workflow run cd-build-sidecar-binaries.yaml \
             --repo "${{ github.repository }}" \
             --ref "${{ steps.tag.outputs.tag }}"

--- a/.github/workflows/cd-cut-adhoc-sidecar-release.yaml
+++ b/.github/workflows/cd-cut-adhoc-sidecar-release.yaml
@@ -28,9 +28,6 @@ jobs:
 
       - name: Check-out the repo
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # actions/checkout@v4
-        with:
-          fetch-depth: 0
-          fetch-tags: true
 
       - name: Cut the local release tag
         id: tag

--- a/.github/workflows/cd-cut-adhoc-sidecar-release.yaml
+++ b/.github/workflows/cd-cut-adhoc-sidecar-release.yaml
@@ -1,5 +1,5 @@
 # Cuts an ad hoc sidecar-only release (DI-4871): a new
-# mf-entry-bin/v<mf_version>+<timestamp>.<sha8> tag for a change to sidecar/mf_entry.py or
+# mf-stdio-sidecar/v<mf_version>+<timestamp>.<sha8> tag for a change to sidecar/mf_entry.py or
 # mf_ipc_protocol.py that doesn't correspond to a new MetricFlow version. The tag cut
 # alongside each MetricFlow release is instead pushed automatically by
 # scripts/release_tool/release_step_3.py -- this workflow is only for sidecar-only changes

--- a/.github/workflows/cd-cut-adhoc-sidecar-release.yaml
+++ b/.github/workflows/cd-cut-adhoc-sidecar-release.yaml
@@ -1,0 +1,75 @@
+# Cuts an ad hoc sidecar-only release (DI-4871): a new sidecar/v<mf_version>+<counter>
+# tag for a change to sidecar/mf_entry.py or mf_ipc_protocol.py that doesn't correspond to
+# a new MetricFlow version. The `+1` baseline for each MetricFlow version is cut
+# automatically by scripts/release_tool/release_step_3.py instead -- this workflow is only
+# for `+2`, `+3`, etc.
+name: Cut Ad Hoc Sidecar Release
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  actions: write
+
+jobs:
+  cut-release:
+    name: Tag and build an ad hoc sidecar release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Restrict to main
+        shell: bash
+        run: |
+          if [[ "${{ github.ref }}" != "refs/heads/main" ]]; then
+            echo "::error::This workflow can only be dispatched from main (got ${{ github.ref }}). An ad hoc sidecar release must not embed unmerged/unreviewed code." >&2
+            exit 1
+          fi
+
+      - name: Check-out the repo
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Resolve MetricFlow version, compute next counter, and push the tag
+        id: tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          # The nearest real MetricFlow release tag reachable from this commit -- not
+          # metricflow/__about__.py's __version__, which is a `.devN` string between
+          # releases. `--tags` is required since release tags are lightweight, not
+          # annotated. DI-4871 explicitly does not guard against metricflow/,
+          # metricflow_semantics/, or metricflow_semantic_interfaces/ having changed
+          # since that release -- build-info.json's recorded commit is the source of
+          # truth if that's ever in question.
+          mf_version="$(git describe --tags --abbrev=0 --match 'v[0-9]*.[0-9]*.[0-9]*' HEAD)"
+          mf_version="${mf_version#v}"
+
+          highest_counter=0
+          for existing_tag in $(git tag -l "sidecar/v${mf_version}+*"); do
+            counter="${existing_tag##*+}"
+            if [[ "$counter" =~ ^[0-9]+$ ]] && (( counter > highest_counter )); then
+              highest_counter="$counter"
+            fi
+          done
+          new_tag="sidecar/v${mf_version}+$((highest_counter + 1))"
+
+          echo "Cutting ${new_tag} at $(git rev-parse HEAD)"
+          git tag "$new_tag"
+          git push origin "refs/tags/${new_tag}"
+
+          echo "tag=${new_tag}" >> "$GITHUB_OUTPUT"
+
+      - name: Trigger the sidecar build+publish workflow for the new tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # A tag pushed with this workflow's own GITHUB_TOKEN does not trigger another
+          # workflow's `on: push: tags:` (GitHub's built-in same-token recursion guard),
+          # so cd-build-sidecar-binaries.yaml must be dispatched explicitly rather than
+          # relying on the push trigger it uses for the automated `+1` baseline tag.
+          gh workflow run cd-build-sidecar-binaries.yaml \
+            --repo "${{ github.repository }}" \
+            --ref "${{ steps.tag.outputs.tag }}"

--- a/scripts/release_tool/mf_release_tool.py
+++ b/scripts/release_tool/mf_release_tool.py
@@ -44,6 +44,7 @@ import time
 from collections.abc import Callable, Iterator, Mapping
 from contextlib import contextmanager
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from itertools import cycle
 from pathlib import Path
 from typing import cast
@@ -210,6 +211,8 @@ class ReleaseToolContext:
     cli_command_runner: CliCommandRunner
     # Function used to sleep between poll iterations.
     sleep: Callable[[float], None]
+    # Function used to get the current UTC time (DI-4871 sidecar release tag timestamps).
+    now: Callable[[], datetime]
 
     def copy(
         self,
@@ -222,6 +225,7 @@ class ReleaseToolContext:
         is_cli_command_available: Callable[[str], bool] | None = None,
         cli_command_runner: CliCommandRunner | None = None,
         sleep: Callable[[float], None] | None = None,
+        now: Callable[[], datetime] | None = None,
     ) -> ReleaseToolContext:
         """Return a copy with any provided fields replaced; pass ``None`` to leave a field unchanged."""
         return ReleaseToolContext(
@@ -237,6 +241,7 @@ class ReleaseToolContext:
             ),
             cli_command_runner=self.cli_command_runner if cli_command_runner is None else cli_command_runner,
             sleep=self.sleep if sleep is None else sleep,
+            now=self.now if now is None else now,
         )
 
 
@@ -261,6 +266,7 @@ def _default_release_tool_context(current_directory: Path) -> ReleaseToolContext
         is_cli_command_available=_is_cli_command_available,
         cli_command_runner=MetricFlowCliCommandRunner(),
         sleep=time.sleep,
+        now=lambda: datetime.now(timezone.utc),
     )
 
 
@@ -510,6 +516,7 @@ def step_3(ctx: click.Context) -> None:
         github_client=github_client,
         release_helper=release_helper,
         sleep=context.sleep,
+        now=context.now,
     )
     step_3_state = step_3_runner.run()
 

--- a/scripts/release_tool/release_helper.py
+++ b/scripts/release_tool/release_helper.py
@@ -59,14 +59,6 @@ class ReleaseHelper:
     METRICFLOW_RELEASE_TAG_PREFIX: ClassVar[str] = "v"
     # Prefix for dbt-metricflow release version tags.
     DBT_METRICFLOW_RELEASE_TAG_PREFIX: ClassVar[str] = "dbt-metricflow/v"
-    # Prefix for sidecar binary release tags (DI-4871). Slash-namespaced, rather than a
-    # suffix on the bare `v<version>` tag, so it can't also match
-    # cd-push-metricflow-to-pypi.yaml's `v[0-9]+.[0-9]+.[0-9]+*` trigger glob.
-    SIDECAR_RELEASE_TAG_PREFIX: ClassVar[str] = "sidecar/v"
-    # Counter suffix for the sidecar tag automatically cut alongside every MetricFlow
-    # release. Ad hoc sidecar-only releases between MetricFlow versions use `+2`, `+3`,
-    # etc., cut by hand or via the ad hoc-release GitHub Action, not by this tool.
-    SIDECAR_BASELINE_COUNTER_SUFFIX: ClassVar[str] = "+1"
     # GitHub Actions workflow file that publishes MetricFlow to PyPI after a release tag.
     CD_PUSH_METRICFLOW_TO_PYPI_WORKFLOW_FILE_NAME: ClassVar[str] = "cd-push-metricflow-to-pypi.yaml"
     # GitHub Actions workflow file that publishes dbt-metricflow to PyPI after a release tag.

--- a/scripts/release_tool/release_helper.py
+++ b/scripts/release_tool/release_helper.py
@@ -59,6 +59,14 @@ class ReleaseHelper:
     METRICFLOW_RELEASE_TAG_PREFIX: ClassVar[str] = "v"
     # Prefix for dbt-metricflow release version tags.
     DBT_METRICFLOW_RELEASE_TAG_PREFIX: ClassVar[str] = "dbt-metricflow/v"
+    # Prefix for sidecar binary release tags (DI-4871). Slash-namespaced, rather than a
+    # suffix on the bare `v<version>` tag, so it can't also match
+    # cd-push-metricflow-to-pypi.yaml's `v[0-9]+.[0-9]+.[0-9]+*` trigger glob.
+    SIDECAR_RELEASE_TAG_PREFIX: ClassVar[str] = "sidecar/v"
+    # Counter suffix for the sidecar tag automatically cut alongside every MetricFlow
+    # release. Ad hoc sidecar-only releases between MetricFlow versions use `+2`, `+3`,
+    # etc., cut by hand or via the ad hoc-release GitHub Action, not by this tool.
+    SIDECAR_BASELINE_COUNTER_SUFFIX: ClassVar[str] = "+1"
     # GitHub Actions workflow file that publishes MetricFlow to PyPI after a release tag.
     CD_PUSH_METRICFLOW_TO_PYPI_WORKFLOW_FILE_NAME: ClassVar[str] = "cd-push-metricflow-to-pypi.yaml"
     # GitHub Actions workflow file that publishes dbt-metricflow to PyPI after a release tag.

--- a/scripts/release_tool/release_step_3.py
+++ b/scripts/release_tool/release_step_3.py
@@ -20,6 +20,8 @@ class ReleaseStep3State(BaseModel):
 
     # Tag created for the MetricFlow release.
     metricflow_release_tag_name: str | None = None
+    # Sidecar baseline tag created alongside the MetricFlow release (DI-4871).
+    sidecar_release_tag_name: str | None = None
     # Merge commit SHA for the step 1 PR that creates the release.
     metricflow_release_merge_commit_sha: str
     # Merge commit SHA for the step 2 PR that changes the metricflow package version to a dev one.
@@ -46,6 +48,10 @@ class ReleaseStep3Runner:
     * Polling until the step-2 PR is ready to merge, then merging it
     * Creating or updating a lightweight ``v$VERSION`` tag pointing to
       the step-1 merge commit and force-pushing it
+    * Creating or updating the sidecar baseline tag
+      (``sidecar/v$VERSION+1``, DI-4871) at the same commit and
+      force-pushing it, so every MetricFlow release always has a
+      matching sidecar binary build with no separate manual step
     * Triggering the publish workflow using the new tag
     """
 
@@ -71,6 +77,10 @@ class ReleaseStep3Runner:
         helper = self.release_helper
         git = helper.git_manager
         tag_name = f"{ReleaseHelper.METRICFLOW_RELEASE_TAG_PREFIX}{self.step_1_state.metricflow_package_version}"
+        sidecar_tag_name = (
+            f"{ReleaseHelper.SIDECAR_RELEASE_TAG_PREFIX}{self.step_1_state.metricflow_package_version}"
+            f"{ReleaseHelper.SIDECAR_BASELINE_COUNTER_SUFFIX}"
+        )
 
         self._wait_for_prs(step_1_pr=step_1_pr, step_2_pr=step_2_pr)
 
@@ -120,8 +130,17 @@ class ReleaseStep3Runner:
                 force=True,
             ),
         )
+        helper.run_confirmed_remote_action(
+            description=f"Create and force push sidecar baseline tag {sidecar_tag_name} at {step_1_merge_sha}",
+            action=lambda: git.push_tag(
+                tag_name=sidecar_tag_name,
+                objectish=step_1_merge_sha,
+                force=True,
+            ),
+        )
         return ReleaseStep3State(
             metricflow_release_tag_name=tag_name,
+            sidecar_release_tag_name=sidecar_tag_name,
             metricflow_release_merge_commit_sha=step_1_merge_sha,
             metricflow_dev_version_commit_sha=step_2_merge_sha,
         )

--- a/scripts/release_tool/release_step_3.py
+++ b/scripts/release_tool/release_step_3.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Callable
 from dataclasses import dataclass
+from datetime import datetime
 from typing import ClassVar
 
 from msi_pydantic_shim import BaseModel
@@ -11,6 +12,7 @@ from scripts.release_tool.github_client import GitHubClient, GitHubMergeMethod
 from scripts.release_tool.release_helper import ReleaseHelper
 from scripts.release_tool.release_step_1 import ReleaseStep1State
 from scripts.release_tool.release_step_2 import ReleaseStep2State
+from scripts.sidecar_release.tag import build_sidecar_release_tag
 
 logger = logging.getLogger(__name__)
 
@@ -48,10 +50,11 @@ class ReleaseStep3Runner:
     * Polling until the step-2 PR is ready to merge, then merging it
     * Creating or updating a lightweight ``v$VERSION`` tag pointing to
       the step-1 merge commit and force-pushing it
-    * Creating or updating the sidecar baseline tag
-      (``sidecar/v$VERSION+1``, DI-4871) at the same commit and
-      force-pushing it, so every MetricFlow release always has a
-      matching sidecar binary build with no separate manual step
+    * Creating or updating a matching sidecar release tag
+      (``mf-entry-bin/v$VERSION+<timestamp>.<sha8>``, DI-4871) at the
+      same commit and force-pushing it, so every MetricFlow release
+      always has a matching sidecar binary build with no separate
+      manual step
     * Triggering the publish workflow using the new tag
     """
 
@@ -67,6 +70,8 @@ class ReleaseStep3Runner:
     release_helper: ReleaseHelper
     # Function used to sleep between poll iterations.
     sleep: Callable[[float], None]
+    # Function used to get the current UTC time for the sidecar release tag (DI-4871).
+    now: Callable[[], datetime]
 
     def run(self) -> ReleaseStep3State:
         """Run step 3 and return state to save."""
@@ -77,10 +82,6 @@ class ReleaseStep3Runner:
         helper = self.release_helper
         git = helper.git_manager
         tag_name = f"{ReleaseHelper.METRICFLOW_RELEASE_TAG_PREFIX}{self.step_1_state.metricflow_package_version}"
-        sidecar_tag_name = (
-            f"{ReleaseHelper.SIDECAR_RELEASE_TAG_PREFIX}{self.step_1_state.metricflow_package_version}"
-            f"{ReleaseHelper.SIDECAR_BASELINE_COUNTER_SUFFIX}"
-        )
 
         self._wait_for_prs(step_1_pr=step_1_pr, step_2_pr=step_2_pr)
 
@@ -122,6 +123,12 @@ class ReleaseStep3Runner:
 
         step_2_merge_sha = self._merge_pr_if_needed(step_2_pr)
 
+        sidecar_tag_name = build_sidecar_release_tag(
+            metricflow_version=self.step_1_state.metricflow_package_version,
+            commit_sha=step_1_merge_sha,
+            timestamp=self.now(),
+        )
+
         helper.run_confirmed_remote_action(
             description=f"Create and force push tag {tag_name} at {step_1_merge_sha}",
             action=lambda: git.push_tag(
@@ -131,7 +138,7 @@ class ReleaseStep3Runner:
             ),
         )
         helper.run_confirmed_remote_action(
-            description=f"Create and force push sidecar baseline tag {sidecar_tag_name} at {step_1_merge_sha}",
+            description=f"Create and force push sidecar release tag {sidecar_tag_name} at {step_1_merge_sha}",
             action=lambda: git.push_tag(
                 tag_name=sidecar_tag_name,
                 objectish=step_1_merge_sha,

--- a/scripts/release_tool/release_step_3.py
+++ b/scripts/release_tool/release_step_3.py
@@ -51,7 +51,7 @@ class ReleaseStep3Runner:
     * Creating or updating a lightweight ``v$VERSION`` tag pointing to
       the step-1 merge commit and force-pushing it
     * Creating or updating a matching sidecar release tag
-      (``mf-entry-bin/v$VERSION+<timestamp>.<sha8>``, DI-4871) at the
+      (``mf-stdio-sidecar/v$VERSION+<timestamp>.<sha8>``, DI-4871) at the
       same commit and force-pushing it, so every MetricFlow release
       always has a matching sidecar binary build with no separate
       manual step

--- a/scripts/sidecar_release/__init__.py
+++ b/scripts/sidecar_release/__init__.py
@@ -1,0 +1,9 @@
+"""Scripts for building and releasing the MetricFlow sidecar binary. See DI-4871.
+
+Every script in this package is stdlib-only by design, so it can be run directly with a
+bare `python3` -- no hatch environment or third-party dependency required -- both in CI and
+locally on a contributor's own machine, per DI-4871's "scriptify the release process"
+decision. Run them as modules from the repo root, e.g.:
+
+    python3 -m scripts.sidecar_release.cut_adhoc_release --dry-run
+"""

--- a/scripts/sidecar_release/cut_adhoc_release.py
+++ b/scripts/sidecar_release/cut_adhoc_release.py
@@ -1,0 +1,97 @@
+"""Cut an ad hoc sidecar release tag for a sidecar-only change (DI-4871).
+
+Replaces the inline bash tag-resolution step in cd-cut-adhoc-sidecar-release.yaml. For a
+change to sidecar/mf_entry.py or mf_ipc_protocol.py that doesn't correspond to a new
+MetricFlow version -- the `+1` baseline for each MetricFlow version is instead cut
+automatically by scripts/release_tool/release_step_3.py, which already knows the version
+and commit it's releasing and calls `build_sidecar_release_tag` directly, with no need to
+resolve either from git the way this script does.
+
+Resolves the nearest MetricFlow release tag reachable from HEAD (not
+metricflow/__about__.py's `__version__`, which is a `.devN` string between releases and not
+a valid tag component) and HEAD's own commit SHA, then creates the tag locally. Does not
+push it -- that, and re-dispatching cd-build-sidecar-binaries.yaml for the new tag, are
+genuinely CI/remote actions and stay as separate, explicit steps in the workflow, matching
+the "the workflow becomes mostly orchestrating these scripts" framing this was written for.
+
+Run with `--dry-run` to preview the tag that would be cut without creating anything --
+runnable locally against a real clone, no CI required.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+
+from scripts.mf_script_helper import MetricFlowScriptHelper
+from scripts.sidecar_release.tag import build_sidecar_release_tag
+
+
+def resolve_nearest_release_tag(repository_directory: Path) -> str:
+    """Return the nearest MetricFlow release tag (bare `v<version>`) reachable from HEAD."""
+    result = MetricFlowScriptHelper.run_command(
+        ["git", "describe", "--tags", "--abbrev=0", "--match", "v[0-9]*.[0-9]*.[0-9]*", "HEAD"],
+        working_directory=repository_directory,
+        capture_output=True,
+    )
+    return result.stdout.decode().strip()
+
+
+def resolve_head_commit_sha(repository_directory: Path) -> str:
+    """Return the full commit SHA at HEAD."""
+    result = MetricFlowScriptHelper.run_command(
+        ["git", "rev-parse", "HEAD"],
+        working_directory=repository_directory,
+        capture_output=True,
+    )
+    return result.stdout.decode().strip()
+
+
+def create_local_tag(tag: str, repository_directory: Path) -> None:
+    """Create a lightweight git tag at HEAD. Does not push it."""
+    MetricFlowScriptHelper.run_command(["git", "tag", tag], working_directory=repository_directory)
+
+
+def cut_adhoc_release(repository_directory: Path, dry_run: bool) -> str:
+    """Resolve the next ad hoc sidecar release tag and, unless `dry_run`, create it locally."""
+    nearest_release_tag = resolve_nearest_release_tag(repository_directory)
+    metricflow_version = nearest_release_tag.removeprefix("v")
+    commit_sha = resolve_head_commit_sha(repository_directory)
+
+    tag = build_sidecar_release_tag(metricflow_version=metricflow_version, commit_sha=commit_sha)
+
+    if dry_run:
+        print(f"[dry run] would create tag: {tag}")
+    else:
+        create_local_tag(tag, repository_directory)
+        print(f"Created local tag: {tag}")
+
+    return tag
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repository-directory", type=Path, default=Path.cwd())
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the tag that would be cut without creating it locally.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> None:  # noqa: D103
+    args = _parse_args(argv)
+    tag = cut_adhoc_release(args.repository_directory, dry_run=args.dry_run)
+
+    # $GITHUB_OUTPUT is only set when running inside a GitHub Actions job; writing to it is
+    # a no-op (skipped) when run locally.
+    github_output = os.environ.get("GITHUB_OUTPUT")
+    if github_output:
+        with Path(github_output).open("a") as output_file:
+            output_file.write(f"tag={tag}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/sidecar_release/cut_adhoc_release.py
+++ b/scripts/sidecar_release/cut_adhoc_release.py
@@ -2,17 +2,25 @@
 
 Replaces the inline bash tag-resolution step in cd-cut-adhoc-sidecar-release.yaml. For a
 change to sidecar/mf_entry.py or mf_ipc_protocol.py that doesn't correspond to a new
-MetricFlow version -- the `+1` baseline for each MetricFlow version is instead cut
+MetricFlow version -- the tag cut alongside each MetricFlow release is instead pushed
 automatically by scripts/release_tool/release_step_3.py, which already knows the version
 and commit it's releasing and calls `build_sidecar_release_tag` directly, with no need to
-resolve either from git the way this script does.
+resolve either the way this script does.
 
-Resolves the nearest MetricFlow release tag reachable from HEAD (not
-metricflow/__about__.py's `__version__`, which is a `.devN` string between releases and not
-a valid tag component) and HEAD's own commit SHA, then creates the tag locally. Does not
-push it -- that, and re-dispatching cd-build-sidecar-binaries.yaml for the new tag, are
-genuinely CI/remote actions and stay as separate, explicit steps in the workflow, matching
-the "the workflow becomes mostly orchestrating these scripts" framing this was written for.
+Resolves MetricFlow's current version from metricflow/__about__.py and HEAD's own commit
+SHA, then creates the tag locally. Does not push it -- that, and re-dispatching
+cd-build-sidecar-binaries.yaml for the new tag, are genuinely CI/remote actions and stay as
+separate, explicit steps in the workflow, matching the "the workflow becomes mostly
+orchestrating these scripts" framing this was written for.
+
+Deliberately reads __about__.py rather than resolving the nearest real release tag via
+`git describe`: between releases, __about__.py holds a `.devN` pre-release version (e.g.
+`0.212.0.dev0`), and an ad hoc release doesn't guard against metricflow/,
+metricflow_semantics/, or metricflow_semantic_interfaces/ having changed since the last real
+release (see the acceptance criteria in DI-4871) -- so labeling it with the last released
+version number would overstate how closely it actually matches that release. `.devN`
+honestly signals "unreleased, in-development state" whether or not real changes happened,
+rather than implying an exact match to a specific release that may not hold.
 
 Run with `--dry-run` to preview the tag that would be cut without creating anything --
 runnable locally against a real clone, no CI required.
@@ -22,20 +30,22 @@ from __future__ import annotations
 
 import argparse
 import os
+import re
 from pathlib import Path
 
 from scripts.mf_script_helper import MetricFlowScriptHelper
 from scripts.sidecar_release.tag import build_sidecar_release_tag
 
+_VERSION_ASSIGNMENT_PATTERN = re.compile(r'__version__\s*=\s*"([^"]+)"')
 
-def resolve_nearest_release_tag(repository_directory: Path) -> str:
-    """Return the nearest MetricFlow release tag (bare `v<version>`) reachable from HEAD."""
-    result = MetricFlowScriptHelper.run_command(
-        ["git", "describe", "--tags", "--abbrev=0", "--match", "v[0-9]*.[0-9]*.[0-9]*", "HEAD"],
-        working_directory=repository_directory,
-        capture_output=True,
-    )
-    return result.stdout.decode().strip()
+
+def resolve_metricflow_version(repository_directory: Path) -> str:
+    """Return MetricFlow's current version, as declared in metricflow/__about__.py."""
+    about_file_path = repository_directory / "metricflow" / "__about__.py"
+    match = _VERSION_ASSIGNMENT_PATTERN.search(about_file_path.read_text())
+    if match is None:
+        raise RuntimeError(f'Could not find a `__version__ = "..."` assignment in {about_file_path}')
+    return match.group(1)
 
 
 def resolve_head_commit_sha(repository_directory: Path) -> str:
@@ -55,8 +65,7 @@ def create_local_tag(tag: str, repository_directory: Path) -> None:
 
 def cut_adhoc_release(repository_directory: Path, dry_run: bool) -> str:
     """Resolve the next ad hoc sidecar release tag and, unless `dry_run`, create it locally."""
-    nearest_release_tag = resolve_nearest_release_tag(repository_directory)
-    metricflow_version = nearest_release_tag.removeprefix("v")
+    metricflow_version = resolve_metricflow_version(repository_directory)
     commit_sha = resolve_head_commit_sha(repository_directory)
 
     tag = build_sidecar_release_tag(metricflow_version=metricflow_version, commit_sha=commit_sha)

--- a/scripts/sidecar_release/generate_build_info.py
+++ b/scripts/sidecar_release/generate_build_info.py
@@ -5,9 +5,9 @@ Replaces the inline python3 heredoc in cd-build-sidecar-binaries.yaml's `publish
 versions actually measured at build time -- the thing to check if a specific binary's exact
 provenance is ever in question, since the tag/archive names alone don't encode the commit.
 
-Deliberately prefix-agnostic (works the same regardless of the tag's namespace prefix, e.g.
-`sidecar/` or `mf-entry-bin/`): the embedded MetricFlow version is parsed as everything after
-the tag's last `/`, before its first `+`, with a leading `v` stripped.
+The embedded MetricFlow version is parsed via `tag.py` -- the single source of truth for
+the sidecar release tag format -- so this stays correct automatically if that format ever
+changes again.
 """
 
 from __future__ import annotations
@@ -16,10 +16,7 @@ import argparse
 import json
 from pathlib import Path
 
-
-def metricflow_version_from_tag(tag: str) -> str:
-    """Return the embedded MetricFlow version encoded in a sidecar release tag."""
-    return tag.rsplit("/", 1)[-1].split("+", 1)[0].removeprefix("v")
+from scripts.sidecar_release.tag import metricflow_version_from_tag
 
 
 def generate_build_info(

--- a/scripts/sidecar_release/generate_build_info.py
+++ b/scripts/sidecar_release/generate_build_info.py
@@ -1,0 +1,67 @@
+"""Generate the build-info.json release asset for a sidecar binary build.
+
+Replaces the inline python3 heredoc in cd-build-sidecar-binaries.yaml's `publish` job
+(DI-4871). Records the embedded MetricFlow version, the source commit, and the Nuitka/Python
+versions actually measured at build time -- the thing to check if a specific binary's exact
+provenance is ever in question, since the tag/archive names alone don't encode the commit.
+
+Deliberately prefix-agnostic (works the same regardless of the tag's namespace prefix, e.g.
+`sidecar/` or `mf-entry-bin/`): the embedded MetricFlow version is parsed as everything after
+the tag's last `/`, before its first `+`, with a leading `v` stripped.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def metricflow_version_from_tag(tag: str) -> str:
+    """Return the embedded MetricFlow version encoded in a sidecar release tag."""
+    return tag.rsplit("/", 1)[-1].split("+", 1)[0].removeprefix("v")
+
+
+def generate_build_info(
+    tag: str,
+    commit_sha: str,
+    nuitka_version: str,
+    python_version: str,
+) -> dict[str, str]:
+    """Return the build-info.json contents for a sidecar binary build."""
+    return {
+        "tag": tag,
+        "metricflow_version": metricflow_version_from_tag(tag),
+        "commit": commit_sha,
+        "nuitka_version": nuitka_version.strip(),
+        "python_version": python_version.strip(),
+    }
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tag", required=True, help="The git tag (or ref name) this release was cut from.")
+    parser.add_argument("--commit", required=True, help="The commit SHA this release was built from.")
+    parser.add_argument(
+        "--nuitka-version-file", type=Path, required=True, help="File containing `nuitka --version` output."
+    )
+    parser.add_argument(
+        "--python-version-file", type=Path, required=True, help="File containing `python --version` output."
+    )
+    parser.add_argument("--output", type=Path, required=True, help="Where to write build-info.json.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> None:  # noqa: D103
+    args = _parse_args(argv)
+    build_info = generate_build_info(
+        tag=args.tag,
+        commit_sha=args.commit,
+        nuitka_version=args.nuitka_version_file.read_text(),
+        python_version=args.python_version_file.read_text(),
+    )
+    args.output.write_text(json.dumps(build_info, indent=2) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/sidecar_release/package_archives.py
+++ b/scripts/sidecar_release/package_archives.py
@@ -1,0 +1,104 @@
+"""Package per-platform mf_entry.dist/ artifact directories into release archives.
+
+Replaces the "Package archives and generate checksums" inline bash step in
+cd-build-sidecar-binaries.yaml (DI-4871), so a contributor can run the exact same logic
+locally against a `hatch run nuitka-build:build-and-validate` output without needing CI.
+
+Expects `--dist-dir` to contain one `mf_entry-<target-triple>/` directory per platform
+(matching the `actions/download-artifact` pattern used in CI, or a single local build
+renamed to that shape). Produces `mf_entry-<version>-<target-triple>.tar.gz` (`.zip` for
+Windows triples) for each, plus a `SHA256SUMS.txt` covering all of them.
+
+`--tag` is the raw git tag (or ref name) this release was cut from, e.g.
+`mf-entry-bin/v0.208.0+2607281534.a1b2c3d4`. Deliberately prefix-agnostic: the archive
+version is just everything after the tag's last `/`, so this script doesn't need to change
+if the tag namespace is ever renamed again -- only the workflow's trigger/publish-gate
+patterns would.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import shutil
+import tarfile
+import zipfile
+from pathlib import Path
+
+
+def archive_version_from_tag(tag: str) -> str:
+    """Return the version component used in archive filenames for a given tag."""
+    return tag.rsplit("/", 1)[-1]
+
+
+def _add_directory_contents_to_tar(tar: tarfile.TarFile, source_dir: Path) -> None:
+    for item in sorted(source_dir.iterdir()):
+        tar.add(item, arcname=item.name, recursive=True)
+
+
+def _add_directory_contents_to_zip(zip_file: zipfile.ZipFile, source_dir: Path) -> None:
+    for path in sorted(source_dir.rglob("*")):
+        if path.is_file():
+            zip_file.write(path, arcname=path.relative_to(source_dir))
+
+
+def package_platform_directory(platform_dir: Path, version: str, dist_dir: Path) -> Path:
+    """Archive one `mf_entry-<triple>/` directory and return the produced archive path."""
+    triple = platform_dir.name.removeprefix("mf_entry-")
+    is_windows = "windows" in triple
+
+    if is_windows:
+        archive_path = dist_dir / f"mf_entry-{version}-{triple}.zip"
+        with zipfile.ZipFile(archive_path, "w", zipfile.ZIP_DEFLATED) as zip_file:
+            _add_directory_contents_to_zip(zip_file, platform_dir)
+    else:
+        archive_path = dist_dir / f"mf_entry-{version}-{triple}.tar.gz"
+        with tarfile.open(archive_path, "w:gz") as tar:
+            _add_directory_contents_to_tar(tar, platform_dir)
+
+    return archive_path
+
+
+def write_checksums(archive_paths: list[Path], output_path: Path) -> None:
+    """Write a SHA256SUMS.txt-style checksum file covering the given archives."""
+    lines = []
+    for archive_path in sorted(archive_paths):
+        digest = hashlib.sha256(archive_path.read_bytes()).hexdigest()
+        lines.append(f"{digest}  {archive_path.name}\n")
+    output_path.write_text("".join(lines))
+
+
+def package_release_archives(dist_dir: Path, tag: str) -> list[Path]:
+    """Package every `mf_entry-<triple>/` directory under `dist_dir` and write checksums."""
+    version = archive_version_from_tag(tag)
+    platform_dirs = sorted(p for p in dist_dir.iterdir() if p.is_dir() and p.name.startswith("mf_entry-"))
+    if not platform_dirs:
+        raise RuntimeError(f"No mf_entry-<triple>/ directories found under {dist_dir}")
+
+    archive_paths = []
+    for platform_dir in platform_dirs:
+        archive_path = package_platform_directory(platform_dir, version, dist_dir)
+        print(f"Packaged {platform_dir.name} -> {archive_path.name}")
+        archive_paths.append(archive_path)
+        shutil.rmtree(platform_dir)
+
+    write_checksums(archive_paths, dist_dir / "SHA256SUMS.txt")
+    return archive_paths
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--dist-dir", type=Path, default=Path("dist"), help="Directory containing mf_entry-<triple>/ dirs."
+    )
+    parser.add_argument("--tag", required=True, help="The git tag (or ref name) this release was cut from.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> None:  # noqa: D103
+    args = _parse_args(argv)
+    package_release_archives(args.dist_dir, args.tag)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/sidecar_release/package_archives.py
+++ b/scripts/sidecar_release/package_archives.py
@@ -10,7 +10,7 @@ renamed to that shape). Produces `mf_entry-<version>-<target-triple>.tar.gz` (`.
 Windows triples) for each, plus a `SHA256SUMS.txt` covering all of them.
 
 `--tag` is the raw git tag (or ref name) this release was cut from, e.g.
-`mf-entry-bin/v0.208.0+2607281534.a1b2c3d4`. Deliberately prefix-agnostic: the archive
+`mf-stdio-sidecar/v0.208.0+2607281534.a1b2c3d4`. Deliberately prefix-agnostic: the archive
 version is just everything after the tag's last `/`, so this script doesn't need to change
 if the tag namespace is ever renamed again -- only the workflow's trigger/publish-gate
 patterns would.

--- a/scripts/sidecar_release/tag.py
+++ b/scripts/sidecar_release/tag.py
@@ -1,0 +1,47 @@
+"""Build and parse `mf-entry-bin/v<version>+<timestamp>.<sha8>` sidecar release tags.
+
+DI-4871: sidecar binary releases are tagged independently of MetricFlow's own release
+tags, so a sidecar-only change (e.g. a new mf_entry.py entry point) can ship without a
+MetricFlow version bump. A tag looks like:
+
+    mf-entry-bin/v0.208.0+2607281534.a1b2c3d4
+
+`<timestamp>` is `YYMMDDHHmm` in UTC and `<sha8>` is the first 8 characters of the commit
+SHA the binary was built from -- together they disambiguate multiple sidecar builds off the
+same MetricFlow version with no stateful counter to compute (no need to scan existing tags
+for the highest value in use). This is not required to be PEP 440-compliant: unlike
+MetricFlow's own `v<version>` tags, this tag never goes through PyPI/`pip`/`twine`, so
+there's no actual constraint on the local-version-segment syntax to satisfy.
+
+This is the single source of truth for the tag format -- both `build_sidecar_release_tag`
+(used by release_step_3.py, which already knows the version/commit it's tagging, and by
+cut_adhoc_release.py, which resolves them from git) and `metricflow_version_from_tag` (used
+by generate_build_info.py) live here so the two directions of the format can't drift apart.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+MF_ENTRY_BIN_TAG_PREFIX = "mf-entry-bin/v"
+
+
+def build_sidecar_release_tag(
+    metricflow_version: str,
+    commit_sha: str,
+    timestamp: datetime | None = None,
+) -> str:
+    """Build a sidecar release tag for the given MetricFlow version and commit."""
+    timestamp = timestamp or datetime.now(timezone.utc)
+    return f"{MF_ENTRY_BIN_TAG_PREFIX}{metricflow_version}+{timestamp.strftime('%y%m%d%H%M')}.{commit_sha[:8]}"
+
+
+def metricflow_version_from_tag(tag: str) -> str:
+    """Return the embedded MetricFlow version encoded in a sidecar release tag.
+
+    Deliberately agnostic to the tag's namespace prefix (works the same whether it's
+    `mf-entry-bin/`, the retired `sidecar/`, or none at all) and to what follows the
+    version -- only relies on the version being between the tag's last `/` and its first
+    `+`, with a leading `v`.
+    """
+    return tag.rsplit("/", 1)[-1].split("+", 1)[0].removeprefix("v")

--- a/scripts/sidecar_release/tag.py
+++ b/scripts/sidecar_release/tag.py
@@ -1,10 +1,10 @@
-"""Build and parse `mf-entry-bin/v<version>+<timestamp>.<sha8>` sidecar release tags.
+"""Build and parse `mf-stdio-sidecar/v<version>+<timestamp>.<sha8>` sidecar release tags.
 
 DI-4871: sidecar binary releases are tagged independently of MetricFlow's own release
 tags, so a sidecar-only change (e.g. a new mf_entry.py entry point) can ship without a
 MetricFlow version bump. A tag looks like:
 
-    mf-entry-bin/v0.208.0+2607281534.a1b2c3d4
+    mf-stdio-sidecar/v0.208.0+2607281534.a1b2c3d4
 
 `<timestamp>` is `YYMMDDHHmm` in UTC and `<sha8>` is the first 8 characters of the commit
 SHA the binary was built from -- together they disambiguate multiple sidecar builds off the
@@ -23,7 +23,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
-MF_ENTRY_BIN_TAG_PREFIX = "mf-entry-bin/v"
+MF_STDIO_SIDECAR_TAG_PREFIX = "mf-stdio-sidecar/v"
 
 
 def build_sidecar_release_tag(
@@ -33,14 +33,14 @@ def build_sidecar_release_tag(
 ) -> str:
     """Build a sidecar release tag for the given MetricFlow version and commit."""
     timestamp = timestamp or datetime.now(timezone.utc)
-    return f"{MF_ENTRY_BIN_TAG_PREFIX}{metricflow_version}+{timestamp.strftime('%y%m%d%H%M')}.{commit_sha[:8]}"
+    return f"{MF_STDIO_SIDECAR_TAG_PREFIX}{metricflow_version}+{timestamp.strftime('%y%m%d%H%M')}.{commit_sha[:8]}"
 
 
 def metricflow_version_from_tag(tag: str) -> str:
     """Return the embedded MetricFlow version encoded in a sidecar release tag.
 
     Deliberately agnostic to the tag's namespace prefix (works the same whether it's
-    `mf-entry-bin/`, the retired `sidecar/`, or none at all) and to what follows the
+    `mf-stdio-sidecar/`, the retired `sidecar/`, or none at all) and to what follows the
     version -- only relies on the version being between the tag's last `/` and its first
     `+`, with a leading `v`.
     """

--- a/sidecar/README.md
+++ b/sidecar/README.md
@@ -60,23 +60,37 @@ hatch run nuitka-build:validate   # validate only (binary must already exist)
 ## CI builds and release artifacts
 
 Sidecar binaries have their own release versioning, decoupled from MetricFlow's (DI-4871).
-Every sidecar release is tagged `sidecar/v<mf_version>+<counter>` — e.g. `sidecar/v0.208.0+1`
-— where `<mf_version>` is the MetricFlow version embedded in the binary and `<counter>`
-distinguishes multiple sidecar builds off that same MetricFlow version. This is a **separate
-GitHub Release from MetricFlow's own `v<mf_version>` tag** (the one used for the PyPI
-publish) — Fusion pins the sidecar tag specifically, not the MetricFlow tag.
+Every sidecar release is tagged `mf-entry-bin/v<mf_version>+<YYMMDDHHmm>.<sha8>` — e.g.
+`mf-entry-bin/v0.208.0+2607281534.a1b2c3d4` — where `<mf_version>` is the MetricFlow version
+embedded in the binary, and the UTC timestamp plus short commit SHA disambiguate multiple
+sidecar builds off that same MetricFlow version with no counter to keep track of. This is a
+**separate GitHub Release from MetricFlow's own `v<mf_version>` tag** (the one used for the
+PyPI publish) — Fusion pins the sidecar tag specifically, not the MetricFlow tag. The format
+isn't PEP 440-constrained: unlike MetricFlow's own tags, this one never goes through
+PyPI/`pip`/`twine`.
 
-**The `+1` baseline.** Every MetricFlow release always gets a matching sidecar build with no
-separate manual step:
-[`scripts/release_tool/release_step_3.py`](../scripts/release_tool/release_step_3.py)
-automatically pushes `sidecar/v<mf_version>+1` alongside MetricFlow's own release tag.
+The tag format itself lives in one place,
+[`scripts/sidecar_release/tag.py`](../scripts/sidecar_release/tag.py)'s
+`build_sidecar_release_tag`/`metricflow_version_from_tag`, so both directions (building a
+tag and parsing one back out) can't drift apart.
 
-**Ad hoc releases (`+2`, `+3`, ...).** For a sidecar-only change — e.g. a new `mf_entry.py`
-entry point — that doesn't correspond to a new MetricFlow version, run
+**Every MetricFlow release always gets a matching sidecar build**, with no separate manual
+step: [`scripts/release_tool/release_step_3.py`](../scripts/release_tool/release_step_3.py)
+pushes one of these tags alongside MetricFlow's own release tag automatically, using the
+version and commit it already knows — no git lookups needed.
+
+**Ad hoc releases.** For a sidecar-only change — e.g. a new `mf_entry.py` entry point — that
+doesn't correspond to a new MetricFlow version, run
 [`Cut Ad Hoc Sidecar Release`](../.github/workflows/cd-cut-adhoc-sidecar-release.yaml) from
 the Actions tab (`workflow_dispatch`, dispatchable only from `main`). It resolves the
-MetricFlow version reachable from the current commit, computes the next counter for that
-version, pushes the tag, and triggers the build.
+MetricFlow version reachable from the current commit, builds the tag, pushes it, and
+triggers the build. The tag-resolution logic is a real script,
+[`scripts/sidecar_release/cut_adhoc_release.py`](../scripts/sidecar_release/cut_adhoc_release.py)
+— run it locally to preview the exact tag a real dispatch would cut, no CI required:
+
+```bash
+python3 -m scripts.sidecar_release.cut_adhoc_release --dry-run
+```
 
 [`cd-build-sidecar-binaries.yaml`](../.github/workflows/cd-build-sidecar-binaries.yaml)
 compiles `mf_entry.py` for every platform Fusion needs and publishes the results as assets
@@ -90,18 +104,33 @@ on that sidecar tag's GitHub Release:
 | `aarch64-unknown-linux-gnu` | ubuntu-24.04-arm | `mf_entry-<version>-aarch64-unknown-linux-gnu.tar.gz` |
 | `x86_64-pc-windows-msvc` | windows-latest | `mf_entry-<version>-x86_64-pc-windows-msvc.zip` |
 
-`<version>` in the archive name is the sidecar tag with its `sidecar/` namespace prefix
-stripped — e.g. tag `sidecar/v0.208.0+1` produces `mf_entry-v0.208.0+1-<triple>.tar.gz`. The
-namespace's only job is keeping the *tag* from also matching
-`cd-push-metricflow-to-pypi.yaml`'s `v[0-9]+.[0-9]+.[0-9]+*` trigger glob, so restating it in
-every filename would be redundant.
+`<version>` in the archive name is the sidecar tag with its `mf-entry-bin/` namespace prefix
+stripped — e.g. tag `mf-entry-bin/v0.208.0+2607281534.a1b2c3d4` produces
+`mf_entry-v0.208.0+2607281534.a1b2c3d4-<triple>.tar.gz`. The namespace's only job is keeping
+the *tag* from also matching `cd-push-metricflow-to-pypi.yaml`'s `v[0-9]+.[0-9]+.[0-9]+*`
+trigger glob, so restating it in every filename would be redundant. Packaging is done by
+[`scripts/sidecar_release/package_archives.py`](../scripts/sidecar_release/package_archives.py)
+— runnable locally against a real build, once it's staged in the `mf_entry-<triple>/`
+layout the script (and CI's `actions/download-artifact`) expect:
+
+```bash
+hatch run nuitka-build:build-and-validate
+mkdir -p dist/mf_entry-aarch64-apple-darwin  # use your own platform's target triple
+cp -r sidecar/mf_entry.dist/. dist/mf_entry-aarch64-apple-darwin/
+python3 -m scripts.sidecar_release.package_archives --dist-dir dist --tag mf-entry-bin/v0.0.0+test.0000000
+```
 
 A `SHA256SUMS.txt` and a `build-info.json` are published alongside the archives.
-`build-info.json` records the embedded MetricFlow version, the source commit, and the
-Nuitka/Python versions actually measured at build time — the thing to check if a specific
-binary's exact provenance is ever in question, since ad hoc releases intentionally don't
-guard against `metricflow`/`metricflow_semantics`/`metricflow_semantic_interfaces` having
-changed since the last MetricFlow release they're tagged against.
+`build-info.json` (generated by
+[`scripts/sidecar_release/generate_build_info.py`](../scripts/sidecar_release/generate_build_info.py))
+records the embedded MetricFlow version, the source commit, and the Nuitka/Python versions
+actually measured at build time — the thing to check if a specific binary's exact
+provenance is ever in question, since ad hoc releases intentionally don't guard against
+`metricflow`/`metricflow_semantics`/`metricflow_semantic_interfaces` having changed since
+the last MetricFlow release they're tagged against.
+
+All three scripts above are stdlib-only — no hatch environment or third-party dependency
+needed, so they run with a bare `python3` both in CI and on a contributor's own machine.
 
 Consumers fetch a specific version at
 `https://github.com/dbt-labs/metricflow/releases/download/<sidecar-tag>/<archive>` — no
@@ -114,8 +143,8 @@ Fusion's perspective, not just a MetricFlow-internal refactor.
 
 **Re-publishing an existing tag fails loudly; it doesn't overwrite.** The release-asset
 publish step sets `overwrite_files: false`, so an accidental re-push of an existing sidecar
-tag (a mistyped or reused ad hoc counter, or a force-moved tag) fails CI instead of silently
-clobbering already-published binaries.
+tag (e.g. a force-moved tag) fails CI instead of silently clobbering already-published
+binaries.
 
 **Version pins:** binaries are compiled with Nuitka `4.1.2` (pinned in
 `pyproject.toml`) against Python 3.10, per `setup-python-env`'s default. Both

--- a/sidecar/README.md
+++ b/sidecar/README.md
@@ -60,8 +60,8 @@ hatch run nuitka-build:validate   # validate only (binary must already exist)
 ## CI builds and release artifacts
 
 Sidecar binaries have their own release versioning, decoupled from MetricFlow's (DI-4871).
-Every sidecar release is tagged `mf-entry-bin/v<mf_version>+<YYMMDDHHmm>.<sha8>` — e.g.
-`mf-entry-bin/v0.208.0+2607281534.a1b2c3d4` — where `<mf_version>` is the MetricFlow version
+Every sidecar release is tagged `mf-stdio-sidecar/v<mf_version>+<YYMMDDHHmm>.<sha8>` — e.g.
+`mf-stdio-sidecar/v0.208.0+2607281534.a1b2c3d4` — where `<mf_version>` is the MetricFlow version
 embedded in the binary, and the UTC timestamp plus short commit SHA disambiguate multiple
 sidecar builds off that same MetricFlow version with no counter to keep track of. This is a
 **separate GitHub Release from MetricFlow's own `v<mf_version>` tag** (the one used for the
@@ -108,8 +108,8 @@ on that sidecar tag's GitHub Release:
 | `aarch64-unknown-linux-gnu` | ubuntu-24.04-arm | `mf_entry-<version>-aarch64-unknown-linux-gnu.tar.gz` |
 | `x86_64-pc-windows-msvc` | windows-latest | `mf_entry-<version>-x86_64-pc-windows-msvc.zip` |
 
-`<version>` in the archive name is the sidecar tag with its `mf-entry-bin/` namespace prefix
-stripped — e.g. tag `mf-entry-bin/v0.208.0+2607281534.a1b2c3d4` produces
+`<version>` in the archive name is the sidecar tag with its `mf-stdio-sidecar/` namespace prefix
+stripped — e.g. tag `mf-stdio-sidecar/v0.208.0+2607281534.a1b2c3d4` produces
 `mf_entry-v0.208.0+2607281534.a1b2c3d4-<triple>.tar.gz`. The namespace's only job is keeping
 the *tag* from also matching `cd-push-metricflow-to-pypi.yaml`'s `v[0-9]+.[0-9]+.[0-9]+*`
 trigger glob, so restating it in every filename would be redundant. Packaging is done by
@@ -121,7 +121,7 @@ layout the script (and CI's `actions/download-artifact`) expect:
 hatch run nuitka-build:build-and-validate
 mkdir -p dist/mf_entry-aarch64-apple-darwin  # use your own platform's target triple
 cp -r sidecar/mf_entry.dist/. dist/mf_entry-aarch64-apple-darwin/
-python3 -m scripts.sidecar_release.package_archives --dist-dir dist --tag mf-entry-bin/v0.0.0+test.0000000
+python3 -m scripts.sidecar_release.package_archives --dist-dir dist --tag mf-stdio-sidecar/v0.0.0+test.0000000
 ```
 
 A `SHA256SUMS.txt` and a `build-info.json` are published alongside the archives.

--- a/sidecar/README.md
+++ b/sidecar/README.md
@@ -59,28 +59,63 @@ hatch run nuitka-build:validate   # validate only (binary must already exist)
 
 ## CI builds and release artifacts
 
-On every MetricFlow release tag (`v<major>.<minor>.<patch>...`),
+Sidecar binaries have their own release versioning, decoupled from MetricFlow's (DI-4871).
+Every sidecar release is tagged `sidecar/v<mf_version>+<counter>` — e.g. `sidecar/v0.208.0+1`
+— where `<mf_version>` is the MetricFlow version embedded in the binary and `<counter>`
+distinguishes multiple sidecar builds off that same MetricFlow version. This is a **separate
+GitHub Release from MetricFlow's own `v<mf_version>` tag** (the one used for the PyPI
+publish) — Fusion pins the sidecar tag specifically, not the MetricFlow tag.
+
+**The `+1` baseline.** Every MetricFlow release always gets a matching sidecar build with no
+separate manual step:
+[`scripts/release_tool/release_step_3.py`](../scripts/release_tool/release_step_3.py)
+automatically pushes `sidecar/v<mf_version>+1` alongside MetricFlow's own release tag.
+
+**Ad hoc releases (`+2`, `+3`, ...).** For a sidecar-only change — e.g. a new `mf_entry.py`
+entry point — that doesn't correspond to a new MetricFlow version, run
+[`Cut Ad Hoc Sidecar Release`](../.github/workflows/cd-cut-adhoc-sidecar-release.yaml) from
+the Actions tab (`workflow_dispatch`, dispatchable only from `main`). It resolves the
+MetricFlow version reachable from the current commit, computes the next counter for that
+version, pushes the tag, and triggers the build.
+
 [`cd-build-sidecar-binaries.yaml`](../.github/workflows/cd-build-sidecar-binaries.yaml)
-compiles `mf_entry.py` for every platform Fusion needs and publishes the
-results as assets on that tag's GitHub Release:
+compiles `mf_entry.py` for every platform Fusion needs and publishes the results as assets
+on that sidecar tag's GitHub Release:
 
 | target triple | runner | archive |
 |---|---|---|
-| `aarch64-apple-darwin` | macos-14 | `mf_entry-<tag>-aarch64-apple-darwin.tar.gz` |
-| `x86_64-apple-darwin` | macos-13 | `mf_entry-<tag>-x86_64-apple-darwin.tar.gz` |
-| `x86_64-unknown-linux-gnu` | ubuntu-22.04 | `mf_entry-<tag>-x86_64-unknown-linux-gnu.tar.gz` |
-| `aarch64-unknown-linux-gnu` | ubuntu-24.04-arm | `mf_entry-<tag>-aarch64-unknown-linux-gnu.tar.gz` |
-| `x86_64-pc-windows-msvc` | windows-latest | `mf_entry-<tag>-x86_64-pc-windows-msvc.zip` |
+| `aarch64-apple-darwin` | macos-14 | `mf_entry-<version>-aarch64-apple-darwin.tar.gz` |
+| `x86_64-apple-darwin` | `vars.MACOS_RUNNER_INTEL` (macos-15-intel) | `mf_entry-<version>-x86_64-apple-darwin.tar.gz` |
+| `x86_64-unknown-linux-gnu` | ubuntu-22.04 | `mf_entry-<version>-x86_64-unknown-linux-gnu.tar.gz` |
+| `aarch64-unknown-linux-gnu` | ubuntu-24.04-arm | `mf_entry-<version>-aarch64-unknown-linux-gnu.tar.gz` |
+| `x86_64-pc-windows-msvc` | windows-latest | `mf_entry-<version>-x86_64-pc-windows-msvc.zip` |
 
-A `SHA256SUMS.txt` asset is published alongside the archives for integrity
-verification. Consumers fetch a specific version at
-`https://github.com/dbt-labs/metricflow/releases/download/<tag>/<archive>` —
-no authentication required, since the repo is public. Each archive extracts
-to the same layout as a local `sidecar/mf_entry.dist/` build.
+`<version>` in the archive name is the sidecar tag with its `sidecar/` namespace prefix
+stripped — e.g. tag `sidecar/v0.208.0+1` produces `mf_entry-v0.208.0+1-<triple>.tar.gz`. The
+namespace's only job is keeping the *tag* from also matching
+`cd-push-metricflow-to-pypi.yaml`'s `v[0-9]+.[0-9]+.[0-9]+*` trigger glob, so restating it in
+every filename would be redundant.
 
-This is the contract Fusion's build tooling depends on — changing the target
-triple list, archive naming, or checksum file name is a breaking change from
+A `SHA256SUMS.txt` and a `build-info.json` are published alongside the archives.
+`build-info.json` records the embedded MetricFlow version, the source commit, and the
+Nuitka/Python versions actually measured at build time — the thing to check if a specific
+binary's exact provenance is ever in question, since ad hoc releases intentionally don't
+guard against `metricflow`/`metricflow_semantics`/`metricflow_semantic_interfaces` having
+changed since the last MetricFlow release they're tagged against.
+
+Consumers fetch a specific version at
+`https://github.com/dbt-labs/metricflow/releases/download/<sidecar-tag>/<archive>` — no
+authentication required, since the repo is public. Each archive extracts to the same layout
+as a local `sidecar/mf_entry.dist/` build.
+
+This is the contract Fusion's build tooling depends on — changing the target triple list,
+archive naming, tag format, or the checksum/build-info file names is a breaking change from
 Fusion's perspective, not just a MetricFlow-internal refactor.
+
+**Re-publishing an existing tag fails loudly; it doesn't overwrite.** The release-asset
+publish step sets `overwrite_files: false`, so an accidental re-push of an existing sidecar
+tag (a mistyped or reused ad hoc counter, or a force-moved tag) fails CI instead of silently
+clobbering already-published binaries.
 
 **Version pins:** binaries are compiled with Nuitka `4.1.2` (pinned in
 `pyproject.toml`) against Python 3.10, per `setup-python-env`'s default. Both

--- a/sidecar/README.md
+++ b/sidecar/README.md
@@ -82,8 +82,12 @@ version and commit it already knows — no git lookups needed.
 **Ad hoc releases.** For a sidecar-only change — e.g. a new `mf_entry.py` entry point — that
 doesn't correspond to a new MetricFlow version, run
 [`Cut Ad Hoc Sidecar Release`](../.github/workflows/cd-cut-adhoc-sidecar-release.yaml) from
-the Actions tab (`workflow_dispatch`, dispatchable only from `main`). It resolves the
-MetricFlow version reachable from the current commit, builds the tag, pushes it, and
+the Actions tab (`workflow_dispatch`, dispatchable only from `main`). It reads MetricFlow's
+current version straight from `metricflow/__about__.py` (often a `.devN` pre-release version
+between MetricFlow releases — deliberately so, since an ad hoc release doesn't guard against
+`metricflow`/`metricflow_semantics`/`metricflow_semantic_interfaces` having changed since the
+last real release, and `.devN` says "unreleased, in development" honestly rather than
+implying an exact match to a release that may not hold), builds the tag, pushes it, and
 triggers the build. The tag-resolution logic is a real script,
 [`scripts/sidecar_release/cut_adhoc_release.py`](../scripts/sidecar_release/cut_adhoc_release.py)
 — run it locally to preview the exact tag a real dispatch would cut, no CI required:

--- a/tests_metricflow/release_tools/release_tool_test_helpers.py
+++ b/tests_metricflow/release_tools/release_tool_test_helpers.py
@@ -4,6 +4,7 @@ import logging
 from abc import ABC, abstractmethod
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Literal
 
@@ -713,3 +714,19 @@ class FakeSleep:
     def sleep(self, seconds: float) -> None:
         """Record the sleep duration."""
         self.durations.append(seconds)
+
+
+class FakeNow:
+    """Returns a fixed UTC time; pass ``now`` to match ``Callable[[], datetime]``.
+
+    Used so DI-4871 sidecar release tags (which embed the current time) are deterministic
+    in snapshot tests instead of embedding the real wall-clock time the test happened to run at.
+    """
+
+    def __init__(self, fixed_now: datetime | None = None) -> None:
+        """Initialize with a fixed UTC time, defaulting to an arbitrary stable value."""
+        self.fixed_now = fixed_now or datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+    def now(self) -> datetime:
+        """Return the fixed time."""
+        return self.fixed_now

--- a/tests_metricflow/release_tools/test_clean.py
+++ b/tests_metricflow/release_tools/test_clean.py
@@ -21,6 +21,7 @@ from tests_metricflow.release_tools.release_tool_test_helpers import (
     FakeGitHubClientFactory,
     FakeGitManager,
     FakeGitManagerFactory,
+    FakeNow,
     FakeSleep,
     _make_metricflow_repo,
     _release_tool_command,
@@ -41,6 +42,7 @@ def _release_tool_context(repo_path: Path, git_manager: FakeGitManager) -> Relea
         is_cli_command_available=("fossa", "changie").__contains__,
         cli_command_runner=FakeCliCommandRunner(),
         sleep=FakeSleep().sleep,
+        now=FakeNow().now,
     )
 
 

--- a/tests_metricflow/release_tools/test_step_1.py
+++ b/tests_metricflow/release_tools/test_step_1.py
@@ -22,6 +22,7 @@ from tests_metricflow.release_tools.release_tool_test_helpers import (
     FakeGitHubClientFactory,
     FakeGitManager,
     FakeGitManagerFactory,
+    FakeNow,
     FakeOperations,
     FakeReleaseStateFile,
     FakeSleep,
@@ -65,6 +66,7 @@ def test_step_1_all_operations_match_snapshot(
         is_cli_command_available=("fossa", "changie").__contains__,
         cli_command_runner=cli_command_runner,
         sleep=FakeSleep().sleep,
+        now=FakeNow().now,
     )
 
     result = CliRunner().invoke(

--- a/tests_metricflow/release_tools/test_step_2.py
+++ b/tests_metricflow/release_tools/test_step_2.py
@@ -24,6 +24,7 @@ from tests_metricflow.release_tools.release_tool_test_helpers import (
     FakeGitHubClientFactory,
     FakeGitManager,
     FakeGitManagerFactory,
+    FakeNow,
     FakeOperations,
     FakeReleaseStateFile,
     FakeSleep,
@@ -77,6 +78,7 @@ def test_step_2_all_operations_match_snapshot(
         is_cli_command_available=("fossa", "changie").__contains__,
         cli_command_runner=cli_command_runner,
         sleep=FakeSleep().sleep,
+        now=FakeNow().now,
     )
 
     result = CliRunner().invoke(

--- a/tests_metricflow/release_tools/test_step_3.py
+++ b/tests_metricflow/release_tools/test_step_3.py
@@ -25,6 +25,7 @@ from tests_metricflow.release_tools.release_tool_test_helpers import (
     FakeGitHubClientFactory,
     FakeGitManager,
     FakeGitManagerFactory,
+    FakeNow,
     FakeOperations,
     FakeReleaseStateFile,
     FakeSleep,
@@ -86,6 +87,7 @@ def test_step_3_all_operations_match_snapshot(
         is_cli_command_available=("fossa", "changie").__contains__,
         cli_command_runner=cli_runner,
         sleep=fake_sleep.sleep,
+        now=FakeNow().now,
     )
 
     result = CliRunner().invoke(

--- a/tests_metricflow/release_tools/test_step_4.py
+++ b/tests_metricflow/release_tools/test_step_4.py
@@ -25,6 +25,7 @@ from tests_metricflow.release_tools.release_tool_test_helpers import (
     FakeGitHubClientFactory,
     FakeGitManager,
     FakeGitManagerFactory,
+    FakeNow,
     FakeOperations,
     FakeReleaseStateFile,
     FakeSleep,
@@ -80,6 +81,7 @@ def test_step_4_all_operations_match_snapshot(
         is_cli_command_available=step_4_cli_commands.__contains__,
         cli_command_runner=cli_command_runner,
         sleep=FakeSleep().sleep,
+        now=FakeNow().now,
     )
 
     result = CliRunner().invoke(

--- a/tests_metricflow/release_tools/test_step_5.py
+++ b/tests_metricflow/release_tools/test_step_5.py
@@ -26,6 +26,7 @@ from tests_metricflow.release_tools.release_tool_test_helpers import (
     FakeGitHubClientFactory,
     FakeGitManager,
     FakeGitManagerFactory,
+    FakeNow,
     FakeOperations,
     FakeReleaseStateFile,
     FakeSleep,
@@ -94,6 +95,7 @@ def test_step_5_all_operations_match_snapshot(
         is_cli_command_available=step_5_cli_commands.__contains__,
         cli_command_runner=cli_command_runner,
         sleep=FakeSleep().sleep,
+        now=FakeNow().now,
     )
 
     result = CliRunner().invoke(

--- a/tests_metricflow/release_tools/test_step_6.py
+++ b/tests_metricflow/release_tools/test_step_6.py
@@ -26,6 +26,7 @@ from tests_metricflow.release_tools.release_tool_test_helpers import (
     FakeGitHubClientFactory,
     FakeGitManager,
     FakeGitManagerFactory,
+    FakeNow,
     FakeOperations,
     FakeReleaseStateFile,
     FakeSleep,
@@ -98,6 +99,7 @@ def test_step_6_all_operations_match_snapshot(
         is_cli_command_available=("fossa", "changie").__contains__,
         cli_command_runner=cli_runner,
         sleep=fake_sleep.sleep,
+        now=FakeNow().now,
     )
 
     result = CliRunner().invoke(

--- a/tests_metricflow/release_tools/test_step_7.py
+++ b/tests_metricflow/release_tools/test_step_7.py
@@ -26,6 +26,7 @@ from tests_metricflow.release_tools.release_tool_test_helpers import (
     FakeGitHubClientFactory,
     FakeGitManager,
     FakeGitManagerFactory,
+    FakeNow,
     FakeOperations,
     FakeReleaseStateFile,
     FakeSleep,
@@ -93,6 +94,7 @@ def test_step_7_all_operations_match_snapshot(
         is_cli_command_available=("fossa", "changie").__contains__,
         cli_command_runner=cli_runner,
         sleep=FakeSleep().sleep,
+        now=FakeNow().now,
     )
 
     result = CliRunner().invoke(

--- a/tests_metricflow/sidecar_release/__init__.py
+++ b/tests_metricflow/sidecar_release/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for scripts/sidecar_release/."""

--- a/tests_metricflow/sidecar_release/test_cut_adhoc_release.py
+++ b/tests_metricflow/sidecar_release/test_cut_adhoc_release.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from scripts.sidecar_release.cut_adhoc_release import (
+    cut_adhoc_release,
+    resolve_head_commit_sha,
+    resolve_nearest_release_tag,
+)
+
+
+def _run_git(args: list[str], repository_directory: Path) -> None:
+    subprocess.run(["git", *args], cwd=repository_directory, check=True, capture_output=True)
+
+
+@pytest.fixture
+def git_repo(tmp_path: Path) -> Path:
+    """A real, throwaway git repository with one commit and one release tag."""
+    repository_directory = tmp_path / "repo"
+    repository_directory.mkdir()
+    _run_git(["init", "-q", "."], repository_directory)
+    _run_git(["config", "user.email", "test@example.com"], repository_directory)
+    _run_git(["config", "user.name", "Test"], repository_directory)
+    (repository_directory / "file.txt").write_text("hello")
+    _run_git(["add", "file.txt"], repository_directory)
+    _run_git(["commit", "-q", "-m", "initial"], repository_directory)
+    _run_git(["tag", "v0.208.0"], repository_directory)
+    return repository_directory
+
+
+def test_resolve_nearest_release_tag(git_repo: Path) -> None:
+    """Should resolve the bare v<version> tag reachable from HEAD."""
+    assert resolve_nearest_release_tag(git_repo) == "v0.208.0"
+
+
+def test_resolve_nearest_release_tag_ignores_sidecar_tags(git_repo: Path) -> None:
+    """A sidecar/mf-entry-bin-namespaced tag at the same commit should not be picked up."""
+    _run_git(["tag", "mf-entry-bin/v0.208.0+2607281534.a1b2c3d4"], git_repo)
+    assert resolve_nearest_release_tag(git_repo) == "v0.208.0"
+
+
+def test_resolve_nearest_release_tag_raises_when_none_reachable(tmp_path: Path) -> None:
+    """No reachable release tag should fail loudly rather than produce a malformed tag."""
+    repository_directory = tmp_path / "repo"
+    repository_directory.mkdir()
+    _run_git(["init", "-q", "."], repository_directory)
+    _run_git(["config", "user.email", "test@example.com"], repository_directory)
+    _run_git(["config", "user.name", "Test"], repository_directory)
+    (repository_directory / "file.txt").write_text("hello")
+    _run_git(["add", "file.txt"], repository_directory)
+    _run_git(["commit", "-q", "-m", "no release tags here"], repository_directory)
+
+    with pytest.raises(subprocess.CalledProcessError):
+        resolve_nearest_release_tag(repository_directory)
+
+
+def test_resolve_head_commit_sha_matches_git_rev_parse(git_repo: Path) -> None:
+    """Should return the same value `git rev-parse HEAD` would print."""
+    expected = (
+        subprocess.run(["git", "rev-parse", "HEAD"], cwd=git_repo, check=True, capture_output=True)
+        .stdout.decode()
+        .strip()
+    )
+    assert resolve_head_commit_sha(git_repo) == expected
+
+
+def test_cut_adhoc_release_dry_run_does_not_create_a_tag(git_repo: Path) -> None:
+    """--dry-run should compute the tag without creating it in the repository."""
+    tag = cut_adhoc_release(git_repo, dry_run=True)
+    assert tag.startswith("mf-entry-bin/v0.208.0+")
+
+    existing_tags = subprocess.run(["git", "tag", "-l"], cwd=git_repo, check=True, capture_output=True).stdout.decode()
+    assert tag not in existing_tags
+
+
+def test_cut_adhoc_release_creates_local_tag(git_repo: Path) -> None:
+    """Without --dry-run, the computed tag should actually be created in the repository."""
+    tag = cut_adhoc_release(git_repo, dry_run=False)
+
+    existing_tags = subprocess.run(["git", "tag", "-l"], cwd=git_repo, check=True, capture_output=True).stdout.decode()
+    assert tag in existing_tags.splitlines()
+
+
+def test_cut_adhoc_release_resets_counter_free_naming_per_version(git_repo: Path) -> None:
+    """Two releases cut back-to-back for the same version differ only by timestamp/sha, not a counter."""
+    first_tag = cut_adhoc_release(git_repo, dry_run=True)
+    second_tag = cut_adhoc_release(git_repo, dry_run=True)
+    # Same commit, same version -- these may coincide if cut within the same UTC minute,
+    # but the format itself (no stateful counter) is what's under test here.
+    assert first_tag.split("+", 1)[0] == second_tag.split("+", 1)[0] == "mf-entry-bin/v0.208.0"

--- a/tests_metricflow/sidecar_release/test_cut_adhoc_release.py
+++ b/tests_metricflow/sidecar_release/test_cut_adhoc_release.py
@@ -77,7 +77,7 @@ def test_resolve_head_commit_sha_matches_git_rev_parse(git_repo: Path) -> None:
 def test_cut_adhoc_release_dry_run_does_not_create_a_tag(git_repo: Path) -> None:
     """--dry-run should compute the tag without creating it in the repository."""
     tag = cut_adhoc_release(git_repo, dry_run=True)
-    assert tag.startswith("mf-entry-bin/v0.212.0.dev0+")
+    assert tag.startswith("mf-stdio-sidecar/v0.212.0.dev0+")
 
     existing_tags = subprocess.run(["git", "tag", "-l"], cwd=git_repo, check=True, capture_output=True).stdout.decode()
     assert tag not in existing_tags

--- a/tests_metricflow/sidecar_release/test_cut_adhoc_release.py
+++ b/tests_metricflow/sidecar_release/test_cut_adhoc_release.py
@@ -8,7 +8,7 @@ import pytest
 from scripts.sidecar_release.cut_adhoc_release import (
     cut_adhoc_release,
     resolve_head_commit_sha,
-    resolve_nearest_release_tag,
+    resolve_metricflow_version,
 )
 
 
@@ -18,43 +18,50 @@ def _run_git(args: list[str], repository_directory: Path) -> None:
 
 @pytest.fixture
 def git_repo(tmp_path: Path) -> Path:
-    """A real, throwaway git repository with one commit and one release tag."""
+    """A real, throwaway git repository with one commit and a metricflow/__about__.py."""
     repository_directory = tmp_path / "repo"
-    repository_directory.mkdir()
+    (repository_directory / "metricflow").mkdir(parents=True)
+    (repository_directory / "metricflow" / "__about__.py").write_text(
+        'from __future__ import annotations\n\n__version__ = "0.212.0.dev0"\n'
+    )
     _run_git(["init", "-q", "."], repository_directory)
     _run_git(["config", "user.email", "test@example.com"], repository_directory)
     _run_git(["config", "user.name", "Test"], repository_directory)
-    (repository_directory / "file.txt").write_text("hello")
-    _run_git(["add", "file.txt"], repository_directory)
+    _run_git(["add", "metricflow/__about__.py"], repository_directory)
     _run_git(["commit", "-q", "-m", "initial"], repository_directory)
-    _run_git(["tag", "v0.208.0"], repository_directory)
     return repository_directory
 
 
-def test_resolve_nearest_release_tag(git_repo: Path) -> None:
-    """Should resolve the bare v<version> tag reachable from HEAD."""
-    assert resolve_nearest_release_tag(git_repo) == "v0.208.0"
+def test_resolve_metricflow_version(git_repo: Path) -> None:
+    """Should resolve MetricFlow's current version from metricflow/__about__.py."""
+    assert resolve_metricflow_version(git_repo) == "0.212.0.dev0"
 
 
-def test_resolve_nearest_release_tag_ignores_sidecar_tags(git_repo: Path) -> None:
-    """A sidecar/mf-entry-bin-namespaced tag at the same commit should not be picked up."""
-    _run_git(["tag", "mf-entry-bin/v0.208.0+2607281534.a1b2c3d4"], git_repo)
-    assert resolve_nearest_release_tag(git_repo) == "v0.208.0"
+def test_resolve_metricflow_version_reads_released_versions_too(git_repo: Path) -> None:
+    """Should resolve a real released version just as readily as a `.devN` one."""
+    (git_repo / "metricflow" / "__about__.py").write_text(
+        'from __future__ import annotations\n\n__version__ = "0.211.0"\n'
+    )
+    assert resolve_metricflow_version(git_repo) == "0.211.0"
 
 
-def test_resolve_nearest_release_tag_raises_when_none_reachable(tmp_path: Path) -> None:
-    """No reachable release tag should fail loudly rather than produce a malformed tag."""
+def test_resolve_metricflow_version_raises_when_about_file_missing(tmp_path: Path) -> None:
+    """A missing __about__.py should fail loudly rather than produce a malformed tag."""
     repository_directory = tmp_path / "repo"
     repository_directory.mkdir()
-    _run_git(["init", "-q", "."], repository_directory)
-    _run_git(["config", "user.email", "test@example.com"], repository_directory)
-    _run_git(["config", "user.name", "Test"], repository_directory)
-    (repository_directory / "file.txt").write_text("hello")
-    _run_git(["add", "file.txt"], repository_directory)
-    _run_git(["commit", "-q", "-m", "no release tags here"], repository_directory)
 
-    with pytest.raises(subprocess.CalledProcessError):
-        resolve_nearest_release_tag(repository_directory)
+    with pytest.raises(FileNotFoundError):
+        resolve_metricflow_version(repository_directory)
+
+
+def test_resolve_metricflow_version_raises_when_version_assignment_missing(tmp_path: Path) -> None:
+    """An __about__.py with no `__version__ = ...` assignment should fail loudly."""
+    repository_directory = tmp_path / "repo"
+    (repository_directory / "metricflow").mkdir(parents=True)
+    (repository_directory / "metricflow" / "__about__.py").write_text("# no version here\n")
+
+    with pytest.raises(RuntimeError, match="Could not find"):
+        resolve_metricflow_version(repository_directory)
 
 
 def test_resolve_head_commit_sha_matches_git_rev_parse(git_repo: Path) -> None:
@@ -70,7 +77,7 @@ def test_resolve_head_commit_sha_matches_git_rev_parse(git_repo: Path) -> None:
 def test_cut_adhoc_release_dry_run_does_not_create_a_tag(git_repo: Path) -> None:
     """--dry-run should compute the tag without creating it in the repository."""
     tag = cut_adhoc_release(git_repo, dry_run=True)
-    assert tag.startswith("mf-entry-bin/v0.208.0+")
+    assert tag.startswith("mf-entry-bin/v0.212.0.dev0+")
 
     existing_tags = subprocess.run(["git", "tag", "-l"], cwd=git_repo, check=True, capture_output=True).stdout.decode()
     assert tag not in existing_tags
@@ -82,12 +89,3 @@ def test_cut_adhoc_release_creates_local_tag(git_repo: Path) -> None:
 
     existing_tags = subprocess.run(["git", "tag", "-l"], cwd=git_repo, check=True, capture_output=True).stdout.decode()
     assert tag in existing_tags.splitlines()
-
-
-def test_cut_adhoc_release_resets_counter_free_naming_per_version(git_repo: Path) -> None:
-    """Two releases cut back-to-back for the same version differ only by timestamp/sha, not a counter."""
-    first_tag = cut_adhoc_release(git_repo, dry_run=True)
-    second_tag = cut_adhoc_release(git_repo, dry_run=True)
-    # Same commit, same version -- these may coincide if cut within the same UTC minute,
-    # but the format itself (no stateful counter) is what's under test here.
-    assert first_tag.split("+", 1)[0] == second_tag.split("+", 1)[0] == "mf-entry-bin/v0.208.0"

--- a/tests_metricflow/sidecar_release/test_generate_build_info.py
+++ b/tests_metricflow/sidecar_release/test_generate_build_info.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.sidecar_release.generate_build_info import (
+    generate_build_info,
+    metricflow_version_from_tag,
+)
+
+
+@pytest.mark.parametrize(
+    ("tag", "expected_version"),
+    [
+        ("sidecar/v0.208.0+1", "0.208.0"),
+        ("mf-entry-bin/v0.208.0+2607281534.a1b2c3d4", "0.208.0"),
+        ("v0.208.0", "0.208.0"),
+    ],
+)
+def test_metricflow_version_from_tag(tag: str, expected_version: str) -> None:
+    """The embedded MetricFlow version should parse out regardless of prefix or suffix shape."""
+    assert metricflow_version_from_tag(tag) == expected_version
+
+
+def test_generate_build_info_contents() -> None:
+    """The assembled dict should carry all five fields with the parsed MetricFlow version."""
+    build_info = generate_build_info(
+        tag="mf-entry-bin/v0.208.0+2607281534.a1b2c3d4",
+        commit_sha="deadbeefcafe",
+        nuitka_version="4.1.2\n",
+        python_version="Python 3.10.19\n",
+    )
+
+    assert build_info == {
+        "tag": "mf-entry-bin/v0.208.0+2607281534.a1b2c3d4",
+        "metricflow_version": "0.208.0",
+        "commit": "deadbeefcafe",
+        "nuitka_version": "4.1.2",
+        "python_version": "Python 3.10.19",
+    }
+
+
+def test_main_writes_valid_json(tmp_path: Path) -> None:
+    """The CLI entrypoint should write parseable JSON to the requested output path."""
+    from scripts.sidecar_release.generate_build_info import main
+
+    nuitka_version_file = tmp_path / "nuitka-version.txt"
+    nuitka_version_file.write_text("4.1.2\n")
+    python_version_file = tmp_path / "python-version.txt"
+    python_version_file.write_text("Python 3.10.19\n")
+    output_path = tmp_path / "build-info.json"
+
+    main(
+        [
+            "--tag",
+            "mf-entry-bin/v0.208.0+2607281534.a1b2c3d4",
+            "--commit",
+            "deadbeefcafe",
+            "--nuitka-version-file",
+            str(nuitka_version_file),
+            "--python-version-file",
+            str(python_version_file),
+            "--output",
+            str(output_path),
+        ]
+    )
+
+    written = json.loads(output_path.read_text())
+    assert written["metricflow_version"] == "0.208.0"
+    assert written["commit"] == "deadbeefcafe"

--- a/tests_metricflow/sidecar_release/test_generate_build_info.py
+++ b/tests_metricflow/sidecar_release/test_generate_build_info.py
@@ -9,14 +9,14 @@ from scripts.sidecar_release.generate_build_info import generate_build_info
 def test_generate_build_info_contents() -> None:
     """The assembled dict should carry all five fields with the parsed MetricFlow version."""
     build_info = generate_build_info(
-        tag="mf-entry-bin/v0.208.0+2607281534.a1b2c3d4",
+        tag="mf-stdio-sidecar/v0.208.0+2607281534.a1b2c3d4",
         commit_sha="deadbeefcafe",
         nuitka_version="4.1.2\n",
         python_version="Python 3.10.19\n",
     )
 
     assert build_info == {
-        "tag": "mf-entry-bin/v0.208.0+2607281534.a1b2c3d4",
+        "tag": "mf-stdio-sidecar/v0.208.0+2607281534.a1b2c3d4",
         "metricflow_version": "0.208.0",
         "commit": "deadbeefcafe",
         "nuitka_version": "4.1.2",
@@ -37,7 +37,7 @@ def test_main_writes_valid_json(tmp_path: Path) -> None:
     main(
         [
             "--tag",
-            "mf-entry-bin/v0.208.0+2607281534.a1b2c3d4",
+            "mf-stdio-sidecar/v0.208.0+2607281534.a1b2c3d4",
             "--commit",
             "deadbeefcafe",
             "--nuitka-version-file",

--- a/tests_metricflow/sidecar_release/test_generate_build_info.py
+++ b/tests_metricflow/sidecar_release/test_generate_build_info.py
@@ -3,25 +3,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-import pytest
-
-from scripts.sidecar_release.generate_build_info import (
-    generate_build_info,
-    metricflow_version_from_tag,
-)
-
-
-@pytest.mark.parametrize(
-    ("tag", "expected_version"),
-    [
-        ("sidecar/v0.208.0+1", "0.208.0"),
-        ("mf-entry-bin/v0.208.0+2607281534.a1b2c3d4", "0.208.0"),
-        ("v0.208.0", "0.208.0"),
-    ],
-)
-def test_metricflow_version_from_tag(tag: str, expected_version: str) -> None:
-    """The embedded MetricFlow version should parse out regardless of prefix or suffix shape."""
-    assert metricflow_version_from_tag(tag) == expected_version
+from scripts.sidecar_release.generate_build_info import generate_build_info
 
 
 def test_generate_build_info_contents() -> None:

--- a/tests_metricflow/sidecar_release/test_package_archives.py
+++ b/tests_metricflow/sidecar_release/test_package_archives.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import tarfile
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from scripts.sidecar_release.package_archives import (
+    archive_version_from_tag,
+    package_release_archives,
+)
+
+
+@pytest.mark.parametrize(
+    ("tag", "expected_version"),
+    [
+        ("sidecar/v0.208.0+2", "v0.208.0+2"),
+        ("mf-entry-bin/v0.208.0+2607281534.a1b2c3d4", "v0.208.0+2607281534.a1b2c3d4"),
+        ("v0.208.0", "v0.208.0"),
+    ],
+)
+def test_archive_version_from_tag_is_prefix_agnostic(tag: str, expected_version: str) -> None:
+    """The archive version should be whatever follows the tag's last `/`, regardless of prefix."""
+    assert archive_version_from_tag(tag) == expected_version
+
+
+def _make_platform_dir(dist_dir: Path, triple: str) -> Path:
+    platform_dir = dist_dir / f"mf_entry-{triple}"
+    (platform_dir / "nested").mkdir(parents=True)
+    (platform_dir / "mf_entry.bin").write_text("fake binary contents")
+    (platform_dir / "nested" / "extension.so").write_text("fake extension contents")
+    return platform_dir
+
+
+def test_package_release_archives_produces_tar_gz_for_non_windows(tmp_path: Path) -> None:
+    """Non-Windows triples should be packaged as a flat .tar.gz with no wrapper directory."""
+    dist_dir = tmp_path / "dist"
+    _make_platform_dir(dist_dir, "x86_64-unknown-linux-gnu")
+
+    archive_paths = package_release_archives(dist_dir, tag="mf-entry-bin/v0.208.0+2")
+
+    assert len(archive_paths) == 1
+    archive_path = archive_paths[0]
+    assert archive_path.name == "mf_entry-v0.208.0+2-x86_64-unknown-linux-gnu.tar.gz"
+
+    with tarfile.open(archive_path) as tar:
+        names = sorted(tar.getnames())
+    # No wrapper directory -- extracting reproduces mf_entry.dist/'s own contents at the root.
+    assert names == ["mf_entry.bin", "nested", "nested/extension.so"]
+
+
+def test_package_release_archives_produces_zip_for_windows(tmp_path: Path) -> None:
+    """Windows triples should be packaged as a flat .zip with no wrapper directory."""
+    dist_dir = tmp_path / "dist"
+    _make_platform_dir(dist_dir, "x86_64-pc-windows-msvc")
+
+    archive_paths = package_release_archives(dist_dir, tag="mf-entry-bin/v0.208.0+2")
+
+    assert len(archive_paths) == 1
+    archive_path = archive_paths[0]
+    assert archive_path.name == "mf_entry-v0.208.0+2-x86_64-pc-windows-msvc.zip"
+
+    with zipfile.ZipFile(archive_path) as zip_file:
+        names = sorted(zip_file.namelist())
+    assert names == ["mf_entry.bin", "nested/extension.so"]
+
+
+def test_package_release_archives_writes_checksums_for_every_archive(tmp_path: Path) -> None:
+    """SHA256SUMS.txt should list every produced archive, one line each."""
+    dist_dir = tmp_path / "dist"
+    _make_platform_dir(dist_dir, "aarch64-apple-darwin")
+    _make_platform_dir(dist_dir, "x86_64-pc-windows-msvc")
+
+    package_release_archives(dist_dir, tag="mf-entry-bin/v0.208.0+2")
+
+    checksums = (dist_dir / "SHA256SUMS.txt").read_text()
+    assert "mf_entry-v0.208.0+2-aarch64-apple-darwin.tar.gz" in checksums
+    assert "mf_entry-v0.208.0+2-x86_64-pc-windows-msvc.zip" in checksums
+    assert len(checksums.strip().splitlines()) == 2
+
+
+def test_package_release_archives_removes_source_directories(tmp_path: Path) -> None:
+    """The source mf_entry-<triple>/ directory should be removed once it's archived."""
+    dist_dir = tmp_path / "dist"
+    platform_dir = _make_platform_dir(dist_dir, "x86_64-unknown-linux-gnu")
+
+    package_release_archives(dist_dir, tag="mf-entry-bin/v0.208.0+2")
+
+    assert not platform_dir.exists()
+
+
+def test_package_release_archives_raises_when_nothing_to_package(tmp_path: Path) -> None:
+    """An empty dist dir should fail loudly rather than silently produce nothing."""
+    dist_dir = tmp_path / "dist"
+    dist_dir.mkdir()
+
+    with pytest.raises(RuntimeError, match="No mf_entry-<triple>/ directories found"):
+        package_release_archives(dist_dir, tag="mf-entry-bin/v0.208.0+2")

--- a/tests_metricflow/sidecar_release/test_package_archives.py
+++ b/tests_metricflow/sidecar_release/test_package_archives.py
@@ -16,7 +16,7 @@ from scripts.sidecar_release.package_archives import (
     ("tag", "expected_version"),
     [
         ("sidecar/v0.208.0+2", "v0.208.0+2"),
-        ("mf-entry-bin/v0.208.0+2607281534.a1b2c3d4", "v0.208.0+2607281534.a1b2c3d4"),
+        ("mf-stdio-sidecar/v0.208.0+2607281534.a1b2c3d4", "v0.208.0+2607281534.a1b2c3d4"),
         ("v0.208.0", "v0.208.0"),
     ],
 )
@@ -38,7 +38,7 @@ def test_package_release_archives_produces_tar_gz_for_non_windows(tmp_path: Path
     dist_dir = tmp_path / "dist"
     _make_platform_dir(dist_dir, "x86_64-unknown-linux-gnu")
 
-    archive_paths = package_release_archives(dist_dir, tag="mf-entry-bin/v0.208.0+2")
+    archive_paths = package_release_archives(dist_dir, tag="mf-stdio-sidecar/v0.208.0+2")
 
     assert len(archive_paths) == 1
     archive_path = archive_paths[0]
@@ -55,7 +55,7 @@ def test_package_release_archives_produces_zip_for_windows(tmp_path: Path) -> No
     dist_dir = tmp_path / "dist"
     _make_platform_dir(dist_dir, "x86_64-pc-windows-msvc")
 
-    archive_paths = package_release_archives(dist_dir, tag="mf-entry-bin/v0.208.0+2")
+    archive_paths = package_release_archives(dist_dir, tag="mf-stdio-sidecar/v0.208.0+2")
 
     assert len(archive_paths) == 1
     archive_path = archive_paths[0]
@@ -72,7 +72,7 @@ def test_package_release_archives_writes_checksums_for_every_archive(tmp_path: P
     _make_platform_dir(dist_dir, "aarch64-apple-darwin")
     _make_platform_dir(dist_dir, "x86_64-pc-windows-msvc")
 
-    package_release_archives(dist_dir, tag="mf-entry-bin/v0.208.0+2")
+    package_release_archives(dist_dir, tag="mf-stdio-sidecar/v0.208.0+2")
 
     checksums = (dist_dir / "SHA256SUMS.txt").read_text()
     assert "mf_entry-v0.208.0+2-aarch64-apple-darwin.tar.gz" in checksums
@@ -85,7 +85,7 @@ def test_package_release_archives_removes_source_directories(tmp_path: Path) -> 
     dist_dir = tmp_path / "dist"
     platform_dir = _make_platform_dir(dist_dir, "x86_64-unknown-linux-gnu")
 
-    package_release_archives(dist_dir, tag="mf-entry-bin/v0.208.0+2")
+    package_release_archives(dist_dir, tag="mf-stdio-sidecar/v0.208.0+2")
 
     assert not platform_dir.exists()
 
@@ -96,4 +96,4 @@ def test_package_release_archives_raises_when_nothing_to_package(tmp_path: Path)
     dist_dir.mkdir()
 
     with pytest.raises(RuntimeError, match="No mf_entry-<triple>/ directories found"):
-        package_release_archives(dist_dir, tag="mf-entry-bin/v0.208.0+2")
+        package_release_archives(dist_dir, tag="mf-stdio-sidecar/v0.208.0+2")

--- a/tests_metricflow/sidecar_release/test_tag.py
+++ b/tests_metricflow/sidecar_release/test_tag.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import re
+from datetime import datetime, timezone
+
+import pytest
+
+from scripts.sidecar_release.tag import build_sidecar_release_tag, metricflow_version_from_tag
+
+
+def test_build_sidecar_release_tag_with_explicit_timestamp() -> None:
+    """The tag should combine the version, a UTC YYMMDDHHmm timestamp, and an 8-char sha."""
+    tag = build_sidecar_release_tag(
+        metricflow_version="0.208.0",
+        commit_sha="a1b2c3d4e5f6789",
+        timestamp=datetime(2026, 7, 28, 15, 34, tzinfo=timezone.utc),
+    )
+    assert tag == "mf-entry-bin/v0.208.0+2607281534.a1b2c3d4"
+
+
+def test_build_sidecar_release_tag_truncates_full_length_sha() -> None:
+    """A full 40-character commit SHA should be truncated to its first 8 characters."""
+    full_sha = "a1b2c3d4e5f6789012345678901234567890abcd"
+    tag = build_sidecar_release_tag(
+        metricflow_version="0.208.0",
+        commit_sha=full_sha,
+        timestamp=datetime(2026, 7, 28, 15, 34, tzinfo=timezone.utc),
+    )
+    assert tag.endswith(".a1b2c3d4")
+
+
+def test_build_sidecar_release_tag_defaults_to_now_when_timestamp_omitted() -> None:
+    """Omitting the timestamp should still produce a validly-shaped tag using the current time."""
+    tag = build_sidecar_release_tag(metricflow_version="0.208.0", commit_sha="a1b2c3d4e5f6")
+    assert re.fullmatch(r"mf-entry-bin/v0\.208\.0\+\d{10}\.a1b2c3d4", tag)
+
+
+@pytest.mark.parametrize(
+    ("tag", "expected_version"),
+    [
+        ("mf-entry-bin/v0.208.0+2607281534.a1b2c3d4", "0.208.0"),
+        ("sidecar/v0.208.0+1", "0.208.0"),
+        ("v0.208.0", "0.208.0"),
+    ],
+)
+def test_metricflow_version_from_tag(tag: str, expected_version: str) -> None:
+    """The embedded MetricFlow version should parse out regardless of prefix or suffix shape."""
+    assert metricflow_version_from_tag(tag) == expected_version

--- a/tests_metricflow/sidecar_release/test_tag.py
+++ b/tests_metricflow/sidecar_release/test_tag.py
@@ -15,7 +15,7 @@ def test_build_sidecar_release_tag_with_explicit_timestamp() -> None:
         commit_sha="a1b2c3d4e5f6789",
         timestamp=datetime(2026, 7, 28, 15, 34, tzinfo=timezone.utc),
     )
-    assert tag == "mf-entry-bin/v0.208.0+2607281534.a1b2c3d4"
+    assert tag == "mf-stdio-sidecar/v0.208.0+2607281534.a1b2c3d4"
 
 
 def test_build_sidecar_release_tag_truncates_full_length_sha() -> None:
@@ -32,13 +32,13 @@ def test_build_sidecar_release_tag_truncates_full_length_sha() -> None:
 def test_build_sidecar_release_tag_defaults_to_now_when_timestamp_omitted() -> None:
     """Omitting the timestamp should still produce a validly-shaped tag using the current time."""
     tag = build_sidecar_release_tag(metricflow_version="0.208.0", commit_sha="a1b2c3d4e5f6")
-    assert re.fullmatch(r"mf-entry-bin/v0\.208\.0\+\d{10}\.a1b2c3d4", tag)
+    assert re.fullmatch(r"mf-stdio-sidecar/v0\.208\.0\+\d{10}\.a1b2c3d4", tag)
 
 
 @pytest.mark.parametrize(
     ("tag", "expected_version"),
     [
-        ("mf-entry-bin/v0.208.0+2607281534.a1b2c3d4", "0.208.0"),
+        ("mf-stdio-sidecar/v0.208.0+2607281534.a1b2c3d4", "0.208.0"),
         ("sidecar/v0.208.0+1", "0.208.0"),
         ("v0.208.0", "0.208.0"),
     ],

--- a/tests_metricflow/snapshots/test_step_3.py/FakeRunSnapshot/test_step_3_all_operations_match_snapshot__result.txt
+++ b/tests_metricflow/snapshots/test_step_3.py/FakeRunSnapshot/test_step_3_all_operations_match_snapshot__result.txt
@@ -31,7 +31,7 @@ FakeRunSnapshot(
     FakeGitOperation(name='push_tag', branch_name='v1.2.3', commit_sha='abc123'),
     FakeGitOperation(
       name='push_tag',
-      branch_name='mf-entry-bin/v1.2.3+2601010000.abc123',
+      branch_name='mf-stdio-sidecar/v1.2.3+2601010000.abc123',
       commit_sha='abc123',
     ),
     FakeReleaseStateFileSnapshot(
@@ -52,7 +52,7 @@ FakeRunSnapshot(
        '    },\n'
        '    "step_3": {\n'
        '        "metricflow_release_tag_name": "v1.2.3",\n'
-       '        "sidecar_release_tag_name": "mf-entry-bin/v1.2.3+2601010000.abc123",\n'
+       '        "sidecar_release_tag_name": "mf-stdio-sidecar/v1.2.3+2601010000.abc123",\n'
        '        "metricflow_release_merge_commit_sha": "abc123",\n'
        '        "metricflow_dev_version_commit_sha": "def456"\n'
        '    },\n'

--- a/tests_metricflow/snapshots/test_step_3.py/FakeRunSnapshot/test_step_3_all_operations_match_snapshot__result.txt
+++ b/tests_metricflow/snapshots/test_step_3.py/FakeRunSnapshot/test_step_3_all_operations_match_snapshot__result.txt
@@ -29,6 +29,7 @@ FakeRunSnapshot(
     FakeGitHubIsMerged(pr_number=200, result=False),
     FakeGitHubMerge(pr_number=200, merge_method='squash'),
     FakeGitOperation(name='push_tag', branch_name='v1.2.3', commit_sha='abc123'),
+    FakeGitOperation(name='push_tag', branch_name='sidecar/v1.2.3+1', commit_sha='abc123'),
     FakeReleaseStateFileSnapshot(
       file_path='<TMP>/metricflow/git_ignored/mf_release_tool_state.json',
       file_text=('{\n'
@@ -47,6 +48,7 @@ FakeRunSnapshot(
        '    },\n'
        '    "step_3": {\n'
        '        "metricflow_release_tag_name": "v1.2.3",\n'
+       '        "sidecar_release_tag_name": "sidecar/v1.2.3+1",\n'
        '        "metricflow_release_merge_commit_sha": "abc123",\n'
        '        "metricflow_dev_version_commit_sha": "def456"\n'
        '    },\n'

--- a/tests_metricflow/snapshots/test_step_3.py/FakeRunSnapshot/test_step_3_all_operations_match_snapshot__result.txt
+++ b/tests_metricflow/snapshots/test_step_3.py/FakeRunSnapshot/test_step_3_all_operations_match_snapshot__result.txt
@@ -29,7 +29,11 @@ FakeRunSnapshot(
     FakeGitHubIsMerged(pr_number=200, result=False),
     FakeGitHubMerge(pr_number=200, merge_method='squash'),
     FakeGitOperation(name='push_tag', branch_name='v1.2.3', commit_sha='abc123'),
-    FakeGitOperation(name='push_tag', branch_name='sidecar/v1.2.3+1', commit_sha='abc123'),
+    FakeGitOperation(
+      name='push_tag',
+      branch_name='mf-entry-bin/v1.2.3+2601010000.abc123',
+      commit_sha='abc123',
+    ),
     FakeReleaseStateFileSnapshot(
       file_path='<TMP>/metricflow/git_ignored/mf_release_tool_state.json',
       file_text=('{\n'
@@ -48,7 +52,7 @@ FakeRunSnapshot(
        '    },\n'
        '    "step_3": {\n'
        '        "metricflow_release_tag_name": "v1.2.3",\n'
-       '        "sidecar_release_tag_name": "sidecar/v1.2.3+1",\n'
+       '        "sidecar_release_tag_name": "mf-entry-bin/v1.2.3+2601010000.abc123",\n'
        '        "metricflow_release_merge_commit_sha": "abc123",\n'
        '        "metricflow_dev_version_commit_sha": "def456"\n'
        '    },\n'

--- a/tests_metricflow/snapshots/test_step_4.py/FakeRunSnapshot/test_step_4_all_operations_match_snapshot__result.txt
+++ b/tests_metricflow/snapshots/test_step_4.py/FakeRunSnapshot/test_step_4_all_operations_match_snapshot__result.txt
@@ -59,6 +59,7 @@ FakeRunSnapshot(
        '    },\n'
        '    "step_3": {\n'
        '        "metricflow_release_tag_name": "v1.2.3",\n'
+       '        "sidecar_release_tag_name": null,\n'
        '        "metricflow_release_merge_commit_sha": "abc123",\n'
        '        "metricflow_dev_version_commit_sha": "def456"\n'
        '    },\n'

--- a/tests_metricflow/snapshots/test_step_7.py/FakeRunSnapshot/test_step_7_all_operations_match_snapshot__result.txt
+++ b/tests_metricflow/snapshots/test_step_7.py/FakeRunSnapshot/test_step_7_all_operations_match_snapshot__result.txt
@@ -34,6 +34,7 @@ FakeRunSnapshot(
        '    },\n'
        '    "step_3": {\n'
        '        "metricflow_release_tag_name": "v1.2.3",\n'
+       '        "sidecar_release_tag_name": null,\n'
        '        "metricflow_release_merge_commit_sha": "abc123",\n'
        '        "metricflow_dev_version_commit_sha": "def456"\n'
        '    },\n'


### PR DESCRIPTION
## Summary

Sidecar binary releases were 1:1 tied to MetricFlow's own `v<version>` tags, so there was no way to publish a new sidecar binary (e.g. a new `mf_entry.py` entry point) without a MetricFlow version bump — and re-publishing under an existing tag silently clobbered assets (`softprops/action-gh-release` defaults to `overwrite_files: true`).

This introduces a `mf-entry-bin/v<mf_version>+<YYMMDDHHmm>.<sha8>` tag namespace, decoupled from MetricFlow's release cadence. The design went through a round of review (see below) before landing here:

- `cd-build-sidecar-binaries.yaml` now triggers on and publishes for `mf-entry-bin/v*` tags exclusively (the bare `v<version>` tag's only remaining job is triggering the PyPI publish workflow — triggering on both would double-build and double-publish for every release).
- `scripts/release_tool/release_step_3.py` automatically pushes a matching sidecar tag alongside every real MetricFlow release, using the version/commit it already knows — no separate manual step, no git lookups needed.
- A new `workflow_dispatch` GitHub Action (`Cut Ad Hoc Sidecar Release`, restricted to `main`) lets a sidecar-only change publish a release between MetricFlow releases — self-service. It resolves `<mf_version>` directly from `metricflow/__about__.py` (often a `.devN` pre-release version between releases — see below for why that's the right call, not a shortcut).
- Both of the above build the *exact same* tag format via one shared function (`scripts/sidecar_release/tag.py`) — there's no more special-cased "baseline" tag vs. "ad hoc" tag, since the timestamp+sha disambiguator needs no stateful counter to compute.
- `overwrite_files: false` so an accidental re-push of an existing tag fails loudly instead of silently overwriting a published release.
- A centralized `build-info.json` records the embedded MetricFlow version, source commit, and the Nuitka/Python versions actually used.
- `sidecar/README.md` documents all of the above.

**Changes from review (Paul):**
1. *Tag naming* — the namespace was originally `sidecar/`. `mf-ipc` was considered and rejected (that name is already taken by the wire protocol, versioned independently as `mf-ipc v1` — conflating the two would tie unrelated axes together). Landed on `mf-entry-bin/`, matching the existing `mf_entry-*` archive-naming convention.
2. *Scriptify the release process* — the archive-packaging, `build-info.json` generation, and ad hoc-release tag resolution were originally inline bash/python embedded directly in the workflow YAML. All three are now real, stdlib-only scripts under `scripts/sidecar_release/`, runnable locally with a bare `python3` (no hatch env) — the workflows now mostly orchestrate these scripts rather than containing the logic themselves.
3. *Version format* — switched from a stateful `+<counter>` (reset per MetricFlow version, computed by scanning existing tags) to `+<YYMMDDHHmm>.<sha8>` (UTC timestamp + short commit SHA). This needs zero git-tag lookups and can't race on concurrent triggers. Not PEP 440-constrained, since unlike MetricFlow's own tags this one never goes through PyPI/pip/twine.

**Further refinement (post-review):** the ad hoc-release script originally resolved `<mf_version>` via `git describe --tags` against the nearest real release tag, specifically to avoid embedding `metricflow/__about__.py`'s `.devN` pre-release version. On reconsideration, that was backwards — between releases, `__about__.py`'s version is exactly as static as the last release tag (nothing bumps either except the release process itself), so the real difference is what each one *claims*. Labeling an ad hoc build with the last released tag asserts "this embeds exactly what that release shipped," which this design already accepts can be false (ad hoc releases don't guard against `metricflow`/`metricflow_semantics`/`metricflow_semantic_interfaces` having changed since). `.devN` makes no such claim — it honestly signals "unreleased, in-development state" either way. Switched to reading `__about__.py` directly, which also removes a failure mode (no reachable release tag) and let the workflow's checkout drop `fetch-depth: 0`/`fetch-tags: true` entirely.

Full design rationale (12 resolved decision points from the original `/grill-me` interview, plus the changes above) is in [DI-4871](https://dbtlabs.atlassian.net/browse/DI-4871).

## Test plan

- [x] `hatch run dev-env:pytest tests_metricflow/sidecar_release/ tests_metricflow/release_tools/` — 32 tests pass, covering: tag building/parsing (`tag.py`), archive packaging incl. tar vs. zip and checksum generation (`package_archives.py`), `build-info.json` assembly (`generate_build_info.py`), and ad hoc-release version/commit resolution against real throwaway git repos incl. missing-`__about__.py` and missing-version-assignment failure cases (`cut_adhoc_release.py`) — plus the release-tool snapshot suite, updated for the new tag format via an injectable clock (`FakeNow`, mirroring the existing `FakeSleep` pattern) so the snapshot doesn't embed real wall-clock time
- [x] `mypy`, `ruff`, `black` clean on all changed Python files
- [x] `actionlint` clean on all workflow files
- [x] Every command in `sidecar/README.md`'s local-usage examples was actually run, not just described — including `package_archives.py`, which needs a build staged into the `mf_entry-<triple>/` layout the script expects before it'll find anything to package (an earlier draft of that example pointed straight at `sidecar/`, which would have silently matched nothing)
- [x] Live-ran `cut_adhoc_release.py --dry-run` against this actual repo/branch to confirm it resolves a real tag end-to-end
- [ ] Not yet exercised in real CI — worth a deliberate watch on the first real use of either the automated release_step_3.py tag (next MetricFlow release) or the ad hoc-release Action

[DI-4871]: https://dbtlabs.atlassian.net/browse/DI-4871

