### PR TITLE
Update `dbt-metricflow` version to 0.16.0.dev0

### DIFF
--- a/dbt-metricflow/dbt_metricflow/__about__.py
+++ b/dbt-metricflow/dbt_metricflow/__about__.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-__version__ = "0.15.0"
+__version__ = "0.16.0.dev0"

--- a/dbt-metricflow/requirements-files/requirements-metricflow.txt
+++ b/dbt-metricflow/requirements-files/requirements-metricflow.txt
@@ -1,1 +1,1 @@
-metricflow==0.213.0
+metricflow @ {root:parent:uri}


### PR DESCRIPTION
Update `dbt-metricflow` version to 0.16.0.dev0 to reflect in-progress development.