### PR TITLE
fix(release-tool): base step 2 PR on main if step 1 already merged

### DIFF
--- a/scripts/release_tool/release_step_2.py
+++ b/scripts/release_tool/release_step_2.py
@@ -8,6 +8,7 @@ from typing import ClassVar
 from packaging.version import Version
 
 from msi_pydantic_shim import BaseModel
+from scripts.release_tool.git_manager import GitManager
 from scripts.release_tool.github_client import GitHubClient
 from scripts.release_tool.package_version import PackageVersionUpdate
 from scripts.release_tool.release_helper import ReleaseHelper
@@ -88,6 +89,15 @@ class ReleaseStep2Runner:
             hatch_project_directory=self.release_helper.metricflow_repo_directory,
         )
         pr_title = self._development_version_pr_title(version=new_version)
+        # Normally step 2's PR stacks on step 1's still-open branch, and step 3 later merges
+        # step 1 first and rebases step 2 onto `main` before merging it too. But if step 1's PR
+        # is merged before step 2 runs (e.g. merged by hand, out of band), GitHub deletes the
+        # step-1 branch on merge, which makes it an invalid PR base. In that case, base step 2
+        # directly on a freshly pulled `main`, which already contains step 1's changes and is
+        # what step 3 would have rebased onto anyway.
+        step_1_pr_merged = self.github_client.is_pr_merged(self.step_1_state.pr_number)
+        base_branch = GitManager.MAIN_BRANCH if step_1_pr_merged else step_1_branch_name
+        pull_base_branch = step_1_pr_merged
         pr_result = ReleasePrRunner(
             release_branch_name=step_2_branch_name,
             pr_title=pr_title,
@@ -100,8 +110,8 @@ class ReleaseStep2Runner:
             ),
             github_client=self.github_client,
             release_helper=self.release_helper,
-            base_branch=step_1_branch_name,
-            pull_base_branch=False,
+            base_branch=base_branch,
+            pull_base_branch=pull_base_branch,
         ).run()
         return ReleaseStep2State(
             metricflow_package_version=new_version,


### PR DESCRIPTION
## Summary

- Step 2 of the release tool always based its dev-version-bump PR on step 1's release branch (a stacked-PR pattern intended for step 3 to merge step 1 first, then rebase/merge step 2 on top).
- If step 1's PR is merged before step 2 runs, GitHub auto-deletes the step-1 branch, so creating a PR with that branch as `base` fails with `422 Validation Failed` (`field: base, code: invalid`).
- Step 2 now checks `github_client.is_pr_merged` on step 1's PR and, if it's already merged, bases the new PR on a freshly-pulled `main` instead — matching what step 3 already does when it rebuilds the step-2 branch before merging.

## Why this approach

Restoring the deleted step-1 branch on GitHub was considered as a workaround but rejected: step 1 merges via squash, so the restored branch would be a stale commit disconnected from `main`'s history. A PR based on it would never reach a clean mergeable state, and if force-merged would land the dev-version bump on the orphaned branch instead of `main`, silently breaking the release.

**Known gap:** this only detects the "already merged" case. If step 1's PR is closed without merging, its branch is also gone, but `is_pr_merged` returns false, so step 2 would still try (and fail) to base off the deleted branch. Left unhandled since that scenario is unusual mid-release.

## Test plan

- [x] Exercised live during the actual 0.213.0 release: step 1's PR (#2135) was merged ahead of step 2, step 2 hit the `422` before this fix, then succeeded after applying it (step 2's PR: #2136).
- [x] Confirmed step 3 proceeded correctly afterward (detected step 1 already merged, rebuilt/force-pushed the step-2 branch onto `main`, merged step 2's PR) for the rest of the 0.213.0 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)