### PR TITLE
entity role: cross-model join matching via entity.role

### DIFF
--- a/.changes/unreleased/Features-20260903-141511.yaml
+++ b/.changes/unreleased/Features-20260903-141511.yaml
@@ -1,0 +1,8 @@
+kind: Features
+body: Support entity `role` for cross-model join matching, so a model can declare multiple
+  differently-named entities (e.g. `buyer`, `seller`) that each join to the same target
+  entity elsewhere (e.g. `user`) under their own local name
+time: 2026-09-03T14:15:11.000000-00:00
+custom:
+  Author: QMalcolm
+  Issue: "2127"

--- a/metricflow/dataflow/builder/dataflow_plan_builder.py
+++ b/metricflow/dataflow/builder/dataflow_plan_builder.py
@@ -1301,7 +1301,9 @@ class DataflowPlanBuilder:
             # Nodes containing the linkable instances will be joined to the source node, so these
             # entities will need to be present in the source node.
             required_local_entity_specs = tuple(
-                EntitySpec.create_from_reference(x.join_on_entity) for x in evaluation.join_recipes if x.join_on_entity
+                EntitySpec.create_from_reference(x.join_on_left_entity or x.join_on_entity)
+                for x in evaluation.join_recipes
+                if x.join_on_entity
             )
             # Same thing with partitions.
             required_local_dimension_specs = tuple(

--- a/metricflow/dataflow/builder/node_evaluator.py
+++ b/metricflow/dataflow/builder/node_evaluator.py
@@ -18,9 +18,10 @@ from __future__ import annotations
 import itertools
 import logging
 from dataclasses import dataclass
-from typing import List, Optional, Sequence, Tuple
+from typing import Dict, List, Optional, Sequence, Tuple
 
-from metricflow_semantics.instances import InstanceSet
+from metricflow_semantics.errors.error_classes import UnableToSatisfyQueryError
+from metricflow_semantics.instances import EntityInstance, InstanceSet
 from metricflow_semantics.model.semantics.semantic_model_join_evaluator import SemanticModelJoinEvaluator
 from metricflow_semantics.model.semantics.semantic_model_lookup import SemanticModelLookup
 from metricflow_semantics.specs.entity_spec import EntitySpec
@@ -59,7 +60,8 @@ class JoinLinkableInstancesRecipe:
     """
 
     node_to_join: DataflowPlanNode
-    # The entity to join "node_to_join" on. Only nullable if using CROSS JOIN.
+    # The entity to join "node_to_join" on, as known to "node_to_join" (the right side). Only nullable if using
+    # CROSS JOIN.
     join_on_entity: Optional[EntityReference]
     # The linkable instances from the query that can be satisfied if we join this node. Note that this is different from
     # the linkable specs in the node that can help to satisfy the query. e.g. "user_id__country" might be one of the
@@ -73,6 +75,11 @@ class JoinLinkableInstancesRecipe:
     join_on_partition_time_dimensions: Tuple[PartitionTimeDimensionJoinDescription, ...]
 
     validity_window: Optional[ValidityWindowJoinDescription] = None
+
+    # The entity to join on, as known to the left node, if different from `join_on_entity` - see `JoinDescription`
+    # for why these can differ (an entity `role`-based join, e.g. `buyer` on the left joining to `user` on the
+    # right).
+    join_on_left_entity: Optional[EntityReference] = None
 
     def __post_init__(self) -> None:  # noqa: D105
         if self.join_on_entity is None and self.join_type != SqlJoinType.CROSS_JOIN:
@@ -128,6 +135,7 @@ class JoinLinkableInstancesRecipe:
         return JoinDescription(
             join_node=selector_node_to_join,
             join_on_entity=self.join_on_entity,
+            join_on_left_entity=self.join_on_left_entity,
             join_on_partition_dimensions=self.join_on_partition_dimensions,
             join_on_partition_time_dimensions=self.join_on_partition_time_dimensions,
             validity_window=self.validity_window,
@@ -253,15 +261,46 @@ class NodeEvaluatorForLinkableInstances:
                         f"Invalid SemanticModelElementReference {entity_instance_in_right_node.defined_from[0]}"
                     )
 
-                entity_instance_in_left_node = None
-                for instance in left_node_instance_set.entity_instances:
-                    if instance.spec.reference == entity_spec_in_right_node.reference:
-                        entity_instance_in_left_node = instance
-                        break
+                # Match by join key (`role` if set, else the entity's own name), not necessarily by the same
+                # literal reference on both sides - this is what lets e.g. a `buyer` entity on the left join to
+                # a `user` entity on the right. The query-facing entity link name (`entity_reference_in_node`,
+                # below) is unaffected - it's still always the right node's own reference.
+                right_entity_join_key = entity_in_right_node.role or entity_in_right_node.name
 
-                if entity_instance_in_left_node is None:
+                matching_left_instances_by_reference: Dict[EntityReference, EntityInstance] = {}
+                for instance in left_node_instance_set.entity_instances:
+                    if len(instance.defined_from) != 1:
+                        continue
+                    left_candidate_entity = self._semantic_model_lookup.get_entity_in_semantic_model(
+                        instance.defined_from[0]
+                    )
+                    if left_candidate_entity is None:
+                        continue
+                    if (left_candidate_entity.role or left_candidate_entity.name) == right_entity_join_key:
+                        matching_left_instances_by_reference[instance.spec.reference] = instance
+
+                if len(matching_left_instances_by_reference) == 0:
                     # The right node can have a superset of entities.
                     continue
+
+                if len(matching_left_instances_by_reference) > 1:
+                    # More than one local entity shares this join key (role) - e.g. `buyer` and `seller` both
+                    # role=`user`. Picking one silently would produce a query that looks correct but joined on
+                    # an arbitrary, possibly unintended entity. There's no "default" mechanism yet to
+                    # disambiguate, so fail loud instead.
+                    raise UnableToSatisfyQueryError(
+                        LazyFormat(
+                            "Ambiguous join: more than one local entity shares the join key needed to reach "
+                            "the requested item. Query using one of these entities directly instead of the "
+                            "shared join key.",
+                            join_key=right_entity_join_key,
+                            candidate_entities=sorted(
+                                reference.element_name for reference in matching_left_instances_by_reference
+                            ),
+                        ).evaluated_value
+                    )
+
+                (entity_instance_in_left_node,) = matching_left_instances_by_reference.values()
 
                 assert len(entity_instance_in_left_node.defined_from) == 1
                 assert len(entity_instance_in_right_node.defined_from) == 1
@@ -277,13 +316,21 @@ class NodeEvaluatorForLinkableInstances:
                         right_semantic_model_reference=entity_instance_in_right_node.defined_from[
                             0
                         ].semantic_model_reference,
-                        on_entity_reference=entity_spec_in_right_node.reference,
+                        left_entity_reference=entity_instance_in_left_node.spec.reference,
+                        right_entity_reference=entity_spec_in_right_node.reference,
                     )
                     or entity_spec_matches_aggregated_specs
                 ):
                     continue
 
                 entity_reference_in_node = entity_spec_in_right_node.reference
+                # `None` unless the join used `role` to match a differently-named entity on the left - see
+                # `JoinDescription.join_on_left_entity`.
+                left_entity_reference_in_node = (
+                    entity_instance_in_left_node.spec.reference
+                    if entity_instance_in_left_node.spec.reference != entity_reference_in_node
+                    else None
+                )
 
                 satisfiable_linkable_specs = []
                 for needed_linkable_spec in needed_linkable_specs:
@@ -336,6 +383,7 @@ class NodeEvaluatorForLinkableInstances:
                         JoinLinkableInstancesRecipe(
                             node_to_join=right_node,
                             join_on_entity=entity_reference_in_node,
+                            join_on_left_entity=left_entity_reference_in_node,
                             satisfiable_linkable_specs=satisfiable_linkable_specs,
                             join_on_partition_dimensions=join_on_partition_dimensions,
                             join_on_partition_time_dimensions=join_on_partition_time_dimensions,
@@ -374,6 +422,7 @@ class NodeEvaluatorForLinkableInstances:
                     JoinLinkableInstancesRecipe(
                         node_to_join=candidate_for_join.node_to_join,
                         join_on_entity=candidate_for_join.join_on_entity,
+                        join_on_left_entity=candidate_for_join.join_on_left_entity,
                         satisfiable_linkable_specs=updated_satisfiable_linkable_specs,
                         join_on_partition_dimensions=candidate_for_join.join_on_partition_dimensions,
                         join_on_partition_time_dimensions=candidate_for_join.join_on_partition_time_dimensions,
@@ -386,6 +435,16 @@ class NodeEvaluatorForLinkableInstances:
             key=lambda x: len(x.satisfiable_linkable_specs),
             reverse=True,
         )
+
+    def _data_set_has_entity_for_join_key(self, instance_set: InstanceSet, join_key: str) -> bool:
+        """Return true if `instance_set` has an entity whose join key (`role` if set, else name) is `join_key`."""
+        for instance in instance_set.entity_instances:
+            if len(instance.defined_from) != 1:
+                continue
+            entity = self._semantic_model_lookup.get_entity_in_semantic_model(instance.defined_from[0])
+            if entity is not None and (entity.role or entity.name) == join_key:
+                return True
+        return False
 
     def evaluate_node(
         self,
@@ -426,9 +485,13 @@ class NodeEvaluatorForLinkableInstances:
                 and (
                     # metric_time is the only element that can be joined without entity links.
                     len(required_linkable_spec.entity_links) == 0
-                    # In order be joinable, the first entity link must be in the left node's dataset.
-                    or EntitySpec.create_from_reference(required_linkable_spec.entity_links[0])
-                    not in data_set_linkable_specs
+                    # In order be joinable, the left node's dataset must have an entity whose join key (`role`
+                    # if set, else name) matches the first entity link - not necessarily an entity with that
+                    # exact name, since a `role`-based join lets a differently-named local entity (e.g. `guest`)
+                    # satisfy a link named after its role (e.g. `user`).
+                    or not self._data_set_has_entity_for_join_key(
+                        candidate_instance_set, required_linkable_spec.entity_links[0].element_name
+                    )
                 )
             )
             if is_local:

--- a/metricflow/dataflow/nodes/join_to_base.py
+++ b/metricflow/dataflow/nodes/join_to_base.py
@@ -31,6 +31,8 @@ class JoinDescription:
     """Describes how data from a node should be joined to data from another node."""
 
     join_node: DataflowPlanNode
+    # The entity to join on, as known to the *right* node (`join_node`) - also what a resulting spec's entity
+    # link is named after, e.g. joining on `user` produces `user__country`.
     join_on_entity: Optional[EntityReference]
     join_type: SqlJoinType
 
@@ -38,6 +40,13 @@ class JoinDescription:
     join_on_partition_time_dimensions: Tuple[PartitionTimeDimensionJoinDescription, ...]
 
     validity_window: Optional[ValidityWindowJoinDescription] = None
+
+    # The entity to join on, as known to the *left* node, if different from `join_on_entity`. `None` means the
+    # left node knows this entity by the same name as the right node (the common case - every join that isn't
+    # using an entity `role` to join two differently-named entities together, e.g. a `buyer` entity joining to
+    # a `user` entity elsewhere). Only ever used to find the join column on the left side; the right side, and
+    # the resulting spec naming, are unaffected and still driven entirely by `join_on_entity`.
+    join_on_left_entity: Optional[EntityReference] = None
 
     def __post_init__(self) -> None:  # noqa: D105
         if self.join_on_entity is None and self.join_type != SqlJoinType.CROSS_JOIN:
@@ -93,6 +102,7 @@ class JoinOnEntitiesNode(DataflowPlanNode):
         for i in range(len(self.join_targets)):
             if (
                 self.join_targets[i].join_on_entity != other_node.join_targets[i].join_on_entity
+                or self.join_targets[i].join_on_left_entity != other_node.join_targets[i].join_on_left_entity
                 or self.join_targets[i].join_on_partition_dimensions
                 != other_node.join_targets[i].join_on_partition_dimensions
                 or self.join_targets[i].join_on_partition_time_dimensions
@@ -114,6 +124,7 @@ class JoinOnEntitiesNode(DataflowPlanNode):
                 JoinDescription(
                     join_node=new_join_nodes[i],
                     join_on_entity=old_join_target.join_on_entity,
+                    join_on_left_entity=old_join_target.join_on_left_entity,
                     join_on_partition_dimensions=old_join_target.join_on_partition_dimensions,
                     join_on_partition_time_dimensions=old_join_target.join_on_partition_time_dimensions,
                     validity_window=old_join_target.validity_window,

--- a/metricflow/plan_conversion/to_sql_plan/sql_join_builder.py
+++ b/metricflow/plan_conversion/to_sql_plan/sql_join_builder.py
@@ -146,8 +146,10 @@ class SqlPlanJoinBuilder:
         if join_on_entity:
             # Figure out which columns in the "left" data set correspond to the entity that we want to join on.
             # The column associations tell us which columns correspond to which instances in the data set.
+            # `join_on_left_entity` is set instead of `join_on_entity` when the left side knows this entity by a
+            # different name than the right side does (an entity `role`-based join) - see `JoinDescription`.
             left_data_set_entity_column_associations = left_data_set.data_set.column_associations_for_entity(
-                join_on_entity
+                join_description.join_on_left_entity or join_on_entity
             )
             left_data_set_entity_cols = [c.column_name for c in left_data_set_entity_column_associations]
 

--- a/metricflow/validation/dataflow_join_validator.py
+++ b/metricflow/validation/dataflow_join_validator.py
@@ -68,6 +68,8 @@ class JoinDataflowOutputValidator:
             # No fan-out check needed since right subquery is aggregated to the entity level, ensuring uniqueness.
             return True
         else:
+            # Multi-hop joins don't support `role`-based matching yet - both sides use the same reference here,
+            # same as before.
             return self._join_evaluator.is_valid_semantic_model_join(
                 left_semantic_model_reference=JoinDataflowOutputValidator._semantic_model_of_entity_in_instance_set(
                     instance_set=left_instance_set, entity_reference=on_entity_reference
@@ -76,5 +78,6 @@ class JoinDataflowOutputValidator:
                     instance_set=right_instance_set,
                     entity_reference=on_entity_reference,
                 ),
-                on_entity_reference=on_entity_reference,
+                left_entity_reference=on_entity_reference,
+                right_entity_reference=on_entity_reference,
             )

--- a/metricflow_semantics/model/semantics/semantic_model_join_evaluator.py
+++ b/metricflow_semantics/model/semantics/semantic_model_join_evaluator.py
@@ -76,15 +76,21 @@ class SemanticModelJoinEvaluator:
         self,
         left_semantic_model_reference: SemanticModelReference,
         right_semantic_model_reference: SemanticModelReference,
-        on_entity_reference: EntityReference,
+        left_entity_reference: EntityReference,
+        right_entity_reference: EntityReference,
     ) -> Optional[SemanticModelEntityJoinType]:
-        """Get valid join type used to join semantic models on given entity, if exists."""
+        """Get valid join type used to join semantic models on given entity, if exists.
+
+        `left_entity_reference` and `right_entity_reference` are usually the same reference - they can differ
+        when the join is via `role` (e.g. a `buyer` entity on the left joining to a `user` entity on the right),
+        in which case the caller has already established that the two entities share a join key.
+        """
         left_entity = self._semantic_model_lookup.get_entity_in_semantic_model(
-            SemanticModelElementReference.create_from_references(left_semantic_model_reference, on_entity_reference)
+            SemanticModelElementReference.create_from_references(left_semantic_model_reference, left_entity_reference)
         )
 
         right_entity = self._semantic_model_lookup.get_entity_in_semantic_model(
-            SemanticModelElementReference.create_from_references(right_semantic_model_reference, on_entity_reference)
+            SemanticModelElementReference.create_from_references(right_semantic_model_reference, right_entity_reference)
         )
         if left_entity is None or right_entity is None:
             return None
@@ -120,14 +126,16 @@ class SemanticModelJoinEvaluator:
         self,
         left_semantic_model_reference: SemanticModelReference,
         right_semantic_model_reference: SemanticModelReference,
-        on_entity_reference: EntityReference,
+        left_entity_reference: EntityReference,
+        right_entity_reference: EntityReference,
     ) -> bool:
         """Return true if we should allow a join with the given parameters to resolve a query."""
         return (
             self.get_valid_semantic_model_entity_join_type(
                 left_semantic_model_reference=left_semantic_model_reference,
                 right_semantic_model_reference=right_semantic_model_reference,
-                on_entity_reference=on_entity_reference,
+                left_entity_reference=left_entity_reference,
+                right_entity_reference=right_entity_reference,
             )
             is not None
         )

--- a/metricflow_semantics/semantic_graph/lookups/entity_lookup.py
+++ b/metricflow_semantics/semantic_graph/lookups/entity_lookup.py
@@ -4,7 +4,7 @@ import logging
 from collections import defaultdict
 from collections.abc import Mapping
 from functools import cached_property
-from typing import Iterable
+from typing import Iterable, List, Tuple
 
 from metricflow_semantics.toolkit.collections.ordered_set import MutableOrderedSet, OrderedSet
 from metricflow_semantics.toolkit.mf_logging.attribute_pretty_format import AttributeMapping, AttributePrettyFormattable
@@ -34,6 +34,22 @@ class EntityLookup(AttributePrettyFormattable):
         return {entity_type: entity_names.as_frozen() for entity_type, entity_names in entity_type_to_names.items()}
 
     @cached_property
+    def join_key_to_entities(self) -> Mapping[str, Tuple[Entity, ...]]:
+        """Mapping from an entity's join key (`entity.role` if set, else `entity.name`) to entities with that key.
+
+        `role` lets multiple, differently-named entities on one model (e.g. `buyer`, `seller`) each join to
+        the same target entity elsewhere (e.g. `user`) under their own local name - see `SemanticModelJoinLookup`,
+        which is what actually consumes this for cross-model matching. Usually one entity per key; a mapping to
+        more than one only matters if a model has more than one entity sharing the same key (unusual, but not
+        rejected here - ambiguity between multiple matches is a downstream resolution concern, not this lookup's).
+        A tuple, not an `OrderedSet`, since `Entity` (a `Protocol`) isn't declared `Hashable`.
+        """
+        join_key_to_entities: dict[str, List[Entity]] = defaultdict(list)
+        for entity in self._entity_name_to_entity.values():
+            join_key_to_entities[entity.role or entity.name].append(entity)
+        return {join_key: tuple(entities) for join_key, entities in join_key_to_entities.items()}
+
+    @cached_property
     @override
     def _attribute_mapping(self) -> AttributeMapping:
         return dict(
@@ -43,6 +59,7 @@ class EntityLookup(AttributePrettyFormattable):
                 for attribute_name in (
                     "entity_name_to_type",
                     "entity_type_to_names",
+                    "join_key_to_entities",
                 )
             },
         )

--- a/metricflow_semantics/semantic_graph/lookups/entity_lookup.py
+++ b/metricflow_semantics/semantic_graph/lookups/entity_lookup.py
@@ -50,6 +50,18 @@ class EntityLookup(AttributePrettyFormattable):
         return {join_key: tuple(entities) for join_key, entities in join_key_to_entities.items()}
 
     @cached_property
+    def join_key_to_entity_names(self) -> Mapping[str, Tuple[str, ...]]:
+        """`join_key_to_entities`, but names only.
+
+        For debug display, where full `Entity` objects are too noisy - they carry file/line metadata
+        (including an absolute path) that isn't meaningful here and isn't stable across checkouts.
+        """
+        return {
+            join_key: tuple(entity.name for entity in entities)
+            for join_key, entities in self.join_key_to_entities.items()
+        }
+
+    @cached_property
     @override
     def _attribute_mapping(self) -> AttributeMapping:
         return dict(
@@ -59,7 +71,7 @@ class EntityLookup(AttributePrettyFormattable):
                 for attribute_name in (
                     "entity_name_to_type",
                     "entity_type_to_names",
-                    "join_key_to_entities",
+                    "join_key_to_entity_names",
                 )
             },
         )

--- a/metricflow_semantics/semantic_graph/lookups/join_lookup.py
+++ b/metricflow_semantics/semantic_graph/lookups/join_lookup.py
@@ -68,8 +68,7 @@ class SemanticModelJoinLookup:
     @override
     def __init__(self, manifest_object_lookup: ManifestObjectLookup) -> None:
         self._model_id_to_lookup = manifest_object_lookup.model_id_to_lookup
-        self._entity_name_to_model_lookups = manifest_object_lookup.entity_name_to_model_lookups
-        self._entity_name_to_model_ids = manifest_object_lookup.entity_name_to_model_ids
+        self._entity_join_key_to_model_ids = manifest_object_lookup.entity_join_key_to_model_ids
 
     @cached_property
     def valid_join_to_entity_types(self) -> OrderedSet[EntityType]:
@@ -92,6 +91,13 @@ class SemanticModelJoinLookup:
 
         The returned dict maps the ID of the semantic model on the right to the entities in the corresponding model
         that can be used as a join key.
+
+        Matching between the left entity and a candidate right entity is by join key (`entity.role` if set, else
+        `entity.name`), not necessarily by the same literal name on both sides - that's what lets e.g. a `buyer`
+        entity on this model join to a `user` entity elsewhere. `JoinModelOnRightDescriptor.entity_name` is always
+        the *right* model's own entity name (never the left's), since that's the identity
+        `EntityJoinSubgraphGenerator` uses to build the right model's `ConfiguredEntityNode` - which must match the
+        node that same model's own self-reference edges build when it is later processed as a left model.
         """
         right_model_id_to_join_descriptors: dict[
             SemanticModelId, MutableOrderedSet[JoinModelOnRightDescriptor]
@@ -100,51 +106,53 @@ class SemanticModelJoinLookup:
         left_model = left_model_lookup.semantic_model
         left_model_has_validity_dimensions = self._model_id_to_has_validity_dimensions[left_model_id]
         for entity in left_model_lookup.semantic_model.entities:
-            left_entity_name = entity.name
             left_entity_type = entity.type
-            other_model_lookups_with_same_entity_name = self._entity_name_to_model_ids[left_entity_name]
-            for right_model_id in other_model_lookups_with_same_entity_name:
+            join_key = entity.role or entity.name
+            other_model_ids_with_matching_join_key = self._entity_join_key_to_model_ids[join_key]
+            for right_model_id in other_model_ids_with_matching_join_key:
                 right_model_lookup = self._model_id_to_lookup[right_model_id]
                 right_model = right_model_lookup.semantic_model
-                right_entity_type = right_model_lookup.entity_lookup.entity_name_to_type[left_entity_name]
                 right_model_has_validity_dimension = self._model_id_to_has_validity_dimensions[right_model_id]
 
-                join_type = EntityJoinType(
-                    left_entity_type=left_entity_type,
-                    right_entity_type=right_entity_type,
-                )
+                for right_entity in right_model_lookup.entity_lookup.join_key_to_entities[join_key]:
+                    right_entity_type = right_entity.type
 
-                if join_type in SemanticModelJoinLookup._VALID_ENTITY_JOINS:
-                    pass
-                elif join_type in SemanticModelJoinLookup._INVALID_ENTITY_JOINS:
-                    continue
-                else:
-                    raise ValueError(
-                        LazyFormat(
-                            "Unknown join type.",
+                    join_type = EntityJoinType(
+                        left_entity_type=left_entity_type,
+                        right_entity_type=right_entity_type,
+                    )
+
+                    if join_type in SemanticModelJoinLookup._VALID_ENTITY_JOINS:
+                        pass
+                    elif join_type in SemanticModelJoinLookup._INVALID_ENTITY_JOINS:
+                        continue
+                    else:
+                        raise ValueError(
+                            LazyFormat(
+                                "Unknown join type.",
+                                join_type=join_type,
+                                join_key=join_key,
+                                left_model=left_model,
+                                right_model=right_model,
+                            )
+                        )
+
+                    if left_model_has_validity_dimensions and right_model_has_validity_dimension:
+                        # We cannot join two semantic models with validity dimensions due to concerns with unexpected fanout
+                        # due to the key structure of these semantic models. Applying multi-stage validity window filters can
+                        # also lead to unexpected removal of interim join keys. Note this will need to be updated if we enable
+                        # simple-metric inputs in such semantic models, since those will need to be converted to a different type of semantic model
+                        # to support such computation.
+                        continue
+
+                    if right_entity_type is EntityType.NATURAL and not right_model_has_validity_dimension:
+                        # There is no way to refine this to a single row per key, so we cannot support this join
+                        continue
+
+                    right_model_id_to_join_descriptors[right_model_id].add(
+                        JoinModelOnRightDescriptor(
+                            entity_name=right_entity.name,
                             join_type=join_type,
-                            left_entity_name=left_entity_name,
-                            left_model=left_model,
-                            right_model=right_model,
                         )
                     )
-
-                if left_model_has_validity_dimensions and right_model_has_validity_dimension:
-                    # We cannot join two semantic models with validity dimensions due to concerns with unexpected fanout
-                    # due to the key structure of these semantic models. Applying multi-stage validity window filters can
-                    # also lead to unexpected removal of interim join keys. Note this will need to be updated if we enable
-                    # simple-metric inputs in such semantic models, since those will need to be converted to a different type of semantic model
-                    # to support such computation.
-                    continue
-
-                if right_entity_type is EntityType.NATURAL and not right_model_has_validity_dimension:
-                    # There is no way to refine this to a single row per key, so we cannot support this join
-                    continue
-
-                right_model_id_to_join_descriptors[right_model_id].add(
-                    JoinModelOnRightDescriptor(
-                        entity_name=left_entity_name,
-                        join_type=join_type,
-                    )
-                )
         return right_model_id_to_join_descriptors

--- a/metricflow_semantics/semantic_graph/lookups/manifest_object_lookup.py
+++ b/metricflow_semantics/semantic_graph/lookups/manifest_object_lookup.py
@@ -127,20 +127,27 @@ class ManifestObjectLookup(AttributePrettyFormattable):
         }
 
     @cached_property
-    def entity_name_to_model_lookups(self) -> Mapping[str, OrderedSet[ModelObjectLookup]]:
-        """Mapping from the entity name to the model lookups that have the entity."""
-        entity_name_to_model_lookups: dict[str, MutableOrderedSet[ModelObjectLookup]] = defaultdict(MutableOrderedSet)
+    def entity_join_key_to_model_lookups(self) -> Mapping[str, OrderedSet[ModelObjectLookup]]:
+        """Mapping from an entity's join key (`entity.role` if set, else `entity.name`) to model lookups with it.
+
+        Used only for cross-model join matching (`SemanticModelJoinLookup`) - `role` lets a model reach the
+        same target entity under a locally-chosen name (e.g. `buyer`/`seller` both joining to `user`), so this
+        is keyed by the join key, not necessarily the entity's own name.
+        """
+        entity_join_key_to_model_lookups: dict[str, MutableOrderedSet[ModelObjectLookup]] = defaultdict(
+            MutableOrderedSet
+        )
         for model_id, lookup in self.model_id_to_lookup.items():
             for entity in lookup.semantic_model.entities:
-                entity_name_to_model_lookups[entity.name].add(lookup)
-        return entity_name_to_model_lookups
+                entity_join_key_to_model_lookups[entity.role or entity.name].add(lookup)
+        return entity_join_key_to_model_lookups
 
     @cached_property
-    def entity_name_to_model_ids(self) -> Mapping[str, OrderedSet[SemanticModelId]]:
-        """Mapping from the entity name to the IDs of the semantic models that contain it."""
+    def entity_join_key_to_model_ids(self) -> Mapping[str, OrderedSet[SemanticModelId]]:
+        """Mapping from an entity's join key (see `entity_join_key_to_model_lookups`) to semantic model IDs."""
         return {
-            entity_name: FrozenOrderedSet(model_lookup.model_id for model_lookup in model_lookups)
-            for entity_name, model_lookups in self.entity_name_to_model_lookups.items()
+            entity_join_key: FrozenOrderedSet(model_lookup.model_id for model_lookup in model_lookups)
+            for entity_join_key, model_lookups in self.entity_join_key_to_model_lookups.items()
         }
 
     def get_metric(self, metric_name: str) -> Metric:  # noqa: D102

--- a/metricflow_semantics/test_helpers/semantic_manifest_yamls/scd_manifest/scd_bookings.yaml
+++ b/metricflow_semantics/test_helpers/semantic_manifest_yamls/scd_manifest/scd_bookings.yaml
@@ -53,14 +53,13 @@ semantic_model:
     - name: listing
       type: foreign
       expr: listing_id
+    # `role: user` lets `user__...` be queried through this entity, joining to whatever model owns the
+    # `user` entity (`users_latest`) - without also declaring a separate, redundantly-defined `user` entity
+    # here that aliases the same `guest_id` column under a different name.
     - name: guest
       type: foreign
       expr: guest_id
+      role: user
     - name: host
       type: foreign
       expr: host_id
-    # Hack around lack of support for entity/role functionality
-    # TODO: Remove this when full support for entity/role/primary role references is available
-    - name: user
-      type: foreign
-      expr: guest_id

--- a/tests_metricflow/dataflow/builder/test_node_evaluator.py
+++ b/tests_metricflow/dataflow/builder/test_node_evaluator.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import logging
+from pathlib import Path
 from typing import Mapping, Sequence
 
 import pytest
+from metricflow_semantics.errors.error_classes import UnableToSatisfyQueryError
 from metricflow_semantics.model.semantic_manifest_lookup import SemanticManifestLookup
 from metricflow_semantics.specs.dimension_spec import DimensionSpec
 from metricflow_semantics.specs.dunder_column_association_resolver import DunderColumnAssociationResolver
@@ -11,6 +13,8 @@ from metricflow_semantics.specs.entity_spec import EntitySpec
 from metricflow_semantics.specs.instance_spec import LinkableInstanceSpec
 from metricflow_semantics.specs.time_dimension_spec import TimeDimensionSpec
 from metricflow_semantics.sql.sql_join_type import SqlJoinType
+from metricflow_semantics.test_helpers.config_helpers import MetricFlowTestConfiguration
+from metricflow_semantics.test_helpers.semantic_manifest_yamls.scd_manifest import SCD_MANIFEST_ANCHOR
 from metricflow_semantics.time.granularity import ExpandedTimeGranularity
 
 from metricflow.dataflow.builder.node_evaluator import (
@@ -24,8 +28,12 @@ from metricflow.dataflow.nodes.join_to_base import ValidityWindowJoinDescription
 from metricflow.dataset.dataset_classes import DataSet
 from metricflow.plan_conversion.node_processor import PreJoinNodeProcessor
 from metricflow.plan_conversion.to_sql_plan.dataflow_to_subquery import DataflowNodeToSqlSubqueryVisitor
+from metricflow.protocols.sql_client import SqlClient
+from metricflow_semantic_interfaces.parsing.dir_to_model import parse_yaml_files_to_validation_ready_semantic_manifest
+from metricflow_semantic_interfaces.parsing.objects import YamlConfigFile
 from metricflow_semantic_interfaces.references import EntityReference
 from metricflow_semantic_interfaces.type_enums.time_granularity import TimeGranularity
+from metricflow_semantic_interfaces.validations.semantic_manifest_validator import SemanticManifestValidator
 from tests_metricflow.fixtures.manifest_fixtures import MetricFlowEngineTestFixture, SemanticManifestSetup
 
 logger = logging.getLogger(__name__)
@@ -765,3 +773,110 @@ def test_node_evaluator_with_invalid_multi_hop_scd(
             ),
         ),
     )
+
+
+def test_node_evaluator_with_role_based_join(
+    mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
+    scd_semantic_manifest_lookup: SemanticManifestLookup,
+) -> None:
+    """Tests joining through an entity `role`: `bookings_source`'s `guest` (role: user) reaches `users_latest`.
+
+    `guest` and `user` are different literal entity names on either side of the join, connected only by
+    `guest`'s `role: user` - this is what lets the resulting recipe's `join_on_entity` (the right side's own
+    reference, used for the dunder-path name and the right side's column lookup) stay `user`, while
+    `join_on_left_entity` carries `guest` for the left side's column lookup specifically. See
+    `JoinDescription.join_on_left_entity`.
+    """
+    node_data_set_resolver: DataflowNodeToSqlSubqueryVisitor = DataflowNodeToSqlSubqueryVisitor(
+        column_association_resolver=DunderColumnAssociationResolver(),
+        semantic_manifest_lookup=scd_semantic_manifest_lookup,
+    )
+    mf_engine_fixture = mf_engine_test_fixture_mapping[SemanticManifestSetup.SCD_MANIFEST]
+    node_evaluator = NodeEvaluatorForLinkableInstances(
+        semantic_model_lookup=scd_semantic_manifest_lookup.semantic_model_lookup,
+        nodes_available_for_joins=tuple(mf_engine_fixture.read_node_mapping.values()),
+        node_data_set_resolver=node_data_set_resolver,
+        time_spine_metric_time_nodes=mf_engine_fixture.source_node_set.time_spine_metric_time_nodes_tuple,
+    )
+
+    evaluation = node_evaluator.evaluate_node(
+        required_linkable_specs=[
+            DimensionSpec(element_name="home_state_latest", entity_links=(EntityReference(element_name="user"),))
+        ],
+        left_node=mf_engine_fixture.read_node_mapping["bookings_source"],
+        default_join_type=SqlJoinType.LEFT_OUTER,
+    )
+
+    assert evaluation == LinkableInstanceSatisfiabilityEvaluation(
+        local_linkable_specs=(),
+        joinable_linkable_specs=(
+            DimensionSpec(element_name="home_state_latest", entity_links=(EntityReference(element_name="user"),)),
+        ),
+        join_recipes=(
+            JoinLinkableInstancesRecipe(
+                node_to_join=mf_engine_fixture.read_node_mapping["users_latest"],
+                join_on_entity=EntityReference("user"),
+                join_on_left_entity=EntityReference("guest"),
+                satisfiable_linkable_specs=[
+                    DimensionSpec(
+                        element_name="home_state_latest", entity_links=(EntityReference(element_name="user"),)
+                    ),
+                ],
+                join_on_partition_dimensions=(),
+                join_on_partition_time_dimensions=(),
+                join_type=SqlJoinType.LEFT_OUTER,
+            ),
+        ),
+        unjoinable_linkable_specs=(),
+    )
+
+
+def test_node_evaluator_rejects_ambiguous_role_based_join(
+    mf_test_configuration: MetricFlowTestConfiguration,
+    sql_client: SqlClient,
+) -> None:
+    """Tests that a role shared by more than one local entity is rejected rather than resolved arbitrarily.
+
+    If both `guest` and `host` declared `role: user`, either could satisfy a join to `users_latest`'s `user`
+    entity - silently picking one would produce a query that looks correct but joined on an arbitrary,
+    possibly unintended entity (e.g. always `guest`, never `host`, with no error and no way to ask for the
+    other one). This must fail loud instead. See `UnableToSatisfyQueryError` in `node_evaluator.py`.
+    """
+    yaml_files = []
+    for path in Path(SCD_MANIFEST_ANCHOR.directory).glob("*.yaml"):
+        contents = path.read_text().replace("$source_schema", mf_test_configuration.mf_source_schema)
+        if path.name == "scd_bookings.yaml":
+            contents = contents.replace(
+                "    - name: host\n      type: foreign\n      expr: host_id\n",
+                "    - name: host\n      type: foreign\n      expr: host_id\n      role: user\n",
+            )
+            assert "expr: host_id\n      role: user" in contents, "Expected `host` to declare `role: user`"
+            assert "expr: guest_id\n      role: user" in contents, "Expected `guest` to declare `role: user`"
+        yaml_files.append(YamlConfigFile(filepath=str(path), contents=contents))
+
+    manifest = parse_yaml_files_to_validation_ready_semantic_manifest(
+        yaml_files, apply_transformations=True
+    ).semantic_manifest
+    SemanticManifestValidator().checked_validations(manifest)
+    manifest_lookup = SemanticManifestLookup(manifest)
+
+    node_data_set_resolver: DataflowNodeToSqlSubqueryVisitor = DataflowNodeToSqlSubqueryVisitor(
+        column_association_resolver=DunderColumnAssociationResolver(),
+        semantic_manifest_lookup=manifest_lookup,
+    )
+    fixture = MetricFlowEngineTestFixture.from_parameters(sql_client=sql_client, semantic_manifest=manifest)
+    node_evaluator = NodeEvaluatorForLinkableInstances(
+        semantic_model_lookup=manifest_lookup.semantic_model_lookup,
+        nodes_available_for_joins=tuple(fixture.read_node_mapping.values()),
+        node_data_set_resolver=node_data_set_resolver,
+        time_spine_metric_time_nodes=fixture.source_node_set.time_spine_metric_time_nodes_tuple,
+    )
+
+    with pytest.raises(UnableToSatisfyQueryError, match="Ambiguous join"):
+        node_evaluator.evaluate_node(
+            required_linkable_specs=[
+                DimensionSpec(element_name="home_state_latest", entity_links=(EntityReference(element_name="user"),))
+            ],
+            left_node=fixture.read_node_mapping["bookings_source"],
+            default_join_type=SqlJoinType.LEFT_OUTER,
+        )

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/DuckDB/test_join_to_scd_dimension__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/DuckDB/test_join_to_scd_dimension__plan0.sql
@@ -121,11 +121,9 @@ FROM (
               , subq_1.listing AS listing
               , subq_1.guest AS guest
               , subq_1.host AS host
-              , subq_1.user AS user
               , subq_1.booking__listing AS booking__listing
               , subq_1.booking__guest AS booking__guest
               , subq_1.booking__host AS booking__host
-              , subq_1.booking__user AS booking__user
               , subq_1.is_instant AS is_instant
               , subq_1.booking__is_instant AS booking__is_instant
               , subq_1.__bookings AS __bookings
@@ -214,11 +212,9 @@ FROM (
                 , subq_0.listing
                 , subq_0.guest
                 , subq_0.host
-                , subq_0.user
                 , subq_0.booking__listing
                 , subq_0.booking__guest
                 , subq_0.booking__host
-                , subq_0.booking__user
                 , subq_0.is_instant
                 , subq_0.booking__is_instant
                 , subq_0.__bookings
@@ -301,11 +297,9 @@ FROM (
                   , bookings_source_src_26000.listing_id AS listing
                   , bookings_source_src_26000.guest_id AS guest
                   , bookings_source_src_26000.host_id AS host
-                  , bookings_source_src_26000.guest_id AS user
                   , bookings_source_src_26000.listing_id AS booking__listing
                   , bookings_source_src_26000.guest_id AS booking__guest
                   , bookings_source_src_26000.host_id AS booking__host
-                  , bookings_source_src_26000.guest_id AS booking__user
                 FROM ***************************.fct_bookings bookings_source_src_26000
               ) subq_0
             ) subq_1

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/DuckDB/test_multi_hop_through_scd_dimension__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/DuckDB/test_multi_hop_through_scd_dimension__plan0.sql
@@ -6,222 +6,218 @@ sql_engine: DuckDB
 ---
 -- Write to DataTable
 SELECT
-  subq_17.metric_time__day
-  , subq_17.listing__user__home_state_latest
-  , subq_17.bookings
+  subq_14.metric_time__day
+  , subq_14.listing__user__home_state_latest
+  , subq_14.bookings
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_16.metric_time__day
-    , subq_16.listing__user__home_state_latest
-    , subq_16.__bookings AS bookings
+    subq_13.metric_time__day
+    , subq_13.listing__user__home_state_latest
+    , subq_13.__bookings AS bookings
   FROM (
     -- Aggregate Inputs for Simple Metrics
     SELECT
-      subq_15.metric_time__day
-      , subq_15.listing__user__home_state_latest
-      , SUM(subq_15.__bookings) AS __bookings
+      subq_12.metric_time__day
+      , subq_12.listing__user__home_state_latest
+      , SUM(subq_12.__bookings) AS __bookings
     FROM (
       -- Select: ['__bookings', 'listing__user__home_state_latest', 'metric_time__day']
       SELECT
-        subq_14.metric_time__day
-        , subq_14.listing__user__home_state_latest
-        , subq_14.__bookings
+        subq_11.metric_time__day
+        , subq_11.listing__user__home_state_latest
+        , subq_11.__bookings
       FROM (
         -- Select: ['__bookings', 'listing__user__home_state_latest', 'metric_time__day']
         SELECT
-          subq_13.metric_time__day
-          , subq_13.listing__user__home_state_latest
-          , subq_13.__bookings
+          subq_10.metric_time__day
+          , subq_10.listing__user__home_state_latest
+          , subq_10.__bookings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_12.user__home_state_latest AS listing__user__home_state_latest
-            , subq_12.window_start__day AS listing__window_start__day
-            , subq_12.window_end__day AS listing__window_end__day
-            , subq_7.ds__day AS ds__day
-            , subq_7.ds__week AS ds__week
-            , subq_7.ds__month AS ds__month
-            , subq_7.ds__quarter AS ds__quarter
-            , subq_7.ds__year AS ds__year
-            , subq_7.ds__extract_year AS ds__extract_year
-            , subq_7.ds__extract_quarter AS ds__extract_quarter
-            , subq_7.ds__extract_month AS ds__extract_month
-            , subq_7.ds__extract_day AS ds__extract_day
-            , subq_7.ds__extract_dow AS ds__extract_dow
-            , subq_7.ds__extract_doy AS ds__extract_doy
-            , subq_7.ds_partitioned__day AS ds_partitioned__day
-            , subq_7.ds_partitioned__week AS ds_partitioned__week
-            , subq_7.ds_partitioned__month AS ds_partitioned__month
-            , subq_7.ds_partitioned__quarter AS ds_partitioned__quarter
-            , subq_7.ds_partitioned__year AS ds_partitioned__year
-            , subq_7.ds_partitioned__extract_year AS ds_partitioned__extract_year
-            , subq_7.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
-            , subq_7.ds_partitioned__extract_month AS ds_partitioned__extract_month
-            , subq_7.ds_partitioned__extract_day AS ds_partitioned__extract_day
-            , subq_7.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
-            , subq_7.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
-            , subq_7.paid_at__day AS paid_at__day
-            , subq_7.paid_at__week AS paid_at__week
-            , subq_7.paid_at__month AS paid_at__month
-            , subq_7.paid_at__quarter AS paid_at__quarter
-            , subq_7.paid_at__year AS paid_at__year
-            , subq_7.paid_at__extract_year AS paid_at__extract_year
-            , subq_7.paid_at__extract_quarter AS paid_at__extract_quarter
-            , subq_7.paid_at__extract_month AS paid_at__extract_month
-            , subq_7.paid_at__extract_day AS paid_at__extract_day
-            , subq_7.paid_at__extract_dow AS paid_at__extract_dow
-            , subq_7.paid_at__extract_doy AS paid_at__extract_doy
-            , subq_7.booking__ds__day AS booking__ds__day
-            , subq_7.booking__ds__week AS booking__ds__week
-            , subq_7.booking__ds__month AS booking__ds__month
-            , subq_7.booking__ds__quarter AS booking__ds__quarter
-            , subq_7.booking__ds__year AS booking__ds__year
-            , subq_7.booking__ds__extract_year AS booking__ds__extract_year
-            , subq_7.booking__ds__extract_quarter AS booking__ds__extract_quarter
-            , subq_7.booking__ds__extract_month AS booking__ds__extract_month
-            , subq_7.booking__ds__extract_day AS booking__ds__extract_day
-            , subq_7.booking__ds__extract_dow AS booking__ds__extract_dow
-            , subq_7.booking__ds__extract_doy AS booking__ds__extract_doy
-            , subq_7.booking__ds_partitioned__day AS booking__ds_partitioned__day
-            , subq_7.booking__ds_partitioned__week AS booking__ds_partitioned__week
-            , subq_7.booking__ds_partitioned__month AS booking__ds_partitioned__month
-            , subq_7.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
-            , subq_7.booking__ds_partitioned__year AS booking__ds_partitioned__year
-            , subq_7.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
-            , subq_7.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
-            , subq_7.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
-            , subq_7.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
-            , subq_7.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
-            , subq_7.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
-            , subq_7.booking__paid_at__day AS booking__paid_at__day
-            , subq_7.booking__paid_at__week AS booking__paid_at__week
-            , subq_7.booking__paid_at__month AS booking__paid_at__month
-            , subq_7.booking__paid_at__quarter AS booking__paid_at__quarter
-            , subq_7.booking__paid_at__year AS booking__paid_at__year
-            , subq_7.booking__paid_at__extract_year AS booking__paid_at__extract_year
-            , subq_7.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
-            , subq_7.booking__paid_at__extract_month AS booking__paid_at__extract_month
-            , subq_7.booking__paid_at__extract_day AS booking__paid_at__extract_day
-            , subq_7.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
-            , subq_7.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
-            , subq_7.metric_time__day AS metric_time__day
-            , subq_7.metric_time__week AS metric_time__week
-            , subq_7.metric_time__month AS metric_time__month
-            , subq_7.metric_time__quarter AS metric_time__quarter
-            , subq_7.metric_time__year AS metric_time__year
-            , subq_7.metric_time__extract_year AS metric_time__extract_year
-            , subq_7.metric_time__extract_quarter AS metric_time__extract_quarter
-            , subq_7.metric_time__extract_month AS metric_time__extract_month
-            , subq_7.metric_time__extract_day AS metric_time__extract_day
-            , subq_7.metric_time__extract_dow AS metric_time__extract_dow
-            , subq_7.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_7.listing AS listing
-            , subq_7.guest AS guest
-            , subq_7.host AS host
-            , subq_7.user AS user
-            , subq_7.booking__listing AS booking__listing
-            , subq_7.booking__guest AS booking__guest
-            , subq_7.booking__host AS booking__host
-            , subq_7.booking__user AS booking__user
-            , subq_7.is_instant AS is_instant
-            , subq_7.booking__is_instant AS booking__is_instant
-            , subq_7.__bookings AS __bookings
-            , subq_7.__family_bookings AS __family_bookings
-            , subq_7.__potentially_lux_bookings AS __potentially_lux_bookings
+            subq_9.user__home_state_latest AS listing__user__home_state_latest
+            , subq_9.window_start__day AS listing__window_start__day
+            , subq_9.window_end__day AS listing__window_end__day
+            , subq_4.ds__day AS ds__day
+            , subq_4.ds__week AS ds__week
+            , subq_4.ds__month AS ds__month
+            , subq_4.ds__quarter AS ds__quarter
+            , subq_4.ds__year AS ds__year
+            , subq_4.ds__extract_year AS ds__extract_year
+            , subq_4.ds__extract_quarter AS ds__extract_quarter
+            , subq_4.ds__extract_month AS ds__extract_month
+            , subq_4.ds__extract_day AS ds__extract_day
+            , subq_4.ds__extract_dow AS ds__extract_dow
+            , subq_4.ds__extract_doy AS ds__extract_doy
+            , subq_4.ds_partitioned__day AS ds_partitioned__day
+            , subq_4.ds_partitioned__week AS ds_partitioned__week
+            , subq_4.ds_partitioned__month AS ds_partitioned__month
+            , subq_4.ds_partitioned__quarter AS ds_partitioned__quarter
+            , subq_4.ds_partitioned__year AS ds_partitioned__year
+            , subq_4.ds_partitioned__extract_year AS ds_partitioned__extract_year
+            , subq_4.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+            , subq_4.ds_partitioned__extract_month AS ds_partitioned__extract_month
+            , subq_4.ds_partitioned__extract_day AS ds_partitioned__extract_day
+            , subq_4.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+            , subq_4.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+            , subq_4.paid_at__day AS paid_at__day
+            , subq_4.paid_at__week AS paid_at__week
+            , subq_4.paid_at__month AS paid_at__month
+            , subq_4.paid_at__quarter AS paid_at__quarter
+            , subq_4.paid_at__year AS paid_at__year
+            , subq_4.paid_at__extract_year AS paid_at__extract_year
+            , subq_4.paid_at__extract_quarter AS paid_at__extract_quarter
+            , subq_4.paid_at__extract_month AS paid_at__extract_month
+            , subq_4.paid_at__extract_day AS paid_at__extract_day
+            , subq_4.paid_at__extract_dow AS paid_at__extract_dow
+            , subq_4.paid_at__extract_doy AS paid_at__extract_doy
+            , subq_4.booking__ds__day AS booking__ds__day
+            , subq_4.booking__ds__week AS booking__ds__week
+            , subq_4.booking__ds__month AS booking__ds__month
+            , subq_4.booking__ds__quarter AS booking__ds__quarter
+            , subq_4.booking__ds__year AS booking__ds__year
+            , subq_4.booking__ds__extract_year AS booking__ds__extract_year
+            , subq_4.booking__ds__extract_quarter AS booking__ds__extract_quarter
+            , subq_4.booking__ds__extract_month AS booking__ds__extract_month
+            , subq_4.booking__ds__extract_day AS booking__ds__extract_day
+            , subq_4.booking__ds__extract_dow AS booking__ds__extract_dow
+            , subq_4.booking__ds__extract_doy AS booking__ds__extract_doy
+            , subq_4.booking__ds_partitioned__day AS booking__ds_partitioned__day
+            , subq_4.booking__ds_partitioned__week AS booking__ds_partitioned__week
+            , subq_4.booking__ds_partitioned__month AS booking__ds_partitioned__month
+            , subq_4.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+            , subq_4.booking__ds_partitioned__year AS booking__ds_partitioned__year
+            , subq_4.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+            , subq_4.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+            , subq_4.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+            , subq_4.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+            , subq_4.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+            , subq_4.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+            , subq_4.booking__paid_at__day AS booking__paid_at__day
+            , subq_4.booking__paid_at__week AS booking__paid_at__week
+            , subq_4.booking__paid_at__month AS booking__paid_at__month
+            , subq_4.booking__paid_at__quarter AS booking__paid_at__quarter
+            , subq_4.booking__paid_at__year AS booking__paid_at__year
+            , subq_4.booking__paid_at__extract_year AS booking__paid_at__extract_year
+            , subq_4.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+            , subq_4.booking__paid_at__extract_month AS booking__paid_at__extract_month
+            , subq_4.booking__paid_at__extract_day AS booking__paid_at__extract_day
+            , subq_4.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+            , subq_4.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_4.metric_time__day AS metric_time__day
+            , subq_4.metric_time__week AS metric_time__week
+            , subq_4.metric_time__month AS metric_time__month
+            , subq_4.metric_time__quarter AS metric_time__quarter
+            , subq_4.metric_time__year AS metric_time__year
+            , subq_4.metric_time__extract_year AS metric_time__extract_year
+            , subq_4.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_4.metric_time__extract_month AS metric_time__extract_month
+            , subq_4.metric_time__extract_day AS metric_time__extract_day
+            , subq_4.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_4.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_4.listing AS listing
+            , subq_4.guest AS guest
+            , subq_4.host AS host
+            , subq_4.booking__listing AS booking__listing
+            , subq_4.booking__guest AS booking__guest
+            , subq_4.booking__host AS booking__host
+            , subq_4.is_instant AS is_instant
+            , subq_4.booking__is_instant AS booking__is_instant
+            , subq_4.__bookings AS __bookings
+            , subq_4.__family_bookings AS __family_bookings
+            , subq_4.__potentially_lux_bookings AS __potentially_lux_bookings
           FROM (
             -- Metric Time Dimension 'ds'
             SELECT
-              subq_6.ds__day
-              , subq_6.ds__week
-              , subq_6.ds__month
-              , subq_6.ds__quarter
-              , subq_6.ds__year
-              , subq_6.ds__extract_year
-              , subq_6.ds__extract_quarter
-              , subq_6.ds__extract_month
-              , subq_6.ds__extract_day
-              , subq_6.ds__extract_dow
-              , subq_6.ds__extract_doy
-              , subq_6.ds_partitioned__day
-              , subq_6.ds_partitioned__week
-              , subq_6.ds_partitioned__month
-              , subq_6.ds_partitioned__quarter
-              , subq_6.ds_partitioned__year
-              , subq_6.ds_partitioned__extract_year
-              , subq_6.ds_partitioned__extract_quarter
-              , subq_6.ds_partitioned__extract_month
-              , subq_6.ds_partitioned__extract_day
-              , subq_6.ds_partitioned__extract_dow
-              , subq_6.ds_partitioned__extract_doy
-              , subq_6.paid_at__day
-              , subq_6.paid_at__week
-              , subq_6.paid_at__month
-              , subq_6.paid_at__quarter
-              , subq_6.paid_at__year
-              , subq_6.paid_at__extract_year
-              , subq_6.paid_at__extract_quarter
-              , subq_6.paid_at__extract_month
-              , subq_6.paid_at__extract_day
-              , subq_6.paid_at__extract_dow
-              , subq_6.paid_at__extract_doy
-              , subq_6.booking__ds__day
-              , subq_6.booking__ds__week
-              , subq_6.booking__ds__month
-              , subq_6.booking__ds__quarter
-              , subq_6.booking__ds__year
-              , subq_6.booking__ds__extract_year
-              , subq_6.booking__ds__extract_quarter
-              , subq_6.booking__ds__extract_month
-              , subq_6.booking__ds__extract_day
-              , subq_6.booking__ds__extract_dow
-              , subq_6.booking__ds__extract_doy
-              , subq_6.booking__ds_partitioned__day
-              , subq_6.booking__ds_partitioned__week
-              , subq_6.booking__ds_partitioned__month
-              , subq_6.booking__ds_partitioned__quarter
-              , subq_6.booking__ds_partitioned__year
-              , subq_6.booking__ds_partitioned__extract_year
-              , subq_6.booking__ds_partitioned__extract_quarter
-              , subq_6.booking__ds_partitioned__extract_month
-              , subq_6.booking__ds_partitioned__extract_day
-              , subq_6.booking__ds_partitioned__extract_dow
-              , subq_6.booking__ds_partitioned__extract_doy
-              , subq_6.booking__paid_at__day
-              , subq_6.booking__paid_at__week
-              , subq_6.booking__paid_at__month
-              , subq_6.booking__paid_at__quarter
-              , subq_6.booking__paid_at__year
-              , subq_6.booking__paid_at__extract_year
-              , subq_6.booking__paid_at__extract_quarter
-              , subq_6.booking__paid_at__extract_month
-              , subq_6.booking__paid_at__extract_day
-              , subq_6.booking__paid_at__extract_dow
-              , subq_6.booking__paid_at__extract_doy
-              , subq_6.ds__day AS metric_time__day
-              , subq_6.ds__week AS metric_time__week
-              , subq_6.ds__month AS metric_time__month
-              , subq_6.ds__quarter AS metric_time__quarter
-              , subq_6.ds__year AS metric_time__year
-              , subq_6.ds__extract_year AS metric_time__extract_year
-              , subq_6.ds__extract_quarter AS metric_time__extract_quarter
-              , subq_6.ds__extract_month AS metric_time__extract_month
-              , subq_6.ds__extract_day AS metric_time__extract_day
-              , subq_6.ds__extract_dow AS metric_time__extract_dow
-              , subq_6.ds__extract_doy AS metric_time__extract_doy
-              , subq_6.listing
-              , subq_6.guest
-              , subq_6.host
-              , subq_6.user
-              , subq_6.booking__listing
-              , subq_6.booking__guest
-              , subq_6.booking__host
-              , subq_6.booking__user
-              , subq_6.is_instant
-              , subq_6.booking__is_instant
-              , subq_6.__bookings
-              , subq_6.__family_bookings
-              , subq_6.__potentially_lux_bookings
+              subq_3.ds__day
+              , subq_3.ds__week
+              , subq_3.ds__month
+              , subq_3.ds__quarter
+              , subq_3.ds__year
+              , subq_3.ds__extract_year
+              , subq_3.ds__extract_quarter
+              , subq_3.ds__extract_month
+              , subq_3.ds__extract_day
+              , subq_3.ds__extract_dow
+              , subq_3.ds__extract_doy
+              , subq_3.ds_partitioned__day
+              , subq_3.ds_partitioned__week
+              , subq_3.ds_partitioned__month
+              , subq_3.ds_partitioned__quarter
+              , subq_3.ds_partitioned__year
+              , subq_3.ds_partitioned__extract_year
+              , subq_3.ds_partitioned__extract_quarter
+              , subq_3.ds_partitioned__extract_month
+              , subq_3.ds_partitioned__extract_day
+              , subq_3.ds_partitioned__extract_dow
+              , subq_3.ds_partitioned__extract_doy
+              , subq_3.paid_at__day
+              , subq_3.paid_at__week
+              , subq_3.paid_at__month
+              , subq_3.paid_at__quarter
+              , subq_3.paid_at__year
+              , subq_3.paid_at__extract_year
+              , subq_3.paid_at__extract_quarter
+              , subq_3.paid_at__extract_month
+              , subq_3.paid_at__extract_day
+              , subq_3.paid_at__extract_dow
+              , subq_3.paid_at__extract_doy
+              , subq_3.booking__ds__day
+              , subq_3.booking__ds__week
+              , subq_3.booking__ds__month
+              , subq_3.booking__ds__quarter
+              , subq_3.booking__ds__year
+              , subq_3.booking__ds__extract_year
+              , subq_3.booking__ds__extract_quarter
+              , subq_3.booking__ds__extract_month
+              , subq_3.booking__ds__extract_day
+              , subq_3.booking__ds__extract_dow
+              , subq_3.booking__ds__extract_doy
+              , subq_3.booking__ds_partitioned__day
+              , subq_3.booking__ds_partitioned__week
+              , subq_3.booking__ds_partitioned__month
+              , subq_3.booking__ds_partitioned__quarter
+              , subq_3.booking__ds_partitioned__year
+              , subq_3.booking__ds_partitioned__extract_year
+              , subq_3.booking__ds_partitioned__extract_quarter
+              , subq_3.booking__ds_partitioned__extract_month
+              , subq_3.booking__ds_partitioned__extract_day
+              , subq_3.booking__ds_partitioned__extract_dow
+              , subq_3.booking__ds_partitioned__extract_doy
+              , subq_3.booking__paid_at__day
+              , subq_3.booking__paid_at__week
+              , subq_3.booking__paid_at__month
+              , subq_3.booking__paid_at__quarter
+              , subq_3.booking__paid_at__year
+              , subq_3.booking__paid_at__extract_year
+              , subq_3.booking__paid_at__extract_quarter
+              , subq_3.booking__paid_at__extract_month
+              , subq_3.booking__paid_at__extract_day
+              , subq_3.booking__paid_at__extract_dow
+              , subq_3.booking__paid_at__extract_doy
+              , subq_3.ds__day AS metric_time__day
+              , subq_3.ds__week AS metric_time__week
+              , subq_3.ds__month AS metric_time__month
+              , subq_3.ds__quarter AS metric_time__quarter
+              , subq_3.ds__year AS metric_time__year
+              , subq_3.ds__extract_year AS metric_time__extract_year
+              , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_3.ds__extract_month AS metric_time__extract_month
+              , subq_3.ds__extract_day AS metric_time__extract_day
+              , subq_3.ds__extract_dow AS metric_time__extract_dow
+              , subq_3.ds__extract_doy AS metric_time__extract_doy
+              , subq_3.listing
+              , subq_3.guest
+              , subq_3.host
+              , subq_3.booking__listing
+              , subq_3.booking__guest
+              , subq_3.booking__host
+              , subq_3.is_instant
+              , subq_3.booking__is_instant
+              , subq_3.__bookings
+              , subq_3.__family_bookings
+              , subq_3.__potentially_lux_bookings
             FROM (
               -- Read Elements From Semantic Model 'bookings_source'
               SELECT
@@ -299,89 +295,87 @@ FROM (
                 , bookings_source_src_26000.listing_id AS listing
                 , bookings_source_src_26000.guest_id AS guest
                 , bookings_source_src_26000.host_id AS host
-                , bookings_source_src_26000.guest_id AS user
                 , bookings_source_src_26000.listing_id AS booking__listing
                 , bookings_source_src_26000.guest_id AS booking__guest
                 , bookings_source_src_26000.host_id AS booking__host
-                , bookings_source_src_26000.guest_id AS booking__user
               FROM ***************************.fct_bookings bookings_source_src_26000
-            ) subq_6
-          ) subq_7
+            ) subq_3
+          ) subq_4
           LEFT OUTER JOIN (
             -- Select: ['user__home_state_latest', 'window_start__day', 'window_end__day', 'listing']
             SELECT
-              subq_11.window_start__day
-              , subq_11.window_end__day
-              , subq_11.listing
-              , subq_11.user__home_state_latest
+              subq_8.window_start__day
+              , subq_8.window_end__day
+              , subq_8.listing
+              , subq_8.user__home_state_latest
             FROM (
               -- Join Standard Outputs
               SELECT
-                subq_10.home_state_latest AS user__home_state_latest
-                , subq_10.ds__day AS user__ds__day
-                , subq_10.ds__week AS user__ds__week
-                , subq_10.ds__month AS user__ds__month
-                , subq_10.ds__quarter AS user__ds__quarter
-                , subq_10.ds__year AS user__ds__year
-                , subq_10.ds__extract_year AS user__ds__extract_year
-                , subq_10.ds__extract_quarter AS user__ds__extract_quarter
-                , subq_10.ds__extract_month AS user__ds__extract_month
-                , subq_10.ds__extract_day AS user__ds__extract_day
-                , subq_10.ds__extract_dow AS user__ds__extract_dow
-                , subq_10.ds__extract_doy AS user__ds__extract_doy
-                , subq_8.window_start__day AS window_start__day
-                , subq_8.window_start__week AS window_start__week
-                , subq_8.window_start__month AS window_start__month
-                , subq_8.window_start__quarter AS window_start__quarter
-                , subq_8.window_start__year AS window_start__year
-                , subq_8.window_start__extract_year AS window_start__extract_year
-                , subq_8.window_start__extract_quarter AS window_start__extract_quarter
-                , subq_8.window_start__extract_month AS window_start__extract_month
-                , subq_8.window_start__extract_day AS window_start__extract_day
-                , subq_8.window_start__extract_dow AS window_start__extract_dow
-                , subq_8.window_start__extract_doy AS window_start__extract_doy
-                , subq_8.window_end__day AS window_end__day
-                , subq_8.window_end__week AS window_end__week
-                , subq_8.window_end__month AS window_end__month
-                , subq_8.window_end__quarter AS window_end__quarter
-                , subq_8.window_end__year AS window_end__year
-                , subq_8.window_end__extract_year AS window_end__extract_year
-                , subq_8.window_end__extract_quarter AS window_end__extract_quarter
-                , subq_8.window_end__extract_month AS window_end__extract_month
-                , subq_8.window_end__extract_day AS window_end__extract_day
-                , subq_8.window_end__extract_dow AS window_end__extract_dow
-                , subq_8.window_end__extract_doy AS window_end__extract_doy
-                , subq_8.listing__window_start__day AS listing__window_start__day
-                , subq_8.listing__window_start__week AS listing__window_start__week
-                , subq_8.listing__window_start__month AS listing__window_start__month
-                , subq_8.listing__window_start__quarter AS listing__window_start__quarter
-                , subq_8.listing__window_start__year AS listing__window_start__year
-                , subq_8.listing__window_start__extract_year AS listing__window_start__extract_year
-                , subq_8.listing__window_start__extract_quarter AS listing__window_start__extract_quarter
-                , subq_8.listing__window_start__extract_month AS listing__window_start__extract_month
-                , subq_8.listing__window_start__extract_day AS listing__window_start__extract_day
-                , subq_8.listing__window_start__extract_dow AS listing__window_start__extract_dow
-                , subq_8.listing__window_start__extract_doy AS listing__window_start__extract_doy
-                , subq_8.listing__window_end__day AS listing__window_end__day
-                , subq_8.listing__window_end__week AS listing__window_end__week
-                , subq_8.listing__window_end__month AS listing__window_end__month
-                , subq_8.listing__window_end__quarter AS listing__window_end__quarter
-                , subq_8.listing__window_end__year AS listing__window_end__year
-                , subq_8.listing__window_end__extract_year AS listing__window_end__extract_year
-                , subq_8.listing__window_end__extract_quarter AS listing__window_end__extract_quarter
-                , subq_8.listing__window_end__extract_month AS listing__window_end__extract_month
-                , subq_8.listing__window_end__extract_day AS listing__window_end__extract_day
-                , subq_8.listing__window_end__extract_dow AS listing__window_end__extract_dow
-                , subq_8.listing__window_end__extract_doy AS listing__window_end__extract_doy
-                , subq_8.listing AS listing
-                , subq_8.user AS user
-                , subq_8.listing__user AS listing__user
-                , subq_8.country AS country
-                , subq_8.is_lux AS is_lux
-                , subq_8.capacity AS capacity
-                , subq_8.listing__country AS listing__country
-                , subq_8.listing__is_lux AS listing__is_lux
-                , subq_8.listing__capacity AS listing__capacity
+                subq_7.home_state_latest AS user__home_state_latest
+                , subq_7.ds__day AS user__ds__day
+                , subq_7.ds__week AS user__ds__week
+                , subq_7.ds__month AS user__ds__month
+                , subq_7.ds__quarter AS user__ds__quarter
+                , subq_7.ds__year AS user__ds__year
+                , subq_7.ds__extract_year AS user__ds__extract_year
+                , subq_7.ds__extract_quarter AS user__ds__extract_quarter
+                , subq_7.ds__extract_month AS user__ds__extract_month
+                , subq_7.ds__extract_day AS user__ds__extract_day
+                , subq_7.ds__extract_dow AS user__ds__extract_dow
+                , subq_7.ds__extract_doy AS user__ds__extract_doy
+                , subq_5.window_start__day AS window_start__day
+                , subq_5.window_start__week AS window_start__week
+                , subq_5.window_start__month AS window_start__month
+                , subq_5.window_start__quarter AS window_start__quarter
+                , subq_5.window_start__year AS window_start__year
+                , subq_5.window_start__extract_year AS window_start__extract_year
+                , subq_5.window_start__extract_quarter AS window_start__extract_quarter
+                , subq_5.window_start__extract_month AS window_start__extract_month
+                , subq_5.window_start__extract_day AS window_start__extract_day
+                , subq_5.window_start__extract_dow AS window_start__extract_dow
+                , subq_5.window_start__extract_doy AS window_start__extract_doy
+                , subq_5.window_end__day AS window_end__day
+                , subq_5.window_end__week AS window_end__week
+                , subq_5.window_end__month AS window_end__month
+                , subq_5.window_end__quarter AS window_end__quarter
+                , subq_5.window_end__year AS window_end__year
+                , subq_5.window_end__extract_year AS window_end__extract_year
+                , subq_5.window_end__extract_quarter AS window_end__extract_quarter
+                , subq_5.window_end__extract_month AS window_end__extract_month
+                , subq_5.window_end__extract_day AS window_end__extract_day
+                , subq_5.window_end__extract_dow AS window_end__extract_dow
+                , subq_5.window_end__extract_doy AS window_end__extract_doy
+                , subq_5.listing__window_start__day AS listing__window_start__day
+                , subq_5.listing__window_start__week AS listing__window_start__week
+                , subq_5.listing__window_start__month AS listing__window_start__month
+                , subq_5.listing__window_start__quarter AS listing__window_start__quarter
+                , subq_5.listing__window_start__year AS listing__window_start__year
+                , subq_5.listing__window_start__extract_year AS listing__window_start__extract_year
+                , subq_5.listing__window_start__extract_quarter AS listing__window_start__extract_quarter
+                , subq_5.listing__window_start__extract_month AS listing__window_start__extract_month
+                , subq_5.listing__window_start__extract_day AS listing__window_start__extract_day
+                , subq_5.listing__window_start__extract_dow AS listing__window_start__extract_dow
+                , subq_5.listing__window_start__extract_doy AS listing__window_start__extract_doy
+                , subq_5.listing__window_end__day AS listing__window_end__day
+                , subq_5.listing__window_end__week AS listing__window_end__week
+                , subq_5.listing__window_end__month AS listing__window_end__month
+                , subq_5.listing__window_end__quarter AS listing__window_end__quarter
+                , subq_5.listing__window_end__year AS listing__window_end__year
+                , subq_5.listing__window_end__extract_year AS listing__window_end__extract_year
+                , subq_5.listing__window_end__extract_quarter AS listing__window_end__extract_quarter
+                , subq_5.listing__window_end__extract_month AS listing__window_end__extract_month
+                , subq_5.listing__window_end__extract_day AS listing__window_end__extract_day
+                , subq_5.listing__window_end__extract_dow AS listing__window_end__extract_dow
+                , subq_5.listing__window_end__extract_doy AS listing__window_end__extract_doy
+                , subq_5.listing AS listing
+                , subq_5.user AS user
+                , subq_5.listing__user AS listing__user
+                , subq_5.country AS country
+                , subq_5.is_lux AS is_lux
+                , subq_5.capacity AS capacity
+                , subq_5.listing__country AS listing__country
+                , subq_5.listing__is_lux AS listing__is_lux
+                , subq_5.listing__capacity AS listing__capacity
               FROM (
                 -- Read Elements From Semantic Model 'listings'
                 SELECT
@@ -439,7 +433,7 @@ FROM (
                   , listings_src_26000.user_id AS user
                   , listings_src_26000.user_id AS listing__user
                 FROM ***************************.dim_listings listings_src_26000
-              ) subq_8
+              ) subq_5
               LEFT OUTER JOIN (
                 -- Select: [
                 --   'home_state_latest',
@@ -469,31 +463,31 @@ FROM (
                 --   'user',
                 -- ]
                 SELECT
-                  subq_9.ds__day
-                  , subq_9.ds__week
-                  , subq_9.ds__month
-                  , subq_9.ds__quarter
-                  , subq_9.ds__year
-                  , subq_9.ds__extract_year
-                  , subq_9.ds__extract_quarter
-                  , subq_9.ds__extract_month
-                  , subq_9.ds__extract_day
-                  , subq_9.ds__extract_dow
-                  , subq_9.ds__extract_doy
-                  , subq_9.user__ds__day
-                  , subq_9.user__ds__week
-                  , subq_9.user__ds__month
-                  , subq_9.user__ds__quarter
-                  , subq_9.user__ds__year
-                  , subq_9.user__ds__extract_year
-                  , subq_9.user__ds__extract_quarter
-                  , subq_9.user__ds__extract_month
-                  , subq_9.user__ds__extract_day
-                  , subq_9.user__ds__extract_dow
-                  , subq_9.user__ds__extract_doy
-                  , subq_9.user
-                  , subq_9.home_state_latest
-                  , subq_9.user__home_state_latest
+                  subq_6.ds__day
+                  , subq_6.ds__week
+                  , subq_6.ds__month
+                  , subq_6.ds__quarter
+                  , subq_6.ds__year
+                  , subq_6.ds__extract_year
+                  , subq_6.ds__extract_quarter
+                  , subq_6.ds__extract_month
+                  , subq_6.ds__extract_day
+                  , subq_6.ds__extract_dow
+                  , subq_6.ds__extract_doy
+                  , subq_6.user__ds__day
+                  , subq_6.user__ds__week
+                  , subq_6.user__ds__month
+                  , subq_6.user__ds__quarter
+                  , subq_6.user__ds__year
+                  , subq_6.user__ds__extract_year
+                  , subq_6.user__ds__extract_quarter
+                  , subq_6.user__ds__extract_month
+                  , subq_6.user__ds__extract_day
+                  , subq_6.user__ds__extract_dow
+                  , subq_6.user__ds__extract_doy
+                  , subq_6.user
+                  , subq_6.home_state_latest
+                  , subq_6.user__home_state_latest
                 FROM (
                   -- Read Elements From Semantic Model 'users_latest'
                   SELECT
@@ -523,31 +517,31 @@ FROM (
                     , users_latest_src_26000.home_state_latest AS user__home_state_latest
                     , users_latest_src_26000.user_id AS user
                   FROM ***************************.dim_users_latest users_latest_src_26000
-                ) subq_9
-              ) subq_10
+                ) subq_6
+              ) subq_7
               ON
-                subq_8.user = subq_10.user
-            ) subq_11
-          ) subq_12
+                subq_5.user = subq_7.user
+            ) subq_8
+          ) subq_9
           ON
             (
-              subq_7.listing = subq_12.listing
+              subq_4.listing = subq_9.listing
             ) AND (
               (
-                subq_7.metric_time__day >= subq_12.window_start__day
+                subq_4.metric_time__day >= subq_9.window_start__day
               ) AND (
                 (
-                  subq_7.metric_time__day < subq_12.window_end__day
+                  subq_4.metric_time__day < subq_9.window_end__day
                 ) OR (
-                  subq_12.window_end__day IS NULL
+                  subq_9.window_end__day IS NULL
                 )
               )
             )
-        ) subq_13
-      ) subq_14
-    ) subq_15
+        ) subq_10
+      ) subq_11
+    ) subq_12
     GROUP BY
-      subq_15.metric_time__day
-      , subq_15.listing__user__home_state_latest
-  ) subq_16
-) subq_17
+      subq_12.metric_time__day
+      , subq_12.listing__user__home_state_latest
+  ) subq_13
+) subq_14

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/DuckDB/test_multi_hop_through_scd_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/DuckDB/test_multi_hop_through_scd_dimension__plan0_optimized.sql
@@ -11,9 +11,9 @@ sql_engine: DuckDB
 -- Compute Metrics via Expressions
 -- Write to DataTable
 SELECT
-  subq_25.metric_time__day AS metric_time__day
-  , subq_30.user__home_state_latest AS listing__user__home_state_latest
-  , SUM(subq_25.__bookings) AS bookings
+  subq_19.metric_time__day AS metric_time__day
+  , subq_24.user__home_state_latest AS listing__user__home_state_latest
+  , SUM(subq_19.__bookings) AS bookings
 FROM (
   -- Read Elements From Semantic Model 'bookings_source'
   -- Metric Time Dimension 'ds'
@@ -22,7 +22,7 @@ FROM (
     , listing_id AS listing
     , 1 AS __bookings
   FROM ***************************.fct_bookings bookings_source_src_26000
-) subq_25
+) subq_19
 LEFT OUTER JOIN (
   -- Join Standard Outputs
   -- Select: ['user__home_state_latest', 'window_start__day', 'window_end__day', 'listing']
@@ -36,21 +36,21 @@ LEFT OUTER JOIN (
     ***************************.dim_users_latest users_latest_src_26000
   ON
     listings_src_26000.user_id = users_latest_src_26000.user_id
-) subq_30
+) subq_24
 ON
   (
-    subq_25.listing = subq_30.listing
+    subq_19.listing = subq_24.listing
   ) AND (
     (
-      subq_25.metric_time__day >= subq_30.window_start__day
+      subq_19.metric_time__day >= subq_24.window_start__day
     ) AND (
       (
-        subq_25.metric_time__day < subq_30.window_end__day
+        subq_19.metric_time__day < subq_24.window_end__day
       ) OR (
-        subq_30.window_end__day IS NULL
+        subq_24.window_end__day IS NULL
       )
     )
   )
 GROUP BY
-  subq_25.metric_time__day
-  , subq_30.user__home_state_latest
+  subq_19.metric_time__day
+  , subq_24.user__home_state_latest

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/DuckDB/test_multi_hop_to_scd_dimension__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/DuckDB/test_multi_hop_to_scd_dimension__plan0.sql
@@ -119,11 +119,9 @@ FROM (
             , subq_4.listing AS listing
             , subq_4.guest AS guest
             , subq_4.host AS host
-            , subq_4.user AS user
             , subq_4.booking__listing AS booking__listing
             , subq_4.booking__guest AS booking__guest
             , subq_4.booking__host AS booking__host
-            , subq_4.booking__user AS booking__user
             , subq_4.is_instant AS is_instant
             , subq_4.booking__is_instant AS booking__is_instant
             , subq_4.__bookings AS __bookings
@@ -212,11 +210,9 @@ FROM (
               , subq_3.listing
               , subq_3.guest
               , subq_3.host
-              , subq_3.user
               , subq_3.booking__listing
               , subq_3.booking__guest
               , subq_3.booking__host
-              , subq_3.booking__user
               , subq_3.is_instant
               , subq_3.booking__is_instant
               , subq_3.__bookings
@@ -299,11 +295,9 @@ FROM (
                 , bookings_source_src_26000.listing_id AS listing
                 , bookings_source_src_26000.guest_id AS guest
                 , bookings_source_src_26000.host_id AS host
-                , bookings_source_src_26000.guest_id AS user
                 , bookings_source_src_26000.listing_id AS booking__listing
                 , bookings_source_src_26000.guest_id AS booking__guest
                 , bookings_source_src_26000.host_id AS booking__host
-                , bookings_source_src_26000.guest_id AS booking__user
               FROM ***************************.fct_bookings bookings_source_src_26000
             ) subq_3
           ) subq_4

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/DuckDB/test_scd_dimension_filter_without_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/DuckDB/test_scd_dimension_filter_without_metric_time__plan0.sql
@@ -113,11 +113,9 @@ FROM (
               , subq_1.listing AS listing
               , subq_1.guest AS guest
               , subq_1.host AS host
-              , subq_1.user AS user
               , subq_1.booking__listing AS booking__listing
               , subq_1.booking__guest AS booking__guest
               , subq_1.booking__host AS booking__host
-              , subq_1.booking__user AS booking__user
               , subq_1.is_instant AS is_instant
               , subq_1.booking__is_instant AS booking__is_instant
               , subq_1.__bookings AS __bookings
@@ -206,11 +204,9 @@ FROM (
                 , subq_0.listing
                 , subq_0.guest
                 , subq_0.host
-                , subq_0.user
                 , subq_0.booking__listing
                 , subq_0.booking__guest
                 , subq_0.booking__host
-                , subq_0.booking__user
                 , subq_0.is_instant
                 , subq_0.booking__is_instant
                 , subq_0.__bookings
@@ -293,11 +289,9 @@ FROM (
                   , bookings_source_src_26000.listing_id AS listing
                   , bookings_source_src_26000.guest_id AS guest
                   , bookings_source_src_26000.host_id AS host
-                  , bookings_source_src_26000.guest_id AS user
                   , bookings_source_src_26000.listing_id AS booking__listing
                   , bookings_source_src_26000.guest_id AS booking__guest
                   , bookings_source_src_26000.host_id AS booking__host
-                  , bookings_source_src_26000.guest_id AS booking__user
                 FROM ***************************.fct_bookings bookings_source_src_26000
               ) subq_0
             ) subq_1

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/DuckDB/test_scd_dimension_group_by_without_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/DuckDB/test_scd_dimension_group_by_without_metric_time__plan0.sql
@@ -117,11 +117,9 @@ FROM (
               , subq_1.listing AS listing
               , subq_1.guest AS guest
               , subq_1.host AS host
-              , subq_1.user AS user
               , subq_1.booking__listing AS booking__listing
               , subq_1.booking__guest AS booking__guest
               , subq_1.booking__host AS booking__host
-              , subq_1.booking__user AS booking__user
               , subq_1.is_instant AS is_instant
               , subq_1.booking__is_instant AS booking__is_instant
               , subq_1.__bookings AS __bookings
@@ -210,11 +208,9 @@ FROM (
                 , subq_0.listing
                 , subq_0.guest
                 , subq_0.host
-                , subq_0.user
                 , subq_0.booking__listing
                 , subq_0.booking__guest
                 , subq_0.booking__host
-                , subq_0.booking__user
                 , subq_0.is_instant
                 , subq_0.booking__is_instant
                 , subq_0.__bookings
@@ -297,11 +293,9 @@ FROM (
                   , bookings_source_src_26000.listing_id AS listing
                   , bookings_source_src_26000.guest_id AS guest
                   , bookings_source_src_26000.host_id AS host
-                  , bookings_source_src_26000.guest_id AS user
                   , bookings_source_src_26000.listing_id AS booking__listing
                   , bookings_source_src_26000.guest_id AS booking__guest
                   , bookings_source_src_26000.host_id AS booking__host
-                  , bookings_source_src_26000.guest_id AS booking__user
                 FROM ***************************.fct_bookings bookings_source_src_26000
               ) subq_0
             ) subq_1

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/DuckDB/test_scd_group_by_and_coarser_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/DuckDB/test_scd_group_by_and_coarser_grain__plan0.sql
@@ -123,11 +123,9 @@ FROM (
               , subq_1.listing AS listing
               , subq_1.guest AS guest
               , subq_1.host AS host
-              , subq_1.user AS user
               , subq_1.booking__listing AS booking__listing
               , subq_1.booking__guest AS booking__guest
               , subq_1.booking__host AS booking__host
-              , subq_1.booking__user AS booking__user
               , subq_1.is_instant AS is_instant
               , subq_1.booking__is_instant AS booking__is_instant
               , subq_1.__bookings AS __bookings
@@ -216,11 +214,9 @@ FROM (
                 , subq_0.listing
                 , subq_0.guest
                 , subq_0.host
-                , subq_0.user
                 , subq_0.booking__listing
                 , subq_0.booking__guest
                 , subq_0.booking__host
-                , subq_0.booking__user
                 , subq_0.is_instant
                 , subq_0.booking__is_instant
                 , subq_0.__bookings
@@ -303,11 +299,9 @@ FROM (
                   , bookings_source_src_26000.listing_id AS listing
                   , bookings_source_src_26000.guest_id AS guest
                   , bookings_source_src_26000.host_id AS host
-                  , bookings_source_src_26000.guest_id AS user
                   , bookings_source_src_26000.listing_id AS booking__listing
                   , bookings_source_src_26000.guest_id AS booking__guest
                   , bookings_source_src_26000.host_id AS booking__host
-                  , bookings_source_src_26000.guest_id AS booking__user
                 FROM ***************************.fct_bookings bookings_source_src_26000
               ) subq_0
             ) subq_1

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Postgres/test_join_to_scd_dimension__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Postgres/test_join_to_scd_dimension__plan0.sql
@@ -121,11 +121,9 @@ FROM (
               , subq_1.listing AS listing
               , subq_1.guest AS guest
               , subq_1.host AS host
-              , subq_1.user AS user
               , subq_1.booking__listing AS booking__listing
               , subq_1.booking__guest AS booking__guest
               , subq_1.booking__host AS booking__host
-              , subq_1.booking__user AS booking__user
               , subq_1.is_instant AS is_instant
               , subq_1.booking__is_instant AS booking__is_instant
               , subq_1.__bookings AS __bookings
@@ -214,11 +212,9 @@ FROM (
                 , subq_0.listing
                 , subq_0.guest
                 , subq_0.host
-                , subq_0.user
                 , subq_0.booking__listing
                 , subq_0.booking__guest
                 , subq_0.booking__host
-                , subq_0.booking__user
                 , subq_0.is_instant
                 , subq_0.booking__is_instant
                 , subq_0.__bookings
@@ -301,11 +297,9 @@ FROM (
                   , bookings_source_src_26000.listing_id AS listing
                   , bookings_source_src_26000.guest_id AS guest
                   , bookings_source_src_26000.host_id AS host
-                  , bookings_source_src_26000.guest_id AS user
                   , bookings_source_src_26000.listing_id AS booking__listing
                   , bookings_source_src_26000.guest_id AS booking__guest
                   , bookings_source_src_26000.host_id AS booking__host
-                  , bookings_source_src_26000.guest_id AS booking__user
                 FROM ***************************.fct_bookings bookings_source_src_26000
               ) subq_0
             ) subq_1

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Postgres/test_multi_hop_through_scd_dimension__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Postgres/test_multi_hop_through_scd_dimension__plan0.sql
@@ -6,222 +6,218 @@ sql_engine: Postgres
 ---
 -- Write to DataTable
 SELECT
-  subq_17.metric_time__day
-  , subq_17.listing__user__home_state_latest
-  , subq_17.bookings
+  subq_14.metric_time__day
+  , subq_14.listing__user__home_state_latest
+  , subq_14.bookings
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_16.metric_time__day
-    , subq_16.listing__user__home_state_latest
-    , subq_16.__bookings AS bookings
+    subq_13.metric_time__day
+    , subq_13.listing__user__home_state_latest
+    , subq_13.__bookings AS bookings
   FROM (
     -- Aggregate Inputs for Simple Metrics
     SELECT
-      subq_15.metric_time__day
-      , subq_15.listing__user__home_state_latest
-      , SUM(subq_15.__bookings) AS __bookings
+      subq_12.metric_time__day
+      , subq_12.listing__user__home_state_latest
+      , SUM(subq_12.__bookings) AS __bookings
     FROM (
       -- Select: ['__bookings', 'listing__user__home_state_latest', 'metric_time__day']
       SELECT
-        subq_14.metric_time__day
-        , subq_14.listing__user__home_state_latest
-        , subq_14.__bookings
+        subq_11.metric_time__day
+        , subq_11.listing__user__home_state_latest
+        , subq_11.__bookings
       FROM (
         -- Select: ['__bookings', 'listing__user__home_state_latest', 'metric_time__day']
         SELECT
-          subq_13.metric_time__day
-          , subq_13.listing__user__home_state_latest
-          , subq_13.__bookings
+          subq_10.metric_time__day
+          , subq_10.listing__user__home_state_latest
+          , subq_10.__bookings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_12.user__home_state_latest AS listing__user__home_state_latest
-            , subq_12.window_start__day AS listing__window_start__day
-            , subq_12.window_end__day AS listing__window_end__day
-            , subq_7.ds__day AS ds__day
-            , subq_7.ds__week AS ds__week
-            , subq_7.ds__month AS ds__month
-            , subq_7.ds__quarter AS ds__quarter
-            , subq_7.ds__year AS ds__year
-            , subq_7.ds__extract_year AS ds__extract_year
-            , subq_7.ds__extract_quarter AS ds__extract_quarter
-            , subq_7.ds__extract_month AS ds__extract_month
-            , subq_7.ds__extract_day AS ds__extract_day
-            , subq_7.ds__extract_dow AS ds__extract_dow
-            , subq_7.ds__extract_doy AS ds__extract_doy
-            , subq_7.ds_partitioned__day AS ds_partitioned__day
-            , subq_7.ds_partitioned__week AS ds_partitioned__week
-            , subq_7.ds_partitioned__month AS ds_partitioned__month
-            , subq_7.ds_partitioned__quarter AS ds_partitioned__quarter
-            , subq_7.ds_partitioned__year AS ds_partitioned__year
-            , subq_7.ds_partitioned__extract_year AS ds_partitioned__extract_year
-            , subq_7.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
-            , subq_7.ds_partitioned__extract_month AS ds_partitioned__extract_month
-            , subq_7.ds_partitioned__extract_day AS ds_partitioned__extract_day
-            , subq_7.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
-            , subq_7.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
-            , subq_7.paid_at__day AS paid_at__day
-            , subq_7.paid_at__week AS paid_at__week
-            , subq_7.paid_at__month AS paid_at__month
-            , subq_7.paid_at__quarter AS paid_at__quarter
-            , subq_7.paid_at__year AS paid_at__year
-            , subq_7.paid_at__extract_year AS paid_at__extract_year
-            , subq_7.paid_at__extract_quarter AS paid_at__extract_quarter
-            , subq_7.paid_at__extract_month AS paid_at__extract_month
-            , subq_7.paid_at__extract_day AS paid_at__extract_day
-            , subq_7.paid_at__extract_dow AS paid_at__extract_dow
-            , subq_7.paid_at__extract_doy AS paid_at__extract_doy
-            , subq_7.booking__ds__day AS booking__ds__day
-            , subq_7.booking__ds__week AS booking__ds__week
-            , subq_7.booking__ds__month AS booking__ds__month
-            , subq_7.booking__ds__quarter AS booking__ds__quarter
-            , subq_7.booking__ds__year AS booking__ds__year
-            , subq_7.booking__ds__extract_year AS booking__ds__extract_year
-            , subq_7.booking__ds__extract_quarter AS booking__ds__extract_quarter
-            , subq_7.booking__ds__extract_month AS booking__ds__extract_month
-            , subq_7.booking__ds__extract_day AS booking__ds__extract_day
-            , subq_7.booking__ds__extract_dow AS booking__ds__extract_dow
-            , subq_7.booking__ds__extract_doy AS booking__ds__extract_doy
-            , subq_7.booking__ds_partitioned__day AS booking__ds_partitioned__day
-            , subq_7.booking__ds_partitioned__week AS booking__ds_partitioned__week
-            , subq_7.booking__ds_partitioned__month AS booking__ds_partitioned__month
-            , subq_7.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
-            , subq_7.booking__ds_partitioned__year AS booking__ds_partitioned__year
-            , subq_7.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
-            , subq_7.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
-            , subq_7.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
-            , subq_7.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
-            , subq_7.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
-            , subq_7.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
-            , subq_7.booking__paid_at__day AS booking__paid_at__day
-            , subq_7.booking__paid_at__week AS booking__paid_at__week
-            , subq_7.booking__paid_at__month AS booking__paid_at__month
-            , subq_7.booking__paid_at__quarter AS booking__paid_at__quarter
-            , subq_7.booking__paid_at__year AS booking__paid_at__year
-            , subq_7.booking__paid_at__extract_year AS booking__paid_at__extract_year
-            , subq_7.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
-            , subq_7.booking__paid_at__extract_month AS booking__paid_at__extract_month
-            , subq_7.booking__paid_at__extract_day AS booking__paid_at__extract_day
-            , subq_7.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
-            , subq_7.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
-            , subq_7.metric_time__day AS metric_time__day
-            , subq_7.metric_time__week AS metric_time__week
-            , subq_7.metric_time__month AS metric_time__month
-            , subq_7.metric_time__quarter AS metric_time__quarter
-            , subq_7.metric_time__year AS metric_time__year
-            , subq_7.metric_time__extract_year AS metric_time__extract_year
-            , subq_7.metric_time__extract_quarter AS metric_time__extract_quarter
-            , subq_7.metric_time__extract_month AS metric_time__extract_month
-            , subq_7.metric_time__extract_day AS metric_time__extract_day
-            , subq_7.metric_time__extract_dow AS metric_time__extract_dow
-            , subq_7.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_7.listing AS listing
-            , subq_7.guest AS guest
-            , subq_7.host AS host
-            , subq_7.user AS user
-            , subq_7.booking__listing AS booking__listing
-            , subq_7.booking__guest AS booking__guest
-            , subq_7.booking__host AS booking__host
-            , subq_7.booking__user AS booking__user
-            , subq_7.is_instant AS is_instant
-            , subq_7.booking__is_instant AS booking__is_instant
-            , subq_7.__bookings AS __bookings
-            , subq_7.__family_bookings AS __family_bookings
-            , subq_7.__potentially_lux_bookings AS __potentially_lux_bookings
+            subq_9.user__home_state_latest AS listing__user__home_state_latest
+            , subq_9.window_start__day AS listing__window_start__day
+            , subq_9.window_end__day AS listing__window_end__day
+            , subq_4.ds__day AS ds__day
+            , subq_4.ds__week AS ds__week
+            , subq_4.ds__month AS ds__month
+            , subq_4.ds__quarter AS ds__quarter
+            , subq_4.ds__year AS ds__year
+            , subq_4.ds__extract_year AS ds__extract_year
+            , subq_4.ds__extract_quarter AS ds__extract_quarter
+            , subq_4.ds__extract_month AS ds__extract_month
+            , subq_4.ds__extract_day AS ds__extract_day
+            , subq_4.ds__extract_dow AS ds__extract_dow
+            , subq_4.ds__extract_doy AS ds__extract_doy
+            , subq_4.ds_partitioned__day AS ds_partitioned__day
+            , subq_4.ds_partitioned__week AS ds_partitioned__week
+            , subq_4.ds_partitioned__month AS ds_partitioned__month
+            , subq_4.ds_partitioned__quarter AS ds_partitioned__quarter
+            , subq_4.ds_partitioned__year AS ds_partitioned__year
+            , subq_4.ds_partitioned__extract_year AS ds_partitioned__extract_year
+            , subq_4.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+            , subq_4.ds_partitioned__extract_month AS ds_partitioned__extract_month
+            , subq_4.ds_partitioned__extract_day AS ds_partitioned__extract_day
+            , subq_4.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+            , subq_4.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+            , subq_4.paid_at__day AS paid_at__day
+            , subq_4.paid_at__week AS paid_at__week
+            , subq_4.paid_at__month AS paid_at__month
+            , subq_4.paid_at__quarter AS paid_at__quarter
+            , subq_4.paid_at__year AS paid_at__year
+            , subq_4.paid_at__extract_year AS paid_at__extract_year
+            , subq_4.paid_at__extract_quarter AS paid_at__extract_quarter
+            , subq_4.paid_at__extract_month AS paid_at__extract_month
+            , subq_4.paid_at__extract_day AS paid_at__extract_day
+            , subq_4.paid_at__extract_dow AS paid_at__extract_dow
+            , subq_4.paid_at__extract_doy AS paid_at__extract_doy
+            , subq_4.booking__ds__day AS booking__ds__day
+            , subq_4.booking__ds__week AS booking__ds__week
+            , subq_4.booking__ds__month AS booking__ds__month
+            , subq_4.booking__ds__quarter AS booking__ds__quarter
+            , subq_4.booking__ds__year AS booking__ds__year
+            , subq_4.booking__ds__extract_year AS booking__ds__extract_year
+            , subq_4.booking__ds__extract_quarter AS booking__ds__extract_quarter
+            , subq_4.booking__ds__extract_month AS booking__ds__extract_month
+            , subq_4.booking__ds__extract_day AS booking__ds__extract_day
+            , subq_4.booking__ds__extract_dow AS booking__ds__extract_dow
+            , subq_4.booking__ds__extract_doy AS booking__ds__extract_doy
+            , subq_4.booking__ds_partitioned__day AS booking__ds_partitioned__day
+            , subq_4.booking__ds_partitioned__week AS booking__ds_partitioned__week
+            , subq_4.booking__ds_partitioned__month AS booking__ds_partitioned__month
+            , subq_4.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+            , subq_4.booking__ds_partitioned__year AS booking__ds_partitioned__year
+            , subq_4.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+            , subq_4.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+            , subq_4.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+            , subq_4.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+            , subq_4.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+            , subq_4.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+            , subq_4.booking__paid_at__day AS booking__paid_at__day
+            , subq_4.booking__paid_at__week AS booking__paid_at__week
+            , subq_4.booking__paid_at__month AS booking__paid_at__month
+            , subq_4.booking__paid_at__quarter AS booking__paid_at__quarter
+            , subq_4.booking__paid_at__year AS booking__paid_at__year
+            , subq_4.booking__paid_at__extract_year AS booking__paid_at__extract_year
+            , subq_4.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+            , subq_4.booking__paid_at__extract_month AS booking__paid_at__extract_month
+            , subq_4.booking__paid_at__extract_day AS booking__paid_at__extract_day
+            , subq_4.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+            , subq_4.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_4.metric_time__day AS metric_time__day
+            , subq_4.metric_time__week AS metric_time__week
+            , subq_4.metric_time__month AS metric_time__month
+            , subq_4.metric_time__quarter AS metric_time__quarter
+            , subq_4.metric_time__year AS metric_time__year
+            , subq_4.metric_time__extract_year AS metric_time__extract_year
+            , subq_4.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_4.metric_time__extract_month AS metric_time__extract_month
+            , subq_4.metric_time__extract_day AS metric_time__extract_day
+            , subq_4.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_4.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_4.listing AS listing
+            , subq_4.guest AS guest
+            , subq_4.host AS host
+            , subq_4.booking__listing AS booking__listing
+            , subq_4.booking__guest AS booking__guest
+            , subq_4.booking__host AS booking__host
+            , subq_4.is_instant AS is_instant
+            , subq_4.booking__is_instant AS booking__is_instant
+            , subq_4.__bookings AS __bookings
+            , subq_4.__family_bookings AS __family_bookings
+            , subq_4.__potentially_lux_bookings AS __potentially_lux_bookings
           FROM (
             -- Metric Time Dimension 'ds'
             SELECT
-              subq_6.ds__day
-              , subq_6.ds__week
-              , subq_6.ds__month
-              , subq_6.ds__quarter
-              , subq_6.ds__year
-              , subq_6.ds__extract_year
-              , subq_6.ds__extract_quarter
-              , subq_6.ds__extract_month
-              , subq_6.ds__extract_day
-              , subq_6.ds__extract_dow
-              , subq_6.ds__extract_doy
-              , subq_6.ds_partitioned__day
-              , subq_6.ds_partitioned__week
-              , subq_6.ds_partitioned__month
-              , subq_6.ds_partitioned__quarter
-              , subq_6.ds_partitioned__year
-              , subq_6.ds_partitioned__extract_year
-              , subq_6.ds_partitioned__extract_quarter
-              , subq_6.ds_partitioned__extract_month
-              , subq_6.ds_partitioned__extract_day
-              , subq_6.ds_partitioned__extract_dow
-              , subq_6.ds_partitioned__extract_doy
-              , subq_6.paid_at__day
-              , subq_6.paid_at__week
-              , subq_6.paid_at__month
-              , subq_6.paid_at__quarter
-              , subq_6.paid_at__year
-              , subq_6.paid_at__extract_year
-              , subq_6.paid_at__extract_quarter
-              , subq_6.paid_at__extract_month
-              , subq_6.paid_at__extract_day
-              , subq_6.paid_at__extract_dow
-              , subq_6.paid_at__extract_doy
-              , subq_6.booking__ds__day
-              , subq_6.booking__ds__week
-              , subq_6.booking__ds__month
-              , subq_6.booking__ds__quarter
-              , subq_6.booking__ds__year
-              , subq_6.booking__ds__extract_year
-              , subq_6.booking__ds__extract_quarter
-              , subq_6.booking__ds__extract_month
-              , subq_6.booking__ds__extract_day
-              , subq_6.booking__ds__extract_dow
-              , subq_6.booking__ds__extract_doy
-              , subq_6.booking__ds_partitioned__day
-              , subq_6.booking__ds_partitioned__week
-              , subq_6.booking__ds_partitioned__month
-              , subq_6.booking__ds_partitioned__quarter
-              , subq_6.booking__ds_partitioned__year
-              , subq_6.booking__ds_partitioned__extract_year
-              , subq_6.booking__ds_partitioned__extract_quarter
-              , subq_6.booking__ds_partitioned__extract_month
-              , subq_6.booking__ds_partitioned__extract_day
-              , subq_6.booking__ds_partitioned__extract_dow
-              , subq_6.booking__ds_partitioned__extract_doy
-              , subq_6.booking__paid_at__day
-              , subq_6.booking__paid_at__week
-              , subq_6.booking__paid_at__month
-              , subq_6.booking__paid_at__quarter
-              , subq_6.booking__paid_at__year
-              , subq_6.booking__paid_at__extract_year
-              , subq_6.booking__paid_at__extract_quarter
-              , subq_6.booking__paid_at__extract_month
-              , subq_6.booking__paid_at__extract_day
-              , subq_6.booking__paid_at__extract_dow
-              , subq_6.booking__paid_at__extract_doy
-              , subq_6.ds__day AS metric_time__day
-              , subq_6.ds__week AS metric_time__week
-              , subq_6.ds__month AS metric_time__month
-              , subq_6.ds__quarter AS metric_time__quarter
-              , subq_6.ds__year AS metric_time__year
-              , subq_6.ds__extract_year AS metric_time__extract_year
-              , subq_6.ds__extract_quarter AS metric_time__extract_quarter
-              , subq_6.ds__extract_month AS metric_time__extract_month
-              , subq_6.ds__extract_day AS metric_time__extract_day
-              , subq_6.ds__extract_dow AS metric_time__extract_dow
-              , subq_6.ds__extract_doy AS metric_time__extract_doy
-              , subq_6.listing
-              , subq_6.guest
-              , subq_6.host
-              , subq_6.user
-              , subq_6.booking__listing
-              , subq_6.booking__guest
-              , subq_6.booking__host
-              , subq_6.booking__user
-              , subq_6.is_instant
-              , subq_6.booking__is_instant
-              , subq_6.__bookings
-              , subq_6.__family_bookings
-              , subq_6.__potentially_lux_bookings
+              subq_3.ds__day
+              , subq_3.ds__week
+              , subq_3.ds__month
+              , subq_3.ds__quarter
+              , subq_3.ds__year
+              , subq_3.ds__extract_year
+              , subq_3.ds__extract_quarter
+              , subq_3.ds__extract_month
+              , subq_3.ds__extract_day
+              , subq_3.ds__extract_dow
+              , subq_3.ds__extract_doy
+              , subq_3.ds_partitioned__day
+              , subq_3.ds_partitioned__week
+              , subq_3.ds_partitioned__month
+              , subq_3.ds_partitioned__quarter
+              , subq_3.ds_partitioned__year
+              , subq_3.ds_partitioned__extract_year
+              , subq_3.ds_partitioned__extract_quarter
+              , subq_3.ds_partitioned__extract_month
+              , subq_3.ds_partitioned__extract_day
+              , subq_3.ds_partitioned__extract_dow
+              , subq_3.ds_partitioned__extract_doy
+              , subq_3.paid_at__day
+              , subq_3.paid_at__week
+              , subq_3.paid_at__month
+              , subq_3.paid_at__quarter
+              , subq_3.paid_at__year
+              , subq_3.paid_at__extract_year
+              , subq_3.paid_at__extract_quarter
+              , subq_3.paid_at__extract_month
+              , subq_3.paid_at__extract_day
+              , subq_3.paid_at__extract_dow
+              , subq_3.paid_at__extract_doy
+              , subq_3.booking__ds__day
+              , subq_3.booking__ds__week
+              , subq_3.booking__ds__month
+              , subq_3.booking__ds__quarter
+              , subq_3.booking__ds__year
+              , subq_3.booking__ds__extract_year
+              , subq_3.booking__ds__extract_quarter
+              , subq_3.booking__ds__extract_month
+              , subq_3.booking__ds__extract_day
+              , subq_3.booking__ds__extract_dow
+              , subq_3.booking__ds__extract_doy
+              , subq_3.booking__ds_partitioned__day
+              , subq_3.booking__ds_partitioned__week
+              , subq_3.booking__ds_partitioned__month
+              , subq_3.booking__ds_partitioned__quarter
+              , subq_3.booking__ds_partitioned__year
+              , subq_3.booking__ds_partitioned__extract_year
+              , subq_3.booking__ds_partitioned__extract_quarter
+              , subq_3.booking__ds_partitioned__extract_month
+              , subq_3.booking__ds_partitioned__extract_day
+              , subq_3.booking__ds_partitioned__extract_dow
+              , subq_3.booking__ds_partitioned__extract_doy
+              , subq_3.booking__paid_at__day
+              , subq_3.booking__paid_at__week
+              , subq_3.booking__paid_at__month
+              , subq_3.booking__paid_at__quarter
+              , subq_3.booking__paid_at__year
+              , subq_3.booking__paid_at__extract_year
+              , subq_3.booking__paid_at__extract_quarter
+              , subq_3.booking__paid_at__extract_month
+              , subq_3.booking__paid_at__extract_day
+              , subq_3.booking__paid_at__extract_dow
+              , subq_3.booking__paid_at__extract_doy
+              , subq_3.ds__day AS metric_time__day
+              , subq_3.ds__week AS metric_time__week
+              , subq_3.ds__month AS metric_time__month
+              , subq_3.ds__quarter AS metric_time__quarter
+              , subq_3.ds__year AS metric_time__year
+              , subq_3.ds__extract_year AS metric_time__extract_year
+              , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_3.ds__extract_month AS metric_time__extract_month
+              , subq_3.ds__extract_day AS metric_time__extract_day
+              , subq_3.ds__extract_dow AS metric_time__extract_dow
+              , subq_3.ds__extract_doy AS metric_time__extract_doy
+              , subq_3.listing
+              , subq_3.guest
+              , subq_3.host
+              , subq_3.booking__listing
+              , subq_3.booking__guest
+              , subq_3.booking__host
+              , subq_3.is_instant
+              , subq_3.booking__is_instant
+              , subq_3.__bookings
+              , subq_3.__family_bookings
+              , subq_3.__potentially_lux_bookings
             FROM (
               -- Read Elements From Semantic Model 'bookings_source'
               SELECT
@@ -299,89 +295,87 @@ FROM (
                 , bookings_source_src_26000.listing_id AS listing
                 , bookings_source_src_26000.guest_id AS guest
                 , bookings_source_src_26000.host_id AS host
-                , bookings_source_src_26000.guest_id AS user
                 , bookings_source_src_26000.listing_id AS booking__listing
                 , bookings_source_src_26000.guest_id AS booking__guest
                 , bookings_source_src_26000.host_id AS booking__host
-                , bookings_source_src_26000.guest_id AS booking__user
               FROM ***************************.fct_bookings bookings_source_src_26000
-            ) subq_6
-          ) subq_7
+            ) subq_3
+          ) subq_4
           LEFT OUTER JOIN (
             -- Select: ['user__home_state_latest', 'window_start__day', 'window_end__day', 'listing']
             SELECT
-              subq_11.window_start__day
-              , subq_11.window_end__day
-              , subq_11.listing
-              , subq_11.user__home_state_latest
+              subq_8.window_start__day
+              , subq_8.window_end__day
+              , subq_8.listing
+              , subq_8.user__home_state_latest
             FROM (
               -- Join Standard Outputs
               SELECT
-                subq_10.home_state_latest AS user__home_state_latest
-                , subq_10.ds__day AS user__ds__day
-                , subq_10.ds__week AS user__ds__week
-                , subq_10.ds__month AS user__ds__month
-                , subq_10.ds__quarter AS user__ds__quarter
-                , subq_10.ds__year AS user__ds__year
-                , subq_10.ds__extract_year AS user__ds__extract_year
-                , subq_10.ds__extract_quarter AS user__ds__extract_quarter
-                , subq_10.ds__extract_month AS user__ds__extract_month
-                , subq_10.ds__extract_day AS user__ds__extract_day
-                , subq_10.ds__extract_dow AS user__ds__extract_dow
-                , subq_10.ds__extract_doy AS user__ds__extract_doy
-                , subq_8.window_start__day AS window_start__day
-                , subq_8.window_start__week AS window_start__week
-                , subq_8.window_start__month AS window_start__month
-                , subq_8.window_start__quarter AS window_start__quarter
-                , subq_8.window_start__year AS window_start__year
-                , subq_8.window_start__extract_year AS window_start__extract_year
-                , subq_8.window_start__extract_quarter AS window_start__extract_quarter
-                , subq_8.window_start__extract_month AS window_start__extract_month
-                , subq_8.window_start__extract_day AS window_start__extract_day
-                , subq_8.window_start__extract_dow AS window_start__extract_dow
-                , subq_8.window_start__extract_doy AS window_start__extract_doy
-                , subq_8.window_end__day AS window_end__day
-                , subq_8.window_end__week AS window_end__week
-                , subq_8.window_end__month AS window_end__month
-                , subq_8.window_end__quarter AS window_end__quarter
-                , subq_8.window_end__year AS window_end__year
-                , subq_8.window_end__extract_year AS window_end__extract_year
-                , subq_8.window_end__extract_quarter AS window_end__extract_quarter
-                , subq_8.window_end__extract_month AS window_end__extract_month
-                , subq_8.window_end__extract_day AS window_end__extract_day
-                , subq_8.window_end__extract_dow AS window_end__extract_dow
-                , subq_8.window_end__extract_doy AS window_end__extract_doy
-                , subq_8.listing__window_start__day AS listing__window_start__day
-                , subq_8.listing__window_start__week AS listing__window_start__week
-                , subq_8.listing__window_start__month AS listing__window_start__month
-                , subq_8.listing__window_start__quarter AS listing__window_start__quarter
-                , subq_8.listing__window_start__year AS listing__window_start__year
-                , subq_8.listing__window_start__extract_year AS listing__window_start__extract_year
-                , subq_8.listing__window_start__extract_quarter AS listing__window_start__extract_quarter
-                , subq_8.listing__window_start__extract_month AS listing__window_start__extract_month
-                , subq_8.listing__window_start__extract_day AS listing__window_start__extract_day
-                , subq_8.listing__window_start__extract_dow AS listing__window_start__extract_dow
-                , subq_8.listing__window_start__extract_doy AS listing__window_start__extract_doy
-                , subq_8.listing__window_end__day AS listing__window_end__day
-                , subq_8.listing__window_end__week AS listing__window_end__week
-                , subq_8.listing__window_end__month AS listing__window_end__month
-                , subq_8.listing__window_end__quarter AS listing__window_end__quarter
-                , subq_8.listing__window_end__year AS listing__window_end__year
-                , subq_8.listing__window_end__extract_year AS listing__window_end__extract_year
-                , subq_8.listing__window_end__extract_quarter AS listing__window_end__extract_quarter
-                , subq_8.listing__window_end__extract_month AS listing__window_end__extract_month
-                , subq_8.listing__window_end__extract_day AS listing__window_end__extract_day
-                , subq_8.listing__window_end__extract_dow AS listing__window_end__extract_dow
-                , subq_8.listing__window_end__extract_doy AS listing__window_end__extract_doy
-                , subq_8.listing AS listing
-                , subq_8.user AS user
-                , subq_8.listing__user AS listing__user
-                , subq_8.country AS country
-                , subq_8.is_lux AS is_lux
-                , subq_8.capacity AS capacity
-                , subq_8.listing__country AS listing__country
-                , subq_8.listing__is_lux AS listing__is_lux
-                , subq_8.listing__capacity AS listing__capacity
+                subq_7.home_state_latest AS user__home_state_latest
+                , subq_7.ds__day AS user__ds__day
+                , subq_7.ds__week AS user__ds__week
+                , subq_7.ds__month AS user__ds__month
+                , subq_7.ds__quarter AS user__ds__quarter
+                , subq_7.ds__year AS user__ds__year
+                , subq_7.ds__extract_year AS user__ds__extract_year
+                , subq_7.ds__extract_quarter AS user__ds__extract_quarter
+                , subq_7.ds__extract_month AS user__ds__extract_month
+                , subq_7.ds__extract_day AS user__ds__extract_day
+                , subq_7.ds__extract_dow AS user__ds__extract_dow
+                , subq_7.ds__extract_doy AS user__ds__extract_doy
+                , subq_5.window_start__day AS window_start__day
+                , subq_5.window_start__week AS window_start__week
+                , subq_5.window_start__month AS window_start__month
+                , subq_5.window_start__quarter AS window_start__quarter
+                , subq_5.window_start__year AS window_start__year
+                , subq_5.window_start__extract_year AS window_start__extract_year
+                , subq_5.window_start__extract_quarter AS window_start__extract_quarter
+                , subq_5.window_start__extract_month AS window_start__extract_month
+                , subq_5.window_start__extract_day AS window_start__extract_day
+                , subq_5.window_start__extract_dow AS window_start__extract_dow
+                , subq_5.window_start__extract_doy AS window_start__extract_doy
+                , subq_5.window_end__day AS window_end__day
+                , subq_5.window_end__week AS window_end__week
+                , subq_5.window_end__month AS window_end__month
+                , subq_5.window_end__quarter AS window_end__quarter
+                , subq_5.window_end__year AS window_end__year
+                , subq_5.window_end__extract_year AS window_end__extract_year
+                , subq_5.window_end__extract_quarter AS window_end__extract_quarter
+                , subq_5.window_end__extract_month AS window_end__extract_month
+                , subq_5.window_end__extract_day AS window_end__extract_day
+                , subq_5.window_end__extract_dow AS window_end__extract_dow
+                , subq_5.window_end__extract_doy AS window_end__extract_doy
+                , subq_5.listing__window_start__day AS listing__window_start__day
+                , subq_5.listing__window_start__week AS listing__window_start__week
+                , subq_5.listing__window_start__month AS listing__window_start__month
+                , subq_5.listing__window_start__quarter AS listing__window_start__quarter
+                , subq_5.listing__window_start__year AS listing__window_start__year
+                , subq_5.listing__window_start__extract_year AS listing__window_start__extract_year
+                , subq_5.listing__window_start__extract_quarter AS listing__window_start__extract_quarter
+                , subq_5.listing__window_start__extract_month AS listing__window_start__extract_month
+                , subq_5.listing__window_start__extract_day AS listing__window_start__extract_day
+                , subq_5.listing__window_start__extract_dow AS listing__window_start__extract_dow
+                , subq_5.listing__window_start__extract_doy AS listing__window_start__extract_doy
+                , subq_5.listing__window_end__day AS listing__window_end__day
+                , subq_5.listing__window_end__week AS listing__window_end__week
+                , subq_5.listing__window_end__month AS listing__window_end__month
+                , subq_5.listing__window_end__quarter AS listing__window_end__quarter
+                , subq_5.listing__window_end__year AS listing__window_end__year
+                , subq_5.listing__window_end__extract_year AS listing__window_end__extract_year
+                , subq_5.listing__window_end__extract_quarter AS listing__window_end__extract_quarter
+                , subq_5.listing__window_end__extract_month AS listing__window_end__extract_month
+                , subq_5.listing__window_end__extract_day AS listing__window_end__extract_day
+                , subq_5.listing__window_end__extract_dow AS listing__window_end__extract_dow
+                , subq_5.listing__window_end__extract_doy AS listing__window_end__extract_doy
+                , subq_5.listing AS listing
+                , subq_5.user AS user
+                , subq_5.listing__user AS listing__user
+                , subq_5.country AS country
+                , subq_5.is_lux AS is_lux
+                , subq_5.capacity AS capacity
+                , subq_5.listing__country AS listing__country
+                , subq_5.listing__is_lux AS listing__is_lux
+                , subq_5.listing__capacity AS listing__capacity
               FROM (
                 -- Read Elements From Semantic Model 'listings'
                 SELECT
@@ -439,7 +433,7 @@ FROM (
                   , listings_src_26000.user_id AS user
                   , listings_src_26000.user_id AS listing__user
                 FROM ***************************.dim_listings listings_src_26000
-              ) subq_8
+              ) subq_5
               LEFT OUTER JOIN (
                 -- Select: [
                 --   'home_state_latest',
@@ -469,31 +463,31 @@ FROM (
                 --   'user',
                 -- ]
                 SELECT
-                  subq_9.ds__day
-                  , subq_9.ds__week
-                  , subq_9.ds__month
-                  , subq_9.ds__quarter
-                  , subq_9.ds__year
-                  , subq_9.ds__extract_year
-                  , subq_9.ds__extract_quarter
-                  , subq_9.ds__extract_month
-                  , subq_9.ds__extract_day
-                  , subq_9.ds__extract_dow
-                  , subq_9.ds__extract_doy
-                  , subq_9.user__ds__day
-                  , subq_9.user__ds__week
-                  , subq_9.user__ds__month
-                  , subq_9.user__ds__quarter
-                  , subq_9.user__ds__year
-                  , subq_9.user__ds__extract_year
-                  , subq_9.user__ds__extract_quarter
-                  , subq_9.user__ds__extract_month
-                  , subq_9.user__ds__extract_day
-                  , subq_9.user__ds__extract_dow
-                  , subq_9.user__ds__extract_doy
-                  , subq_9.user
-                  , subq_9.home_state_latest
-                  , subq_9.user__home_state_latest
+                  subq_6.ds__day
+                  , subq_6.ds__week
+                  , subq_6.ds__month
+                  , subq_6.ds__quarter
+                  , subq_6.ds__year
+                  , subq_6.ds__extract_year
+                  , subq_6.ds__extract_quarter
+                  , subq_6.ds__extract_month
+                  , subq_6.ds__extract_day
+                  , subq_6.ds__extract_dow
+                  , subq_6.ds__extract_doy
+                  , subq_6.user__ds__day
+                  , subq_6.user__ds__week
+                  , subq_6.user__ds__month
+                  , subq_6.user__ds__quarter
+                  , subq_6.user__ds__year
+                  , subq_6.user__ds__extract_year
+                  , subq_6.user__ds__extract_quarter
+                  , subq_6.user__ds__extract_month
+                  , subq_6.user__ds__extract_day
+                  , subq_6.user__ds__extract_dow
+                  , subq_6.user__ds__extract_doy
+                  , subq_6.user
+                  , subq_6.home_state_latest
+                  , subq_6.user__home_state_latest
                 FROM (
                   -- Read Elements From Semantic Model 'users_latest'
                   SELECT
@@ -523,31 +517,31 @@ FROM (
                     , users_latest_src_26000.home_state_latest AS user__home_state_latest
                     , users_latest_src_26000.user_id AS user
                   FROM ***************************.dim_users_latest users_latest_src_26000
-                ) subq_9
-              ) subq_10
+                ) subq_6
+              ) subq_7
               ON
-                subq_8.user = subq_10.user
-            ) subq_11
-          ) subq_12
+                subq_5.user = subq_7.user
+            ) subq_8
+          ) subq_9
           ON
             (
-              subq_7.listing = subq_12.listing
+              subq_4.listing = subq_9.listing
             ) AND (
               (
-                subq_7.metric_time__day >= subq_12.window_start__day
+                subq_4.metric_time__day >= subq_9.window_start__day
               ) AND (
                 (
-                  subq_7.metric_time__day < subq_12.window_end__day
+                  subq_4.metric_time__day < subq_9.window_end__day
                 ) OR (
-                  subq_12.window_end__day IS NULL
+                  subq_9.window_end__day IS NULL
                 )
               )
             )
-        ) subq_13
-      ) subq_14
-    ) subq_15
+        ) subq_10
+      ) subq_11
+    ) subq_12
     GROUP BY
-      subq_15.metric_time__day
-      , subq_15.listing__user__home_state_latest
-  ) subq_16
-) subq_17
+      subq_12.metric_time__day
+      , subq_12.listing__user__home_state_latest
+  ) subq_13
+) subq_14

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Postgres/test_multi_hop_through_scd_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Postgres/test_multi_hop_through_scd_dimension__plan0_optimized.sql
@@ -11,9 +11,9 @@ sql_engine: Postgres
 -- Compute Metrics via Expressions
 -- Write to DataTable
 SELECT
-  subq_25.metric_time__day AS metric_time__day
-  , subq_30.user__home_state_latest AS listing__user__home_state_latest
-  , SUM(subq_25.__bookings) AS bookings
+  subq_19.metric_time__day AS metric_time__day
+  , subq_24.user__home_state_latest AS listing__user__home_state_latest
+  , SUM(subq_19.__bookings) AS bookings
 FROM (
   -- Read Elements From Semantic Model 'bookings_source'
   -- Metric Time Dimension 'ds'
@@ -22,7 +22,7 @@ FROM (
     , listing_id AS listing
     , 1 AS __bookings
   FROM ***************************.fct_bookings bookings_source_src_26000
-) subq_25
+) subq_19
 LEFT OUTER JOIN (
   -- Join Standard Outputs
   -- Select: ['user__home_state_latest', 'window_start__day', 'window_end__day', 'listing']
@@ -36,21 +36,21 @@ LEFT OUTER JOIN (
     ***************************.dim_users_latest users_latest_src_26000
   ON
     listings_src_26000.user_id = users_latest_src_26000.user_id
-) subq_30
+) subq_24
 ON
   (
-    subq_25.listing = subq_30.listing
+    subq_19.listing = subq_24.listing
   ) AND (
     (
-      subq_25.metric_time__day >= subq_30.window_start__day
+      subq_19.metric_time__day >= subq_24.window_start__day
     ) AND (
       (
-        subq_25.metric_time__day < subq_30.window_end__day
+        subq_19.metric_time__day < subq_24.window_end__day
       ) OR (
-        subq_30.window_end__day IS NULL
+        subq_24.window_end__day IS NULL
       )
     )
   )
 GROUP BY
-  subq_25.metric_time__day
-  , subq_30.user__home_state_latest
+  subq_19.metric_time__day
+  , subq_24.user__home_state_latest

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Postgres/test_multi_hop_to_scd_dimension__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Postgres/test_multi_hop_to_scd_dimension__plan0.sql
@@ -119,11 +119,9 @@ FROM (
             , subq_4.listing AS listing
             , subq_4.guest AS guest
             , subq_4.host AS host
-            , subq_4.user AS user
             , subq_4.booking__listing AS booking__listing
             , subq_4.booking__guest AS booking__guest
             , subq_4.booking__host AS booking__host
-            , subq_4.booking__user AS booking__user
             , subq_4.is_instant AS is_instant
             , subq_4.booking__is_instant AS booking__is_instant
             , subq_4.__bookings AS __bookings
@@ -212,11 +210,9 @@ FROM (
               , subq_3.listing
               , subq_3.guest
               , subq_3.host
-              , subq_3.user
               , subq_3.booking__listing
               , subq_3.booking__guest
               , subq_3.booking__host
-              , subq_3.booking__user
               , subq_3.is_instant
               , subq_3.booking__is_instant
               , subq_3.__bookings
@@ -299,11 +295,9 @@ FROM (
                 , bookings_source_src_26000.listing_id AS listing
                 , bookings_source_src_26000.guest_id AS guest
                 , bookings_source_src_26000.host_id AS host
-                , bookings_source_src_26000.guest_id AS user
                 , bookings_source_src_26000.listing_id AS booking__listing
                 , bookings_source_src_26000.guest_id AS booking__guest
                 , bookings_source_src_26000.host_id AS booking__host
-                , bookings_source_src_26000.guest_id AS booking__user
               FROM ***************************.fct_bookings bookings_source_src_26000
             ) subq_3
           ) subq_4

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Postgres/test_scd_dimension_filter_without_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Postgres/test_scd_dimension_filter_without_metric_time__plan0.sql
@@ -113,11 +113,9 @@ FROM (
               , subq_1.listing AS listing
               , subq_1.guest AS guest
               , subq_1.host AS host
-              , subq_1.user AS user
               , subq_1.booking__listing AS booking__listing
               , subq_1.booking__guest AS booking__guest
               , subq_1.booking__host AS booking__host
-              , subq_1.booking__user AS booking__user
               , subq_1.is_instant AS is_instant
               , subq_1.booking__is_instant AS booking__is_instant
               , subq_1.__bookings AS __bookings
@@ -206,11 +204,9 @@ FROM (
                 , subq_0.listing
                 , subq_0.guest
                 , subq_0.host
-                , subq_0.user
                 , subq_0.booking__listing
                 , subq_0.booking__guest
                 , subq_0.booking__host
-                , subq_0.booking__user
                 , subq_0.is_instant
                 , subq_0.booking__is_instant
                 , subq_0.__bookings
@@ -293,11 +289,9 @@ FROM (
                   , bookings_source_src_26000.listing_id AS listing
                   , bookings_source_src_26000.guest_id AS guest
                   , bookings_source_src_26000.host_id AS host
-                  , bookings_source_src_26000.guest_id AS user
                   , bookings_source_src_26000.listing_id AS booking__listing
                   , bookings_source_src_26000.guest_id AS booking__guest
                   , bookings_source_src_26000.host_id AS booking__host
-                  , bookings_source_src_26000.guest_id AS booking__user
                 FROM ***************************.fct_bookings bookings_source_src_26000
               ) subq_0
             ) subq_1

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Postgres/test_scd_dimension_group_by_without_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Postgres/test_scd_dimension_group_by_without_metric_time__plan0.sql
@@ -117,11 +117,9 @@ FROM (
               , subq_1.listing AS listing
               , subq_1.guest AS guest
               , subq_1.host AS host
-              , subq_1.user AS user
               , subq_1.booking__listing AS booking__listing
               , subq_1.booking__guest AS booking__guest
               , subq_1.booking__host AS booking__host
-              , subq_1.booking__user AS booking__user
               , subq_1.is_instant AS is_instant
               , subq_1.booking__is_instant AS booking__is_instant
               , subq_1.__bookings AS __bookings
@@ -210,11 +208,9 @@ FROM (
                 , subq_0.listing
                 , subq_0.guest
                 , subq_0.host
-                , subq_0.user
                 , subq_0.booking__listing
                 , subq_0.booking__guest
                 , subq_0.booking__host
-                , subq_0.booking__user
                 , subq_0.is_instant
                 , subq_0.booking__is_instant
                 , subq_0.__bookings
@@ -297,11 +293,9 @@ FROM (
                   , bookings_source_src_26000.listing_id AS listing
                   , bookings_source_src_26000.guest_id AS guest
                   , bookings_source_src_26000.host_id AS host
-                  , bookings_source_src_26000.guest_id AS user
                   , bookings_source_src_26000.listing_id AS booking__listing
                   , bookings_source_src_26000.guest_id AS booking__guest
                   , bookings_source_src_26000.host_id AS booking__host
-                  , bookings_source_src_26000.guest_id AS booking__user
                 FROM ***************************.fct_bookings bookings_source_src_26000
               ) subq_0
             ) subq_1

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Postgres/test_scd_group_by_and_coarser_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlPlan/Postgres/test_scd_group_by_and_coarser_grain__plan0.sql
@@ -123,11 +123,9 @@ FROM (
               , subq_1.listing AS listing
               , subq_1.guest AS guest
               , subq_1.host AS host
-              , subq_1.user AS user
               , subq_1.booking__listing AS booking__listing
               , subq_1.booking__guest AS booking__guest
               , subq_1.booking__host AS booking__host
-              , subq_1.booking__user AS booking__user
               , subq_1.is_instant AS is_instant
               , subq_1.booking__is_instant AS booking__is_instant
               , subq_1.__bookings AS __bookings
@@ -216,11 +214,9 @@ FROM (
                 , subq_0.listing
                 , subq_0.guest
                 , subq_0.host
-                , subq_0.user
                 , subq_0.booking__listing
                 , subq_0.booking__guest
                 , subq_0.booking__host
-                , subq_0.booking__user
                 , subq_0.is_instant
                 , subq_0.booking__is_instant
                 , subq_0.__bookings
@@ -303,11 +299,9 @@ FROM (
                   , bookings_source_src_26000.listing_id AS listing
                   , bookings_source_src_26000.guest_id AS guest
                   , bookings_source_src_26000.host_id AS host
-                  , bookings_source_src_26000.guest_id AS user
                   , bookings_source_src_26000.listing_id AS booking__listing
                   , bookings_source_src_26000.guest_id AS booking__guest
                   , bookings_source_src_26000.host_id AS booking__host
-                  , bookings_source_src_26000.guest_id AS booking__user
                 FROM ***************************.fct_bookings bookings_source_src_26000
               ) subq_0
             ) subq_1

--- a/tests_metricflow/validation/test_join_validator.py
+++ b/tests_metricflow/validation/test_join_validator.py
@@ -38,6 +38,15 @@ def test_natural_entity_instance_set_validation(
         semantic_model_lookup=scd_semantic_manifest_lookup.semantic_model_lookup
     )
 
+    # `is_valid_instance_set_join` takes a single shared entity reference for both sides (it doesn't support
+    # `role`-based joins, where the two sides differ) - `bookings_source` only reaches `user` via `guest`'s
+    # `role: user`, so the foreign<->natural cases below use `bookings_source`'s own `listing` entity against
+    # `listings`' natural-typed `listing` entity instead, which are still literally the same name on both sides.
+    natural_listing_instance_set = (
+        mf_engine_test_fixture_mapping[SemanticManifestSetup.SCD_MANIFEST].data_set_mapping["listings"].instance_set
+    )
+    listing_entity_reference = EntityReference(element_name="listing")
+
     # Valid cases
     natural_primary = join_evaluator.is_valid_instance_set_join(
         left_instance_set=natural_user_instance_set,
@@ -51,8 +60,8 @@ def test_natural_entity_instance_set_validation(
     )
     foreign_natural = join_evaluator.is_valid_instance_set_join(
         left_instance_set=foreign_user_instance_set,
-        right_instance_set=natural_user_instance_set,
-        on_entity_reference=user_entity_reference,
+        right_instance_set=natural_listing_instance_set,
+        on_entity_reference=listing_entity_reference,
     )
     primary_natural = join_evaluator.is_valid_instance_set_join(
         left_instance_set=primary_user_instance_set,
@@ -66,9 +75,9 @@ def test_natural_entity_instance_set_validation(
     )
     # Invalid cases
     natural_foreign = join_evaluator.is_valid_instance_set_join(
-        left_instance_set=natural_user_instance_set,
+        left_instance_set=natural_listing_instance_set,
         right_instance_set=foreign_user_instance_set,
-        on_entity_reference=user_entity_reference,
+        on_entity_reference=listing_entity_reference,
     )
     natural_natural = join_evaluator.is_valid_instance_set_join(
         left_instance_set=natural_user_instance_set,

--- a/tests_metricflow_semantics/model/semantics/test_semantic_model_join_evaluator.py
+++ b/tests_metricflow_semantics/model/semantics/test_semantic_model_join_evaluator.py
@@ -95,32 +95,38 @@ def test_distinct_target_semantic_model_join_validation(
     foreign_primary = join_evaluator.is_valid_semantic_model_join(
         left_semantic_model_reference=semantic_model_references[EntityType.FOREIGN],
         right_semantic_model_reference=semantic_model_references[EntityType.PRIMARY],
-        on_entity_reference=user_entity_reference,
+        left_entity_reference=user_entity_reference,
+        right_entity_reference=user_entity_reference,
     )
     primary_primary = join_evaluator.is_valid_semantic_model_join(
         left_semantic_model_reference=semantic_model_references[EntityType.PRIMARY],
         right_semantic_model_reference=semantic_model_references[EntityType.PRIMARY],
-        on_entity_reference=user_entity_reference,
+        left_entity_reference=user_entity_reference,
+        right_entity_reference=user_entity_reference,
     )
     unique_primary = join_evaluator.is_valid_semantic_model_join(
         left_semantic_model_reference=semantic_model_references[EntityType.UNIQUE],
         right_semantic_model_reference=semantic_model_references[EntityType.PRIMARY],
-        on_entity_reference=user_entity_reference,
+        left_entity_reference=user_entity_reference,
+        right_entity_reference=user_entity_reference,
     )
     foreign_unique = join_evaluator.is_valid_semantic_model_join(
         left_semantic_model_reference=semantic_model_references[EntityType.FOREIGN],
         right_semantic_model_reference=semantic_model_references[EntityType.UNIQUE],
-        on_entity_reference=user_entity_reference,
+        left_entity_reference=user_entity_reference,
+        right_entity_reference=user_entity_reference,
     )
     primary_unique = join_evaluator.is_valid_semantic_model_join(
         left_semantic_model_reference=semantic_model_references[EntityType.PRIMARY],
         right_semantic_model_reference=semantic_model_references[EntityType.UNIQUE],
-        on_entity_reference=user_entity_reference,
+        left_entity_reference=user_entity_reference,
+        right_entity_reference=user_entity_reference,
     )
     unique_unique = join_evaluator.is_valid_semantic_model_join(
         left_semantic_model_reference=semantic_model_references[EntityType.UNIQUE],
         right_semantic_model_reference=semantic_model_references[EntityType.UNIQUE],
-        on_entity_reference=user_entity_reference,
+        left_entity_reference=user_entity_reference,
+        right_entity_reference=user_entity_reference,
     )
 
     results = {
@@ -153,17 +159,20 @@ def test_foreign_target_semantic_model_join_validation(simple_semantic_manifest_
     foreign_foreign = join_evaluator.is_valid_semantic_model_join(
         left_semantic_model_reference=semantic_model_references[EntityType.FOREIGN],
         right_semantic_model_reference=semantic_model_references[EntityType.FOREIGN],
-        on_entity_reference=user_entity_reference,
+        left_entity_reference=user_entity_reference,
+        right_entity_reference=user_entity_reference,
     )
     primary_foreign = join_evaluator.is_valid_semantic_model_join(
         left_semantic_model_reference=semantic_model_references[EntityType.PRIMARY],
         right_semantic_model_reference=semantic_model_references[EntityType.FOREIGN],
-        on_entity_reference=user_entity_reference,
+        left_entity_reference=user_entity_reference,
+        right_entity_reference=user_entity_reference,
     )
     unique_foreign = join_evaluator.is_valid_semantic_model_join(
         left_semantic_model_reference=semantic_model_references[EntityType.UNIQUE],
         right_semantic_model_reference=semantic_model_references[EntityType.FOREIGN],
-        on_entity_reference=user_entity_reference,
+        left_entity_reference=user_entity_reference,
+        right_entity_reference=user_entity_reference,
     )
 
     results = {
@@ -197,7 +206,8 @@ def test_semantic_model_join_validation_on_missing_entity(
     assert not join_evaluator.is_valid_semantic_model_join(
         left_semantic_model_reference=no_listing_semantic_model.reference,
         right_semantic_model_reference=primary_listing_semantic_model.reference,
-        on_entity_reference=listing_entity_reference,
+        left_entity_reference=listing_entity_reference,
+        right_entity_reference=listing_entity_reference,
     ), (
         "Found valid join on `listing` involving the `id_verifications` semantic model, which does not include the "
         "`listing` entity!"
@@ -222,6 +232,9 @@ def test_natural_entity_semantic_model_validation(scd_semantic_manifest_lookup: 
         SemanticModelReference("companies")
     )
     user_entity_reference = EntityReference(element_name="user")
+    # `bookings_source` doesn't declare a literal `user` entity - it reaches the `user` entity via `guest`
+    # (`role: user`), so joins involving it as the foreign side use `guest`'s own reference.
+    guest_entity_reference = EntityReference(element_name="guest")
     join_evaluator = SemanticModelJoinEvaluator(
         semantic_model_lookup=scd_semantic_manifest_lookup.semantic_model_lookup
     )
@@ -235,38 +248,45 @@ def test_natural_entity_semantic_model_validation(scd_semantic_manifest_lookup: 
     natural_primary = join_evaluator.is_valid_semantic_model_join(
         left_semantic_model_reference=natural_user_semantic_model.reference,
         right_semantic_model_reference=primary_user_semantic_model.reference,
-        on_entity_reference=user_entity_reference,
+        left_entity_reference=user_entity_reference,
+        right_entity_reference=user_entity_reference,
     )
     natural_unique = join_evaluator.is_valid_semantic_model_join(
         left_semantic_model_reference=natural_user_semantic_model.reference,
         right_semantic_model_reference=unique_user_semantic_model.reference,
-        on_entity_reference=user_entity_reference,
+        left_entity_reference=user_entity_reference,
+        right_entity_reference=user_entity_reference,
     )
     foreign_natural = join_evaluator.is_valid_semantic_model_join(
         left_semantic_model_reference=foreign_user_semantic_model.reference,
         right_semantic_model_reference=natural_user_semantic_model.reference,
-        on_entity_reference=user_entity_reference,
+        left_entity_reference=guest_entity_reference,
+        right_entity_reference=user_entity_reference,
     )
     primary_natural = join_evaluator.is_valid_semantic_model_join(
         left_semantic_model_reference=primary_user_semantic_model.reference,
         right_semantic_model_reference=natural_user_semantic_model.reference,
-        on_entity_reference=user_entity_reference,
+        left_entity_reference=user_entity_reference,
+        right_entity_reference=user_entity_reference,
     )
     unique_natural = join_evaluator.is_valid_semantic_model_join(
         left_semantic_model_reference=unique_user_semantic_model.reference,
         right_semantic_model_reference=natural_user_semantic_model.reference,
-        on_entity_reference=user_entity_reference,
+        left_entity_reference=user_entity_reference,
+        right_entity_reference=user_entity_reference,
     )
     # Invalid cases
     natural_foreign = join_evaluator.is_valid_semantic_model_join(
         left_semantic_model_reference=natural_user_semantic_model.reference,
         right_semantic_model_reference=foreign_user_semantic_model.reference,
-        on_entity_reference=user_entity_reference,
+        left_entity_reference=user_entity_reference,
+        right_entity_reference=guest_entity_reference,
     )
     natural_natural = join_evaluator.is_valid_semantic_model_join(
         left_semantic_model_reference=natural_user_semantic_model.reference,
         right_semantic_model_reference=natural_user_semantic_model.reference,
-        on_entity_reference=user_entity_reference,
+        left_entity_reference=user_entity_reference,
+        right_entity_reference=user_entity_reference,
     )
 
     valid_joins = {

--- a/tests_metricflow_semantics/snapshots/test_manifest_object_lookup.py/ManifestObjectLookup/test_lookup_attributes__result.txt
+++ b/tests_metricflow_semantics/snapshots/test_manifest_object_lookup.py/ManifestObjectLookup/test_lookup_attributes__result.txt
@@ -11,44 +11,7 @@ ManifestObjectLookup(
       entity_lookup=EntityLookup(
         entity_name_to_type={'booking': PRIMARY, 'listing': FOREIGN},
         entity_type_to_names={PRIMARY: {'booking'}, FOREIGN: {'listing'}},
-        join_key_to_entities={
-          'booking': (
-            PydanticEntity(
-              name='booking',
-              type=PRIMARY,
-              metadata=PydanticMetadata(
-                repo_file_path='/Users/quigleymalcolm/Developer/dbt-labs/metricflow/metricflow_semantics/test_helpers/semantic_manifest_yamls/sg_02_single_join/manifest.yaml',
-                file_slice=PydanticFileSlice(
-                  filename='manifest.yaml',
-                  content=('name: '
-                   'booking\n'
-                   'type: '
-                   'primary\n'),
-                  start_line_number=14,
-                  end_line_number=15,
-                ),
-              ),
-            ),
-          ),
-          'listing': (
-            PydanticEntity(
-              name='listing',
-              type=FOREIGN,
-              metadata=PydanticMetadata(
-                repo_file_path='/Users/quigleymalcolm/Developer/dbt-labs/metricflow/metricflow_semantics/test_helpers/semantic_manifest_yamls/sg_02_single_join/manifest.yaml',
-                file_slice=PydanticFileSlice(
-                  filename='manifest.yaml',
-                  content=('name: '
-                   'listing\n'
-                   'type: '
-                   'foreign\n'),
-                  start_line_number=16,
-                  end_line_number=18,
-                ),
-              ),
-            ),
-          ),
-        },
+        join_key_to_entity_names={'booking': ('booking',), 'listing': ('listing',)},
       ),
       aggregation_configuration_to_simple_metric_inputs={
         SimpleMetricAggregationConfiguration(
@@ -62,26 +25,7 @@ ManifestObjectLookup(
       entity_lookup=EntityLookup(
         entity_name_to_type={'listing': PRIMARY},
         entity_type_to_names={PRIMARY: {'listing'}},
-        join_key_to_entities={
-          'listing': (
-            PydanticEntity(
-              name='listing',
-              type=PRIMARY,
-              metadata=PydanticMetadata(
-                repo_file_path='/Users/quigleymalcolm/Developer/dbt-labs/metricflow/metricflow_semantics/test_helpers/semantic_manifest_yamls/sg_02_single_join/manifest.yaml',
-                file_slice=PydanticFileSlice(
-                  filename='manifest.yaml',
-                  content=('name: '
-                   'listing\n'
-                   'type: '
-                   'primary\n'),
-                  start_line_number=39,
-                  end_line_number=41,
-                ),
-              ),
-            ),
-          ),
-        },
+        join_key_to_entity_names={'listing': ('listing',)},
       ),
     ),
   ),

--- a/tests_metricflow_semantics/snapshots/test_manifest_object_lookup.py/ManifestObjectLookup/test_lookup_attributes__result.txt
+++ b/tests_metricflow_semantics/snapshots/test_manifest_object_lookup.py/ManifestObjectLookup/test_lookup_attributes__result.txt
@@ -11,6 +11,44 @@ ManifestObjectLookup(
       entity_lookup=EntityLookup(
         entity_name_to_type={'booking': PRIMARY, 'listing': FOREIGN},
         entity_type_to_names={PRIMARY: {'booking'}, FOREIGN: {'listing'}},
+        join_key_to_entities={
+          'booking': (
+            PydanticEntity(
+              name='booking',
+              type=PRIMARY,
+              metadata=PydanticMetadata(
+                repo_file_path='/Users/quigleymalcolm/Developer/dbt-labs/metricflow/metricflow_semantics/test_helpers/semantic_manifest_yamls/sg_02_single_join/manifest.yaml',
+                file_slice=PydanticFileSlice(
+                  filename='manifest.yaml',
+                  content=('name: '
+                   'booking\n'
+                   'type: '
+                   'primary\n'),
+                  start_line_number=14,
+                  end_line_number=15,
+                ),
+              ),
+            ),
+          ),
+          'listing': (
+            PydanticEntity(
+              name='listing',
+              type=FOREIGN,
+              metadata=PydanticMetadata(
+                repo_file_path='/Users/quigleymalcolm/Developer/dbt-labs/metricflow/metricflow_semantics/test_helpers/semantic_manifest_yamls/sg_02_single_join/manifest.yaml',
+                file_slice=PydanticFileSlice(
+                  filename='manifest.yaml',
+                  content=('name: '
+                   'listing\n'
+                   'type: '
+                   'foreign\n'),
+                  start_line_number=16,
+                  end_line_number=18,
+                ),
+              ),
+            ),
+          ),
+        },
       ),
       aggregation_configuration_to_simple_metric_inputs={
         SimpleMetricAggregationConfiguration(
@@ -24,6 +62,26 @@ ManifestObjectLookup(
       entity_lookup=EntityLookup(
         entity_name_to_type={'listing': PRIMARY},
         entity_type_to_names={PRIMARY: {'listing'}},
+        join_key_to_entities={
+          'listing': (
+            PydanticEntity(
+              name='listing',
+              type=PRIMARY,
+              metadata=PydanticMetadata(
+                repo_file_path='/Users/quigleymalcolm/Developer/dbt-labs/metricflow/metricflow_semantics/test_helpers/semantic_manifest_yamls/sg_02_single_join/manifest.yaml',
+                file_slice=PydanticFileSlice(
+                  filename='manifest.yaml',
+                  content=('name: '
+                   'listing\n'
+                   'type: '
+                   'primary\n'),
+                  start_line_number=39,
+                  end_line_number=41,
+                ),
+              ),
+            ),
+          ),
+        },
       ),
     ),
   ),


### PR DESCRIPTION
## Summary

**Stacked on #2126** (`mfsql-where-translator`) — this PR targets that branch, not `main`.

Widens cross-model join matching from requiring the exact same entity name on both sides
to matching on join key (`entity.role` if set, else `entity.name`). This lets a model
declare multiple, differently-named entities (e.g. `buyer`, `seller`) that each join to
the same target entity elsewhere (e.g. `user`) under their own local name.

`Entity.role` already existed in the schema/protocol/impl but was dead code - never read
anywhere in join-building. This PR makes it do something, and removes a hack the project
had already hit and documented: `scd_bookings.yaml` carried a duplicate `user` entity
aliasing `guest_id`, commented `"Hack around lack of support for entity/role
functionality"` with its own `TODO: Remove this when full support ... is available`.
`guest` now declares `role: user` directly instead.

## What this touches, and why it's bigger than "widen a few dict keys"

Investigation before writing code found **two separate, independently-implemented
join-matching systems**, both keyed on literal entity-name equality, both required for a
role-based join to actually work end-to-end rather than validate-then-crash:

1. **Query resolution** (`join_lookup.py`, `manifest_object_lookup.py`,
   `entity_lookup.py`) - decides whether a query is valid. Now matches by join key;
   `JoinModelOnRightDescriptor` always carries the *right* model's own entity name (never
   the left's), since that's the identity `entity_join_subgraph.py` needs for graph
   connectivity.
2. **Dataflow plan building** (`node_evaluator.py`,
   `semantic_model_join_evaluator.py`) - a wholly separate, legacy implementation that
   `dataflow_plan_builder.py` routes through instead of the semantic_graph module.
   Confirmed by direct testing: with only (1) fixed, a role-based query resolved
   successfully and then failed at plan-building with "Unable to join all items in
   request" - exactly the validate-then-crash risk flagged before starting.
   `is_valid_semantic_model_join` now takes separate `left_entity_reference`/
   `right_entity_reference`. A fourth call site inside `evaluate_node` (an early
   "is this even joinable" classification, easy to miss) had the same literal-name
   assumption and needed the same fix.
3. **SQL predicate construction** (`sql_join_builder.py`) - the deepest layer.
   `join_on_entity` (a single shared reference) is used to find the join column on
   *both* sides via `column_associations_for_entity`; with genuinely different left/right
   names, the left-side lookup finds nothing. Added `join_on_left_entity` to
   `JoinDescription`/`JoinLinkableInstancesRecipe` - `None` means "same as
   `join_on_entity`" (every existing non-role join, unchanged). Verified the actual
   generated SQL end-to-end (`subq.guest = users_latest.user_id`, using `guest_id`
   correctly).

Also found and fixed a real correctness risk before shipping: if more than one local
entity shares a role (e.g. both `guest` and `host` declared `role: user`), the naive
implementation silently picked whichever was iterated first - a query that looks correct
but joins on an arbitrary entity, no error, no way to ask for the other one. Added an
explicit check that raises a clear error naming the competing entities instead. There's
no "default" disambiguation mechanism yet (unlike the POC design that motivated this
work) - deliberately deferred, which is why `scd_bookings.yaml` only adds `role: user` to
`guest`, not `host`.

## Explicitly out of scope (separate, larger pieces)

- Full query-surface role names - `guest__x`/`host__x` resolving independently as
  distinct dunder paths. Dunder-path resolution today still uses the *target* entity's
  own name (`user__x`), confirmed empirically, not the role-aliased local name.
- Multi-hop role-based joins (`dataflow_join_validator.py`'s `JoinDataflowOutputValidator`
  is unchanged, still single-shared-reference).
- A `default`-style disambiguation mechanism for the multi-role-per-model ambiguity case.

## Test plan

- [x] New tests in `test_node_evaluator.py`: a passing single-role join (asserting
      `join_on_left_entity` is set correctly) and the ambiguous-multi-role rejection.
- [x] Full `tests_metricflow_semantics` suite (287 passed) and `tests_metricflow` suite
      (1159 passed, 4 pre-existing/unrelated `release_validation` failures confirmed
      present on the base commit too via `git stash` comparison) - zero regressions.
- [x] Existing golden-SQL snapshot diffs for SCD tests reviewed and confirmed as the
      expected, purely mechanical removal of the redundant `user`/`booking__user`
      columns `bookings_source` no longer emits.
- [x] Cross-checked against the real-data DuckDB integration suite (`itest_scd.yaml`,
      which already covers the exact `listing__user__home_state_latest` path) that
      nothing about correctness changed, only SQL text/aliasing.
- [x] ruff/black/mypy clean.
- [ ] No changelog entry yet - stacked on an unmerged PR, not yet ready for release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)