### PR TITLE
OSI converter: read/write datatype for Ossie round-trip fidelity

### DIFF
--- a/.changes/unreleased/Features-20260901-111954.yaml
+++ b/.changes/unreleased/Features-20260901-111954.yaml
@@ -1,0 +1,8 @@
+kind: Features
+body: The Ossie converter now reads and writes the `datatype` field on `Field`/`Metric`,
+  preserving Ossie's specific data type through an Ossie -> MetricFlow -> Ossie round
+  trip instead of collapsing it into the coarse DimensionType bucket
+time: 2026-09-01T11:19:54.741523-05:00
+custom:
+  Author: QMalcolm
+  Issue: "2122"

--- a/metricflow/converters/datatype_mapping.py
+++ b/metricflow/converters/datatype_mapping.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from typing import Dict, Optional
+
+from metricflow.converters.models import OSIDataType
+from metricflow_semantic_interfaces.type_enums import DataType
+
+# Single source of truth for the OSI <-> MSI datatype mapping. The two enums are semantically
+# equivalent 1:1 today; if Ossie's DataType enum changes (e.g. gains a new value), update here.
+_OSI_TO_MSI_DATATYPE: Dict[OSIDataType, DataType] = {
+    OSIDataType.STRING: DataType.STRING,
+    OSIDataType.INTEGER: DataType.INTEGER,
+    OSIDataType.DECIMAL: DataType.DECIMAL,
+    OSIDataType.FLOAT: DataType.FLOAT,
+    OSIDataType.BOOLEAN: DataType.BOOLEAN,
+    OSIDataType.DATE: DataType.DATE,
+    OSIDataType.TIME: DataType.TIME,
+    OSIDataType.DATE_TIME: DataType.DATETIME,
+    OSIDataType.DATE_TIME_TZ: DataType.DATETIME_TZ,
+    OSIDataType.OPAQUE: DataType.OPAQUE,
+}
+_MSI_TO_OSI_DATATYPE: Dict[DataType, OSIDataType] = {msi: osi for osi, msi in _OSI_TO_MSI_DATATYPE.items()}
+
+
+def osi_datatype_to_msi(datatype: Optional[OSIDataType]) -> Optional[DataType]:
+    """Map an OSI `Field`/`Metric.datatype` value to its MSI `DataType` equivalent."""
+    return _OSI_TO_MSI_DATATYPE.get(datatype) if datatype is not None else None
+
+
+def msi_datatype_to_osi(datatype: Optional[DataType]) -> Optional[OSIDataType]:
+    """Map an MSI `DataType` value to its OSI `Field`/`Metric.datatype` equivalent."""
+    return _MSI_TO_OSI_DATATYPE.get(datatype) if datatype is not None else None

--- a/metricflow/converters/models.py
+++ b/metricflow/converters/models.py
@@ -31,6 +31,21 @@ class OSIAIContextObject(FrozenBaseModel):
 OSIAIContext = Union[str, OSIAIContextObject]
 
 
+class OSIDataType(str, Enum):
+    """Logical data type for OSI fields and metrics (see apache/ossie core-spec/ossie-schema.json)."""
+
+    STRING = "String"
+    INTEGER = "Integer"
+    DECIMAL = "Decimal"
+    FLOAT = "Float"
+    BOOLEAN = "Boolean"
+    DATE = "Date"
+    TIME = "Time"
+    DATE_TIME = "DateTime"
+    DATE_TIME_TZ = "DateTimeTz"
+    OPAQUE = "Opaque"
+
+
 class OSIVendor(str, Enum):
     """Vendors with supported custom extensions."""
 
@@ -73,6 +88,7 @@ class OSIField(FrozenBaseModel):
     name: str
     expression: OSIExpression
     dimension: Optional[OSIDimension] = None
+    datatype: Optional[OSIDataType] = None
     label: Optional[str] = None
     description: Optional[str] = None
     ai_context: Optional[OSIAIContext] = None
@@ -113,6 +129,7 @@ class OSIMetric(FrozenBaseModel):
 
     name: str
     expression: OSIExpression
+    datatype: Optional[OSIDataType] = None
     description: Optional[str] = None
     ai_context: Optional[OSIAIContext] = None
     custom_extensions: Optional[List[OSICustomExtension]] = None

--- a/metricflow/converters/msi_to_osi.py
+++ b/metricflow/converters/msi_to_osi.py
@@ -9,6 +9,7 @@ from typing import Dict, List, Optional, Sequence, Tuple
 from metricflow_semantics.toolkit.mf_logging.lazy_formattable import LazyFormat
 
 from metricflow.converters.converter_issues import ConverterIssue, ConverterIssueType, ConverterResult
+from metricflow.converters.datatype_mapping import msi_datatype_to_osi
 from metricflow.converters.filter_utils import _collect_filter_sql, _merge_filter_sqls
 from metricflow.converters.models import (
     OSIDataset,
@@ -101,6 +102,7 @@ class MSIToOSIConverter:
                 OSIMetric(
                     name=metric.name,
                     expression=self._make_expression(expr),
+                    datatype=msi_datatype_to_osi(metric.datatype),
                     description=metric.description,
                 )
             )
@@ -149,6 +151,7 @@ class MSIToOSIConverter:
             name=dim.name,
             expression=self._make_expression(expr),
             dimension=OSIDimension(is_time=is_time),
+            datatype=msi_datatype_to_osi(dim.datatype),
             label=dim.label,
             description=dim.description,
         )

--- a/metricflow/converters/osi_to_msi.py
+++ b/metricflow/converters/osi_to_msi.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from typing import List, Optional, Set
 
 from metricflow.converters.converter_issues import ConverterResult
+from metricflow.converters.datatype_mapping import osi_datatype_to_msi
 from metricflow.converters.expression_utils import (
     _extract_agg_info,
     _get_raw_inner_col,
@@ -12,6 +13,7 @@ from metricflow.converters.expression_utils import (
 )
 from metricflow.converters.models import (
     OSIDataset,
+    OSIDataType,
     OSIDialect,
     OSIDocument,
     OSIExpression,
@@ -217,6 +219,7 @@ class OSIToMSIConverter:
                 PydanticDimension(
                     name=field.name,
                     type=DimensionType.TIME,
+                    datatype=osi_datatype_to_msi(field.datatype),
                     type_params=PydanticDimensionTypeParams(time_granularity=TimeGranularity.DAY),
                     expr=expr_or_none,
                     description=field.description,
@@ -229,6 +232,7 @@ class OSIToMSIConverter:
             PydanticDimension(
                 name=field.name,
                 type=DimensionType.CATEGORICAL,
+                datatype=osi_datatype_to_msi(field.datatype),
                 type_params=None,
                 expr=expr_or_none,
                 description=field.description,
@@ -245,7 +249,9 @@ class OSIToMSIConverter:
         metrics: List[PydanticMetric] = []
         for metric in osi_sm.metrics or []:
             expr_str = self._get_expression(metric.expression)
-            metrics.extend(self._convert_metric(metric.name, expr_str, metric.description, osi_sm.datasets))
+            metrics.extend(
+                self._convert_metric(metric.name, expr_str, metric.description, metric.datatype, osi_sm.datasets)
+            )
         return metrics
 
     def _convert_metric(
@@ -253,6 +259,7 @@ class OSIToMSIConverter:
         name: str,
         expr_str: str,
         description: Optional[str],
+        datatype: Optional[OSIDataType],
         datasets: List[OSIDataset],
     ) -> List[PydanticMetric]:
         """Return one or more PydanticMetric objects for the given OSI expression.
@@ -274,6 +281,7 @@ class OSIToMSIConverter:
                     name=name,
                     description=description,
                     type=MetricType.SIMPLE,
+                    datatype=osi_datatype_to_msi(datatype),
                     type_params=PydanticMetricTypeParams(
                         expr=col,
                         metric_aggregation_params=PydanticMetricAggregationParams(
@@ -296,12 +304,15 @@ class OSIToMSIConverter:
             num_expr, den_expr = ratio_result
             num_name = f"{name}_numerator"
             den_name = f"{name}_denominator"
-            num_metrics = self._convert_metric(num_name, num_expr, None, datasets)
-            den_metrics = self._convert_metric(den_name, den_expr, None, datasets)
+            # The numerator/denominator are auto-generated sub-metrics with no OSI-side identity of
+            # their own, so — like `description` — the parent's `datatype` is not propagated to them.
+            num_metrics = self._convert_metric(num_name, num_expr, None, None, datasets)
+            den_metrics = self._convert_metric(den_name, den_expr, None, None, datasets)
             ratio_metric = PydanticMetric(
                 name=name,
                 description=description,
                 type=MetricType.RATIO,
+                datatype=osi_datatype_to_msi(datatype),
                 type_params=PydanticMetricTypeParams(
                     numerator=PydanticMetricInput(name=num_name, filter=None, alias=None),
                     denominator=PydanticMetricInput(name=den_name, filter=None, alias=None),
@@ -321,6 +332,7 @@ class OSIToMSIConverter:
                 name=name,
                 description=description,
                 type=MetricType.SIMPLE,
+                datatype=osi_datatype_to_msi(datatype),
                 type_params=PydanticMetricTypeParams(
                     expr=expr_str,
                     metric_aggregation_params=PydanticMetricAggregationParams(

--- a/tests_metricflow_semantic_interfaces/osi/helpers.py
+++ b/tests_metricflow_semantic_interfaces/osi/helpers.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from metricflow.converters.models import (
     OSIDataset,
+    OSIDataType,
     OSIDialect,
     OSIDialectExpression,
     OSIDimension,
@@ -38,6 +39,7 @@ from metricflow_semantic_interfaces.implementations.semantic_manifest import (
 from metricflow_semantic_interfaces.test_utils import default_meta
 from metricflow_semantic_interfaces.type_enums import (
     AggregationType,
+    DataType,
     DimensionType,
     EntityType,
     MetricType,
@@ -64,11 +66,13 @@ def _simple_metric(
     name: str,
     measure_name: str,
     description: str | None = None,
+    datatype: DataType | None = None,
 ) -> PydanticMetric:
     return PydanticMetric(
         name=name,
         description=description,
         type=MetricType.SIMPLE,
+        datatype=datatype,
         type_params=PydanticMetricTypeParams(
             measure=PydanticMetricInputMeasure(name=measure_name),
         ),
@@ -85,11 +89,13 @@ def _dimension(
     description: str | None = None,
     label: str | None = None,
     granularity: TimeGranularity | None = None,
+    datatype: DataType | None = None,
 ) -> PydanticDimension:
     type_params = PydanticDimensionTypeParams(time_granularity=granularity) if granularity else None
     return PydanticDimension(
         name=name,
         type=dim_type,
+        datatype=datatype,
         expr=expr,
         description=description,
         label=label,
@@ -152,11 +158,13 @@ def _osi_field(
     is_time: bool | None = None,
     description: str | None = None,
     label: str | None = None,
+    datatype: OSIDataType | None = None,
 ) -> OSIField:
     return OSIField(
         name=name,
         expression=_osi_expr(expression if expression is not None else name),
         dimension=OSIDimension(is_time=is_time) if is_time is not None else None,
+        datatype=datatype,
         description=description,
         label=label,
     )
@@ -180,8 +188,13 @@ def _osi_dataset(
     )
 
 
-def _osi_metric(name: str, expression: str, description: str | None = None) -> OSIMetric:
-    return OSIMetric(name=name, expression=_osi_expr(expression), description=description)
+def _osi_metric(
+    name: str,
+    expression: str,
+    description: str | None = None,
+    datatype: OSIDataType | None = None,
+) -> OSIMetric:
+    return OSIMetric(name=name, expression=_osi_expr(expression), datatype=datatype, description=description)
 
 
 def _osi_relationship(

--- a/tests_metricflow_semantic_interfaces/osi/test_msi_to_osi.py
+++ b/tests_metricflow_semantic_interfaces/osi/test_msi_to_osi.py
@@ -12,7 +12,7 @@ from metricflow_semantics.test_helpers.snapshot_helpers import (
 
 from metricflow.converters.converter_issues import ConverterIssueType
 from metricflow.converters.filter_utils import _render_filter_template
-from metricflow.converters.models import OSIDialect, OSIDocument
+from metricflow.converters.models import OSIDataType, OSIDialect, OSIDocument
 from metricflow.converters.msi_to_osi import MSIToOSIConverter
 from metricflow_semantic_interfaces.implementations.metric import (
     PydanticConversionTypeParams,
@@ -31,6 +31,7 @@ from metricflow_semantic_interfaces.implementations.semantic_model import (
 from metricflow_semantic_interfaces.test_utils import default_meta, semantic_model_with_guaranteed_meta
 from metricflow_semantic_interfaces.type_enums import (
     AggregationType,
+    DataType,
     DimensionType,
     EntityType,
     MetricType,
@@ -168,6 +169,24 @@ class TestDimensionConversion:  # noqa: D101
         field = _fields(result)[0]
         assert field.description == "Order status"
         assert field.label == "Status"
+
+    def test_dimension_datatype_carried_over(self) -> None:  # noqa: D102
+        sm = semantic_model_with_guaranteed_meta(
+            name="orders",
+            dimensions=[_dimension("status", datatype=DataType.STRING)],
+        )
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm])).output
+
+        assert _fields(result)[0].datatype is OSIDataType.STRING
+
+    def test_dimension_without_datatype_is_none(self) -> None:  # noqa: D102
+        sm = semantic_model_with_guaranteed_meta(
+            name="orders",
+            dimensions=[_dimension("status")],
+        )
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm])).output
+
+        assert _fields(result)[0].datatype is None
 
 
 class TestMeasureConversion:  # noqa: D101
@@ -512,6 +531,26 @@ class TestMetricConversion:  # noqa: D101
         result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm], metrics=[metric])).output
 
         assert _osi_metrics(result)[0].description == "Total revenue"
+
+    def test_simple_metric_datatype_carried_over(self) -> None:  # noqa: D102
+        sm = semantic_model_with_guaranteed_meta(
+            name="orders",
+            measures=[_measure("revenue", agg=AggregationType.SUM, expr="amount")],
+        )
+        metric = _simple_metric("revenue", measure_name="revenue", datatype=DataType.DECIMAL)
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm], metrics=[metric])).output
+
+        assert _osi_metrics(result)[0].datatype is OSIDataType.DECIMAL
+
+    def test_simple_metric_without_datatype_is_none(self) -> None:  # noqa: D102
+        sm = semantic_model_with_guaranteed_meta(
+            name="orders",
+            measures=[_measure("revenue", agg=AggregationType.SUM, expr="amount")],
+        )
+        metric = _simple_metric("revenue", measure_name="revenue")
+        result = MSIToOSIConverter().convert(_manifest(semantic_models=[sm], metrics=[metric])).output
+
+        assert _osi_metrics(result)[0].datatype is None
 
     def test_simple_metric_with_metric_aggregation_params(self) -> None:  # noqa: D102
         sm = semantic_model_with_guaranteed_meta(name="orders")

--- a/tests_metricflow_semantic_interfaces/osi/test_osi_to_msi.py
+++ b/tests_metricflow_semantic_interfaces/osi/test_osi_to_msi.py
@@ -9,10 +9,12 @@ from metricflow_semantics.test_helpers.snapshot_helpers import (
     assert_object_snapshot_equal,
 )
 
+from metricflow.converters.models import OSIDataType
 from metricflow.converters.msi_to_osi import MSIToOSIConverter
 from metricflow.converters.osi_to_msi import OSIToMSIConverter
 from metricflow_semantic_interfaces.type_enums import (
     AggregationType,
+    DataType,
     DimensionType,
     MetricType,
 )
@@ -200,6 +202,31 @@ class TestOSIToMSIFieldClassification:  # noqa: D101
         assert dim.description == "Order status"
         assert dim.label == "Status"
 
+    def test_datatype_carried_over_to_categorical_dimension(self) -> None:  # noqa: D102
+        doc = _osi_doc(datasets=[_osi_dataset("orders", fields=[_osi_field("status", datatype=OSIDataType.STRING)])])
+        sm = OSIToMSIConverter().convert(doc).output.semantic_models[0]
+
+        assert sm.dimensions[0].datatype is DataType.STRING
+
+    def test_datatype_carried_over_to_time_dimension(self) -> None:  # noqa: D102
+        doc = _osi_doc(
+            datasets=[
+                _osi_dataset(
+                    "orders",
+                    fields=[_osi_field("created_at", is_time=True, datatype=OSIDataType.DATE_TIME_TZ)],
+                )
+            ]
+        )
+        sm = OSIToMSIConverter().convert(doc).output.semantic_models[0]
+
+        assert sm.dimensions[0].datatype is DataType.DATETIME_TZ
+
+    def test_missing_datatype_on_dimension_is_none(self) -> None:  # noqa: D102
+        doc = _osi_doc(datasets=[_osi_dataset("orders", fields=[_osi_field("status")])])
+        sm = OSIToMSIConverter().convert(doc).output.semantic_models[0]
+
+        assert sm.dimensions[0].datatype is None
+
 
 class TestOSIToMSIMetricConversion:  # noqa: D101
     def test_sum_expression_produces_simple_metric(self) -> None:  # noqa: D102
@@ -287,6 +314,37 @@ class TestOSIToMSIMetricConversion:  # noqa: D101
         result = OSIToMSIConverter().convert(doc).output
 
         assert result.metrics[0].description == "Total revenue"
+
+    def test_simple_metric_datatype_carried_over(self) -> None:  # noqa: D102
+        doc = _osi_doc(
+            datasets=[_osi_dataset("orders", fields=[_osi_field("amount")])],
+            metrics=[_osi_metric("revenue", "SUM(amount)", datatype=OSIDataType.DECIMAL)],
+        )
+        result = OSIToMSIConverter().convert(doc).output
+
+        assert result.metrics[0].datatype is DataType.DECIMAL
+
+    def test_missing_datatype_on_metric_is_none(self) -> None:  # noqa: D102
+        doc = _osi_doc(
+            datasets=[_osi_dataset("orders", fields=[_osi_field("amount")])],
+            metrics=[_osi_metric("revenue", "SUM(amount)")],
+        )
+        result = OSIToMSIConverter().convert(doc).output
+
+        assert result.metrics[0].datatype is None
+
+    def test_ratio_metric_datatype_not_propagated_to_sub_metrics(self) -> None:  # noqa: D102
+        """Only the RATIO metric itself carries the OSI metric's datatype, not its auto-generated sub-metrics."""
+        doc = _osi_doc(
+            datasets=[_osi_dataset("orders", fields=[_osi_field("amount"), _osi_field("cnt")])],
+            metrics=[_osi_metric("arpu", "(SUM(amount)) / (COUNT(cnt))", datatype=OSIDataType.FLOAT)],
+        )
+        result = OSIToMSIConverter().convert(doc).output
+
+        ratio = next(m for m in result.metrics if m.type == MetricType.RATIO)
+        sub_metrics = [m for m in result.metrics if m.type == MetricType.SIMPLE]
+        assert ratio.datatype is DataType.FLOAT
+        assert all(m.datatype is None for m in sub_metrics)
 
     def test_no_metrics_produces_empty_list(self) -> None:  # noqa: D102
         doc = _osi_doc(datasets=[_osi_dataset("orders")])
@@ -380,3 +438,31 @@ class TestOSIToMSIRoundTrip:  # noqa: D101
             snapshot_configuration=snapshot_configuration,
             obj=osi_doc,
         )
+
+    def test_datatype_round_trips_through_osi_to_msi_to_osi(self) -> None:  # noqa: D102
+        """An OSI Field/Metric.datatype value survives an OSI -> MSI -> OSI round trip unchanged."""
+        original = _osi_doc(
+            datasets=[
+                _osi_dataset(
+                    "orders",
+                    fields=[
+                        _osi_field("status", datatype=OSIDataType.STRING),
+                        _osi_field("created_at", is_time=True, datatype=OSIDataType.DATE_TIME_TZ),
+                        _osi_field("amount"),
+                    ],
+                )
+            ],
+            metrics=[_osi_metric("revenue", "SUM(amount)", datatype=OSIDataType.DECIMAL)],
+        )
+
+        msi = OSIToMSIConverter().convert(original).output
+        osi_doc = MSIToOSIConverter().convert(msi).output
+
+        fields = {f.name: f for f in osi_doc.semantic_model[0].datasets[0].fields or []}
+        assert fields["status"].datatype is OSIDataType.STRING
+        assert fields["created_at"].datatype is OSIDataType.DATE_TIME_TZ
+        assert fields["amount"].datatype is None
+
+        metrics = osi_doc.semantic_model[0].metrics or []
+        assert len(metrics) == 1
+        assert metrics[0].datatype is OSIDataType.DECIMAL


### PR DESCRIPTION
## Summary
Phase 3 (converter) of [PRD-330](https://app.notion.com/p/3acbb38ebda780979fb3fcfb9102c1d0), building on the `datatype` field added to `Dimension`/`Metric` in #2121.

- `OSIToMSIConverter` previously collapsed Ossie's specific `datatype` into one of `DimensionType`'s two buckets (TIME/CATEGORICAL). `MSIToOSIConverter` had no type information to draw from at all when writing a dimension back out, so a specific Ossie type could never survive a round trip.
- Added `OSIDataType` and optional `datatype` fields to `OSIField`/`OSIMetric` (the local, hand-maintained OSI wire-format models in `metricflow/converters/models.py`, which didn't expose the field at all yet).
- Centralized the OSI ↔ MSI value mapping in a new `metricflow/converters/datatype_mapping.py` — a single source of truth, since the PRD itself flags enum drift between the two type systems as an ongoing maintenance risk.
- Both conversion directions now read/write `datatype` on dimensions and metrics. A RATIO metric's auto-generated numerator/denominator sub-metrics intentionally do *not* inherit the parent's `datatype` (mirroring existing `description` handling for those synthetic sub-metrics).
- Entities and measures are untouched — MSI's `datatype` field only exists on `Dimension`/`Metric` (per #2121), so there's nothing to convert for those element types.

Closes #2122