### PR TITLE
Add engine option to snapshot generation scripts

### DIFF
--- a/.changes/unreleased/Under the Hood-20260820-144046.yaml
+++ b/.changes/unreleased/Under the Hood-20260820-144046.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Add engine option to snapshot generation scripts
+time: 2026-08-20T14:40:46.707705-07:00
+custom:
+    Author: plypaul
+    Issue: "2118"

--- a/.github/workflows/ci-metricflow-unit-tests.yaml
+++ b/.github/workflows/ci-metricflow-unit-tests.yaml
@@ -48,7 +48,7 @@ jobs:
 
       - uses: ./.github/actions/run-mf-tests
         with:
-          make-target: "test-postgresql"
+          make-target: "test-postgres"
           hatch-environment-cache-config-json: >-
             {
               "configs": [

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,7 @@ This project uses **hatch** for dependency management and testing:
 - Include `logger = logging.getLogger(__name__)` in Python files.
 - Avoid the use of `isinstance()`.
 - Avoid dynamic field access with `getattr`.
+- Avoid plural class names.
 - Prefer to use immutable data types.
 - Prioritize code clarity and readability.
 - Docstrings should be concise, capture behavior, capture assumptions, and

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ If you're not sure whether your change qualifies, err on the side of opening an 
 You're ready to start! Note all `make` and `hatch` commands should be run from your repository root unless otherwise indicated.
 
 `pyproject.yaml` includes a definition for a Hatch environment named `dev-env` that is similar to a virtual environment
-and allows packages to be installed in isolation. The `Makefile` includes a number of other useful commands as well, such as `make test`, which handle the environment switching. For engine-specific testing refer to the `<engine>-env` environments defined in `pyproject.yaml` and the `test-<engine>` commands in the `Makefile` - for example, postgres tests are most easily run through the `postgres-env` instead of `dev-env`, or via `make test-postgresql`.
+and allows packages to be installed in isolation. The `Makefile` includes a number of other useful commands as well, such as `make test`, which handle the environment switching. For engine-specific testing refer to the `<engine>-env` environments defined in `pyproject.yaml` and the `test-<engine>` commands in the `Makefile` - for example, postgres tests are most easily run through the `postgres-env` instead of `dev-env`, or via `make test-postgres`.
 
 When running any one of the hatch commands, the environment is automatically set up for you.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,7 +78,14 @@ When running any one of the hatch commands, the environment is automatically set
     - Run `hatch run dev-env:mf --help`
     - Follow the CLI help from there, just remember your local CLI is always `hatch run dev-env:run mf <COMMAND>`!
     - Note this will only work if you invoke the command from within a properly configured dbt project, so it may be simpler to clone the [jaffle-sl-template repo](https://github.com/dbt-labs/jaffle-sl-template) and do an editable install (via `pip install -e /path/to/metricflow/repo`) in a separate Python virtual environment.
-6. Some tests generate snapshots in the test directory. Separate snapshots may be generated for each SQL engine. You can regenerate these snapshots by running `make regenerate-test-snapshots`.
+6. Some tests generate snapshots in the test directory. To update the
+   snapshots for tests in a pytest session, rerun the pytest command with
+   `--overwrite-snapshots`, such as
+   `hatch run dev-env:pytest --overwrite-snapshots <path-to-test>`. Do not edit
+   snapshot files directly. Separate snapshots may be generated for each SQL
+   engine. To regenerate snapshots for all engines, run
+   `make regenerate-test-snapshots`. To run for a single engine, run
+   `make regenerate-test-snapshots ENGINE=<engine>`.
 
 ## Adding or modifying a CHANGELOG Entry!
 

--- a/Makefile
+++ b/Makefile
@@ -54,8 +54,8 @@ test-include-slow-dbt-metricflow:
 .PHONY: test-include-slow
 test-include-slow: test-include-slow-metricflow test-include-slow-dbt-metricflow
 
-.PHONY: test-postgresql
-test-postgresql:
+.PHONY: test-postgres
+test-postgres:
 	hatch -v run postgres-env:pytest -vv -n $(PARALLELISM) $(ADDITIONAL_PYTEST_OPTIONS) $(TESTS_METRICFLOW)/
 
 # Engine-specific test environments.
@@ -110,13 +110,13 @@ lint:
 	cd dbt-metricflow && hatch -v run dev-env:pre-commit run --verbose --all-files $(ADDITIONAL_PRECOMMIT_OPTIONS)
 
 # Running data warehouses locally
-.PHONY: postgresql postgres
-postgresql postgres:
-	make -C local-data-warehouses postgresql
+.PHONY: postgres
+postgres:
+	$(MAKE) -C local-data-warehouses postgres
 
 .PHONY: trino
 trino:
-	make -C local-data-warehouses trino
+	$(MAKE) -C local-data-warehouses trino
 
 # Re-generate test snapshots using all supported SQL engines, or one engine when ENGINE is set.
 .PHONY: regenerate-test-snapshots
@@ -136,15 +136,15 @@ sync-dsi:
 # Re-generate snapshots for the default SQL engine.
 .PHONY: test-snap
 test-snap:
-	make test ADDITIONAL_PYTEST_OPTIONS=--overwrite-snapshots
+	$(MAKE) test ADDITIONAL_PYTEST_OPTIONS=--overwrite-snapshots
 
 .PHONY: testx
 testx:
-	make test ADDITIONAL_PYTEST_OPTIONS=-x
+	$(MAKE) test ADDITIONAL_PYTEST_OPTIONS=-x
 
 .PHONY: testx-snap
 testx-snap:
-	make test ADDITIONAL_PYTEST_OPTIONS='-x --overwrite-snapshots'
+	$(MAKE) test ADDITIONAL_PYTEST_OPTIONS='-x --overwrite-snapshots'
 
 .PHONY: test-snap-slow
 test-snap-slow:

--- a/Makefile
+++ b/Makefile
@@ -123,10 +123,10 @@ trino:
 regenerate-test-snapshots:
 	python3 -m scripts.generate_snapshots $(if $(ENGINE),--engine=$(ENGINE))
 
-# Populate persistent source schemas for all relevant SQL engines.
+# Populate persistent source schemas for all relevant SQL engines, or one engine when ENGINE is set.
 .PHONY: populate-persistent-source-schemas
 populate-persistent-source-schemas:
-	python3 -m scripts.populate_persistent_source_schemas
+	python3 -m scripts.populate_persistent_source_schemas $(if $(ENGINE),--engine=$(ENGINE))
 
 # Sync dbt-semantic-interfaces files to metricflow-semantic-interfaces folder
 .PHONY: sync-dsi

--- a/Makefile
+++ b/Makefile
@@ -118,10 +118,10 @@ postgresql postgres:
 trino:
 	make -C local-data-warehouses trino
 
-# Re-generate test snapshots using all supported SQL engines.
+# Re-generate test snapshots using all supported SQL engines, or one engine when ENGINE is set.
 .PHONY: regenerate-test-snapshots
 regenerate-test-snapshots:
-	python3 -m scripts.generate_snapshots
+	python3 -m scripts.generate_snapshots $(if $(ENGINE),--engine=$(ENGINE))
 
 # Populate persistent source schemas for all relevant SQL engines.
 .PHONY: populate-persistent-source-schemas

--- a/local-data-warehouses/Makefile
+++ b/local-data-warehouses/Makefile
@@ -2,8 +2,8 @@
 # Local Data Warehouse Setup
 #
 
-.PHONY: postgresql
-postgresql:
+.PHONY: postgres
+postgres:
 	docker-compose -f postgresql/docker-compose.yaml up
 
 .PHONY: trino

--- a/local-data-warehouses/postgresql/docker-compose.yaml
+++ b/local-data-warehouses/postgresql/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: "3.7"
-
 services:
   postgres:
     container_name: postgres

--- a/scripts/generate_snapshots.py
+++ b/scripts/generate_snapshots.py
@@ -4,7 +4,7 @@ Credentials are stored as a JSON string in an environment variable set via a she
 
 export MF_TEST_ENGINE_CREDENTIAL_SETS=$(cat <<EOF
 {
-    "duck_db": {
+    "duckdb": {
         "engine_url": null,
         "engine_password": null
     },
@@ -20,7 +20,7 @@ export MF_TEST_ENGINE_CREDENTIAL_SETS=$(cat <<EOF
         "engine_url": "snowflake://...",
         "engine_password": "..."
     },
-    "big_query": {
+    "bigquery": {
         "engine_url": "bigquery://",
         "engine_password": "..."
     },
@@ -58,7 +58,7 @@ logger = logging.getLogger(__name__)
 MF_TEST_DIRECTORY = "tests_metricflow"
 MF_SEMANTICS_TEST_DIRECTORY = "tests_metricflow_semantics"
 
-DUCKDB_ENGINE_NAME: Final[str] = "duck_db"
+DUCKDB_ENGINE_NAME: Final[str] = "duckdb"
 
 # Maps the engine name in the credentials JSON to the `hatch` environment name.
 ENGINE_NAME_TO_HATCH_ENVIRONMENT_NAME: Final[dict[str, str]] = {
@@ -66,14 +66,14 @@ ENGINE_NAME_TO_HATCH_ENVIRONMENT_NAME: Final[dict[str, str]] = {
     "athena": "athena-env",
     "redshift": "redshift-env",
     "snowflake": "snowflake-env",
-    "big_query": "bigquery-env",
+    "bigquery": "bigquery-env",
     "databricks": "databricks-env",
     "postgres": "postgres-env",
     "trino": "trino-env",
 }
 
 ENGINES_WITH_PERSISTENT_SOURCE_SCHEMAS: Final[frozenset[str]] = frozenset(
-    ("athena", "redshift", "snowflake", "big_query", "databricks")
+    ("athena", "redshift", "snowflake", "bigquery", "databricks")
 )
 
 # Tests that generate SQL engine snapshots have this `pytest` marker set.

--- a/scripts/generate_snapshots.py
+++ b/scripts/generate_snapshots.py
@@ -43,6 +43,7 @@ EOF
 
 from __future__ import annotations
 
+import argparse
 import json
 import logging
 import os
@@ -90,6 +91,22 @@ class MetricFlowEngineConfiguration:  # noqa: D101
     engine: str
     hatch_environment: str
     credential_set: MetricFlowTestCredentialSet
+
+
+@dataclass(frozen=True)
+class GenerateSnapshotsConfig:  # noqa: D101
+    engine: Optional[str]
+
+
+def _parse_args(argv: Optional[Sequence[str]] = None) -> GenerateSnapshotsConfig:
+    parser = argparse.ArgumentParser(description="Generate test snapshots for supported SQL engines.")
+    parser.add_argument(
+        "--engine",
+        choices=tuple(ENGINE_NAME_TO_HATCH_ENVIRONMENT_NAME),
+        help="Generate snapshots for only the specified engine.",
+    )
+    args = parser.parse_args(argv)
+    return GenerateSnapshotsConfig(engine=args.engine)
 
 
 def _credential_set_from_json(credential_set_json: dict[str, object]) -> MetricFlowTestCredentialSet:
@@ -217,12 +234,18 @@ def load_credential_sets() -> Sequence[MetricFlowEngineConfiguration]:
     return parse_credential_sets(credential_sets_json_str)
 
 
-if __name__ == "__main__":
+def main(argv: Optional[Sequence[str]] = None) -> None:
+    """Generate snapshots for all engines, or for the requested engine."""
+    args = _parse_args(argv)
     setup_logging()
-    credential_sets = load_credential_sets()
+    engine_configs = load_credential_sets()
+    if args.engine is not None:
+        engine_configs = tuple(engine_config for engine_config in engine_configs if engine_config.engine == args.engine)
     logger.info(f"Running tests in {MF_TEST_DIRECTORY} with the marker {SQL_ENGINE_SNAPSHOT_MARKER_NAME}")
-    for test_configuration in credential_sets:
-        logger.info(
-            f"Running tests for {test_configuration.engine} with URL: {test_configuration.credential_set.engine_url}"
-        )
-        run_tests(test_configuration)
+    for engine_config in engine_configs:
+        logger.info(f"Running tests for {engine_config.engine} with URL: {engine_config.credential_set.engine_url}")
+        run_tests(engine_config)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate_snapshots.py
+++ b/scripts/generate_snapshots.py
@@ -222,7 +222,7 @@ def setup_logging() -> None:
     logging.basicConfig(level=logging.INFO, format=dev_format)
 
 
-def load_credential_sets() -> Sequence[MetricFlowEngineConfiguration]:
+def load_engine_configs() -> Sequence[MetricFlowEngineConfiguration]:
     """Load test credential sets from the environment."""
     credential_sets_json_str = os.environ.get("MF_TEST_ENGINE_CREDENTIAL_SETS")
     if credential_sets_json_str is None:
@@ -238,7 +238,7 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
     """Generate snapshots for all engines, or for the requested engine."""
     args = _parse_args(argv)
     setup_logging()
-    engine_configs = load_credential_sets()
+    engine_configs = load_engine_configs()
     if args.engine is not None:
         engine_configs = tuple(engine_config for engine_config in engine_configs if engine_config.engine == args.engine)
     logger.info(f"Running tests in {MF_TEST_DIRECTORY} with the marker {SQL_ENGINE_SNAPSHOT_MARKER_NAME}")

--- a/scripts/generate_snapshots.py
+++ b/scripts/generate_snapshots.py
@@ -4,20 +4,8 @@ Credentials are stored as a JSON string in an environment variable set via a she
 
 export MF_TEST_ENGINE_CREDENTIAL_SETS=$(cat <<EOF
 {
-    "duckdb": {
-        "engine_url": null,
-        "engine_password": null
-    },
     "athena": {
         "engine_url": "athena://...",
-        "engine_password": "..."
-    },
-    "redshift": {
-        "engine_url": "redshift://...",
-        "engine_password": "..."
-    },
-    "snowflake": {
-        "engine_url": "snowflake://...",
         "engine_password": "..."
     },
     "bigquery": {
@@ -28,8 +16,20 @@ export MF_TEST_ENGINE_CREDENTIAL_SETS=$(cat <<EOF
         "engine_url": "databricks://...",
         "engine_password": "..."
     },
+    "duckdb": {
+        "engine_url": null,
+        "engine_password": null
+    },
     "postgres": {
         "engine_url": postgres://...",
+        "engine_password": "..."
+    },
+    "redshift": {
+        "engine_url": "redshift://...",
+        "engine_password": "..."
+    },
+    "snowflake": {
+        "engine_url": "snowflake://...",
         "engine_password": "..."
     },
     "trino": {

--- a/scripts/populate_persistent_source_schemas.py
+++ b/scripts/populate_persistent_source_schemas.py
@@ -11,7 +11,7 @@ from scripts.generate_snapshots import (
     ENGINE_NAME_TO_HATCH_ENVIRONMENT_NAME,
     ENGINES_WITH_PERSISTENT_SOURCE_SCHEMAS,
     MetricFlowEngineConfiguration,
-    load_credential_sets,
+    load_engine_configs,
     run_hatch_command,
     set_engine_env_variables,
     setup_logging,
@@ -66,7 +66,7 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
     """Populate persistent source schemas for all relevant engines, or for the requested engine."""
     config = _parse_args(argv)
     setup_logging()
-    engine_configs = load_credential_sets()
+    engine_configs = load_engine_configs()
     if config.engine is not None:
         engine_configs = tuple(
             engine_config for engine_config in engine_configs if engine_config.engine == config.engine

--- a/scripts/populate_persistent_source_schemas.py
+++ b/scripts/populate_persistent_source_schemas.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import argparse
 import logging
+from dataclasses import dataclass
+from typing import Optional, Sequence
 
 from scripts.generate_snapshots import (
     ENGINE_NAME_TO_HATCH_ENVIRONMENT_NAME,
@@ -15,6 +18,27 @@ from scripts.generate_snapshots import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class PopulatePersistentSourceSchemaConfig:  # noqa: D101
+    # Engine to populate, or None to populate every relevant engine.
+    engine: Optional[str]
+
+
+def _parse_args(argv: Optional[Sequence[str]] = None) -> PopulatePersistentSourceSchemaConfig:
+    parser = argparse.ArgumentParser(description="Populate persistent source schemas for supported SQL engines.")
+    parser.add_argument(
+        "--engine",
+        choices=tuple(
+            engine
+            for engine in ENGINE_NAME_TO_HATCH_ENVIRONMENT_NAME
+            if engine in ENGINES_WITH_PERSISTENT_SOURCE_SCHEMAS
+        ),
+        help="Populate the persistent source schema for only the specified engine.",
+    )
+    args = parser.parse_args(argv)
+    return PopulatePersistentSourceSchemaConfig(engine=args.engine)
 
 
 def populate_schemas(test_configuration: MetricFlowEngineConfiguration) -> None:  # noqa: D103
@@ -38,11 +62,22 @@ def populate_schemas(test_configuration: MetricFlowEngineConfiguration) -> None:
         raise ValueError(f"Unsupported engine: {test_configuration.engine}")
 
 
-if __name__ == "__main__":
+def main(argv: Optional[Sequence[str]] = None) -> None:
+    """Populate persistent source schemas for all relevant engines, or for the requested engine."""
+    config = _parse_args(argv)
     setup_logging()
-    for test_configuration in load_credential_sets():
-        logger.info(
-            f"Populating persistent source schema for {test_configuration.engine} with URL: "
-            f"{test_configuration.credential_set.engine_url}"
+    engine_configs = load_credential_sets()
+    if config.engine is not None:
+        engine_configs = tuple(
+            engine_config for engine_config in engine_configs if engine_config.engine == config.engine
         )
-        populate_schemas(test_configuration)
+    for engine_config in engine_configs:
+        logger.info(
+            f"Populating persistent source schema for {engine_config.engine} with URL: "
+            f"{engine_config.credential_set.engine_url}"
+        )
+        populate_schemas(engine_config)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR updates the scripts used to regenerate test snapshots to accept a SQL engine argument. By default, snapshots for all engines are generated so this can speed up iteration cycles when developing for a single engine.