### PR TITLE
fix: sandbox Jinja rendering of where-filter templates (GHSA-g857-633q-gjj8)

### DIFF
--- a/.changes/unreleased/Security-20260908-153530.yaml
+++ b/.changes/unreleased/Security-20260908-153530.yaml
@@ -1,0 +1,7 @@
+kind: Security
+body: Sandbox Jinja rendering of where-filter templates (`where_sql_template`) to
+  close a Server-Side Template Injection vector that allowed arbitrary code execution
+time: 2026-09-08T15:35:30.31144-05:00
+custom:
+  Author: QMalcolm
+  Issue: "2134"

--- a/metricflow/converters/filter_utils.py
+++ b/metricflow/converters/filter_utils.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import List, Optional, Sequence
 
 import jinja2
+from jinja2.sandbox import SandboxedEnvironment
 
 from metricflow_semantic_interfaces.protocols.where_filter import WhereFilterIntersection
 
@@ -100,12 +101,22 @@ def _render_filter_template(template: str) -> str:
     and `{{ Metric('revenue') }}` are resolved to their column-name
     equivalents using lightweight stubs.  The output is a best-effort SQL
     string suitable for embedding in an OSI expression.
+
+    `template` is caller/model-controlled (a metric's `where` filter text), so it is rendered
+    through a `SandboxedEnvironment` rather than a plain `jinja2.Template` -- the plain API allows
+    unrestricted attribute access (e.g. `{{ cycler.__init__.__globals__.os.popen(...) }}`), which is
+    an SSTI-to-RCE vector. This mirrors the sandboxing already used for the same field in
+    `metricflow_semantic_interfaces/parsing/text_input/ti_processor.py`.
     """
-    return jinja2.Template(template, undefined=jinja2.StrictUndefined).render(
-        Dimension=_DimensionStub,
-        TimeDimension=_TimeDimensionStub,
-        Entity=_EntityStub,
-        Metric=_MetricStub,
+    return (
+        SandboxedEnvironment(undefined=jinja2.StrictUndefined)
+        .from_string(template)
+        .render(
+            Dimension=_DimensionStub,
+            TimeDimension=_TimeDimensionStub,
+            Entity=_EntityStub,
+            Metric=_MetricStub,
+        )
     )
 
 

--- a/metricflow_semantics/specs/where_filter/where_filter_spec_factory.py
+++ b/metricflow_semantics/specs/where_filter/where_filter_spec_factory.py
@@ -4,6 +4,7 @@ import logging
 from typing import List, Optional, Sequence
 
 import jinja2
+from jinja2.sandbox import SandboxedEnvironment
 from metricflow_semantics.errors.error_classes import RenderSqlTemplateException
 from metricflow_semantics.query.group_by_item.filter_spec_resolution.filter_location import WhereFilterLocation
 from metricflow_semantics.query.group_by_item.filter_spec_resolution.filter_spec_lookup import (
@@ -90,16 +91,26 @@ class WhereFilterSpecFactory:
             )
             try:
                 # If there was an error with the template, it should have been caught while resolving the specs for
-                # the filters during query resolution.
-                where_sql = jinja2.Template(where_filter.where_sql_template, undefined=jinja2.StrictUndefined).render(
-                    {
-                        "Dimension": dimension_factory.create,
-                        "TimeDimension": time_dimension_factory.create,
-                        "Entity": entity_factory.create,
-                        "Metric": metric_factory.create,
-                    }
+                # the filters during query resolution. `SandboxedEnvironment` is used here (rather than a plain
+                # `jinja2.Template`) as defense in depth against SSTI, since `where_sql_template` is
+                # caller/model-controlled -- see GHSA-g857-633q-gjj8.
+                where_sql = (
+                    SandboxedEnvironment(undefined=jinja2.StrictUndefined)
+                    .from_string(where_filter.where_sql_template)
+                    .render(
+                        {
+                            "Dimension": dimension_factory.create,
+                            "TimeDimension": time_dimension_factory.create,
+                            "Entity": entity_factory.create,
+                            "Metric": metric_factory.create,
+                        }
+                    )
                 )
-            except (jinja2.exceptions.UndefinedError, jinja2.exceptions.TemplateSyntaxError) as e:
+            except (
+                jinja2.exceptions.UndefinedError,
+                jinja2.exceptions.TemplateSyntaxError,
+                jinja2.exceptions.SecurityError,
+            ) as e:
                 raise RenderSqlTemplateException(
                     f"Error while rendering Jinja template:\n{where_filter.where_sql_template}"
                 ) from e

--- a/tests_metricflow_semantic_interfaces/osi/test_msi_to_osi.py
+++ b/tests_metricflow_semantic_interfaces/osi/test_msi_to_osi.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 from typing import List, Optional
 
+import jinja2
 import pytest
 from _pytest.fixtures import FixtureRequest
 from metricflow_semantics.test_helpers.snapshot_helpers import (
@@ -1023,6 +1024,16 @@ class TestFilterRendering:  # noqa: D101
 
     def test_metric_reference(self) -> None:  # noqa: D102
         assert _render_filter_template("{{ Metric('revenue') }} > 0") == "revenue > 0"
+
+    def test_ssti_gadget_payload_is_blocked(self) -> None:  # noqa: D102
+        """Regression test for GHSA-g857-633q-gjj8: `where_sql_template` must render in a sandboxed environment.
+
+        A plain, unsandboxed `jinja2.Template` allows arbitrary attribute traversal (e.g. reaching
+        `os.popen` via `cycler.__init__.__globals__`), which is SSTI-to-RCE. `SandboxedEnvironment`
+        raises `SecurityError` on this instead of executing it.
+        """
+        with pytest.raises(jinja2.exceptions.SecurityError):
+            _render_filter_template("{{ cycler.__init__.__globals__.os.popen('id').read() }}")
 
 
 class TestMetricFilterFlattening:  # noqa: D101

--- a/tests_metricflow_semantics/model/test_where_filter_spec.py
+++ b/tests_metricflow_semantics/model/test_where_filter_spec.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 
 import pytest
+from metricflow_semantics.errors.error_classes import RenderSqlTemplateException
 from metricflow_semantics.model.linkable_element_property import GroupByItemProperty
 from metricflow_semantics.model.semantic_manifest_lookup import SemanticManifestLookup
 from metricflow_semantics.model.semantics.linkable_element import LinkableElementType
@@ -530,6 +531,26 @@ def test_metric_in_filter(  # noqa: D103
         entity_specs=(),
         group_by_metric_specs=(group_by_metric_spec,),
     )
+
+
+def test_ssti_gadget_payload_is_blocked(  # noqa: D103
+    column_association_resolver: ColumnAssociationResolver,
+    simple_semantic_manifest_lookup: SemanticManifestLookup,
+) -> None:
+    """Regression test for GHSA-g857-633q-gjj8's anti-pattern in this factory's own Jinja render.
+
+    `create_from_where_filter_intersection` renders `where_sql_template` in a step separate from the
+    sandboxed parse that runs during query resolution, so it needs its own guard against SSTI gadget
+    chains (e.g. reaching `os.popen` via `cycler.__init__.__globals__`).
+    """
+    where_filter = PydanticWhereFilter(where_sql_template="{{ cycler.__init__.__globals__.os.popen('id').read() }}")
+
+    with pytest.raises(RenderSqlTemplateException):
+        WhereFilterSpecFactory(
+            column_association_resolver=column_association_resolver,
+            spec_resolution_lookup=FilterSpecResolutionLookUp.empty_instance(),
+            custom_grain_names=simple_semantic_manifest_lookup.semantic_model_lookup.custom_granularity_names,
+        ).create_from_where_filter(EXAMPLE_FILTER_LOCATION, where_filter)
 
 
 def test_dimension_time_dimension_parity(  # noqa: D103


### PR DESCRIPTION
## Summary
- Fixes GHSA-g857-633q-gjj8: `_render_filter_template` in `metricflow/converters/filter_utils.py` rendered a metric's `where_sql_template` (caller/model-controlled) through a plain `jinja2.Template`, which allows arbitrary attribute traversal and Server-Side Template Injection to RCE (e.g. `{{ cycler.__init__.__globals__.os.popen('id').read() }}`). Switched to `jinja2.sandbox.SandboxedEnvironment`, matching the pattern already used for the same field in `metricflow_semantic_interfaces/parsing/text_input/ti_processor.py`.
- While auditing, found the identical unsandboxed-`jinja2.Template` pattern in `metricflow_semantics/specs/where_filter/where_filter_spec_factory.py`, on the core query-execution path. It appears to be gated today by an earlier sandboxed parse in the query resolver (which rejects unsafe templates with `InvalidQueryException` before this factory runs), so it isn't known to be independently exploitable — but that's an implicit, unenforced ordering invariant across several files, not a guarantee in the function itself. Hardened it too, in a separate commit, for defense in depth.