### PR TITLE
Require metrics for metric-scoped list commands

### DIFF
--- a/.changes/unreleased/Fixes-20260805-200603.yaml
+++ b/.changes/unreleased/Fixes-20260805-200603.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Require --metrics for metric-scoped dimension and entity list commands
+time: 2026-08-05T20:06:03.842688283+08:00
+custom:
+    Author: fanruan-tuco
+    Issue: "2109"

--- a/dbt-metricflow/dbt_metricflow/cli/main.py
+++ b/dbt-metricflow/dbt_metricflow/cli/main.py
@@ -346,14 +346,14 @@ def metrics(cfg: CLIConfiguration, show_all_dimensions: bool = False, search: Op
 @click.option(
     "--metrics",
     type=click_custom.SequenceParamType(min_length=1),
-    default="",
+    required=True,
     help="List dimensions by given metrics (intersection). Ex. --metrics bookings,messages",
 )
 @pass_config
 @exception_handler
 @log_call(module_name=__name__, telemetry_reporter=_telemetry_reporter)
 def dimensions(cfg: CLIConfiguration, metrics: List[str]) -> None:
-    """List all unique dimensions."""
+    """List dimensions common to the specified metrics."""
     if not cfg.is_setup:
         cfg.setup()
     spinner = Halo(
@@ -375,14 +375,14 @@ def dimensions(cfg: CLIConfiguration, metrics: List[str]) -> None:
 @click.option(
     "--metrics",
     type=click_custom.SequenceParamType(min_length=1),
-    default="",
+    required=True,
     help="List entities by given metrics (intersection). Ex. --metrics bookings,messages",
 )
 @pass_config
 @exception_handler
 @log_call(module_name=__name__, telemetry_reporter=_telemetry_reporter)
 def entities(cfg: CLIConfiguration, metrics: List[str]) -> None:
-    """List all unique entities."""
+    """List entities common to the specified metrics."""
     if not cfg.is_setup:
         cfg.setup()
     spinner = Halo(

--- a/dbt-metricflow/tests_dbt_metricflow/cli/test_cli.py
+++ b/dbt-metricflow/tests_dbt_metricflow/cli/test_cli.py
@@ -7,6 +7,7 @@ initialized.
 from __future__ import annotations
 
 import logging
+import re
 import shutil
 import tempfile
 import textwrap
@@ -15,6 +16,7 @@ from pathlib import Path
 from typing import Iterator
 
 from _pytest.fixtures import FixtureRequest
+from click.testing import CliRunner
 from metricflow_semantics.test_helpers.config_helpers import MetricFlowTestConfiguration
 from metricflow_semantics.test_helpers.snapshot_helpers import (
     assert_snapshot_text_equal,
@@ -22,6 +24,7 @@ from metricflow_semantics.test_helpers.snapshot_helpers import (
 )
 from metricflow_semantics.toolkit.mf_logging.lazy_formattable import LazyFormat
 
+from dbt_metricflow.cli.main import dimensions, entities
 from tests_dbt_metricflow.cli.cli_test_helpers import (
     create_tutorial_project_files,
     run_and_check_cli_command,
@@ -193,6 +196,20 @@ def test_list_entities(  # noqa: D103
         command_enum=IsolatedCliCommandEnum.MF_ENTITIES,
         args=["--metrics", "transactions"],
     )
+
+
+def test_metric_scoped_list_commands_require_metrics() -> None:
+    """Metric-scoped list commands should identify `--metrics` as required when it is omitted."""
+    runner = CliRunner()
+
+    for command in (dimensions, entities):
+        help_result = runner.invoke(command, ["--help"], terminal_width=160)
+        missing_metrics_result = runner.invoke(command)
+
+        assert help_result.exit_code == 0
+        assert re.search(r"--metrics SEQUENCE.*\[required\]", help_result.output)
+        assert missing_metrics_result.exit_code == 2
+        assert "Missing option '--metrics'." in missing_metrics_result.output
 
 
 def test_list_saved_queries(  # noqa: D103


### PR DESCRIPTION
## Summary

- mark `--metrics` as required for `mf list dimensions` and `mf list entities`
- replace the misleading all-object command descriptions with metric-scoped wording
- add shared regression coverage for help output and missing-option errors
- add a changelog entry for the CLI fix

Both commands already require at least one metric through `SequenceParamType(min_length=1)`. Replacing the empty-string defaults with `required=True` makes the Click contract match the existing behavior and produces the standard missing-option error.

## Testing

- `hatch run dev-env:pytest tests_dbt_metricflow/cli/test_cli.py` (16 passed)
- dbt-metricflow pre-commit: ruff, black, mypy, and file checks passed
- `changie batch --dry-run 999.999.999` passed

Fixes #2109