### PR TITLE
feat(sidecar): add validate_semantic_manifest IPC command

### DIFF
--- a/.changes/unreleased/Features-20260908-191213.yaml
+++ b/.changes/unreleased/Features-20260908-191213.yaml
@@ -5,4 +5,4 @@ body: Add a `validate_semantic_manifest` command to the mf_entry IPC sidecar, ru
 time: 2026-09-08T19:12:13.000000-00:00
 custom:
   Author: QMalcolm
-  Issue: ""
+  Issue: "2133"

--- a/.changes/unreleased/Features-20260908-191213.yaml
+++ b/.changes/unreleased/Features-20260908-191213.yaml
@@ -1,0 +1,8 @@
+kind: Features
+body: Add a `validate_semantic_manifest` command to the mf_entry IPC sidecar, running
+  the manifest-only validation suite (no data warehouse connection) and returning
+  structured errors, future_errors, and warnings instead of raising
+time: 2026-09-08T19:12:13.000000-00:00
+custom:
+  Author: QMalcolm
+  Issue: ""

--- a/sidecar/README.md
+++ b/sidecar/README.md
@@ -5,8 +5,9 @@ The sidecar is MetricFlow compiled into a standalone native binary by
 subprocess and communicates with it over NDJSON on stdin/stdout using the
 **mf-ipc v1** protocol.
 
-The sidecar's only job is to compile metric queries to SQL without executing
-them. It wraps `MetricFlowEngine.explain()`.
+The sidecar's job is to compile metric queries to SQL without executing them,
+and to validate semantic manifests without a data warehouse connection. It
+wraps `MetricFlowEngine.explain()` and `SemanticManifestValidator`.
 
 ## Directory layout
 
@@ -236,6 +237,56 @@ Response:
 ```json
 {"id": "1", "ok": true, "sql": "SELECT ..."}
 ```
+
+#### `validate_semantic_manifest`
+
+Runs the manifest-only validation suite (`SemanticManifestValidator`'s default
+rules) against a semantic manifest — the same checks `dbt-metricflow`'s
+`validate-configs` CLI command runs before its data-warehouse validations,
+minus the data-warehouse validations themselves. It never opens a warehouse
+connection.
+
+```json
+{
+  "id": "1",
+  "method": "validate_semantic_manifest",
+  "protocol_version": 1,
+  "params": {
+    "manifest_path": "/path/to/manifest.json"
+  }
+}
+```
+
+- `manifest_path` — path to a `manifest.json` file **or** a YAML semantic
+  manifest directory (for development/testing), same as `explain`
+
+Unlike `explain`, the manifest is not cached: this method reparses and
+revalidates the manifest on every call.
+
+Response:
+
+```json
+{
+  "id": "1",
+  "ok": true,
+  "has_blocking_issues": false,
+  "errors": [],
+  "future_errors": [],
+  "warnings": []
+}
+```
+
+`has_blocking_issues` is `true` if `errors` is non-empty. Each entry in
+`errors`, `future_errors`, and `warnings` has this shape:
+
+```json
+{"message": "...", "context": {...}, "extra_detail": null, "error_date": null}
+```
+
+`context` describes where the issue occurred (file, metric, semantic model,
+element, or saved query, depending on the rule) and is `null` when a rule
+doesn't attach one. `error_date` is only ever populated on `future_errors`
+entries — the date the issue is scheduled to become a blocking error.
 
 #### `ping`
 

--- a/sidecar/mf_entry.py
+++ b/sidecar/mf_entry.py
@@ -10,6 +10,9 @@ Protocol v1:
                 "manifest_path":"...","metric_names":[...],"group_by_names":[...],
                 "where_constraints":null,"order_by_names":null,"limit":null,"sql_engine":"DUCKDB"
             }} → {"id":"...","ok":true,"sql":"..."}
+  validate_semantic_manifest: {"id":"...","method":"validate_semantic_manifest","protocol_version":1,"params":{
+                "manifest_path":"..."
+            }} → {"id":"...","ok":true,"has_blocking_issues":false,"errors":[],"future_errors":[],"warnings":[]}
   ping:     {"id":"...","method":"ping","protocol_version":1} → {"id":"...","ok":true}
   shutdown: {"id":"...","method":"shutdown","protocol_version":1} → {"id":"...","ok":true}
   error:    {"id":"...","ok":false,"error":{"type":"ExceptionClass","message":"..."}}
@@ -22,6 +25,7 @@ from __future__ import annotations
 
 import argparse
 import importlib.metadata
+import json
 import logging
 import os
 import signal
@@ -48,6 +52,9 @@ from mf_ipc_protocol import (
     RequestEnvelope,
     RequestId,
     StartupErrorMessage,
+    ValidateSemanticManifestParams,
+    ValidateSemanticManifestResponse,
+    ValidationIssueModel,
 )
 from pydantic import BaseModel, ValidationError
 
@@ -63,6 +70,9 @@ from metricflow.sql.render.snowflake import SnowflakeSqlPlanRenderer
 from metricflow.sql.render.sql_plan_renderer import SqlPlanRenderer
 from metricflow.sql.render.trino import TrinoSqlPlanRenderer
 from metricflow_semantic_interfaces.implementations.semantic_manifest import PydanticSemanticManifest
+from metricflow_semantic_interfaces.parsing.dir_to_model import parse_directory_of_yaml_files_to_semantic_manifest
+from metricflow_semantic_interfaces.validations.semantic_manifest_validator import SemanticManifestValidator
+from metricflow_semantic_interfaces.validations.validator_helpers import ValidationIssue
 
 try:
     _MF_VERSION = importlib.metadata.version("metricflow")
@@ -132,10 +142,30 @@ def _renderer_for(engine: SqlEngine) -> SqlPlanRenderer:
             raise ValueError(f"No renderer for engine: {engine!r}")
 
 
+_TEMPLATE_MAPPING = {"source_schema": "production"}
+
+
 def _load_manifest(path: str) -> PydanticSemanticManifest:
     p = Path(path)
     if p.is_dir():
-        return mf_load_manifest_from_yaml_directory(p, {"source_schema": "production"})
+        return mf_load_manifest_from_yaml_directory(p, _TEMPLATE_MAPPING)
+    return mf_load_manifest_from_json_file(p)
+
+
+def _load_manifest_unvalidated(path: str) -> PydanticSemanticManifest:
+    """Parse a manifest without running SemanticManifestValidator.
+
+    Unlike _load_manifest, this must succeed even when the manifest is
+    invalid: validate_semantic_manifest needs the parsed manifest so it can
+    run the validator itself and return the structured issues, whereas
+    mf_load_manifest_from_yaml_directory (used by _load_manifest) calls
+    checked_validations() internally and collapses any validation failure
+    into an opaque RuntimeError.
+    """
+    p = Path(path)
+    if p.is_dir():
+        build_result = parse_directory_of_yaml_files_to_semantic_manifest(str(p), template_mapping=_TEMPLATE_MAPPING)
+        return build_result.semantic_manifest
     return mf_load_manifest_from_json_file(p)
 
 
@@ -187,7 +217,40 @@ def _handle_explain(req_id: RequestId, raw_params: dict) -> ExplainResponse | Er
         return _err(req_id, e)
 
 
-def _dispatch(envelope: RequestEnvelope) -> ExplainResponse | OkResponse | ErrorResponse:
+def _issue_model(issue: ValidationIssue) -> ValidationIssueModel:
+    # issue.json() (pydantic v1 API, via msi_pydantic_shim) already knows how to
+    # serialize the enum/date fields nested in context/error_date; round-tripping
+    # through it is simpler than re-deriving that logic here.
+    payload = json.loads(issue.json())
+    return ValidationIssueModel(
+        message=payload["message"],
+        context=payload.get("context"),
+        extra_detail=payload.get("extra_detail"),
+        error_date=payload.get("error_date"),
+    )
+
+
+def _handle_validate_semantic_manifest(
+    req_id: RequestId, raw_params: dict
+) -> ValidateSemanticManifestResponse | ErrorResponse:
+    try:
+        params = ValidateSemanticManifestParams.model_validate(raw_params)
+        manifest = _load_manifest_unvalidated(params.manifest_path)
+        results = SemanticManifestValidator[PydanticSemanticManifest]().validate_semantic_manifest(manifest)
+        return ValidateSemanticManifestResponse(
+            id=req_id,
+            has_blocking_issues=results.has_blocking_issues,
+            errors=tuple(_issue_model(issue) for issue in results.errors),
+            future_errors=tuple(_issue_model(issue) for issue in results.future_errors),
+            warnings=tuple(_issue_model(issue) for issue in results.warnings),
+        )
+    except Exception as e:
+        return _err(req_id, e)
+
+
+def _dispatch(
+    envelope: RequestEnvelope,
+) -> ExplainResponse | OkResponse | ValidateSemanticManifestResponse | ErrorResponse:
     """Route a validated envelope to its method handler.
 
     `shutdown` is handled by the caller (main's IPC loop), not here: it needs
@@ -206,6 +269,8 @@ def _dispatch(envelope: RequestEnvelope) -> ExplainResponse | OkResponse | Error
         return OkResponse(id=envelope.id)
     if envelope.method == Method.EXPLAIN:
         return _handle_explain(envelope.id, envelope.params or {})
+    if envelope.method == Method.VALIDATE_SEMANTIC_MANIFEST:
+        return _handle_validate_semantic_manifest(envelope.id, envelope.params or {})
     return ErrorResponse(
         id=envelope.id,
         error=ErrorDetail(

--- a/sidecar/mf_ipc_protocol.py
+++ b/sidecar/mf_ipc_protocol.py
@@ -40,6 +40,7 @@ class Method(str, Enum):
     EXPLAIN = "explain"
     PING = "ping"
     SHUTDOWN = "shutdown"
+    VALIDATE_SEMANTIC_MANIFEST = "validate_semantic_manifest"
 
 
 class _FrozenModel(BaseModel):
@@ -107,6 +108,29 @@ class ExplainParams(_FrozenModel):
     sql_engine: str = "DUCKDB"
 
 
+class ValidateSemanticManifestParams(_FrozenModel):
+    """Params for the `validate_semantic_manifest` method."""
+
+    manifest_path: str
+
+
+class ValidationIssueModel(_FrozenModel):
+    """One issue from the manifest validation suite (an error, future_error, or warning).
+
+    `context` is passed through as a plain dict rather than modeling
+    ValidationContext's union of shapes here: that union is owned by
+    metricflow_semantic_interfaces.validations.validator_helpers, and
+    re-declaring each variant in the wire protocol would duplicate that
+    source of truth without changing anything on the wire. `error_date` is
+    only ever populated on issues that came from `future_errors`.
+    """
+
+    message: str
+    context: dict | None = None
+    extra_detail: str | None = None
+    error_date: str | None = None
+
+
 class ErrorDetail(_FrozenModel):
     """The `error` payload of an ErrorResponse."""
 
@@ -136,3 +160,14 @@ class ExplainResponse(_FrozenModel):
     id: RequestId
     ok: Literal[True] = True
     sql: str
+
+
+class ValidateSemanticManifestResponse(_FrozenModel):
+    """Successful response for the `validate_semantic_manifest` method."""
+
+    id: RequestId
+    ok: Literal[True] = True
+    has_blocking_issues: bool
+    errors: tuple[ValidationIssueModel, ...] = ()
+    future_errors: tuple[ValidationIssueModel, ...] = ()
+    warnings: tuple[ValidationIssueModel, ...] = ()

--- a/sidecar/tests/test_mf_entry.py
+++ b/sidecar/tests/test_mf_entry.py
@@ -14,7 +14,7 @@ from pathlib import Path
 import mf_entry
 import pytest
 from metricflow_semantics.test_helpers.semantic_manifest_yamls.sg_00_minimal_manifest import SG_00_MINIMAL_MANIFEST
-from mf_ipc_protocol import ExplainParams, Method, RequestEnvelope
+from mf_ipc_protocol import ExplainParams, Method, RequestEnvelope, ValidateSemanticManifestParams
 
 _MF_ENTRY = Path(mf_entry.__file__)
 _MANIFEST_DIR = SG_00_MINIMAL_MANIFEST.directory
@@ -87,6 +87,54 @@ def test_explain_invalid_metric_returns_structured_error(sidecar: subprocess.Pop
     assert resp["ok"] is False
     assert resp["error"]["type"] == "InvalidQueryException"
     assert "nonexistent_metric" in resp["error"]["message"]
+
+
+def test_validate_semantic_manifest_valid_manifest_has_no_blocking_issues(sidecar: subprocess.Popen) -> None:  # type: ignore[type-arg]
+    """A manifest that passes all rules returns ok:true with has_blocking_issues:false and no errors."""
+    params = ValidateSemanticManifestParams(manifest_path=str(_MANIFEST_DIR))
+    resp = _send(
+        sidecar,
+        RequestEnvelope(id="validate-1", method=Method.VALIDATE_SEMANTIC_MANIFEST.value, params=params.model_dump()),
+    )
+    assert resp["id"] == "validate-1"
+    assert resp["ok"] is True
+    assert resp["has_blocking_issues"] is False
+    assert resp["errors"] == []
+
+
+def test_validate_semantic_manifest_invalid_manifest_returns_errors(
+    sidecar: subprocess.Popen,  # type: ignore[type-arg]
+    tmp_path: Path,
+) -> None:
+    """An empty manifest fails NonEmptyRule; the errors come back as structured issues, not a raised exception."""
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(
+        json.dumps({"semantic_models": [], "metrics": [], "saved_queries": [], "project_configuration": {}})
+    )
+    params = ValidateSemanticManifestParams(manifest_path=str(manifest_path))
+    resp = _send(
+        sidecar,
+        RequestEnvelope(id="validate-2", method=Method.VALIDATE_SEMANTIC_MANIFEST.value, params=params.model_dump()),
+    )
+    assert resp["id"] == "validate-2"
+    assert resp["ok"] is True
+    assert resp["has_blocking_issues"] is True
+    messages = {issue["message"] for issue in resp["errors"]}
+    assert "No semantic models present in the model." in messages
+    assert "No metrics present in the model." in messages
+
+
+def test_validate_semantic_manifest_unknown_manifest_path_returns_structured_error(
+    sidecar: subprocess.Popen,  # type: ignore[type-arg]
+) -> None:
+    """A manifest_path that doesn't exist fails to load and returns ok:false, not a crash."""
+    params = ValidateSemanticManifestParams(manifest_path="/no/such/manifest.json")
+    resp = _send(
+        sidecar,
+        RequestEnvelope(id="validate-3", method=Method.VALIDATE_SEMANTIC_MANIFEST.value, params=params.model_dump()),
+    )
+    assert resp["id"] == "validate-3"
+    assert resp["ok"] is False
 
 
 def test_unknown_method(sidecar: subprocess.Popen) -> None:  # type: ignore[type-arg]

--- a/sidecar/tests/test_mf_ipc_protocol.py
+++ b/sidecar/tests/test_mf_ipc_protocol.py
@@ -15,6 +15,9 @@ from mf_ipc_protocol import (
     ReadyMessage,
     RequestEnvelope,
     StartupErrorMessage,
+    ValidateSemanticManifestParams,
+    ValidateSemanticManifestResponse,
+    ValidationIssueModel,
 )
 from pydantic import BaseModel, ValidationError
 
@@ -70,7 +73,7 @@ def test_request_envelope_rejects_non_mapping_input() -> None:
         RequestEnvelope.model_validate([1, 2, 3])
 
 
-@pytest.mark.parametrize("model_cls", [RequestEnvelope, ExplainParams])
+@pytest.mark.parametrize("model_cls", [RequestEnvelope, ExplainParams, ValidateSemanticManifestParams])
 def test_extra_fields_are_ignored_not_rejected(model_cls: type[BaseModel]) -> None:
     """An older MetricFlow shouldn't reject a newer Fusion's request over an unknown field."""
     payload = {"id": "1", "manifest_path": "/some/path", "some_future_field": "value"}
@@ -106,3 +109,41 @@ def test_ok_and_explain_response_ok_field_is_fixed() -> None:
     """Ok is always True on these two response types, regardless of construction order."""
     assert OkResponse(id="1").ok is True
     assert ExplainResponse(id="1", sql="SELECT 1").ok is True
+
+
+def test_validate_semantic_manifest_params_requires_manifest_path() -> None:
+    """manifest_path has no default; omitting it must raise a field-level ValidationError."""
+    with pytest.raises(ValidationError, match="manifest_path"):
+        ValidateSemanticManifestParams.model_validate({})
+
+
+def test_validation_issue_model_defaults() -> None:
+    """context, extra_detail, and error_date are optional and default to None."""
+    issue = ValidationIssueModel(message="No metrics present in the model.")
+    assert issue.context is None
+    assert issue.extra_detail is None
+    assert issue.error_date is None
+
+
+def test_validate_semantic_manifest_response_shape() -> None:
+    """ValidateSemanticManifestResponse dumps to the exact shape documented in sidecar/README.md."""
+    resp = ValidateSemanticManifestResponse(
+        id="1",
+        has_blocking_issues=True,
+        errors=(ValidationIssueModel(message="No metrics present in the model."),),
+    )
+    assert resp.model_dump() == {
+        "id": "1",
+        "ok": True,
+        "has_blocking_issues": True,
+        "errors": (
+            {
+                "message": "No metrics present in the model.",
+                "context": None,
+                "extra_detail": None,
+                "error_date": None,
+            },
+        ),
+        "future_errors": (),
+        "warnings": (),
+    }


### PR DESCRIPTION
## Summary
Prior to this PR the mf_entry for the IPC sidecar only had an `explain` command. This adds a `validate` command which allows for applications utilizing the sidecar leverage it for validating semantic manifest. This is necessary for dbt-core v2 which does not currently validate the semantic manifest it produces.

- Adds a `validate_semantic_manifest` method to the `mf_entry` IPC sidecar that runs `SemanticManifestValidator`'s default rule set against a manifest (YAML directory or `manifest.json`) and returns structured `errors`/`future_errors`/`warnings` plus `has_blocking_issues` — no data warehouse connection, mirroring the manifest-only half of `dbt-metricflow`'s `validate-configs --skip-dw` path.
- Adds `ValidateSemanticManifestParams`/`ValidateSemanticManifestResponse`/`ValidationIssueModel` to the mf-ipc v1 wire protocol, and documents the new method in `sidecar/README.md`.
- Adds a `.changes/unreleased/` entry (Issue left blank — will fill in with this PR's number).
