### PR TITLE
Fix TimeSpineRule to only warn for agg_time_dimensions

### DIFF
--- a/.changes/unreleased/Fixes-20260908-120000.yaml
+++ b/.changes/unreleased/Fixes-20260908-120000.yaml
@@ -1,0 +1,8 @@
+kind: Fixes
+body: Only warn about a time spine being coarser than a time dimension when that dimension
+  is actually used as an `agg_time_dimension`. Plain time dimensions used only for
+  filtering no longer trigger a spurious time spine granularity warning.
+time: 2026-09-08T12:00:00.000000+00:00
+custom:
+    Author: beratli
+    Issue: "2115"

--- a/.changes/unreleased/Fixes-20260908-120000.yaml
+++ b/.changes/unreleased/Fixes-20260908-120000.yaml
@@ -1,7 +1,6 @@
 kind: Fixes
-body: Only warn about a time spine being coarser than a time dimension when that dimension
-  is actually used as an `agg_time_dimension`. Plain time dimensions used only for
-  filtering no longer trigger a spurious time spine granularity warning.
+body: Stop warning about a coarse time spine for time dimensions that are never used
+  as an `agg_time_dimension`.
 time: 2026-09-08T12:00:00.000000+00:00
 custom:
     Author: beratli

--- a/metricflow_semantic_interfaces/validations/time_spines.py
+++ b/metricflow_semantic_interfaces/validations/time_spines.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-from typing import Dict, Generic, List, Sequence, Set
+from typing import Dict, Generic, List, Optional, Sequence, Set
 
 from metricflow_semantic_interfaces.protocols import SemanticManifestT, TimeSpine
-from metricflow_semantic_interfaces.type_enums import TimeGranularity
+from metricflow_semantic_interfaces.type_enums import DimensionType, TimeGranularity
 from metricflow_semantic_interfaces.validations.validator_helpers import (
     SemanticManifestValidationRule,
     ValidationIssue,
@@ -59,14 +59,51 @@ class TimeSpineRule(SemanticManifestValidationRule[SemanticManifestT], Generic[S
                 )
             )
 
-        # Warn if there is a time dimension configured with a smaller granularity than the smallest time spine
-        dimension_granularities = {
-            dimension.type_params.time_granularity
+        # Only dimensions used as an `agg_time_dimension` can trigger a time-spine join, so only they can hit a real
+        # granularity gap with the time spine. See https://github.com/dbt-labs/metricflow/issues/2115.
+        default_agg_time_dimension_by_model: Dict[str, Optional[str]] = {
+            semantic_model.name: (
+                semantic_model.defaults.agg_time_dimension if semantic_model.defaults is not None else None
+            )
             for semantic_model in semantic_manifest.semantic_models
-            for dimension in semantic_model.dimensions
-            if dimension.type_params
         }
-        if len(dimension_granularities) == 0:
+        agg_time_dimension_names_by_model: Dict[str, Set[str]] = {
+            semantic_model.name: set() for semantic_model in semantic_manifest.semantic_models
+        }
+        for semantic_model in semantic_manifest.semantic_models:
+            default_agg_time_dimension = default_agg_time_dimension_by_model[semantic_model.name]
+            for measure in semantic_model.measures:
+                agg_time_dimension_name = measure.agg_time_dimension or default_agg_time_dimension
+                if agg_time_dimension_name is not None:
+                    agg_time_dimension_names_by_model[semantic_model.name].add(agg_time_dimension_name)
+        # Simple metrics defined without a measure carry their own `agg_time_dimension` referencing a model.
+        for metric in semantic_manifest.metrics:
+            agg_params = metric.type_params.metric_aggregation_params
+            if agg_params is None:
+                continue
+            agg_time_dimension_name = agg_params.agg_time_dimension or default_agg_time_dimension_by_model.get(
+                agg_params.semantic_model
+            )
+            if agg_time_dimension_name is not None:
+                agg_time_dimension_names_by_model.setdefault(agg_params.semantic_model, set()).add(
+                    agg_time_dimension_name
+                )
+
+        # `time_dimension_granularities` tracks all time dimensions so the "no time dimensions configured" warning
+        # still fires, while the granularity-gap check below only considers agg_time_dimensions.
+        time_dimension_granularities: Set[TimeGranularity] = set()
+        agg_time_dimension_granularities: Set[TimeGranularity] = set()
+        for semantic_model in semantic_manifest.semantic_models:
+            agg_time_dimension_names = agg_time_dimension_names_by_model[semantic_model.name]
+            for dimension in semantic_model.dimensions:
+                if dimension.type is not DimensionType.TIME or dimension.type_params is None:
+                    continue
+                granularity = dimension.type_params.time_granularity
+                time_dimension_granularities.add(granularity)
+                if dimension.name in agg_time_dimension_names:
+                    agg_time_dimension_granularities.add(granularity)
+
+        if len(time_dimension_granularities) == 0:
             issues.append(
                 ValidationWarning(
                     message="No time dimensions configured. To avoid unexpected query errors, configuring a "
@@ -74,16 +111,18 @@ class TimeSpineRule(SemanticManifestValidationRule[SemanticManifestT], Generic[S
                 )
             )
             return issues
-        smallest_dim_granularity = min(dimension_granularities)
-        smallest_time_spine_granularity = min(time_spines_by_granularity.keys())
-        if smallest_dim_granularity < smallest_time_spine_granularity:
-            issues.append(
-                ValidationWarning(
-                    message=f"To avoid unexpected query errors, configuring a time spine at or below the smallest time "
-                    f"dimension granularity is recommended. Smallest time dimension granularity: "
-                    f"{smallest_dim_granularity.name}; Smallest time spine granularity: "
-                    f"{smallest_time_spine_granularity}"
+
+        if agg_time_dimension_granularities:
+            smallest_dim_granularity = min(agg_time_dimension_granularities)
+            smallest_time_spine_granularity = min(time_spines_by_granularity.keys())
+            if smallest_dim_granularity < smallest_time_spine_granularity:
+                issues.append(
+                    ValidationWarning(
+                        message=f"To avoid unexpected query errors, configuring a time spine at or below the smallest "
+                        f"time dimension granularity is recommended. Smallest time dimension granularity: "
+                        f"{smallest_dim_granularity.name}; Smallest time spine granularity: "
+                        f"{smallest_time_spine_granularity}"
+                    )
                 )
-            )
 
         return issues

--- a/tests_metricflow_semantic_interfaces/validations/test_time_spines.py
+++ b/tests_metricflow_semantic_interfaces/validations/test_time_spines.py
@@ -255,6 +255,12 @@ def test_dimension_granularity_smaller_than_time_spine() -> None:  # noqa: D103
 
 
 def test_no_warning_for_non_agg_time_dimension_finer_than_time_spine() -> None:
+    """A finer-grained time dimension that is never an agg_time_dimension should not trigger the warning.
+
+    Regression test for https://github.com/dbt-labs/metricflow/issues/2115. Only agg_time_dimensions can trigger a
+    time-spine join, so a plain time dimension used only for filtering (here `last_modified_at` at SECOND grain)
+    should not be compared against the time spine granularity.
+    """
     validator = SemanticManifestValidator[PydanticSemanticManifest]([TimeSpineRule()])
     semantic_manifest = PydanticSemanticManifest(
         semantic_models=[

--- a/tests_metricflow_semantic_interfaces/validations/test_time_spines.py
+++ b/tests_metricflow_semantic_interfaces/validations/test_time_spines.py
@@ -254,6 +254,46 @@ def test_dimension_granularity_smaller_than_time_spine() -> None:  # noqa: D103
     )
 
 
+def test_no_warning_for_non_agg_time_dimension_finer_than_time_spine() -> None:
+    validator = SemanticManifestValidator[PydanticSemanticManifest]([TimeSpineRule()])
+    semantic_manifest = PydanticSemanticManifest(
+        semantic_models=[
+            semantic_model_with_guaranteed_meta(
+                name="sum_measure",
+                measures=[
+                    PydanticMeasure(name="foo", agg=AggregationType.SUM, agg_time_dimension="ds", create_metric=True)
+                ],
+                dimensions=[
+                    PydanticDimension(
+                        name="ds",
+                        type=DimensionType.TIME,
+                        type_params=PydanticDimensionTypeParams(time_granularity=TimeGranularity.DAY),
+                    ),
+                    PydanticDimension(
+                        name="last_modified_at",
+                        type=DimensionType.TIME,
+                        type_params=PydanticDimensionTypeParams(time_granularity=TimeGranularity.SECOND),
+                    ),
+                ],
+                entities=[PydanticEntity(name="entity", type=EntityType.PRIMARY)],
+            ),
+        ],
+        metrics=[],
+        project_configuration=PydanticProjectConfiguration(
+            time_spine_table_configurations=[],
+            time_spines=[
+                PydanticTimeSpine(
+                    node_relation=PydanticNodeRelation(alias="time_spine", schema_name="my_fav_schema"),
+                    primary_column=PydanticTimeSpinePrimaryColumn(name="ds", time_granularity=TimeGranularity.DAY),
+                ),
+            ],
+        ),
+    )
+    issues = validator.validate_semantic_manifest(semantic_manifest)
+    assert not issues.has_blocking_issues
+    assert len(issues.warnings) == 0
+
+
 def test_time_spines_with_invalid_names() -> None:  # noqa: D103
     semantic_manifest = PydanticSemanticManifest(
         semantic_models=[


### PR DESCRIPTION
## Summary

`TimeSpineRule.validate_manifest` warns when a time dimension is finer-grained than the smallest configured time spine. Today the check looks at **every** time-typed dimension in the manifest, so it also fires for plain time dimensions that are never used as an `agg_time_dimension` (e.g. a `last_modified_at` timestamp at `second` grain used only for filtering) — even though a finer-grained time spine is only ever needed for a dimension that can be joined to the spine via `JoinToTimeSpineNode` (cumulative metrics, `fill_nulls_with`, offset windows).

The result is a spurious warning that can't be silenced per-dimension without also suppressing unrelated semantic-manifest warnings.

## Change

- Restrict the granularity-gap check to dimensions actually referenced as an `agg_time_dimension`, resolved from:
  - each measure's `agg_time_dimension` (falling back to the model's `defaults.agg_time_dimension`), and
  - measure-less simple metrics' `metric_aggregation_params.agg_time_dimension`.
- Keep considering **all** time dimensions for the existing "No time dimensions configured" warning.
- Add a regression test covering a non-agg time dimension finer than the time spine (no warning), verified to fail against the previous implementation.

## Testing

- `tests_metricflow_semantic_interfaces/validations/` — 165 passed, 1 skipped.
- `ruff` / `black` / `mypy` clean on changed files.

Fixes #2115