### PR TITLE
Clean up Vertica changelog entries (follow-up to #2082)

### DIFF
--- a/.changes/unreleased/Dependencies-20260717-120000.yaml
+++ b/.changes/unreleased/Dependencies-20260717-120000.yaml
@@ -1,6 +1,0 @@
-kind: Dependencies
-body: Allow `dbt-core` 1.12.x in the `dbt-metricflow` CLI and dev environment
-time: 2026-07-17T12:00:00.000000+03:00
-custom:
-    Author: beratli
-    Issue: ""

--- a/.changes/unreleased/Features-20260710-120000.yaml
+++ b/.changes/unreleased/Features-20260710-120000.yaml
@@ -3,4 +3,4 @@ body: Add support for the Vertica engine
 time: 2026-07-10T12:00:00.000000+03:00
 custom:
     Author: beratli
-    Issue: ""
+    Issue: "2082"


### PR DESCRIPTION
Follow-up to #2082 addressing @plypaul's review nits:

- Set the `Issue` field to the PR number (`2082`) in the Vertica Features changelog entry
- Remove the `Dependencies` entry — the dbt-core 1.12.x bump was handled in a separate PR