### PR TITLE
Remove Python 3.13 in CI

### DIFF
--- a/.changes/0.212.0.md
+++ b/.changes/0.212.0.md
@@ -28,7 +28,7 @@
 
 - Update DuckDB dev dependency to `>= 1.5` ([#2051](https://github.com/dbt-labs/metricflow/issues/2051))
 - Update `dbt-core` to `>=1.11, <1.13` ([#2105](https://github.com/dbt-labs/metricflow/issues/2105))
-- Support Python 3.14 in `dbt-metricflow`
+- Support Python 3.14 in `dbt-metricflow` ([#2108](https://github.com/dbt-labs/metricflow/issues/2108))
 
 ### Contributors
 - [@2108](https://github.com/2108)
@@ -36,4 +36,4 @@
 - [@courtneyholcomb](https://github.com/courtneyholcomb) ([#2078](https://github.com/dbt-labs/metricflow/issues/2078))
 - [@faaabi963](https://github.com/faaabi963) ([#979](https://github.com/dbt-labs/metricflow/issues/979))
 - [@ota2000](https://github.com/ota2000) ([#2091](https://github.com/dbt-labs/metricflow/issues/2091))
-- [@plypaul](https://github.com/plypaul) ([#2066](https://github.com/dbt-labs/metricflow/issues/2066), [#2055](https://github.com/dbt-labs/metricflow/issues/2055), [#2056](https://github.com/dbt-labs/metricflow/issues/2056), [#2064](https://github.com/dbt-labs/metricflow/issues/2064), [#2065](https://github.com/dbt-labs/metricflow/issues/2065), [#2075](https://github.com/dbt-labs/metricflow/issues/2075), [#2076](https://github.com/dbt-labs/metricflow/issues/2076), [#2084](https://github.com/dbt-labs/metricflow/issues/2084), [#2085](https://github.com/dbt-labs/metricflow/issues/2085), [#2088](https://github.com/dbt-labs/metricflow/issues/2088), [#2102](https://github.com/dbt-labs/metricflow/issues/2102), [#2051](https://github.com/dbt-labs/metricflow/issues/2051), [#2105](https://github.com/dbt-labs/metricflow/issues/2105))
+- [@plypaul](https://github.com/plypaul) ([#2066](https://github.com/dbt-labs/metricflow/issues/2066), [#2055](https://github.com/dbt-labs/metricflow/issues/2055), [#2056](https://github.com/dbt-labs/metricflow/issues/2056), [#2064](https://github.com/dbt-labs/metricflow/issues/2064), [#2065](https://github.com/dbt-labs/metricflow/issues/2065), [#2075](https://github.com/dbt-labs/metricflow/issues/2075), [#2076](https://github.com/dbt-labs/metricflow/issues/2076), [#2084](https://github.com/dbt-labs/metricflow/issues/2084), [#2085](https://github.com/dbt-labs/metricflow/issues/2085), [#2088](https://github.com/dbt-labs/metricflow/issues/2088), [#2102](https://github.com/dbt-labs/metricflow/issues/2102), [#2051](https://github.com/dbt-labs/metricflow/issues/2051), [#2105](https://github.com/dbt-labs/metricflow/issues/2105), [#2108](https://github.com/dbt-labs/metricflow/issues/2108))

--- a/.changes/unreleased/Under the Hood-20260820-143954.yaml
+++ b/.changes/unreleased/Under the Hood-20260820-143954.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Remove Python 3.13 in CI
+time: 2026-08-20T14:39:54.624428-07:00
+custom:
+    Author: plypaul
+    Issue: "2116"

--- a/.github/workflows/ci-metricflow-unit-tests.yaml
+++ b/.github/workflows/ci-metricflow-unit-tests.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.13", "3.14"]
+        python-version: ["3.10", "3.14"]
     steps:
       - name: Check-out the repo
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # actions/checkout@v4
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "3.10", "3.13", "3.14" ]
+        python-version: [ "3.10", "3.14" ]
     steps:
 
       - name: Check-out the repo
@@ -99,7 +99,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.13"]
+        python-version: ["3.10", "3.14"]
     steps:
       - name: Check-out the repo
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # actions/checkout@v4
@@ -114,7 +114,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "3.10", "3.13" ]
+        python-version: [ "3.10", "3.14" ]
     steps:
 
       - name: Check-out the repo

--- a/dbt-metricflow/requirements-files/dev-env-requirements.txt
+++ b/dbt-metricflow/requirements-files/dev-env-requirements.txt
@@ -1,7 +1,1 @@
-halo>=0.0.31, <0.1.0
-update-checker>=0.18.0, <0.19.0
-# Bug with mypy: https://github.com/pallets/click/issues/2558#issuecomment-1656546003
-click>=8.1.6
-dbt-core>=1.10.4, <1.12.0
 dbt-duckdb>=1.8.0, <1.9.0
-duckdb >=1.5, <1.6

--- a/dbt-metricflow/tests_dbt_metricflow/snapshots/test_cli.py/str/test_tutorial_message__result.txt
+++ b/dbt-metricflow/tests_dbt_metricflow/snapshots/test_cli.py/str/test_tutorial_message__result.txt
@@ -37,7 +37,7 @@ docstring:
         --start-time 2022-03-20 --end-time 2022-04-01
 12. Before integrating metrics into your project, read up on adding a time spine.
     (<Control>+<Left Click> may work in your terminal to follow the link)
-       https://docs.getdbt.com/docs/build/metricflow-time-spine?version=1.11
+       https://docs.getdbt.com/docs/build/metricflow-time-spine?version=1.12
 
 If you found MetricFlow to be helpful, consider adding a Github star to promote the project:
        https://github.com/dbt-labs/metricflow


### PR DESCRIPTION
This PR removes Python 3.13 from the version matrix in CI as 3.14 is the latest supported version.