### PR TITLE
Support Python 3.14 in `dbt-metricflow`

### DIFF
--- a/.changes/unreleased/Dependencies-20260730-131112.yaml
+++ b/.changes/unreleased/Dependencies-20260730-131112.yaml
@@ -1,0 +1,6 @@
+kind: Dependencies
+body: Support Python 3.14 in `dbt-metricflow`
+time: 2026-07-30T13:11:12.543413-07:00
+custom:
+    Author: "2108"
+    Issue: plypaul

--- a/dbt-metricflow/pyproject.toml
+++ b/dbt-metricflow/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "dbt-metricflow"
 description = "Execute commands against the MetricFlow semantic layer with dbt."
 readme = "README.md"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10,<3.15"
 license = "Apache-2.0"
 authors = [
   { name = "dbt Labs", email = "info@dbtlabs.com" },
@@ -19,6 +19,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]


### PR DESCRIPTION
This PR adds Python 3.14 to `dbt-metricflow`'s list of supported Python versions to align with `metricflow` / `dbt-core`.