### PR TITLE
Fix blank error from mf list dimension-values on empty result

### DIFF
--- a/.changes/unreleased/Fixes-20260908-140000.yaml
+++ b/.changes/unreleased/Fixes-20260908-140000.yaml
@@ -1,6 +1,5 @@
 kind: Fixes
-body: Fix `mf list dimension-values` failing with a blank error when a dimension has
-  no values.
+body: '`mf list dimension-values` no longer errors when a dimension has no values.'
 time: 2026-09-08T14:00:00.000000+00:00
 custom:
     Author: beratli

--- a/.changes/unreleased/Fixes-20260908-140000.yaml
+++ b/.changes/unreleased/Fixes-20260908-140000.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: '`mf list dimension-values` no longer fails with a blank error message when a
+  dimension has no values; it now reports that zero values were found.'
+time: 2026-09-08T14:00:00.000000+00:00
+custom:
+    Author: beratli
+    Issue: "685"

--- a/.changes/unreleased/Fixes-20260908-140000.yaml
+++ b/.changes/unreleased/Fixes-20260908-140000.yaml
@@ -1,6 +1,6 @@
 kind: Fixes
-body: '`mf list dimension-values` no longer fails with a blank error message when a
-  dimension has no values; it now reports that zero values were found.'
+body: Fix `mf list dimension-values` failing with a blank error when a dimension has
+  no values.
 time: 2026-09-08T14:00:00.000000+00:00
 custom:
     Author: beratli

--- a/dbt-metricflow/dbt_metricflow/cli/main.py
+++ b/dbt-metricflow/dbt_metricflow/cli/main.py
@@ -472,7 +472,7 @@ def dimension_values(
         )
         exit(1)
 
-    assert dim_vals
+    assert dim_vals is not None
     spinner.succeed(
         f"🌱 We've found {len(dim_vals)} dimension values for dimension {dimension} of metrics {', '.join(metrics)}."
     )


### PR DESCRIPTION
## Summary

`mf list dimension-values` asserts `assert dim_vals` after querying. When a dimension has **no values** (e.g. it's defined over an empty table), `get_dimension_values` returns an empty list, and `assert []` raises an `AssertionError` with no message — so the CLI fails with a blank error instead of telling the user what happened.

## Change

Assert only that the result is not `None` (`assert dim_vals is not None`, which still narrows the `Optional` for type-checking) so an empty result falls through to the normal success path and reports `🌱 We've found 0 dimension values ...`.

## Testing

- `ruff` / `black` / `mypy` clean on the changed file.

Note: the empty-result path requires a dimension over an empty warehouse table, which the existing isolated CLI test harness (which builds a real dbt project) isn't set up to produce, so this is not covered by an automated test.

Fixes #685