### PR TITLE
Add optional datatype field to Dimension and Metric

### DIFF
--- a/.changes/unreleased/Features-20260828-112649.yaml
+++ b/.changes/unreleased/Features-20260828-112649.yaml
@@ -1,6 +1,6 @@
 kind: Features
 body: Add optional `datatype` field to `Dimension` and `Metric` in metricflow-semantic-interfaces,
-  enabling downstream consumers (e.g. the OSI converter) to preserve specific data
+  enabling downstream consumers (e.g. the Ossie converter) to preserve specific data
   types instead of the coarse DimensionType bucket
 time: 2026-08-28T11:26:49.742777-05:00
 custom:

--- a/.changes/unreleased/Features-20260828-112649.yaml
+++ b/.changes/unreleased/Features-20260828-112649.yaml
@@ -1,0 +1,8 @@
+kind: Features
+body: Add optional `datatype` field to `Dimension` and `Metric` in metricflow-semantic-interfaces,
+  enabling downstream consumers (e.g. the OSI converter) to preserve specific data
+  types instead of the coarse DimensionType bucket
+time: 2026-08-28T11:26:49.742777-05:00
+custom:
+  Author: QMalcolm
+  Issue: "2121"

--- a/metricflow_semantic_interfaces/implementations/elements/dimension.py
+++ b/metricflow_semantic_interfaces/implementations/elements/dimension.py
@@ -14,7 +14,7 @@ from metricflow_semantic_interfaces.references import (
     DimensionReference,
     TimeDimensionReference,
 )
-from metricflow_semantic_interfaces.type_enums import DimensionType, TimeGranularity
+from metricflow_semantic_interfaces.type_enums import DataType, DimensionType, TimeGranularity
 
 ISO8601_FMT = "YYYY-MM-DD"
 
@@ -46,6 +46,7 @@ class PydanticDimension(HashableBaseModel, ModelWithMetadataParsing):
     name: str
     description: Optional[str]
     type: DimensionType
+    datatype: Optional[DataType] = None
     is_partition: bool = False
     type_params: Optional[PydanticDimensionTypeParams]
     expr: Optional[str] = None

--- a/metricflow_semantic_interfaces/implementations/metric.py
+++ b/metricflow_semantic_interfaces/implementations/metric.py
@@ -31,6 +31,7 @@ from metricflow_semantic_interfaces.references import MeasureReference, MetricRe
 from metricflow_semantic_interfaces.type_enums import (
     AggregationType,
     ConversionCalculationType,
+    DataType,
     MetricType,
     PeriodAggregation,
     TimeGranularity,
@@ -239,6 +240,7 @@ class PydanticMetric(HashableBaseModel, ModelWithMetadataParsing, ProtocolHint[M
     name: str
     description: Optional[str]
     type: MetricType
+    datatype: Optional[DataType] = None
     type_params: PydanticMetricTypeParams
     filter: Optional[PydanticWhereFilterIntersection]
     metadata: Optional[PydanticMetadata]

--- a/metricflow_semantic_interfaces/parsing/generated_json_schemas/default_explicit_schema.json
+++ b/metricflow_semantic_interfaces/parsing/generated_json_schemas/default_explicit_schema.json
@@ -153,16 +153,6 @@
                 },
                 "datatype": {
                     "enum": [
-                        "STRING",
-                        "INTEGER",
-                        "DECIMAL",
-                        "FLOAT",
-                        "BOOLEAN",
-                        "DATE",
-                        "TIME",
-                        "DATETIME",
-                        "DATETIME_TZ",
-                        "OPAQUE",
                         "string",
                         "integer",
                         "decimal",
@@ -591,16 +581,6 @@
                 },
                 "datatype": {
                     "enum": [
-                        "STRING",
-                        "INTEGER",
-                        "DECIMAL",
-                        "FLOAT",
-                        "BOOLEAN",
-                        "DATE",
-                        "TIME",
-                        "DATETIME",
-                        "DATETIME_TZ",
-                        "OPAQUE",
                         "string",
                         "integer",
                         "decimal",

--- a/metricflow_semantic_interfaces/parsing/generated_json_schemas/default_explicit_schema.json
+++ b/metricflow_semantic_interfaces/parsing/generated_json_schemas/default_explicit_schema.json
@@ -151,6 +151,30 @@
                 "config": {
                     "$ref": "#/definitions/dimension_config_schema"
                 },
+                "datatype": {
+                    "enum": [
+                        "STRING",
+                        "INTEGER",
+                        "DECIMAL",
+                        "FLOAT",
+                        "BOOLEAN",
+                        "DATE",
+                        "TIME",
+                        "DATETIME",
+                        "DATETIME_TZ",
+                        "OPAQUE",
+                        "string",
+                        "integer",
+                        "decimal",
+                        "float",
+                        "boolean",
+                        "date",
+                        "time",
+                        "datetime",
+                        "datetime_tz",
+                        "opaque"
+                    ]
+                },
                 "description": {
                     "type": "string"
                 },

--- a/metricflow_semantic_interfaces/parsing/generated_json_schemas/default_explicit_schema.json
+++ b/metricflow_semantic_interfaces/parsing/generated_json_schemas/default_explicit_schema.json
@@ -589,6 +589,30 @@
                 "config": {
                     "$ref": "#/definitions/metric_config_schema"
                 },
+                "datatype": {
+                    "enum": [
+                        "STRING",
+                        "INTEGER",
+                        "DECIMAL",
+                        "FLOAT",
+                        "BOOLEAN",
+                        "DATE",
+                        "TIME",
+                        "DATETIME",
+                        "DATETIME_TZ",
+                        "OPAQUE",
+                        "string",
+                        "integer",
+                        "decimal",
+                        "float",
+                        "boolean",
+                        "date",
+                        "time",
+                        "datetime",
+                        "datetime_tz",
+                        "opaque"
+                    ]
+                },
                 "description": {
                     "type": "string"
                 },

--- a/metricflow_semantic_interfaces/parsing/schemas.py
+++ b/metricflow_semantic_interfaces/parsing/schemas.py
@@ -54,6 +54,20 @@ time_granularity_values += [x.lower() for x in time_granularity_values]
 dimension_type_values = ["CATEGORICAL", "TIME"]
 dimension_type_values += [x.lower() for x in dimension_type_values]
 
+data_type_values = [
+    "STRING",
+    "INTEGER",
+    "DECIMAL",
+    "FLOAT",
+    "BOOLEAN",
+    "DATE",
+    "TIME",
+    "DATETIME",
+    "DATETIME_TZ",
+    "OPAQUE",
+]
+data_type_values += [x.lower() for x in data_type_values]
+
 time_dimension_type_values = ["TIME", "time"]
 
 export_destination_type_values = ["TABLE", "VIEW"]
@@ -325,6 +339,7 @@ dimension_schema = {
         },
         "description": {"type": "string"},
         "type": {"enum": dimension_type_values},
+        "datatype": {"enum": data_type_values},
         "is_partition": {"type": "boolean"},
         "expr": {"type": ["string", "boolean"]},
         "type_params": {"$ref": "dimension_type_params_schema"},

--- a/metricflow_semantic_interfaces/parsing/schemas.py
+++ b/metricflow_semantic_interfaces/parsing/schemas.py
@@ -377,6 +377,7 @@ metric_schema = {
             "pattern": TRANSFORM_OBJECT_NAME_PATTERN,
         },
         "type": {"enum": metric_types_enum_values},
+        "datatype": {"enum": data_type_values},
         "type_params": {"$ref": "metric_type_params"},
         "filter": {"$ref": "filter_schema"},
         "description": {"type": "string"},

--- a/metricflow_semantic_interfaces/parsing/schemas.py
+++ b/metricflow_semantic_interfaces/parsing/schemas.py
@@ -54,19 +54,20 @@ time_granularity_values += [x.lower() for x in time_granularity_values]
 dimension_type_values = ["CATEGORICAL", "TIME"]
 dimension_type_values += [x.lower() for x in dimension_type_values]
 
+# DataType is a plain Enum (not ExtendedEnum), so parsing is case-sensitive; only its canonical
+# lowercase values are accepted here.
 data_type_values = [
-    "STRING",
-    "INTEGER",
-    "DECIMAL",
-    "FLOAT",
-    "BOOLEAN",
-    "DATE",
-    "TIME",
-    "DATETIME",
-    "DATETIME_TZ",
-    "OPAQUE",
+    "string",
+    "integer",
+    "decimal",
+    "float",
+    "boolean",
+    "date",
+    "time",
+    "datetime",
+    "datetime_tz",
+    "opaque",
 ]
-data_type_values += [x.lower() for x in data_type_values]
 
 time_dimension_type_values = ["TIME", "time"]
 

--- a/metricflow_semantic_interfaces/protocols/dimension.py
+++ b/metricflow_semantic_interfaces/protocols/dimension.py
@@ -9,7 +9,7 @@ from metricflow_semantic_interfaces.references import (
     DimensionReference,
     TimeDimensionReference,
 )
-from metricflow_semantic_interfaces.type_enums import DimensionType, TimeGranularity
+from metricflow_semantic_interfaces.type_enums import DataType, DimensionType, TimeGranularity
 
 
 class DimensionValidityParams(Protocol):
@@ -63,6 +63,16 @@ class Dimension(Protocol):
     @property
     @abstractmethod
     def type(self) -> DimensionType:  # noqa: D102
+        pass
+
+    @property
+    @abstractmethod
+    def datatype(self) -> Optional[DataType]:
+        """Specific logical data type of the dimension, if known.
+
+        Unused by MetricFlow's own validation or query logic. Purely a passthrough annotation for downstream
+        consumers (e.g. round-tripping Ossie's `Field.datatype` through a semantic manifest).
+        """
         pass
 
     @property

--- a/metricflow_semantic_interfaces/protocols/metric.py
+++ b/metricflow_semantic_interfaces/protocols/metric.py
@@ -14,6 +14,7 @@ from metricflow_semantic_interfaces.references import MeasureReference, MetricRe
 from metricflow_semantic_interfaces.type_enums import (
     AggregationType,
     ConversionCalculationType,
+    DataType,
     MetricType,
     PeriodAggregation,
     TimeGranularity,
@@ -364,6 +365,16 @@ class Metric(Protocol):
     @property
     @abstractmethod
     def type(self) -> MetricType:  # noqa: D102
+        pass
+
+    @property
+    @abstractmethod
+    def datatype(self) -> Optional[DataType]:
+        """Specific logical data type of the metric's value, if known.
+
+        Unused by MetricFlow's own validation or query logic. Purely a passthrough annotation for downstream
+        consumers (e.g. round-tripping Ossie's `Metric.datatype` through a semantic manifest).
+        """
         pass
 
     @property

--- a/metricflow_semantic_interfaces/type_enums/__init__.py
+++ b/metricflow_semantic_interfaces/type_enums/__init__.py
@@ -6,6 +6,7 @@ from metricflow_semantic_interfaces.type_enums.aggregation_type import (  # noqa
 from metricflow_semantic_interfaces.type_enums.conversion_calculation_type import (  # noqa:F401
     ConversionCalculationType,
 )
+from metricflow_semantic_interfaces.type_enums.data_type import DataType  # noqa:F401
 from metricflow_semantic_interfaces.type_enums.date_part import DatePart  # noqa:F401
 from metricflow_semantic_interfaces.type_enums.dimension_type import DimensionType  # noqa:F401
 from metricflow_semantic_interfaces.type_enums.entity_type import EntityType  # noqa:F401

--- a/metricflow_semantic_interfaces/type_enums/data_type.py
+++ b/metricflow_semantic_interfaces/type_enums/data_type.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-from metricflow_semantic_interfaces.enum_extension import ExtendedEnum
+from enum import Enum
 
 
-class DataType(ExtendedEnum):
+class DataType(Enum):
     """Logical data type of a dimension or metric value, independent of physical representation.
 
     This is a passthrough annotation, not used by MetricFlow's own validation or query logic. It exists so

--- a/metricflow_semantic_interfaces/type_enums/data_type.py
+++ b/metricflow_semantic_interfaces/type_enums/data_type.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from metricflow_semantic_interfaces.enum_extension import ExtendedEnum
+
+
+class DataType(ExtendedEnum):
+    """Logical data type of a dimension or metric value, independent of physical representation.
+
+    This is a passthrough annotation, not used by MetricFlow's own validation or query logic. It exists so
+    that specific data types (e.g. from Ossie's `datatype` field) can be preserved through conversions without
+    being collapsed into `DimensionType`'s coarse CATEGORICAL/TIME buckets.
+    """
+
+    STRING = "string"
+    INTEGER = "integer"
+    DECIMAL = "decimal"
+    FLOAT = "float"
+    BOOLEAN = "boolean"
+    DATE = "date"
+    TIME = "time"
+    DATETIME = "datetime"
+    DATETIME_TZ = "datetime_tz"
+    OPAQUE = "opaque"

--- a/tests_metricflow_semantic_interfaces/parsing/test_metric_parsing.py
+++ b/tests_metricflow_semantic_interfaces/parsing/test_metric_parsing.py
@@ -122,8 +122,9 @@ def test_metric_datatype_parsing() -> None:
           type: simple
           datatype: decimal
           type_params:
-            measure:
-              name: metadata_test_measure
+            metric_aggregation_params:
+              semantic_model: base_semantic_model
+              agg: sum
         """
     )
     file = YamlConfigFile(filepath="test_dir/inline_for_test", contents=yaml_contents)
@@ -142,8 +143,9 @@ def test_metric_without_datatype_parsing() -> None:
           name: base_test
           type: simple
           type_params:
-            measure:
-              name: metadata_test_measure
+            metric_aggregation_params:
+              semantic_model: base_semantic_model
+              agg: sum
         """
     )
     file = YamlConfigFile(filepath="test_dir/inline_for_test", contents=yaml_contents)

--- a/tests_metricflow_semantic_interfaces/parsing/test_metric_parsing.py
+++ b/tests_metricflow_semantic_interfaces/parsing/test_metric_parsing.py
@@ -18,6 +18,7 @@ from metricflow_semantic_interfaces.parsing.dir_to_model import (
 from metricflow_semantic_interfaces.parsing.objects import YamlConfigFile
 from metricflow_semantic_interfaces.type_enums import (
     ConversionCalculationType,
+    DataType,
     MetricType,
     TimeGranularity,
 )
@@ -110,6 +111,47 @@ def test_base_metric_parsing() -> None:
     assert metric.type == metric_type
     assert metric.description == description
     assert metric.label == label
+
+
+def test_metric_datatype_parsing() -> None:
+    """Test for parsing a metric's optional datatype out of a metric specification."""
+    yaml_contents = textwrap.dedent(
+        """\
+        metric:
+          name: base_test
+          type: simple
+          datatype: decimal
+          type_params:
+            measure:
+              name: metadata_test_measure
+        """
+    )
+    file = YamlConfigFile(filepath="test_dir/inline_for_test", contents=yaml_contents)
+
+    build_result = parse_yaml_files_to_semantic_manifest(files=[file, EXAMPLE_PROJECT_CONFIGURATION_YAML_CONFIG_FILE])
+    assert len(build_result.semantic_manifest.metrics) == 1
+    metric = build_result.semantic_manifest.metrics[0]
+    assert metric.datatype is DataType.DECIMAL
+
+
+def test_metric_without_datatype_parsing() -> None:
+    """Test that a metric's datatype defaults to None when not specified, for backward compatibility."""
+    yaml_contents = textwrap.dedent(
+        """\
+        metric:
+          name: base_test
+          type: simple
+          type_params:
+            measure:
+              name: metadata_test_measure
+        """
+    )
+    file = YamlConfigFile(filepath="test_dir/inline_for_test", contents=yaml_contents)
+
+    build_result = parse_yaml_files_to_semantic_manifest(files=[file, EXAMPLE_PROJECT_CONFIGURATION_YAML_CONFIG_FILE])
+    assert len(build_result.semantic_manifest.metrics) == 1
+    metric = build_result.semantic_manifest.metrics[0]
+    assert metric.datatype is None
 
 
 def test_metric_metadata_parsing() -> None:

--- a/tests_metricflow_semantic_interfaces/parsing/test_semantic_model_parsing.py
+++ b/tests_metricflow_semantic_interfaces/parsing/test_semantic_model_parsing.py
@@ -8,6 +8,7 @@ from metricflow_semantic_interfaces.parsing.dir_to_model import (
 from metricflow_semantic_interfaces.parsing.objects import YamlConfigFile
 from metricflow_semantic_interfaces.type_enums import (
     AggregationType,
+    DataType,
     DimensionType,
     EntityType,
     TimeGranularity,
@@ -347,6 +348,57 @@ def test_semantic_model_categorical_dimension_parsing() -> None:
     assert dimension.name == "example_categorical_dimension"
     assert dimension.type is DimensionType.CATEGORICAL
     assert dimension.is_partition is not True
+
+
+def test_semantic_model_dimension_datatype_parsing() -> None:
+    """Test for parsing a dimension's optional datatype out of a semantic model specification."""
+    yaml_contents = textwrap.dedent(
+        """\
+        semantic_model:
+          name: dimension_parsing_test
+          node_relation:
+            alias: source_table
+            schema_name: some_schema
+          dimensions:
+            - name: example_categorical_dimension
+              type: categorical
+              datatype: integer
+        """
+    )
+    file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
+
+    build_result = parse_yaml_files_to_semantic_manifest(files=[file, EXAMPLE_PROJECT_CONFIGURATION_YAML_CONFIG_FILE])
+
+    assert len(build_result.semantic_manifest.semantic_models) == 1
+    semantic_model = build_result.semantic_manifest.semantic_models[0]
+    assert len(semantic_model.dimensions) == 1
+    dimension = semantic_model.dimensions[0]
+    assert dimension.datatype is DataType.INTEGER
+
+
+def test_semantic_model_dimension_without_datatype_parsing() -> None:
+    """Test that a dimension's datatype defaults to None when not specified, for backward compatibility."""
+    yaml_contents = textwrap.dedent(
+        """\
+        semantic_model:
+          name: dimension_parsing_test
+          node_relation:
+            alias: source_table
+            schema_name: some_schema
+          dimensions:
+            - name: example_categorical_dimension
+              type: categorical
+        """
+    )
+    file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
+
+    build_result = parse_yaml_files_to_semantic_manifest(files=[file, EXAMPLE_PROJECT_CONFIGURATION_YAML_CONFIG_FILE])
+
+    assert len(build_result.semantic_manifest.semantic_models) == 1
+    semantic_model = build_result.semantic_manifest.semantic_models[0]
+    assert len(semantic_model.dimensions) == 1
+    dimension = semantic_model.dimensions[0]
+    assert dimension.datatype is None
 
 
 def test_semantic_model_partition_dimension_parsing() -> None:


### PR DESCRIPTION
## Summary
Add new metadata only datatypes to dimensions and metrics to support round-tripping of data types with Ossie. The new datatypes are optional.

- New `DataType` enum (`string`, `integer`, `decimal`, `float`, `boolean`, `date`, `time`, `datetime`, `datetime_tz`, `opaque`) — defined independently from Ossie's own `DataType` enum (see decision log in the first commit) so MSI's public contract doesn't inherit Ossie's naming/schema evolution.
- `datatype: Optional[DataType] = None` added to `Dimension` and `Metric` protocols + Pydantic implementations, plus matching JSON schema / parsing support.
- Field is unused by MetricFlow's own validation/query logic — purely a passthrough annotation. No behavior change for existing manifests that don't set it.

Converter changes to actually populate/consume this field during OSI ↔ MSI conversion are tracked separately in #2122.

Closes #2121